### PR TITLE
Move benchmark summary to standalone script to fix YAML parsing

### DIFF
--- a/.github/workflows/benchmark-analysis.yml
+++ b/.github/workflows/benchmark-analysis.yml
@@ -120,27 +120,7 @@ jobs:
             echo "" >> "$GITHUB_STEP_SUMMARY"
 
             # Extract key metrics from JSON
-            cat <<'PYEOF' > /tmp/benchmark_summary.py
-import json
-
-def fmt(val):
-    return f"{val:,}" if isinstance(val, (int, float)) else str(val)
-
-with open("data/scripts_output/benchmark_evaluation.json") as f:
-    d = json.load(f)
-
-print("| Metric | Count |")
-print("|--------|-------|")
-for key, label in [
-    ("total_companies_evaluated", "Companies evaluated"),
-    ("companies_subject_to_transition", "Subject to transition benchmark"),
-    ("companies_failing_transition", "Failing transition benchmark"),
-    ("companies_subject_to_commercialization", "Subject to commercialization benchmark"),
-    ("companies_failing_commercialization", "Failing commercialization benchmark"),
-]:
-    print(f"| {label} | {fmt(d.get(key, 0))} |")
-PYEOF
-            uv run python /tmp/benchmark_summary.py >> "$GITHUB_STEP_SUMMARY"
+            uv run python scripts/ci/benchmark_summary.py "$EVAL" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/scripts/ci/benchmark_summary.py
+++ b/scripts/ci/benchmark_summary.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Generate a GitHub Actions step summary table from benchmark evaluation JSON."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def fmt(val):
+    return f"{val:,}" if isinstance(val, (int, float)) else str(val)
+
+
+def main():
+    eval_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/scripts_output/benchmark_evaluation.json")
+    if not eval_path.exists():
+        print("Benchmark evaluation file not found.", file=sys.stderr)
+        sys.exit(1)
+
+    with open(eval_path) as f:
+        d = json.load(f)
+
+    print("| Metric | Count |")
+    print("|--------|-------|")
+    for key, label in [
+        ("total_companies_evaluated", "Companies evaluated"),
+        ("companies_subject_to_transition", "Subject to transition benchmark"),
+        ("companies_failing_transition", "Failing transition benchmark"),
+        ("companies_subject_to_commercialization", "Subject to commercialization benchmark"),
+        ("companies_failing_commercialization", "Failing commercialization benchmark"),
+    ]:
+        print(f"| {label} | {fmt(d.get(key, 0))} |")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Heredoc Python blocks inside YAML block scalars break parsing because unindented content is interpreted as ending the run: | block. Extract the summary table generator to scripts/ci/benchmark_summary.py.

https://claude.ai/code/session_0178sKrUJA98p6AarP76vTvu

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
