### PR TITLE
Clean up test return statements and mark slow tests

### DIFF
--- a/tests/e2e/test_fiscal_stateio_pipeline.py
+++ b/tests/e2e/test_fiscal_stateio_pipeline.py
@@ -221,8 +221,6 @@ class TestFiscalStateIOPipelineE2E:
         )
         assert state_coverage >= 0.90, "State coverage should be ≥90% for fiscal analysis"
 
-        return enriched
-
     def test_step2_enrich_with_sam_gov(
         self, sample_sbir_awards_fiscal, sample_usaspending_fiscal, sample_sam_gov_fiscal
     ):
@@ -250,8 +248,6 @@ class TestFiscalStateIOPipelineE2E:
         # Verify NAICS coverage (required for fiscal analysis)
         naics_coverage = enriched["sam_primary_naics"].notna().sum() / len(enriched)
         assert naics_coverage >= 0.85, "NAICS coverage should be ≥85% for fiscal analysis"
-
-        return enriched
 
     def test_step3_map_naics_to_bea(
         self,
@@ -290,8 +286,6 @@ class TestFiscalStateIOPipelineE2E:
         assert all(code == "54" for code in enriched["bea_sector_code"].dropna()), (
             "All sample NAICS codes should map to BEA sector 54"
         )
-
-        return enriched
 
     def test_step4_calculate_fiscal_years(self, sample_sbir_awards_fiscal):
         """Step 4: Test fiscal year calculation."""
@@ -394,8 +388,6 @@ class TestFiscalStateIOPipelineE2E:
         # Verify we have multiple states
         assert shock_aggregates["state"].nunique() >= 3, "Should have shocks in multiple states"
 
-        return shock_aggregates
-
     def test_step6_calculate_tax_estimates(
         self,
         sample_sbir_awards_fiscal,
@@ -493,8 +485,6 @@ class TestFiscalStateIOPipelineE2E:
             "Tax receipts should be less than total investment (without multiplier effects)"
         )
 
-        return tax_df
-
     def test_step7_calculate_roi_metrics(
         self,
         sample_sbir_awards_fiscal,
@@ -569,8 +559,6 @@ class TestFiscalStateIOPipelineE2E:
         print(f"  ROI Ratio: {roi_summary.roi_ratio:.2%}")
         print(f"  Benefit-Cost Ratio: {roi_summary.benefit_cost_ratio:.2f}")
         print(f"  Payback Period: {roi_summary.payback_period_years} years")
-
-        return roi_summary
 
     def test_complete_pipeline_integration(
         self,

--- a/tests/e2e/transition/conftest.py
+++ b/tests/e2e/transition/conftest.py
@@ -40,7 +40,7 @@ def transition_contracts_sample(transition_awards_sample: pd.DataFrame) -> pd.Da
                 transition_awards_sample.iloc[i % len(transition_awards_sample)]["UEI"]
                 for i in range(sample_size)
             ],
-            "action_date": pd.date_range("2022-06-01", periods=sample_size, freq="12H"),
+            "action_date": pd.date_range("2022-06-01", periods=sample_size, freq="12h"),
             "description": [f"Contract {i}" for i in range(sample_size)],
             "awarding_agency_name": [agencies[i % len(agencies)] for i in range(sample_size)],
             "amount": [50000 + (i * 1500) for i in range(sample_size)],

--- a/tests/unit/enrichers/test_search_providers.py
+++ b/tests/unit/enrichers/test_search_providers.py
@@ -216,6 +216,7 @@ class TestBaseSearchProvider:
 
         assert result == "success"
 
+    @pytest.mark.slow
     def test_backoff_retry_success_after_retries(self):
         """Test retry logic succeeds after failures."""
         provider = ConcreteProvider("test")
@@ -232,6 +233,7 @@ class TestBaseSearchProvider:
         assert result == "success"
         assert len(attempts) == 3
 
+    @pytest.mark.slow
     def test_backoff_retry_exhausted(self):
         """Test retry logic exhausts all retries."""
         provider = ConcreteProvider("test")

--- a/tests/unit/enrichers/usaspending/test_client.py
+++ b/tests/unit/enrichers/usaspending/test_client.py
@@ -266,6 +266,7 @@ class TestHTTPRequests:
         with pytest.raises(APIError, match="HTTP 404"):
             await client._make_request("GET", "/test/")
 
+    @pytest.mark.slow
     @pytest.mark.asyncio
     async def test_make_request_timeout(self, client, mock_http_client):
         """Test timeout error handling after retries."""


### PR DESCRIPTION
## Description

This PR makes two types of improvements to the test suite:

1. **Removes unnecessary return statements from test methods** in `test_fiscal_stateio_pipeline.py`. Test methods should not return values as they are not used by the test framework. Removed returns from:
   - `test_step1_enrich_with_usaspending`
   - `test_step2_enrich_with_sam_gov`
   - `test_step3_map_naics_to_bea`
   - `test_step5_aggregate_into_shocks`
   - `test_step6_calculate_tax_estimates`
   - `test_step7_calculate_roi_metrics`

2. **Marks slow-running tests with `@pytest.mark.slow`** to allow them to be skipped during quick test runs:
   - `test_backoff_retry_success_after_retries` in `test_search_providers.py`
   - `test_backoff_retry_exhausted` in `test_search_providers.py`
   - `test_make_request_timeout` in `test_client.py`

3. **Fixes a deprecation warning** in `conftest.py` by changing `freq="12H"` to `freq="12h"` (pandas now prefers lowercase frequency strings).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update

## Testing

- [x] All tests pass locally
- The removed return statements don't affect test execution (they were unused)
- The `@pytest.mark.slow` markers enable filtering of slow tests without changing their behavior
- The frequency string change is a deprecation fix with no functional impact

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

https://claude.ai/code/session_01Wo5VEce2zCEfHoeSGgF65e