### PR TITLE
Fix NameError: undefined sbir_awards variable in categorize_companies

### DIFF
--- a/test_categorization_validation.py
+++ b/test_categorization_validation.py
@@ -214,10 +214,13 @@ def categorize_companies(
     for idx, (_, company) in enumerate(companies.iterrows(), 1):
         uei = company.get("UEI")
         name = company.get("Company Name", "Unknown")
+        sbir_awards = company.get("SBIR Awards", 0)
 
-        # Convert pandas NaN to None for Pydantic compatibility
+        # Convert pandas NaN to None/default values for Pydantic compatibility
         if pd.isna(uei):
             uei = None
+        if pd.isna(sbir_awards):
+            sbir_awards = 0
 
         logger.info(
             f"\n[{idx}/{len(companies)}] Processing: {name} (UEI: {uei})"


### PR DESCRIPTION
The sbir_awards variable was being referenced in result_dict creation
(lines 261 and 312) but was never extracted from the company DataFrame row.

This fix:
- Extracts sbir_awards from the company row using company.get("SBIR Awards", 0)
- Handles NaN values by converting them to 0 for consistency
- Follows the same pattern used for other company attributes (uei, name)

The SBIR Awards column comes from the validation dataset CSV which contains
the expected number of SBIR awards from the original dataset, used for
comparison against what's found in USAspending.