### PR TITLE
feat: add Python linting to precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,45 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-added-large-files
       - id: end-of-file-fixer
       - id: trailing-whitespace
+
+  # Python linting and formatting
+  - repo: https://github.com/psf/black
+    rev: 25.11.0
+    hooks:
+      - id: black
+        language_version: python3.11
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.4
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.18.2
+    hooks:
+      - id: mypy
+        additional_dependencies: [
+          pandas-stubs,
+          types-psutil,
+          types-PyYAML,
+          types-tqdm,
+          types-requests
+        ]
+        args: [--config-file=pyproject.toml]
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.6
+    hooks:
+      - id: bandit
+        args: [-c, pyproject.toml]
+        additional_dependencies: ["bandit[toml]"]
 
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0


### PR DESCRIPTION
Added comprehensive Python linting and formatting to pre-commit hooks:
- black: Code formatting with Python 3.11 support
- ruff: Fast linting and auto-fixing with isort integration
- mypy: Static type checking with project type stubs
- bandit: Security vulnerability scanning

Updated all hook versions to latest releases to address deprecation warnings.

These hooks will now run automatically before commits to ensure code quality,
consistent formatting, and security best practices.