### PR TITLE
Fix benchmark summary rendering and add artifact download links

### DIFF
--- a/.github/workflows/benchmark-analysis.yml
+++ b/.github/workflows/benchmark-analysis.yml
@@ -118,43 +118,10 @@ jobs:
 
       - name: Summary
         if: always()
-        run: |
-          REPORT="data/scripts_output/sensitivity_report_fy${{ steps.params.outputs.fy }}.md"
-          EVAL="data/scripts_output/benchmark_evaluation.json"
-          MANIFEST="data/scripts_output/run_manifest.json"
-
-          if [ -f "$MANIFEST" ]; then
-            echo "## Run Provenance" >> "$GITHUB_STEP_SUMMARY"
-            echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            cat "$MANIFEST" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          if [ -f "$EVAL" ]; then
-            echo "## Benchmark Evaluation — FY ${{ steps.params.outputs.fy }}" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            uv run python scripts/ci/benchmark_summary.py "$EVAL" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          if [ -f "$REPORT" ]; then
-            echo "<details><summary>Full Sensitivity Report</summary>" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            cat "$REPORT" >> "$GITHUB_STEP_SUMMARY"
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-          ARTIFACTS="data/scripts_output/artifact_manifest.json"
-          if [ -f "$ARTIFACTS" ]; then
-            echo "" >> "$GITHUB_STEP_SUMMARY"
-            echo "<details><summary>Artifact Manifest</summary>" >> "$GITHUB_STEP_SUMMARY"
-            echo '```json' >> "$GITHUB_STEP_SUMMARY"
-            cat "$ARTIFACTS" >> "$GITHUB_STEP_SUMMARY"
-            echo '```' >> "$GITHUB_STEP_SUMMARY"
-            echo "</details>" >> "$GITHUB_STEP_SUMMARY"
-          fi
+        env:
+          BENCHMARK_FY: ${{ steps.params.outputs.fy }}
+          BENCHMARK_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: uv run python scripts/ci/benchmark_summary.py data/scripts_output >> "$GITHUB_STEP_SUMMARY"
         shell: bash
 
       # Upload input data so every evaluation can be fully reproduced

--- a/scripts/ci/benchmark_summary.py
+++ b/scripts/ci/benchmark_summary.py
@@ -1,34 +1,121 @@
 #!/usr/bin/env python3
-"""Generate a GitHub Actions step summary table from benchmark evaluation JSON."""
+"""Generate a GitHub Actions step summary from benchmark evaluation outputs.
+
+Produces clean markdown with:
+- Evaluation results table (always shown)
+- Run provenance table (from run_manifest.json)
+- Sensitivity report (collapsed)
+- Artifact download table with links to the run page
+"""
 
 import json
+import os
 import sys
 from pathlib import Path
 
 
 def fmt(val):
-    return f"{val:,}" if isinstance(val, (int, float)) else str(val)
+    if isinstance(val, float):
+        return f"{val:,.2f}" if val != int(val) else f"{int(val):,}"
+    if isinstance(val, int):
+        return f"{val:,}"
+    return str(val)
 
 
-def main():
-    eval_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/scripts_output/benchmark_evaluation.json")
-    if not eval_path.exists():
-        print("Benchmark evaluation file not found.", file=sys.stderr)
-        sys.exit(1)
-
-    with open(eval_path) as f:
-        d = json.load(f)
-
+def print_evaluation(d: dict) -> None:
+    """Print the main evaluation results table."""
+    print("## Benchmark Evaluation\n")
     print("| Metric | Count |")
-    print("|--------|-------|")
+    print("|--------|------:|")
     for key, label in [
         ("total_companies_evaluated", "Companies evaluated"),
         ("companies_subject_to_transition", "Subject to transition benchmark"),
-        ("companies_failing_transition", "Failing transition benchmark"),
+        ("companies_failing_transition", "**Failing transition benchmark**"),
         ("companies_subject_to_commercialization", "Subject to commercialization benchmark"),
-        ("companies_failing_commercialization", "Failing commercialization benchmark"),
+        ("companies_failing_commercialization", "**Failing commercialization benchmark**"),
     ]:
