### PR TITLE
Fix CI pipeline build and push cache

### DIFF
--- a/.github/workflows/docker-cache.yml
+++ b/.github/workflows/docker-cache.yml
@@ -44,7 +44,9 @@ jobs:
             build_args: BUILD_WITH_R=false
             tag_suffix: ""
           - name: with-r
-            build_args: BUILD_WITH_R=true
+            build_args: |
+              BUILD_WITH_R=true
+              USE_R_BASE_IMAGE=true
             tag_suffix: -r
 
     steps:

--- a/dagster_cloud.yaml
+++ b/dagster_cloud.yaml
@@ -13,6 +13,7 @@ locations:
     build:
       directory: .
       python_version: "3.11"
+      base_requirements_txt: requirements.txt
     container_context:
       k8s:
         env_vars:


### PR DESCRIPTION
The with-r variant was timing out after 30 minutes because it was building R packages (arrow, stateior) from scratch. This change enables USE_R_BASE_IMAGE=true to copy pre-built R packages from the cached R base image, reducing build time from 30+ minutes to ~30 seconds.

The R base image is maintained by the build-r-base.yml workflow and rebuilt weekly with all necessary R packages pre-installed.

Fixes the timeout error in Build and Push Cache Images (with-r).

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
