### PR TITLE
Remove Neo4j Aura support, standardize on self-hosted containers

### DIFF
--- a/docs/architecture/shared-tech-stack.md
+++ b/docs/architecture/shared-tech-stack.md
@@ -212,8 +212,8 @@ def load_config(config_name: str, config_class: type[BaseModel]) -> BaseModel:
 ## Shared infrastructure (Production - Cloud)
 
 export SBIR_ETL_ENV=prod
-export SBIR_ETL_NEO4J_URI=bolt://your-neo4j-host:7687  # Neo4j EC2
-export SBIR_ETL_NEO4J_PASSWORD=${AWS_SECRET}  # Retrieved from AWS Secrets Manager
+export NEO4J_URI=bolt://your-neo4j-host:7687  # Neo4j on cloud VM
+export NEO4J_PASSWORD=${AWS_SECRET}  # Retrieved from AWS Secrets Manager
 export SBIR_ETL_LOG_LEVEL=INFO
 export SBIR_ETL_S3_BUCKET=sbir-analytics-data-prod
 export SBIR_ETL_USE_S3=true
@@ -221,8 +221,8 @@ export SBIR_ETL_USE_S3=true
 ## Shared infrastructure (Development - Local)
 
 export SBIR_ETL_ENV=dev
-export SBIR_ETL_NEO4J_URI=bolt://localhost:7687  # Docker Neo4j
-export SBIR_ETL_NEO4J_PASSWORD=neo4j
+export NEO4J_URI=bolt://localhost:7687  # Docker Neo4j
+export NEO4J_PASSWORD=neo4j
 export SBIR_ETL_USE_S3=false  # Use local filesystem
 
 ## Module-specific overrides

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -79,9 +79,11 @@ Set these in GitHub → Settings → Secrets:
 | Secret | Description |
 |--------|-------------|
 | `AWS_ROLE_ARN` | IAM role for AWS access |
-| `NEO4J_URI` | Neo4j connection URI |
+| `NEO4J_URI` | Production Neo4j connection URI |
 | `NEO4J_USER` | Neo4j username |
-| `NEO4J_PASSWORD` | Neo4j password |
+| `NEO4J_PASSWORD` | Production Neo4j password |
+| `NEO4J_TEST_URI` | Test Neo4j connection URI (used when `environment: test`) |
+| `NEO4J_TEST_PASSWORD` | Test Neo4j password (used when `environment: test`) |
 
 ## Local Development
 

--- a/infrastructure/cdk/stacks/batch_stack.py
+++ b/infrastructure/cdk/stacks/batch_stack.py
@@ -10,6 +10,7 @@ from aws_cdk import (
     aws_events_targets as targets,
     aws_iam as iam,
     aws_logs as logs,
+    aws_secretsmanager as secretsmanager,
     aws_sns as sns,
     aws_sns_subscriptions as subscriptions,
 )
@@ -125,15 +126,10 @@ class BatchStack(Stack):
         )
 
         # Grant Secrets Manager access for Neo4j credentials
-        job_task_role.add_to_policy(
-            iam.PolicyStatement(
-                effect=iam.Effect.ALLOW,
-                actions=["secretsmanager:GetSecretValue"],
-                resources=[
-                    f"arn:aws:secretsmanager:{self.region}:{self.account}:secret:sbir-analytics/neo4j*"
-                ],
-            )
+        neo4j_secret = secretsmanager.Secret.from_secret_name_v2(
+            self, "Neo4jSecretRef", secret_name="sbir-analytics/neo4j"
         )
+        neo4j_secret.grant_read(job_task_role)
 
         # Compute environment using Fargate (serverless)
         # Avoids EC2 instance type restrictions and quota issues

--- a/infrastructure/cdk/stacks/security.py
+++ b/infrastructure/cdk/stacks/security.py
@@ -41,15 +41,7 @@ class SecurityStack(Stack):
             s3_bucket.grant_read_write(self.lambda_role)
 
             # Secrets Manager permissions for Lambda
-            self.lambda_role.add_to_policy(
-                iam.PolicyStatement(
-                    effect=iam.Effect.ALLOW,
-                    actions=["secretsmanager:GetSecretValue"],
-                    resources=[
-                        f"arn:aws:secretsmanager:{self.region}:{self.account}:secret:sbir-analytics/neo4j*"
-                    ],
-                )
-            )
+            self.neo4j_secret.grant_read(self.lambda_role)
 
             # Create new Step Functions execution role
             self.step_functions_role = iam.Role(


### PR DESCRIPTION
## Description

This PR removes all Neo4j Aura (cloud-managed) support from the codebase and standardizes on self-hosted Neo4j containers across all environments (development, test/CI, and production). 

**Key Changes:**

1. **Documentation Updates**
   - Simplified `neo4j-testing-environments-guide.md` to focus only on self-hosted Docker and cloud VM deployments
   - Removed Aura-specific sections (setup, limitations, node counting, CI setup)
   - Removed dedicated `neo4j-aura-setup.md` and `neo4j-aura-e2e.md` files
   - Updated environment summaries to reflect Docker (dev) and Cloud VM (test/prod) only

2. **Configuration Changes**
   - Removed deprecated `config/test-aura.yaml` configuration file
   - Removed `use_aura` field from `Neo4jConfig` schema
   - Updated `config/dev.yaml` to remove Aura-specific environment variable documentation

3. **CI/CD Pipeline Updates**
   - Removed `e2e-aura` job from `.github/workflows/ci.yml` that tested against Neo4j Aura Free
   - Removed `AURA_SAMPLE_LIMIT` environment variable (kept `DOCKER_SAMPLE_LIMIT`)
   - Removed Aura credential checks and database cleanup steps

4. **Removed Scripts**
   - `scripts/neo4j/check_aura_usage.py` - Aura-specific usage monitoring
   - `scripts/ci/cleanup_neo4j_aura.py` - Aura-specific cleanup
   - `scripts/ci/verify_neo4j_aura_connection.py` - Aura connection verification
   - `scripts/ci/check_neo4j_node_count.py` - Aura node limit checking

5. **Documentation References**
   - Updated `CONTRIBUTING.md`, `local-development.md`, and other docs to remove Aura references
   - Updated architecture and deployment documentation to reflect self-hosted-only approach
   - Removed Aura setup from `mkdocs.yml` navigation

**Rationale:**

Self-hosted Neo4j containers provide:
- Full control over node limits (no 100K node restriction)
- Consistent environment across dev/test/prod
- Simplified infrastructure (no managed service dependencies)
- Cost predictability (VM-based vs. managed service pricing)
- Easier local development and testing

## Type of Change

- [x] Breaking change (removes Neo4j Aura support)
- [x] Documentation update

## Testing

- Existing Docker-based tests remain unchanged and continue to pass
- CI pipeline simplified by removing Aura-specific job
- No new tests needed - this is a removal of deprecated infrastructure

## Checklist

- [x] Documentation updated to reflect changes
- [x] Deprecated code and configuration removed
- [x] CI/CD pipeline updated
- [x] No breaking changes to core ETL functionality
- [x] All references to Aura removed from codebase

https://claude.ai/code/session_01GTNandXUAA3nbQxf6j3WiU