-        print(f"| {label} | {fmt(d.get(key, 0))} |")
+        val = d.get(key, 0)
+        print(f"| {label} | {fmt(val)} |")
+    print()
+
+
+def print_provenance(manifest: dict) -> None:
+    """Print run provenance as a readable table."""
+    params = manifest.get("parameters", {})
+    sources = manifest.get("data_sources", {})
+    sbir = sources.get("sbir_awards", {})
+    usa = sources.get("usaspending", {})
+
+    print("<details><summary>Run Provenance</summary>\n")
+    print("| Parameter | Value |")
+    print("|-----------|-------|")
+    if ts := manifest.get("run_timestamp"):
+        print(f"| Timestamp | `{ts[:19]}Z` |")
+    if fy := params.get("evaluation_fy"):
+        print(f"| Fiscal year | {fy} |")
+    if ma := params.get("sensitivity_margin_awards"):
+        print(f"| Margin (awards) | {ma} |")
+    if mr := params.get("sensitivity_margin_ratio"):
+        print(f"| Margin (ratio) | {mr} |")
+    if src := sbir.get("source"):
+        print(f"| SBIR source | {src} |")
+    if rc := sbir.get("row_count"):
+        print(f"| SBIR awards rows | {fmt(rc)} |")
+    if src := usa.get("source"):
+        print(f"| USAspending source | {src} |")
+    if qc := usa.get("companies_queried"):
+        print(f"| USAspending companies queried | {fmt(qc)} |")
+    print("\n</details>\n")
+
+
+def print_sensitivity_report(report_path: Path) -> None:
+    """Print the sensitivity report in a collapsible section."""
+    content = report_path.read_text().strip()
+    print("<details><summary>Sensitivity Report</summary>\n")
+    print(content)
+    print("\n</details>\n")
+
+
+def print_artifact_links(fy: str, run_url: str) -> None:
+    """Print artifact download table linking to the run page."""
+    print(f"## Artifacts\n")
+    print(f"Download from the [workflow run artifacts]({run_url}#artifacts).\n")
+    print("| Artifact | Contents |")
+    print("|----------|----------|")
+    print(f"| `benchmark-results-fy{fy}` | Evaluation JSON, sensitivity report, at-risk list, manifests |")
+    print(f"| `evaluation-detail-fy{fy}` | Per-company transition & commercialization CSVs |")
+    print(f"| `sbir-awards-input-fy{fy}` | Raw SBIR award data used as input |")
+    print(f"| `usaspending-data-fy{fy}` | USAspending API cache & obligations CSV |")
+    print()
+
+
+def main():
+    output_dir = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/scripts_output")
+    fy = os.environ.get("BENCHMARK_FY", "2026")
+    run_url = os.environ.get("BENCHMARK_RUN_URL", "")
+
+    # Evaluation results
+    eval_path = output_dir / "benchmark_evaluation.json"
+    if eval_path.exists():
+        with open(eval_path) as f:
+            print_evaluation(json.load(f))
+    else:
+        print("> [!WARNING]\n> Benchmark evaluation file not found.\n")
+
+    # Provenance
+    manifest_path = output_dir / "run_manifest.json"
+    if manifest_path.exists():
+        with open(manifest_path) as f:
+            print_provenance(json.load(f))
+
+    # Sensitivity report
+    report_path = output_dir / f"sensitivity_report_fy{fy}.md"
+    if report_path.exists():
+        print_sensitivity_report(report_path)
+
+    # Artifact download links
+    if run_url:
+        print_artifact_links(fy, run_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The GitHub Actions step summary was mixing raw JSON dumps with markdown, producing a cluttered, hard-to-read page. Rewrote benchmark_summary.py to generate the entire summary from one script:

- Evaluation results table shown prominently at the top
- Run provenance rendered as a readable table in a collapsible section (was a raw JSON code block)
- Sensitivity report in a collapsible section (unchanged)
- New "Artifacts" section with a direct link to the run's artifacts page and a table describing what each artifact contains
- Removed the raw artifact_manifest.json dump (replaced by the table)

The workflow Summary step is now a single `uv run` call instead of 40 lines of shell string concatenation.

https://claude.ai/code/session_0178sKrUJA98p6AarP76vTvu

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
