### PR TITLE
Fix award year validation mismatch error

### DIFF
--- a/tests/unit/models/test_award.py
+++ b/tests/unit/models/test_award.py
@@ -271,18 +271,46 @@ class TestAwardModel:
         )
         assert award.award_year == 2023
 
-    def test_award_year_validator_rejects_mismatch(self):
-        """Test award_year validator rejects mismatch with award_date."""
-        with pytest.raises(ValidationError) as exc_info:
-            Award(
-                award_id="TEST-15",
-                company_name="Test Corp",
-                award_amount=10000,
-                award_date=date(2023, 1, 1),
-                program="SBIR",
-                award_year=2022,
-            )
-        assert "award_year must match award_date year" in str(exc_info.value)
+    def test_award_year_validator_auto_corrects_from_award_date(self):
+        """Test award_year validator auto-corrects from award_date when mismatch."""
+        award = Award(
+            award_id="TEST-15",
+            company_name="Test Corp",
+            award_amount=10000,
+            award_date=date(2023, 1, 1),
+            program="SBIR",
+            award_year=2022,  # Mismatch - should be auto-corrected to 2023
+        )
+        # award_date takes priority, so award_year should be auto-corrected to 2023
+        assert award.award_year == 2023
+
+    def test_award_year_populated_from_award_date_when_none(self):
+        """Test award_year is populated from award_date when not provided."""
+        award = Award(
+            award_id="TEST-15A",
+            company_name="Test Corp",
+            award_amount=10000,
+            award_date=date(2023, 6, 15),
+            program="SBIR",
+            # award_year not provided
+        )
+        # Should be auto-populated from award_date
+        assert award.award_year == 2023
+
+    def test_award_year_preserved_when_no_award_date(self):
+        """Test award_year is preserved as-is when award_date not available (fallback)."""
+        # This would fail in practice due to award_date being required,
+        # but tests the validator logic if award_date were somehow unavailable during validation
+        # In real usage, this scenario would be caught by required field validation first
+        award = Award(
+            award_id="TEST-15B",
+            company_name="Test Corp",
+            award_amount=10000,
+            award_date=date(2022, 1, 1),  # Required field
+            program="SBIR",
+            award_year=2022,
+        )
+        assert award.award_year == 2022
 
     def test_company_uei_validator_normalizes_to_uppercase(self):
         """Test company_uei validator normalizes to uppercase."""


### PR DESCRIPTION
Changed award_year validation from rejecting mismatches to auto-correcting from award_date. This preserves data that previously would have been dropped due to inconsistencies between award_year and award_date fields.

Changes:
- Modified award_year field validator to auto-correct from award_date.year when both fields are present, prioritizing award_date as source of truth
- Added model_validator to populate award_year from award_date when award_year is not provided
- Updated tests to verify auto-correction behavior instead of rejection

This resolves validation warnings where award_year and award_date.year didn't match, allowing the system to accept and correct the data rather than rejecting the entire record.