### PR TITLE
Fix bug retrieval system

### DIFF
--- a/src/transformers/company_categorization.py
+++ b/src/transformers/company_categorization.py
@@ -52,7 +52,9 @@ def classify_contract(contract: dict) -> ContractClassification:
     """
     # Extract fields with safe defaults
     award_id = contract.get("award_id", "")
-    psc = contract.get("psc", "")
+    # Convert PSC to string if it's a number (handles numeric PSC codes stored as int)
+    psc_raw = contract.get("psc", "")
+    psc = str(psc_raw) if psc_raw else ""
     contract_type = contract.get("contract_type", "")
     pricing = contract.get("pricing", "")
     description = contract.get("description", "") or ""
@@ -208,8 +210,13 @@ def _classify_by_psc(psc: str) -> tuple[str, str, float]:
     if not psc:
         return ("Service", "default", 0.50)
 
+    # Ensure PSC is a string (handles cases where numeric PSC might be passed as int)
+    psc_str = str(psc) if psc else ""
+    if not psc_str:
+        return ("Service", "default", 0.50)
+
     # Get first character of PSC
-    first_char = psc[0].upper()
+    first_char = psc_str[0].upper()
 
     # Numeric PSC → Product
     if first_char.isdigit():
@@ -352,7 +359,10 @@ def aggregate_company_classification(
     psc_families = set()
     for c in classified_contracts:
         if c.psc:
-            psc_families.add(c.psc[0].upper())
+            # Ensure PSC is string (defensive programming)
+            psc_str = str(c.psc) if c.psc else ""
+            if psc_str:
+                psc_families.add(psc_str[0].upper())
 
     # Apply override rules and determine classification
     override_reason = None


### PR DESCRIPTION
Fixed bug where numeric PSC codes stored as integers would cause "'int' object has no attribute 'startswith'" errors.

Changes:
- Convert PSC codes to strings when extracting from contracts
- Add defensive type conversion in _classify_by_psc function
- Add safety check when counting PSC families in aggregation

This ensures PSC codes work correctly whether they come from the database/API as integers (numeric codes like 1234) or strings (alphanumeric codes like "R425").