### PR TITLE
Switch to spending_by_award endpoint and retry on 500s

### DIFF
--- a/src/transition/analysis/usaspending_commercialization.py
+++ b/src/transition/analysis/usaspending_commercialization.py
@@ -325,7 +325,9 @@ def _fetch_obligations_for_uei(
 ) -> float | None:
     """Query the USAspending API for total obligation amount for a single UEI.
 
-    Paginates through all results and sums ``Transaction Amount``.
+    Uses ``/search/spending_by_award/`` which returns award-level aggregates
+    instead of individual transactions — far fewer rows and less server load.
+    Paginates through all results and sums ``Award Amount``.
     Returns None on error.
     """
     total = 0.0
@@ -338,22 +340,29 @@ def _fetch_obligations_for_uei(
                 "recipient_search_text": [uei],
                 "time_period": [{"start_date": date_start, "end_date": date_end}],
             },
-            "fields": ["Transaction Amount", "Recipient UEI"],
-            "sort": "Transaction Amount",
+            "fields": [
+                "Award Amount",
+                "Recipient Name",
+                "Recipient UEI",
+                "Award ID",
+                "Start Date",
+            ],
+            "sort": "Award Amount",
             "order": "desc",
             "page": page,
             "limit": _PAGE_LIMIT,
+            "subawards": False,
         }
 
         try:
-            data = _api_post("/search/spending_by_transaction/", payload)
+            data = _api_post("/search/spending_by_award/", payload)
         except Exception as e:
             print(f"    API error for UEI {uei}: {e}", file=sys.stderr)
             return None
 
         results = data.get("results", [])
-        for txn in results:
-            amount = txn.get("Transaction Amount")
+        for award in results:
+            amount = award.get("Award Amount")
             if amount is not None:
                 try:
                     total += float(amount)
@@ -420,12 +429,13 @@ def _api_post(endpoint: str, payload: dict, *, retries: int = 3) -> dict:
     for attempt in range(retries):
         try:
             req = urllib.request.Request(url, data=body, headers=headers, method="POST")
-            with urllib.request.urlopen(req, timeout=30, context=ctx) as resp:
+            with urllib.request.urlopen(req, timeout=60, context=ctx) as resp:
                 return json.load(resp)
         except urllib.error.HTTPError as e:
-            if e.code == 429:
+            if e.code in (429, 500, 502, 503, 504):
                 wait = 2 ** (attempt + 1)
-                print(f"    Rate limited, waiting {wait}s...", file=sys.stderr)
+                label = "Rate limited" if e.code == 429 else f"Server error {e.code}"
+                print(f"    {label}, waiting {wait}s...", file=sys.stderr)
                 time.sleep(wait)
                 last_exc = e
                 continue

--- a/tests/validation/test_transaction_endpoint.py
+++ b/tests/validation/test_transaction_endpoint.py
@@ -7,33 +7,35 @@ import urllib.request
 
 
 def test_transaction_endpoint(uei: str) -> None:
-    """Test the spending_by_transaction endpoint with a UEI."""
+    """Test the spending_by_award endpoint with a UEI."""
 
     print("=" * 80)
-    print("Transaction Endpoint Test (No Dependencies)")
+    print("Award Endpoint Test (No Dependencies)")
     print("=" * 80)
     print(f"\nTesting with UEI: {uei}")
     print()
 
-    # Build the API request
-    url = "https://api.usaspending.gov/api/v2/search/spending_by_transaction/"
+    # Build the API request — uses spending_by_award for award-level aggregates
+    # (lighter server load than spending_by_transaction)
+    url = "https://api.usaspending.gov/api/v2/search/spending_by_award/"
 
     payload = {
         "filters": {"award_type_codes": ["A", "B", "C", "D"], "recipient_search_text": [uei]},
         "fields": [
             "Award ID",
             "Recipient Name",
-            "Transaction Amount",
-            "Transaction Description",
-            "Action Date",
+            "Award Amount",
+            "Description",
+            "Start Date",
             "PSC",
             "Recipient UEI",
             "Award Type",
         ],
-        "sort": "Transaction Amount",
+        "sort": "Award Amount",
         "order": "desc",
         "page": 1,
         "limit": 5,  # Just get 5 for quick test
+        "subawards": False,
     }
 
     print("Request payload:")
@@ -68,12 +70,12 @@ def test_transaction_endpoint(uei: str) -> None:
         print()
 
         if not results:
-            print("❌ No transactions found for this UEI")
+            print("❌ No awards found for this UEI")
             return
 
         # Check first result structure
         first_result = results[0]
-        print("First transaction keys:")
+        print("First award keys:")
         print(f"  {list(first_result.keys())}")
         print()
 
@@ -85,13 +87,13 @@ def test_transaction_endpoint(uei: str) -> None:
         print()
 
         # Show sample transactions
-        print("Sample transactions:")
+        print("Sample awards:")
         print("-" * 80)
         for i, transaction in enumerate(results[:3], 1):
             award_id = transaction.get("Award ID", "N/A")
             psc = transaction.get("PSC", "(missing)")
-            amount = transaction.get("Transaction Amount", 0)
-            desc = transaction.get("Transaction Description", "N/A")[:60]
+            amount = transaction.get("Award Amount", 0)
+            desc = transaction.get("Description", "N/A")[:60]
 
             print(f"\n{i}. Award ID: {award_id}")
             print(f"   PSC: {psc}")
@@ -102,18 +104,18 @@ def test_transaction_endpoint(uei: str) -> None:
         print("=" * 80)
 
         if psc_coverage >= 80:
-            print("✓ SUCCESS: Transaction endpoint returns PSC codes!")
+            print("✓ SUCCESS: Award endpoint returns PSC codes!")
         elif psc_coverage > 0:
-            print(f"⚠ PARTIAL: {psc_coverage:.1f}% of transactions have PSC codes")
+            print(f"⚠ PARTIAL: {psc_coverage:.1f}% of awards have PSC codes")
         else:
-            print("❌ FAILURE: No PSC codes in transaction response")
+            print("❌ FAILURE: No PSC codes in award response")
 
         print("=" * 80)
 
         # Save full response for inspection
-        with open("/tmp/transaction_response.json", "w") as f:
+        with open("/tmp/award_response.json", "w") as f:
             json.dump(data, f, indent=2)
-        print("\n✓ Full response saved to: /tmp/transaction_response.json")
+        print("\n✓ Full response saved to: /tmp/award_response.json")
 
     except urllib.error.HTTPError as e:
         print(f"❌ HTTP Error {e.code}: {e.reason}")


### PR DESCRIPTION
Two fixes for USAspending API errors (HTTP 500, connection resets):

1. Use /search/spending_by_award/ instead of /search/spending_by_transaction/ The award-level endpoint returns aggregated data per award rather than individual transactions, producing far fewer rows per UEI query and reducing server-side load that was causing 500s on large result sets.

2. Retry on 500/502/503/504 server errors (previously only retried 429s) with exponential backoff. Also increased request timeout from 30s to 60s since award queries can be slower than transaction queries.

Updated validation test to match the new endpoint.

https://claude.ai/code/session_0178sKrUJA98p6AarP76vTvu