### PR TITLE
Fix misleading SBIR award count in processing logs

### DIFF
--- a/test_categorization_validation.py
+++ b/test_categorization_validation.py
@@ -214,10 +214,9 @@ def categorize_companies(
     for idx, (_, company) in enumerate(companies.iterrows(), 1):
         uei = company.get("UEI")
         name = company.get("Company Name", "Unknown")
-        sbir_awards = company.get("SBIR Awards", 0)
 
         logger.info(
-            f"\n[{idx}/{len(companies)}] Processing: {name} (UEI: {uei}, SBIR Awards: {sbir_awards})"
+            f"\n[{idx}/{len(companies)}] Processing: {name} (UEI: {uei})"
         )
 
         # Retrieve USAspending contracts (non-SBIR/STTR for categorization)


### PR DESCRIPTION
Remove incorrect "SBIR Awards: 0" from initial processing log message. The value was being read from input dataframe (which is 0) instead of the actual count retrieved from USAspending API. The correct SBIR award count is already logged in the USAspending breakdown after retrieval.