### PR TITLE
Fix unspecified issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ env:
   DAGSTER_CLOUD_URL: "http://sbir.dagster.cloud"
   DAGSTER_CLOUD_API_TOKEN: ${{ secrets.DAGSTER_CLOUD_API_TOKEN }}
   ENABLE_FAST_DEPLOYS: 'true'
-  PYTHON_VERSION: '3.10'
+  PYTHON_VERSION: '3.11'
   DAGSTER_CLOUD_FILE: 'dagster_cloud.yaml'
 
 jobs:

--- a/dagster_cloud.yaml
+++ b/dagster_cloud.yaml
@@ -8,7 +8,7 @@
 locations:
   - location_name: sbir-analytics-production
     code_source:
-      package_name: sbir-analytics
       python_module: src.definitions
     build:
+      directory: .
       python_version: "3.11"


### PR DESCRIPTION
- Add missing 'directory' field to dagster_cloud.yaml build config
- Remove invalid 'package_name' field from code_source section
- Update workflow Python version from 3.10 to 3.11 to match pyproject.toml requirements

Fixes TypeError: join() argument must be str, bytes, or os.PathLike object, not 'NoneType' This error occurred because the Dagster Cloud CLI expected a directory path but received None when parsing the location configuration.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
