### PR TITLE
Add weekly SBIR awards report CI job

### DIFF
--- a/.github/workflows/weekly-awards-report.yml
+++ b/.github/workflows/weekly-awards-report.yml
@@ -1,0 +1,65 @@
+name: Weekly SBIR Awards Report
+
+on:
+  schedule:
+    # Every Monday at 10 AM UTC (after data-refresh downloads new data at 9 AM)
+    - cron: "0 10 * * 1"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days to look back"
+        required: false
+        default: "7"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: weekly-awards-report
+  cancel-in-progress: true
+
+jobs:
+  generate-report:
+    name: Generate Weekly Awards Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Python and UV
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: "3.11"
+          install-dev-deps: "false"
+
+      - name: Install report dependencies
+        run: uv pip install requests
+
+      - name: Generate weekly awards report
+        env:
+          DAYS: ${{ github.event.inputs.days || '7' }}
+        run: |
+          mkdir -p reports
+          uv run python scripts/data/weekly_awards_report.py \
+            --days "$DAYS" \
+            --output reports/weekly-awards.md
+
+      - name: Post report to job summary
+        if: always()
+        run: |
+          if [ -f reports/weekly-awards.md ]; then
+            cat reports/weekly-awards.md >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Weekly Awards Report" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Report generation failed. Check logs for details." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weekly-awards-report-${{ github.run_id }}
+          path: reports/weekly-awards.md
+          retention-days: 30

--- a/.github/workflows/weekly-awards-report.yml
+++ b/.github/workflows/weekly-awards-report.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Generate weekly awards report
         env:
           DAYS: ${{ github.event.inputs.days || '7' }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           mkdir -p reports
           uv run python scripts/data/weekly_awards_report.py \

--- a/.github/workflows/weekly-awards-report.yml
+++ b/.github/workflows/weekly-awards-report.yml
@@ -33,13 +33,11 @@ jobs:
           python-version: "3.11"
           install-dev-deps: "false"
 
-      - name: Install report dependencies
-        run: uv pip install requests
-
       - name: Generate weekly awards report
         env:
           DAYS: ${{ github.event.inputs.days || '7' }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET || '' }}
         run: |
           mkdir -p reports
           uv run python scripts/data/weekly_awards_report.py \

--- a/.github/workflows/weekly-awards-report.yml
+++ b/.github/workflows/weekly-awards-report.yml
@@ -47,8 +47,17 @@ jobs:
       - name: Post report to job summary
         if: always()
         run: |
+          MAX_SIZE=55000  # GitHub step summary limit is ~1 MiB; stay well under
           if [ -f reports/weekly-awards.md ]; then
-            cat reports/weekly-awards.md >> $GITHUB_STEP_SUMMARY
+            SIZE=$(wc -c < reports/weekly-awards.md)
+            if [ "$SIZE" -gt "$MAX_SIZE" ]; then
+              head -c "$MAX_SIZE" reports/weekly-awards.md >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "---" >> $GITHUB_STEP_SUMMARY
+              echo "*Report truncated (${SIZE} bytes). Full report available in the artifact.*" >> $GITHUB_STEP_SUMMARY
+            else
+              cat reports/weekly-awards.md >> $GITHUB_STEP_SUMMARY
+            fi
           else
             echo "## Weekly Awards Report" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -57,7 +66,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-awards-report-${{ github.run_id }}
           path: reports/weekly-awards.md

--- a/packages/sbir-analytics/sbir_analytics/lambda/weekly_refresh_handler.py
+++ b/packages/sbir-analytics/sbir_analytics/lambda/weekly_refresh_handler.py
@@ -52,9 +52,15 @@ def lambda_handler(event: dict, context) -> dict:
             payload = json.loads(event["body"])
 
         force_refresh = payload.get("force_refresh", False)
+        try:
+            from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL
+
+            _default_url = SBIR_AWARDS_CSV_URL
+        except ImportError:
+            _default_url = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
         source_url = payload.get("source_url") or os.getenv(
             "DEFAULT_SOURCE_URL",
-            "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv",
+            _default_url,
         )
         s3_bucket = payload.get("s3_bucket") or os.getenv("S3_BUCKET")
         neo4j_secret_name = payload.get("neo4j_secret_name") or os.getenv("NEO4J_SECRET_NAME")

--- a/sbir_etl/extractors/sbir_gov_api.py
+++ b/sbir_etl/extractors/sbir_gov_api.py
@@ -30,6 +30,10 @@ from ..exceptions import APIError
 
 SBIR_GOV_API_BASE = "https://api.www.sbir.gov/public/api"
 
+# Canonical URL for the SBIR.gov bulk awards CSV export.
+# Used by download_sbir.py, weekly_awards_report.py, awards_refresh_validation.py, etc.
+SBIR_AWARDS_CSV_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+
 # Agencies that participate in SBIR/STTR
 SBIR_PARTICIPATING_AGENCIES = [
     "DOD",
@@ -313,5 +317,6 @@ __all__ = [
     "SbirGovClient",
     "SbirGovLookupIndex",
     "SBIR_GOV_API_BASE",
+    "SBIR_AWARDS_CSV_URL",
     "SBIR_PARTICIPATING_AGENCIES",
 ]

--- a/scripts/data/awards_refresh_validation.py
+++ b/scripts/data/awards_refresh_validation.py
@@ -14,7 +14,10 @@ from typing import Any
 from collections.abc import Iterable, Sequence
 
 
-DEFAULT_SOURCE_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+try:
+    from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as DEFAULT_SOURCE_URL
+except ImportError:
+    DEFAULT_SOURCE_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/data/download_sbir.py
+++ b/scripts/data/download_sbir.py
@@ -15,7 +15,10 @@ from datetime import datetime, UTC
 import boto3
 import requests
 
-SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+try:
+    from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
+except ImportError:
+    SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
 
 
 def download_sbir_awards(s3_bucket: str) -> dict:

--- a/scripts/data/run_benchmark_analysis.py
+++ b/scripts/data/run_benchmark_analysis.py
@@ -38,12 +38,14 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL
+
 
 def download_from_sbir_gov(dest: Path) -> Path:
     """Download latest SBIR awards CSV from sbir.gov."""
     import requests
 
-    url = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+    url = SBIR_AWARDS_CSV_URL
     print(f"Downloading SBIR awards from: {url}")
 
     response = requests.get(url, stream=True, timeout=300)
@@ -431,7 +433,7 @@ def main():
         sbir_source = f"s3://{args.s3_bucket}"
     else:
         awards_path = download_from_sbir_gov(dest)
-        sbir_source = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+        sbir_source = SBIR_AWARDS_CSV_URL
 
     usaspending_path = None
     usaspending_api = args.usaspending_api

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -5,14 +5,21 @@ Downloads the SBIR bulk CSV from SBIR.gov and filters for awards
 whose Proposal Award Date falls within the past 7 days, then outputs a
 markdown summary with links to SBIR.gov, solicitations, and USAspending.
 
+When OPENAI_API_KEY is set, uses the OpenAI API to generate:
+- A two-paragraph synopsis of all weekly award activity (top of report)
+- A brief plain-language description for each award
+
 Usage:
     python scripts/data/weekly_awards_report.py
     python scripts/data/weekly_awards_report.py --days 14 --output report.md
+    OPENAI_API_KEY=sk-... python scripts/data/weekly_awards_report.py
 """
 
 import argparse
 import csv
 import io
+import json
+import os
 import sys
 from datetime import datetime, timedelta, UTC
 from urllib.parse import quote
@@ -25,6 +32,12 @@ SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
 SBIR_AWARD_SEARCH_URL = "https://www.sbir.gov/sbirsearch/award/all"
 SBIR_SOLICITATION_URL = "https://www.sbir.gov/sbirsearch/topic/default"
 USASPENDING_SEARCH_URL = "https://www.usaspending.gov/search"
+
+OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_MODEL = "gpt-4.1-mini"
+
+# Batch size for per-award descriptions (awards per API call)
+DESCRIPTION_BATCH_SIZE = 10
 
 
 def parse_award_date(date_str: str) -> datetime | None:
@@ -83,14 +96,10 @@ def format_amount(amount_str: str) -> str:
 
 
 def build_sbir_award_url(award: dict) -> str:
-    """Build a link to the SBIR.gov award search page for this award.
-
-    Uses the contract number as a keyword search on SBIR.gov's award listing.
-    """
+    """Build a link to the SBIR.gov award search page for this award."""
     contract = award.get("Contract", "").strip()
     if contract:
         return f"{SBIR_AWARD_SEARCH_URL}/{quote(contract)}"
-    # Fall back to company name search
     company = award.get("Company", "").strip()
     if company:
         return f"{SBIR_AWARD_SEARCH_URL}/{quote(company)}"
@@ -98,14 +107,9 @@ def build_sbir_award_url(award: dict) -> str:
 
 
 def build_solicitation_url(award: dict) -> str | None:
-    """Build a link to the SBIR.gov solicitation/topic page.
-
-    Links to the SBIR.gov topic search using the solicitation number.
-    Returns None if no solicitation info is available.
-    """
+    """Build a link to the SBIR.gov solicitation/topic page."""
     solicitation = award.get("Solicitation Number", "").strip()
     topic_code = award.get("Topic Code", "").strip()
-
     if solicitation:
         return f"{SBIR_SOLICITATION_URL}?keyword={quote(solicitation)}"
     if topic_code:
@@ -114,10 +118,7 @@ def build_solicitation_url(award: dict) -> str | None:
 
 
 def build_usaspending_url(award: dict) -> str | None:
-    """Build a link to USAspending.gov search for this award's contract.
-
-    Returns None if no contract number is available.
-    """
+    """Build a link to USAspending.gov search for this award's contract."""
     contract = award.get("Contract", "").strip()
     if not contract:
         return None
@@ -125,7 +126,196 @@ def build_usaspending_url(award: dict) -> str | None:
     return f'{USASPENDING_SEARCH_URL}?form_fields={{"search_term":"{search_term}"}}'
 
 
-def generate_markdown(awards: list[dict], days: int) -> str:
+# ---------------------------------------------------------------------------
+# OpenAI integration
+# ---------------------------------------------------------------------------
+
+
+def _openai_chat(api_key: str, system: str, user: str) -> str | None:
+    """Call the OpenAI chat completions API. Returns the assistant message text."""
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": OPENAI_MODEL,
+        "temperature": 0.3,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ],
+    }
+    try:
+        resp = requests.post(
+            OPENAI_API_URL, headers=headers, json=payload, timeout=120
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+    except Exception as e:
+        print(f"OpenAI API error: {e}", file=sys.stderr)
+        return None
+
+
+def _award_digest(award: dict) -> str:
+    """Build a compact text digest of an award for LLM context."""
+    parts = [
+        f"Title: {award.get('Award Title', 'N/A')}",
+        f"Company: {award.get('Company', 'N/A')}",
+        f"Agency: {award.get('Agency', 'N/A')}",
+        f"Program: {award.get('Program', 'N/A')} {award.get('Phase', '')}",
+        f"Amount: {award.get('Award Amount', 'N/A')}",
+        f"State: {award.get('State', 'N/A')}",
+        f"Date: {award.get('Proposal Award Date', 'N/A')}",
+    ]
+    abstract = award.get("Abstract", "").strip()
+    if abstract:
+        if len(abstract) > 1500:
+            abstract = abstract[:1500] + "..."
+        parts.append(f"Abstract: {abstract}")
+    topic_code = award.get("Topic Code", "").strip()
+    if topic_code:
+        parts.append(f"Topic Code: {topic_code}")
+    solicitation = award.get("Solicitation Number", "").strip()
+    if solicitation:
+        parts.append(f"Solicitation: {solicitation}")
+    solicitation_year = award.get("Solicitation Year", "").strip()
+    if solicitation_year:
+        parts.append(f"Solicitation Year: {solicitation_year}")
+    contract = award.get("Contract", "").strip()
+    if contract:
+        parts.append(f"Contract: {contract}")
+        parts.append(
+            f"USAspending Record: https://www.usaspending.gov/search"
+            f'?form_fields={{"search_term":"{contract}"}}'
+        )
+    solicitation_url = build_solicitation_url(award)
+    if solicitation_url:
+        parts.append(f"Solicitation Reference: {solicitation_url}")
+    return "\n".join(parts)
+
+
+def generate_weekly_synopsis(api_key: str, awards: list[dict], days: int) -> str | None:
+    """Generate a two-paragraph synopsis of all weekly award activity."""
+    if not awards:
+        return None
+
+    total_amount = 0
+    agencies: dict[str, int] = {}
+    for a in awards:
+        try:
+            total_amount += float(
+                a.get("Award Amount", "0").replace(",", "").replace("$", "")
+            )
+        except (ValueError, AttributeError):
+            pass
+        ag = a.get("Agency", "Unknown")
+        agencies[ag] = agencies.get(ag, 0) + 1
+
+    # Include up to 50 award digests for context
+    digests = []
+    for i, a in enumerate(awards[:50]):
+        digests.append(f"[{i+1}] {_award_digest(a)}")
+    digest_block = "\n\n".join(digests)
+    if len(awards) > 50:
+        digest_block += f"\n\n... and {len(awards) - 50} additional awards."
+
+    system = (
+        "You are an analyst writing a concise executive briefing about weekly "
+        "SBIR/STTR federal small business innovation award activity. "
+        "Write in a professional, informative tone. Do not use markdown headers. "
+        "Do not use bullet points. Write exactly two paragraphs."
+    )
+    user = (
+        f"Write a two-paragraph synopsis of this week's SBIR/STTR award activity.\n\n"
+        f"Period: past {days} days\n"
+        f"Total awards: {len(awards)}\n"
+        f"Total funding: ${total_amount:,.0f}\n"
+        f"Agencies: {json.dumps(agencies)}\n\n"
+        f"Award details:\n{digest_block}"
+    )
+
+    print("Generating weekly synopsis via OpenAI...", file=sys.stderr)
+    return _openai_chat(api_key, system, user)
+
+
+def generate_award_descriptions(
+    api_key: str, awards: list[dict]
+) -> dict[int, str]:
+    """Generate a brief description for each award using batched API calls.
+
+    The LLM receives each award's abstract, solicitation context, and
+    USAspending reference so the description is informed by the full
+    award context.
+
+    Returns a dict mapping award index (0-based) to description text.
+    """
+    descriptions: dict[int, str] = {}
+    if not awards:
+        return descriptions
+
+    system = (
+        "You summarize SBIR/STTR awards in plain language. "
+        "For each award, write 2-3 sentences explaining what the project does "
+        "and why it matters. Use the abstract, solicitation context, and "
+        "associated federal spending data to inform your description. "
+        "Be specific about the technology and its intended application. "
+        "Avoid generic filler.\n\n"
+        "Respond with a JSON object mapping the award number (as a string key) "
+        'to its description string. Example: {"1": "Description.", "2": "Description."}'
+    )
+
+    for batch_start in range(0, len(awards), DESCRIPTION_BATCH_SIZE):
+        batch = awards[batch_start : batch_start + DESCRIPTION_BATCH_SIZE]
+        digests = []
+        for i, a in enumerate(batch):
+            idx = batch_start + i + 1
+            digests.append(f"[{idx}] {_award_digest(a)}")
+
+        user = (
+            "Generate a brief plain-language description for each award below. "
+            "Each description should convey the technology, its application, "
+            "and the significance of the federal investment. "
+            "Respond ONLY with a JSON object.\n\n" + "\n\n".join(digests)
+        )
+
+        batch_label = f"{batch_start + 1}-{batch_start + len(batch)}"
+        print(
+            f"Generating descriptions for awards {batch_label} of {len(awards)}...",
+            file=sys.stderr,
+        )
+        raw = _openai_chat(api_key, system, user)
+        if not raw:
+            continue
+
+        # Strip markdown code fences if present
+        text = raw.strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[-1]
+        if text.endswith("```"):
+            text = text.rsplit("```", 1)[0]
+        text = text.strip()
+
+        try:
+            batch_descriptions = json.loads(text)
+            for key, desc in batch_descriptions.items():
+                descriptions[int(key) - 1] = desc  # convert to 0-based
+        except (json.JSONDecodeError, ValueError) as e:
+            print(f"Failed to parse description batch {batch_label}: {e}", file=sys.stderr)
+
+    return descriptions
+
+
+# ---------------------------------------------------------------------------
+# Markdown generation
+# ---------------------------------------------------------------------------
+
+
+def generate_markdown(
+    awards: list[dict],
+    days: int,
+    synopsis: str | None = None,
+    descriptions: dict[int, str] | None = None,
+) -> str:
     """Generate markdown report from filtered awards."""
     now = datetime.now(UTC)
     cutoff = now - timedelta(days=days)
@@ -143,11 +333,15 @@ def generate_markdown(awards: list[dict], days: int) -> str:
         lines.append("No new awards found for this period.")
         return "\n".join(lines)
 
+    # Weekly synopsis at the very top
+    if synopsis:
+        lines.append(synopsis)
+        lines.append("")
+
     # Summary statistics
     total_amount = 0
     agencies: dict[str, int] = {}
     programs: dict[str, int] = {}
-    phases: dict[str, int] = {}
     states: dict[str, int] = {}
 
     for a in awards:
@@ -161,8 +355,6 @@ def generate_markdown(awards: list[dict], days: int) -> str:
         agencies[agency] = agencies.get(agency, 0) + 1
         program = a.get("Program", "Unknown")
         programs[program] = programs.get(program, 0) + 1
-        phase = a.get("Phase", "Unknown")
-        phases[phase] = phases.get(phase, 0) + 1
         state = a.get("State", "Unknown")
         if state:
             states[state] = states.get(state, 0) + 1
@@ -202,11 +394,11 @@ def generate_markdown(awards: list[dict], days: int) -> str:
         lines.append(f"| {program} | {phase} | {count} |")
     lines.append("")
 
-    # Awards list with links
+    # Individual awards
     lines.append("## Awards")
     lines.append("")
 
-    for i, a in enumerate(awards, 1):
+    for i, a in enumerate(awards):
         date = a.get("Proposal Award Date", "")
         company = a.get("Company", "")
         title = a.get("Award Title", "")
@@ -225,11 +417,21 @@ def generate_markdown(awards: list[dict], days: int) -> str:
         solicitation_url = build_solicitation_url(a)
         usaspending_url = build_usaspending_url(a)
 
-        # Award header with title linked to SBIR.gov
-        lines.append(f"### {i}. [{title}]({sbir_url})")
+        # Award header
+        lines.append(f"### {i + 1}. {title}")
+        lines.append("")
+        lines.append(f"**{company}** | {agency} {program} {phase} | {amount} | {state} | {date}")
         lines.append("")
 
+        # AI-generated description
+        if descriptions and i in descriptions:
+            lines.append(descriptions[i])
+            lines.append("")
+
         # Details table
+        lines.append("<details>")
+        lines.append("<summary>Award details</summary>")
+        lines.append("")
         lines.append("| Field | Value |")
         lines.append("|-------|-------|")
         lines.append(f"| **Company** | {company} |")
@@ -248,15 +450,17 @@ def generate_markdown(awards: list[dict], days: int) -> str:
             lines.append(f"| **Solicitation** | `{solicitation}` |")
         if topic_code:
             lines.append(f"| **Topic Code** | `{topic_code}` |")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
 
-        # Links
+        # Reference links
+        lines.append("**References:** ")
         link_parts = [f"[SBIR.gov Award]({sbir_url})"]
         if solicitation_url:
             link_parts.append(f"[Solicitation]({solicitation_url})")
         if usaspending_url:
             link_parts.append(f"[USAspending]({usaspending_url})")
-
-        lines.append("")
         lines.append(" | ".join(link_parts))
         lines.append("")
 
@@ -281,10 +485,32 @@ def main():
         default=None,
         help="Output file path (default: stdout)",
     )
+    parser.add_argument(
+        "--no-ai",
+        action="store_true",
+        help="Skip AI-generated summaries even if OPENAI_API_KEY is set",
+    )
     args = parser.parse_args()
 
     awards = fetch_weekly_awards(days=args.days)
-    report = generate_markdown(awards, days=args.days)
+
+    # Generate AI descriptions if API key is available
+    synopsis = None
+    descriptions = None
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if api_key and not args.no_ai:
+        synopsis = generate_weekly_synopsis(api_key, awards, args.days)
+        descriptions = generate_award_descriptions(api_key, awards)
+    elif not api_key and not args.no_ai:
+        print(
+            "OPENAI_API_KEY not set - skipping AI summaries. "
+            "Set the env var or use --no-ai to silence this message.",
+            file=sys.stderr,
+        )
+
+    report = generate_markdown(
+        awards, days=args.days, synopsis=synopsis, descriptions=descriptions
+    )
 
     if args.output:
         with open(args.output, "w") as f:

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -30,18 +30,18 @@ from urllib.parse import quote
 
 import requests
 
-SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
-
 # Lazy imports from the sbir_etl package.  These are optional — the script
 # falls back to a standalone CSV download + Python-based filtering when the
 # full package isn't installed (e.g. lightweight CI runners).
 try:
     from sbir_etl.extractors.sbir import SbirDuckDBExtractor
+    from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
     from sbir_etl.utils.cloud_storage import find_latest_sbir_awards, get_s3_bucket_from_env
     from sbir_etl.utils.date_utils import parse_date as _parse_date
 
     _HAS_SBIR_ETL = True
 except ImportError:
+    SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
     _HAS_SBIR_ETL = False
     SbirDuckDBExtractor = None  # type: ignore[assignment, misc]
 

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """Generate a weekly SBIR awards report in markdown.
 
-Downloads the SBIR bulk CSV from SBIR.gov and filters for awards
-whose Proposal Award Date falls within the past 7 days, then outputs a
-markdown summary with links to SBIR.gov, solicitations, and USAspending.
+Downloads the SBIR bulk CSV (from S3 if available, else direct from
+SBIR.gov) and uses DuckDB to filter for awards whose Proposal Award
+Date falls within the past 7 days, then outputs a markdown summary
+with links to SBIR.gov, solicitations, and USAspending.
 
 When OPENAI_API_KEY is set, uses the OpenAI API to:
 - Search the web for public info on each awardee company
@@ -18,18 +19,45 @@ Usage:
 """
 
 import argparse
-import csv
-import io
 import json
 import os
 import sys
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, UTC
+from pathlib import Path
 from urllib.parse import quote
 
 import requests
 
 SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+
+# Lazy imports from the sbir_etl package.  These are optional — the script
+# falls back to a standalone CSV download + Python-based filtering when the
+# full package isn't installed (e.g. lightweight CI runners).
+try:
+    from sbir_etl.extractors.sbir import SbirDuckDBExtractor
+    from sbir_etl.utils.cloud_storage import find_latest_sbir_awards, get_s3_bucket_from_env
+    from sbir_etl.utils.date_utils import parse_date as _parse_date
+
+    _HAS_SBIR_ETL = True
+except ImportError:
+    _HAS_SBIR_ETL = False
+    SbirDuckDBExtractor = None  # type: ignore[assignment, misc]
+
+    def _parse_date(value, **_kwargs):  # type: ignore[misc]
+        """Minimal fallback date parser when sbir_etl is unavailable."""
+        from datetime import date as _date
+
+        if not value or not str(value).strip():
+            return None
+        s = str(value).strip()
+        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y-%m-%d %H:%M:%S", "%m/%d/%y"):
+            try:
+                return datetime.strptime(s, fmt).date()
+            except ValueError:
+                continue
+        return None
 
 # URL templates for external links
 SBIR_AWARD_SEARCH_URL = "https://www.sbir.gov/sbirsearch/award/all"
@@ -58,71 +86,132 @@ class CompanyResearch:
 
 
 # ---------------------------------------------------------------------------
-# Parsing and URL helpers
+# Data loading (reuses SbirDuckDBExtractor + cloud_storage)
 # ---------------------------------------------------------------------------
 
 
-def parse_award_date(date_str: str) -> datetime | None:
-    """Parse award date from CSV, trying common formats."""
-    if not date_str or not date_str.strip():
-        return None
-    date_str = date_str.strip()
-    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y-%m-%d %H:%M:%S", "%m/%d/%y"):
-        try:
-            return datetime.strptime(date_str, fmt)
-        except ValueError:
-            continue
-    return None
+def _resolve_csv_path() -> Path:
+    """Resolve the SBIR CSV path: try S3 first, then download fresh.
 
+    In CI the data-refresh workflow uploads the CSV to S3 weekly, so we
+    prefer that cached copy.  Falls back to downloading directly from
+    SBIR.gov when S3 isn't configured or the file isn't found.
+    """
+    # Try S3 first (only when sbir_etl is installed)
+    if _HAS_SBIR_ETL:
+        bucket = get_s3_bucket_from_env()
+        if bucket:
+            s3_url = find_latest_sbir_awards(bucket)
+            if s3_url:
+                print(f"Using S3-cached CSV: {s3_url}", file=sys.stderr)
+                return Path(s3_url)
 
-def fetch_weekly_awards(days: int = 7) -> list[dict]:
-    """Download SBIR CSV and filter for awards in the past N days."""
-    print(f"Downloading SBIR awards from {SBIR_AWARDS_URL}...", file=sys.stderr)
-
+    # Fall back to direct download
+    print(f"S3 not available; downloading from {SBIR_AWARDS_URL}...", file=sys.stderr)
     response = requests.get(SBIR_AWARDS_URL, timeout=600)
     response.raise_for_status()
 
-    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
+    tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
+    tmp.write_bytes(response.content)
+    print(f"Downloaded {tmp.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
+    return tmp
 
-    reader = csv.DictReader(io.StringIO(response.text))
+
+def fetch_weekly_awards(days: int = 7) -> list[dict]:
+    """Load SBIR CSV and filter for awards in the past N days.
+
+    When sbir_etl is installed, uses SbirDuckDBExtractor for fast
+    columnar import and SQL-based date filtering.  Otherwise falls back
+    to csv.DictReader with Python-level filtering.
+    """
+    csv_path = _resolve_csv_path()
+    cutoff_str = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
+
+    if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
+        # Fast path: DuckDB columnar import + SQL filtering
+        extractor = SbirDuckDBExtractor(
+            csv_path=csv_path,
+            duckdb_path=":memory:",
+            use_s3_first=False,  # we already resolved the path
+        )
+        extractor.import_csv()
+
+        table = extractor._table_identifier
+        query = (
+            f"SELECT * FROM {table} "
+            f"WHERE \"Proposal Award Date\" >= '{cutoff_str}' "
+            f"ORDER BY \"Proposal Award Date\" DESC, "
+            f"TRY_CAST(\"Award Amount\" AS DOUBLE) DESC"
+        )
+
+        df = extractor.duckdb_client.execute_query_df(query)
+        print(f"Found {len(df)} awards since {cutoff_str} (DuckDB)", file=sys.stderr)
+        return df.fillna("").to_dict("records")
+
+    # Fallback: csv.DictReader + Python filtering
+    import csv
+    import io
+
+    print(f"Using csv.DictReader fallback for filtering", file=sys.stderr)
+    cutoff_dt = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
+
+    text = csv_path.read_text(encoding="utf-8")
+    reader = csv.DictReader(io.StringIO(text))
     awards = []
     for row in reader:
-        award_date = parse_award_date(row.get("Proposal Award Date", ""))
-        if award_date and award_date >= cutoff:
-            awards.append(row)
+        parsed = _parse_date(row.get("Proposal Award Date", ""))
+        if parsed:
+            # parse_date returns date; compare as datetime
+            row_dt = datetime(parsed.year, parsed.month, parsed.day)
+            if row_dt >= cutoff_dt:
+                awards.append(row)
 
-    # Sort by date descending, then by amount descending
     def sort_key(a):
-        dt = parse_award_date(a.get("Proposal Award Date", "")) or datetime.min
+        dt = _parse_date(a.get("Proposal Award Date", ""))
+        ts = datetime(dt.year, dt.month, dt.day).timestamp() if dt else 0
         try:
-            amount = float(a.get("Award Amount", "0").replace(",", "").replace("$", ""))
+            amount = float(str(a.get("Award Amount", "0")).replace(",", "").replace("$", ""))
         except (ValueError, AttributeError):
             amount = 0
-        return (-dt.timestamp(), -amount)
+        return (-ts, -amount)
 
     awards.sort(key=sort_key)
+    print(f"Found {len(awards)} awards since {cutoff_str} (csv fallback)", file=sys.stderr)
     return awards
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
 
 
 def format_amount(amount_str: str) -> str:
     """Format dollar amount for display."""
     try:
-        amount = float(amount_str.replace(",", "").replace("$", ""))
+        amount = float(str(amount_str).replace(",", "").replace("$", ""))
         if amount >= 1_000_000:
             return f"${amount / 1_000_000:.2f}M"
         if amount >= 1_000:
             return f"${amount / 1_000:.0f}K"
         return f"${amount:,.0f}"
-    except (ValueError, AttributeError):
-        return amount_str or "N/A"
+    except (ValueError, AttributeError, TypeError):
+        return str(amount_str) if amount_str else "N/A"
+
+
+def _format_date(value) -> str:
+    """Format a date value for display using the project's date parser."""
+    parsed = _parse_date(value)
+    if parsed:
+        return parsed.isoformat()
+    return str(value) if value else ""
 
 
 def build_sbir_award_url(award: dict) -> str:
     """Build a link to the SBIR.gov award search page for this award."""
-    contract = award.get("Contract", "").strip()
+    contract = str(award.get("Contract", "")).strip()
     if contract:
         return f"{SBIR_AWARD_SEARCH_URL}/{quote(contract)}"
-    company = award.get("Company", "").strip()
+    company = str(award.get("Company", "")).strip()
     if company:
         return f"{SBIR_AWARD_SEARCH_URL}/{quote(company)}"
     return SBIR_AWARD_SEARCH_URL
@@ -130,8 +219,8 @@ def build_sbir_award_url(award: dict) -> str:
 
 def build_solicitation_url(award: dict) -> str | None:
     """Build a link to the SBIR.gov solicitation/topic page."""
-    solicitation = award.get("Solicitation Number", "").strip()
-    topic_code = award.get("Topic Code", "").strip()
+    solicitation = str(award.get("Solicitation Number", "")).strip()
+    topic_code = str(award.get("Topic Code", "")).strip()
     if solicitation:
         return f"{SBIR_SOLICITATION_URL}?keyword={quote(solicitation)}"
     if topic_code:
@@ -141,7 +230,7 @@ def build_solicitation_url(award: dict) -> str | None:
 
 def build_usaspending_url(award: dict) -> str | None:
     """Build a link to USAspending.gov search for this award's contract."""
-    contract = award.get("Contract", "").strip()
+    contract = str(award.get("Contract", "")).strip()
     if not contract:
         return None
     search_term = quote(contract)
@@ -179,11 +268,7 @@ def _openai_chat(api_key: str, system: str, user: str) -> str | None:
 
 
 def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
-    """Use the OpenAI Responses API with web_search_preview to research a company.
-
-    Returns a CompanyResearch with a text summary and source URLs extracted
-    from the response annotations.
-    """
+    """Use the OpenAI Responses API with web_search_preview to research a company."""
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
@@ -210,7 +295,6 @@ def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
         print(f"OpenAI Responses API error for web search: {e}", file=sys.stderr)
         return None
 
-    # Extract text and source URLs from the response
     summary_text = ""
     source_urls: list[str] = []
 
@@ -219,7 +303,6 @@ def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
             for content_block in output_item.get("content", []):
                 if content_block.get("type") == "output_text":
                     summary_text = content_block.get("text", "")
-                    # Extract URLs from annotations
                     for annotation in content_block.get("annotations", []):
                         url = annotation.get("url", "")
                         if url and url not in source_urls:
@@ -234,23 +317,18 @@ def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
 def research_companies(
     api_key: str, awards: list[dict]
 ) -> dict[str, CompanyResearch]:
-    """Research each unique awardee company via web search.
-
-    Returns a dict mapping normalized company name to CompanyResearch.
-    Results are cached per company so duplicates aren't searched twice.
-    """
-    # Collect unique companies with their state and website for better search
+    """Research each unique awardee company via web search."""
     companies: dict[str, dict] = {}
     for a in awards:
-        name = a.get("Company", "").strip()
+        name = str(a.get("Company", "")).strip()
         if not name:
             continue
         key = name.upper()
         if key not in companies:
             companies[key] = {
                 "name": name,
-                "state": a.get("State", ""),
-                "website": a.get("Company Website", ""),
+                "state": str(a.get("State", "")),
+                "website": str(a.get("Company Website", "")),
             }
 
     results: dict[str, CompanyResearch] = {}
@@ -261,14 +339,6 @@ def research_companies(
         state = info["state"]
         website = info["website"]
 
-        # Build a targeted search query
-        query_parts = [f'"{name}"']
-        if state:
-            query_parts.append(state)
-        query_parts.append("SBIR company")
-        if website:
-            query_parts.append(f"site:{website}")
-
         query = (
             f"Find public information about {name}"
             + (f" based in {state}" if state else "")
@@ -278,10 +348,7 @@ def research_companies(
             + "What is their technology focus? Any notable contracts or previous SBIR awards?"
         )
 
-        print(
-            f"Researching company {idx}/{total}: {name}...",
-            file=sys.stderr,
-        )
+        print(f"Researching company {idx}/{total}: {name}...", file=sys.stderr)
         research = _openai_web_search(api_key, query)
         if research:
             results[key] = research
@@ -300,21 +367,21 @@ def _award_digest(award: dict, company_research: CompanyResearch | None = None) 
         f"State: {award.get('State', 'N/A')}",
         f"Date: {award.get('Proposal Award Date', 'N/A')}",
     ]
-    abstract = award.get("Abstract", "").strip()
+    abstract = str(award.get("Abstract", "")).strip()
     if abstract:
         if len(abstract) > 1500:
             abstract = abstract[:1500] + "..."
         parts.append(f"Abstract: {abstract}")
-    topic_code = award.get("Topic Code", "").strip()
+    topic_code = str(award.get("Topic Code", "")).strip()
     if topic_code:
         parts.append(f"Topic Code: {topic_code}")
-    solicitation = award.get("Solicitation Number", "").strip()
+    solicitation = str(award.get("Solicitation Number", "")).strip()
     if solicitation:
         parts.append(f"Solicitation: {solicitation}")
-    solicitation_year = award.get("Solicitation Year", "").strip()
+    solicitation_year = str(award.get("Solicitation Year", "")).strip()
     if solicitation_year:
         parts.append(f"Solicitation Year: {solicitation_year}")
-    contract = award.get("Contract", "").strip()
+    contract = str(award.get("Contract", "")).strip()
     if contract:
         parts.append(f"Contract: {contract}")
         parts.append(
@@ -324,15 +391,12 @@ def _award_digest(award: dict, company_research: CompanyResearch | None = None) 
     solicitation_url = build_solicitation_url(award)
     if solicitation_url:
         parts.append(f"Solicitation Reference: {solicitation_url}")
-
-    # Include company research if available
     if company_research:
         parts.append(f"Company Background (from web research): {company_research.summary}")
         if company_research.source_urls:
             parts.append(
                 "Company Sources: " + ", ".join(company_research.source_urls[:5])
             )
-
     return "\n".join(parts)
 
 
@@ -351,19 +415,18 @@ def generate_weekly_synopsis(
     for a in awards:
         try:
             total_amount += float(
-                a.get("Award Amount", "0").replace(",", "").replace("$", "")
+                str(a.get("Award Amount", "0")).replace(",", "").replace("$", "")
             )
         except (ValueError, AttributeError):
             pass
-        ag = a.get("Agency", "Unknown")
+        ag = str(a.get("Agency", "Unknown"))
         agencies[ag] = agencies.get(ag, 0) + 1
 
-    # Include up to 50 award digests for context
     digests = []
     for i, a in enumerate(awards[:50]):
         cr = None
         if company_research:
-            cr = company_research.get(a.get("Company", "").strip().upper())
+            cr = company_research.get(str(a.get("Company", "")).strip().upper())
         digests.append(f"[{i+1}] {_award_digest(a, cr)}")
     digest_block = "\n\n".join(digests)
     if len(awards) > 50:
@@ -394,14 +457,7 @@ def generate_award_descriptions(
     awards: list[dict],
     company_research: dict[str, CompanyResearch] | None = None,
 ) -> dict[int, str]:
-    """Generate a brief description for each award using batched API calls.
-
-    The LLM receives each award's abstract, solicitation context,
-    USAspending reference, and company web research so the description
-    is informed by the full award context.
-
-    Returns a dict mapping award index (0-based) to description text.
-    """
+    """Generate a brief description for each award using batched API calls."""
     descriptions: dict[int, str] = {}
     if not awards:
         return descriptions
@@ -426,7 +482,7 @@ def generate_award_descriptions(
             idx = batch_start + i + 1
             cr = None
             if company_research:
-                cr = company_research.get(a.get("Company", "").strip().upper())
+                cr = company_research.get(str(a.get("Company", "")).strip().upper())
             digests.append(f"[{idx}] {_award_digest(a, cr)}")
 
         user = (
@@ -445,7 +501,6 @@ def generate_award_descriptions(
         if not raw:
             continue
 
-        # Strip markdown code fences if present
         text = raw.strip()
         if text.startswith("```"):
             text = text.split("\n", 1)[-1]
@@ -456,7 +511,7 @@ def generate_award_descriptions(
         try:
             batch_descriptions = json.loads(text)
             for key, desc in batch_descriptions.items():
-                descriptions[int(key) - 1] = desc  # convert to 0-based
+                descriptions[int(key) - 1] = desc
         except (json.JSONDecodeError, ValueError) as e:
             print(f"Failed to parse description batch {batch_label}: {e}", file=sys.stderr)
 
@@ -506,15 +561,15 @@ def generate_markdown(
     for a in awards:
         try:
             total_amount += float(
-                a.get("Award Amount", "0").replace(",", "").replace("$", "")
+                str(a.get("Award Amount", "0")).replace(",", "").replace("$", "")
             )
         except (ValueError, AttributeError):
             pass
-        agency = a.get("Agency", "Unknown")
+        agency = str(a.get("Agency", "Unknown"))
         agencies[agency] = agencies.get(agency, 0) + 1
-        program = a.get("Program", "Unknown")
+        program = str(a.get("Program", "Unknown"))
         programs[program] = programs.get(program, 0) + 1
-        state = a.get("State", "Unknown")
+        state = str(a.get("State", ""))
         if state:
             states[state] = states.get(state, 0) + 1
 
@@ -547,7 +602,7 @@ def generate_markdown(
     lines.append("|---------|-------|--------|")
     program_phase: dict[tuple[str, str], int] = {}
     for a in awards:
-        key = (a.get("Program", "Unknown"), a.get("Phase", "Unknown"))
+        key = (str(a.get("Program", "Unknown")), str(a.get("Phase", "Unknown")))
         program_phase[key] = program_phase.get(key, 0) + 1
     for (program, phase), count in sorted(program_phase.items(), key=lambda x: -x[1]):
         lines.append(f"| {program} | {phase} | {count} |")
@@ -558,18 +613,18 @@ def generate_markdown(
     lines.append("")
 
     for i, a in enumerate(awards):
-        date = a.get("Proposal Award Date", "")
-        company = a.get("Company", "")
-        title = a.get("Award Title", "")
-        agency = a.get("Agency", "")
-        program = a.get("Program", "")
-        phase = a.get("Phase", "")
-        amount = format_amount(a.get("Award Amount", ""))
-        state = a.get("State", "")
-        contract = a.get("Contract", "").strip()
-        solicitation = a.get("Solicitation Number", "").strip()
-        topic_code = a.get("Topic Code", "").strip()
-        pi_name = a.get("PI Name", "").strip()
+        date = _format_date(a.get("Proposal Award Date", ""))
+        company = str(a.get("Company", ""))
+        title = str(a.get("Award Title", ""))
+        agency = str(a.get("Agency", ""))
+        program = str(a.get("Program", ""))
+        phase = str(a.get("Phase", ""))
+        amount = format_amount(str(a.get("Award Amount", "")))
+        state = str(a.get("State", ""))
+        contract = str(a.get("Contract", "")).strip()
+        solicitation = str(a.get("Solicitation Number", "")).strip()
+        topic_code = str(a.get("Topic Code", "")).strip()
+        pi_name = str(a.get("PI Name", "")).strip()
 
         # Build links
         sbir_url = build_sbir_award_url(a)
@@ -618,7 +673,7 @@ def generate_markdown(
         lines.append("</details>")
         lines.append("")
 
-        # Reference links — award, solicitation, USAspending, and company sources
+        # Reference links
         link_parts = [f"[SBIR.gov Award]({sbir_url})"]
         if solicitation_url:
             link_parts.append(f"[Solicitation]({solicitation_url})")
@@ -626,7 +681,6 @@ def generate_markdown(
             link_parts.append(f"[USAspending]({usaspending_url})")
         if cr and cr.source_urls:
             for url in cr.source_urls[:3]:
-                # Derive a short label from the domain
                 domain = url.split("//")[-1].split("/")[0].replace("www.", "")
                 link_parts.append(f"[{domain}]({url})")
 
@@ -670,13 +724,8 @@ def main():
     api_key = os.environ.get("OPENAI_API_KEY", "")
 
     if api_key and not args.no_ai:
-        # Step 1: Research companies via web search
         company_info = research_companies(api_key, awards)
-
-        # Step 2: Generate synopsis (with company context)
         synopsis = generate_weekly_synopsis(api_key, awards, args.days, company_info)
-
-        # Step 3: Generate per-award descriptions (with company context)
         descriptions = generate_award_descriptions(api_key, awards, company_info)
     elif not api_key and not args.no_ai:
         print(

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Generate a weekly SBIR awards report in markdown.
+
+Downloads the SBIR bulk CSV from SBIR.gov and filters for awards
+whose Award Date falls within the past 7 days, then outputs a
+markdown summary.
+
+Usage:
+    python scripts/data/weekly_awards_report.py
+    python scripts/data/weekly_awards_report.py --days 14 --output report.md
+"""
+
+import argparse
+import csv
+import io
+import sys
+from datetime import datetime, timedelta, UTC
+
+import requests
+
+SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+
+
+def parse_award_date(date_str: str) -> datetime | None:
+    """Parse award date from CSV, trying common formats."""
+    if not date_str or not date_str.strip():
+        return None
+    date_str = date_str.strip()
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y-%m-%d %H:%M:%S", "%m/%d/%y"):
+        try:
+            return datetime.strptime(date_str, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def fetch_weekly_awards(days: int = 7) -> list[dict]:
+    """Download SBIR CSV and filter for awards in the past N days."""
+    print(f"Downloading SBIR awards from {SBIR_AWARDS_URL}...", file=sys.stderr)
+
+    response = requests.get(SBIR_AWARDS_URL, timeout=600)
+    response.raise_for_status()
+
+    cutoff = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
+
+    reader = csv.DictReader(io.StringIO(response.text))
+    awards = []
+    for row in reader:
+        award_date = parse_award_date(row.get("Award Date", ""))
+        if award_date and award_date >= cutoff:
+            awards.append(row)
+
+    # Sort by date descending, then by amount descending
+    def sort_key(a):
+        dt = parse_award_date(a.get("Award Date", "")) or datetime.min
+        try:
+            amount = float(a.get("Award Amount", "0").replace(",", "").replace("$", ""))
+        except (ValueError, AttributeError):
+            amount = 0
+        return (-dt.timestamp(), -amount)
+
+    awards.sort(key=sort_key)
+    return awards
+
+
+def format_amount(amount_str: str) -> str:
+    """Format dollar amount for display."""
+    try:
+        amount = float(amount_str.replace(",", "").replace("$", ""))
+        if amount >= 1_000_000:
+            return f"${amount / 1_000_000:.2f}M"
+        if amount >= 1_000:
+            return f"${amount / 1_000:.0f}K"
+        return f"${amount:,.0f}"
+    except (ValueError, AttributeError):
+        return amount_str or "N/A"
+
+
+def generate_markdown(awards: list[dict], days: int) -> str:
+    """Generate markdown report from filtered awards."""
+    now = datetime.now(UTC)
+    cutoff = now - timedelta(days=days)
+
+    lines = []
+    lines.append(f"# SBIR Weekly Awards Report")
+    lines.append("")
+    lines.append(
+        f"**Period:** {cutoff.strftime('%B %d, %Y')} - {now.strftime('%B %d, %Y')}"
+    )
+    lines.append(f"**Total new awards:** {len(awards)}")
+    lines.append("")
+
+    if not awards:
+        lines.append("No new awards found for this period.")
+        return "\n".join(lines)
+
+    # Summary statistics
+    total_amount = 0
+    agencies: dict[str, int] = {}
+    programs: dict[str, int] = {}
+    phases: dict[str, int] = {}
+    states: dict[str, int] = {}
+
+    for a in awards:
+        try:
+            total_amount += float(
+                a.get("Award Amount", "0").replace(",", "").replace("$", "")
+            )
+        except (ValueError, AttributeError):
+            pass
+        agency = a.get("Agency", "Unknown")
+        agencies[agency] = agencies.get(agency, 0) + 1
+        program = a.get("Program", "Unknown")
+        programs[program] = programs.get(program, 0) + 1
+        phase = a.get("Phase", "Unknown")
+        phases[phase] = phases.get(phase, 0) + 1
+        state = a.get("State", "Unknown")
+        if state:
+            states[state] = states.get(state, 0) + 1
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(f"| Metric | Value |")
+    lines.append(f"|--------|-------|")
+    lines.append(f"| Total Awards | {len(awards)} |")
+    lines.append(f"| Total Funding | {format_amount(str(total_amount))} |")
+    lines.append(
+        f"| Avg Award Size | {format_amount(str(total_amount / len(awards)))} |"
+    )
+    lines.append(f"| Agencies | {len(agencies)} |")
+    lines.append(f"| States | {len(states)} |")
+    lines.append("")
+
+    # Breakdown by agency
+    lines.append("## By Agency")
+    lines.append("")
+    lines.append("| Agency | Awards |")
+    lines.append("|--------|--------|")
+    for agency, count in sorted(agencies.items(), key=lambda x: -x[1]):
+        lines.append(f"| {agency} | {count} |")
+    lines.append("")
+
+    # Breakdown by program/phase
+    lines.append("## By Program & Phase")
+    lines.append("")
+    lines.append("| Program | Phase | Awards |")
+    lines.append("|---------|-------|--------|")
+    program_phase: dict[tuple[str, str], int] = {}
+    for a in awards:
+        key = (a.get("Program", "Unknown"), a.get("Phase", "Unknown"))
+        program_phase[key] = program_phase.get(key, 0) + 1
+    for (program, phase), count in sorted(program_phase.items(), key=lambda x: -x[1]):
+        lines.append(f"| {program} | {phase} | {count} |")
+    lines.append("")
+
+    # Awards table
+    lines.append("## Awards")
+    lines.append("")
+    lines.append("| Date | Company | Award Title | Agency | Program | Phase | Amount | State |")
+    lines.append("|------|---------|-------------|--------|---------|-------|--------|-------|")
+
+    for a in awards:
+        date = a.get("Award Date", "")
+        company = a.get("Company", "")
+        title = a.get("Award Title", "")
+        # Truncate long titles for table readability
+        if len(title) > 80:
+            title = title[:77] + "..."
+        agency = a.get("Agency", "")
+        program = a.get("Program", "")
+        phase = a.get("Phase", "")
+        amount = format_amount(a.get("Award Amount", ""))
+        state = a.get("State", "")
+        lines.append(
+            f"| {date} | {company} | {title} | {agency} | {program} | {phase} | {amount} | {state} |"
+        )
+
+    lines.append("")
+    lines.append(
+        f"---\n*Generated on {now.strftime('%Y-%m-%d %H:%M UTC')} from [SBIR.gov](https://www.sbir.gov) bulk data.*"
+    )
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate weekly SBIR awards report")
+    parser.add_argument(
+        "--days",
+        type=int,
+        default=7,
+        help="Number of days to look back (default: 7)",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    awards = fetch_weekly_awards(days=args.days)
+    report = generate_markdown(awards, days=args.days)
+
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(report)
+        print(f"Report written to {args.output} ({len(awards)} awards)", file=sys.stderr)
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -90,7 +90,17 @@ class CompanyResearch:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_csv_path() -> Path:
+@dataclass
+class DataSource:
+    """Metadata about the resolved CSV data source."""
+
+    path: Path
+    origin: str  # "s3" or "download"
+    # S3 key date (e.g. "2026-04-01" from raw/awards/2026-04-01/award_data.csv)
+    s3_key_date: str | None = None
+
+
+def _resolve_csv_path() -> DataSource:
     """Resolve the SBIR CSV path: try S3 first, then download fresh.
 
     In CI the data-refresh workflow uploads the CSV to S3 weekly, so we
@@ -104,7 +114,12 @@ def _resolve_csv_path() -> Path:
             s3_url = find_latest_sbir_awards(bucket)
             if s3_url:
                 print(f"Using S3-cached CSV: {s3_url}", file=sys.stderr)
-                return Path(s3_url)
+                # Extract date from S3 key: raw/awards/YYYY-MM-DD/award_data.csv
+                import re
+
+                date_match = re.search(r"raw/awards/(\d{4}-\d{2}-\d{2})/", s3_url)
+                key_date = date_match.group(1) if date_match else None
+                return DataSource(path=Path(s3_url), origin="s3", s3_key_date=key_date)
 
     # Fall back to direct download
     print(f"S3 not available; downloading from {SBIR_AWARDS_URL}...", file=sys.stderr)
@@ -114,23 +129,65 @@ def _resolve_csv_path() -> Path:
     tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
     tmp.write_bytes(response.content)
     print(f"Downloaded {tmp.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
-    return tmp
+    return DataSource(path=tmp, origin="download")
 
 
-def fetch_weekly_awards(days: int = 7) -> list[dict]:
+def _check_data_freshness(
+    source: DataSource,
+    max_award_date: str | None,
+    days: int,
+) -> list[str]:
+    """Verify that the bulk data is fresh enough for the reporting window.
+
+    Returns a list of warning strings (empty if everything looks good).
+    """
+    warnings: list[str] = []
+    now = datetime.now(UTC).replace(tzinfo=None)
+
+    # Check 1: S3 key date — was the data-refresh recent?
+    if source.s3_key_date:
+        key_dt = _parse_date(source.s3_key_date)
+        if key_dt:
+            key_datetime = datetime(key_dt.year, key_dt.month, key_dt.day)
+            age_days = (now - key_datetime).days
+            if age_days > days + 3:  # allow a few days of slack
+                warnings.append(
+                    f"S3 data is {age_days} days old (key date: {source.s3_key_date}). "
+                    f"The data-refresh workflow may have failed."
+                )
+
+    # Check 2: max Proposal Award Date in the data — is the data itself current?
+    if max_award_date:
+        max_dt = _parse_date(max_award_date)
+        if max_dt:
+            max_datetime = datetime(max_dt.year, max_dt.month, max_dt.day)
+            data_age = (now - max_datetime).days
+            if data_age > days + 14:
+                warnings.append(
+                    f"Most recent award in data is from {max_award_date} "
+                    f"({data_age} days ago). SBIR.gov bulk data may not have "
+                    f"been updated recently."
+                )
+
+    return warnings
+
+
+def fetch_weekly_awards(days: int = 7) -> tuple[list[dict], list[str]]:
     """Load SBIR CSV and filter for awards in the past N days.
 
     When sbir_etl is installed, uses SbirDuckDBExtractor for fast
     columnar import and SQL-based date filtering.  Otherwise falls back
     to csv.DictReader with Python-level filtering.
+
+    Returns (awards, freshness_warnings).
     """
-    csv_path = _resolve_csv_path()
+    source = _resolve_csv_path()
     cutoff_str = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
 
     if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
         # Fast path: DuckDB columnar import + SQL filtering
         extractor = SbirDuckDBExtractor(
-            csv_path=csv_path,
+            csv_path=source.path,
             duckdb_path=":memory:",
             use_s3_first=False,  # we already resolved the path
         )
@@ -146,38 +203,55 @@ def fetch_weekly_awards(days: int = 7) -> list[dict]:
 
         df = extractor.duckdb_client.execute_query_df(query)
         print(f"Found {len(df)} awards since {cutoff_str} (DuckDB)", file=sys.stderr)
-        return df.fillna("").to_dict("records")
+        awards = df.fillna("").to_dict("records")
 
-    # Fallback: csv.DictReader + Python filtering
-    import csv
-    import io
+        # Get max date across the full dataset for freshness check
+        max_date_df = extractor.duckdb_client.execute_query_df(
+            f'SELECT MAX("Proposal Award Date") AS max_date FROM {table}'
+        )
+        max_award_date = str(max_date_df.iloc[0]["max_date"]) if len(max_date_df) else None
 
-    print(f"Using csv.DictReader fallback for filtering", file=sys.stderr)
-    cutoff_dt = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
+    else:
+        # Fallback: csv.DictReader + Python filtering
+        import csv
+        import io
 
-    text = csv_path.read_text(encoding="utf-8")
-    reader = csv.DictReader(io.StringIO(text))
-    awards = []
-    for row in reader:
-        parsed = _parse_date(row.get("Proposal Award Date", ""))
-        if parsed:
-            # parse_date returns date; compare as datetime
-            row_dt = datetime(parsed.year, parsed.month, parsed.day)
-            if row_dt >= cutoff_dt:
-                awards.append(row)
+        print("Using csv.DictReader fallback for filtering", file=sys.stderr)
+        cutoff_dt = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
 
-    def sort_key(a):
-        dt = _parse_date(a.get("Proposal Award Date", ""))
-        ts = datetime(dt.year, dt.month, dt.day).timestamp() if dt else 0
-        try:
-            amount = float(str(a.get("Award Amount", "0")).replace(",", "").replace("$", ""))
-        except (ValueError, AttributeError):
-            amount = 0
-        return (-ts, -amount)
+        text = source.path.read_text(encoding="utf-8")
+        reader = csv.DictReader(io.StringIO(text))
+        awards = []
+        all_dates: list[str] = []
+        for row in reader:
+            date_val = row.get("Proposal Award Date", "")
+            if date_val:
+                all_dates.append(date_val)
+            parsed = _parse_date(date_val)
+            if parsed:
+                row_dt = datetime(parsed.year, parsed.month, parsed.day)
+                if row_dt >= cutoff_dt:
+                    awards.append(row)
 
-    awards.sort(key=sort_key)
-    print(f"Found {len(awards)} awards since {cutoff_str} (csv fallback)", file=sys.stderr)
-    return awards
+        def sort_key(a):
+            dt = _parse_date(a.get("Proposal Award Date", ""))
+            ts = datetime(dt.year, dt.month, dt.day).timestamp() if dt else 0
+            try:
+                amount = float(str(a.get("Award Amount", "0")).replace(",", "").replace("$", ""))
+            except (ValueError, AttributeError):
+                amount = 0
+            return (-ts, -amount)
+
+        awards.sort(key=sort_key)
+        max_award_date = max(all_dates) if all_dates else None
+        print(f"Found {len(awards)} awards since {cutoff_str} (csv fallback)", file=sys.stderr)
+
+    # Verify data freshness
+    freshness_warnings = _check_data_freshness(source, max_award_date, days)
+    for w in freshness_warnings:
+        print(f"WARNING: {w}", file=sys.stderr)
+
+    return awards, freshness_warnings
 
 
 # ---------------------------------------------------------------------------
@@ -529,6 +603,7 @@ def generate_markdown(
     synopsis: str | None = None,
     descriptions: dict[int, str] | None = None,
     company_research: dict[str, CompanyResearch] | None = None,
+    freshness_warnings: list[str] | None = None,
 ) -> str:
     """Generate markdown report from filtered awards."""
     now = datetime.now(UTC)
@@ -542,6 +617,14 @@ def generate_markdown(
     )
     lines.append(f"**Total new awards:** {len(awards)}")
     lines.append("")
+
+    # Data freshness warnings
+    if freshness_warnings:
+        lines.append("> **Data Freshness Warning**")
+        lines.append(">")
+        for w in freshness_warnings:
+            lines.append(f"> - {w}")
+        lines.append("")
 
     if not awards:
         lines.append("No new awards found for this period.")
@@ -715,7 +798,7 @@ def main():
     )
     args = parser.parse_args()
 
-    awards = fetch_weekly_awards(days=args.days)
+    awards, freshness_warnings = fetch_weekly_awards(days=args.days)
 
     # Generate AI content if API key is available
     synopsis = None
@@ -740,6 +823,7 @@ def main():
         synopsis=synopsis,
         descriptions=descriptions,
         company_research=company_info,
+        freshness_warnings=freshness_warnings,
     )
 
     if args.output:

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -71,6 +71,14 @@ OPENAI_MODEL = "gpt-4.1-mini"
 # Batch size for per-award descriptions (awards per API call)
 DESCRIPTION_BATCH_SIZE = 10
 
+# Caps on OpenAI API usage (override via env vars)
+MAX_COMPANIES_TO_RESEARCH = int(os.environ.get("MAX_COMPANIES_TO_RESEARCH", "50"))
+MAX_AWARDS_TO_DESCRIBE = int(os.environ.get("MAX_AWARDS_TO_DESCRIBE", "100"))
+
+# Retry configuration for OpenAI API calls
+OPENAI_MAX_RETRIES = 3
+OPENAI_RETRY_BACKOFF_BASE = 2  # seconds
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -259,6 +267,11 @@ def fetch_weekly_awards(days: int = 7) -> tuple[list[dict], list[str]]:
 # ---------------------------------------------------------------------------
 
 
+def _escape_md_cell(value: str) -> str:
+    """Escape a string for safe use inside a markdown table cell."""
+    return value.replace("|", "\\|").replace("\n", " ").replace("\r", "")
+
+
 def format_amount(amount_str: str) -> str:
     """Format dollar amount for display."""
     try:
@@ -316,6 +329,44 @@ def build_usaspending_url(award: dict) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+def _openai_request_with_retry(
+    method: str,
+    url: str,
+    headers: dict,
+    payload: dict,
+    timeout: int = 120,
+) -> requests.Response | None:
+    """Make an OpenAI API request with retry/backoff for 429 and 5xx errors."""
+    import time
+
+    for attempt in range(OPENAI_MAX_RETRIES + 1):
+        try:
+            resp = requests.request(
+                method, url, headers=headers, json=payload, timeout=timeout
+            )
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < OPENAI_MAX_RETRIES:
+                    wait = OPENAI_RETRY_BACKOFF_BASE ** (attempt + 1)
+                    print(
+                        f"OpenAI API returned {resp.status_code}, retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{OPENAI_MAX_RETRIES})...",
+                        file=sys.stderr,
+                    )
+                    time.sleep(wait)
+                    continue
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.HTTPError:
+            if attempt < OPENAI_MAX_RETRIES:
+                continue
+            print(f"OpenAI API error after {OPENAI_MAX_RETRIES} retries: {resp.status_code}", file=sys.stderr)
+            return None
+        except Exception as e:
+            print(f"OpenAI API request error: {e}", file=sys.stderr)
+            return None
+    return None
+
+
 def _openai_chat(api_key: str, system: str, user: str) -> str | None:
     """Call the OpenAI chat completions API. Returns the assistant message text."""
     headers = {
@@ -330,14 +381,13 @@ def _openai_chat(api_key: str, system: str, user: str) -> str | None:
             {"role": "user", "content": user},
         ],
     }
+    resp = _openai_request_with_retry("POST", OPENAI_CHAT_URL, headers, payload)
+    if resp is None:
+        return None
     try:
-        resp = requests.post(
-            OPENAI_CHAT_URL, headers=headers, json=payload, timeout=120
-        )
-        resp.raise_for_status()
         return resp.json()["choices"][0]["message"]["content"].strip()
-    except Exception as e:
-        print(f"OpenAI Chat API error: {e}", file=sys.stderr)
+    except (KeyError, IndexError) as e:
+        print(f"OpenAI Chat API unexpected response: {e}", file=sys.stderr)
         return None
 
 
@@ -359,15 +409,10 @@ def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
         ),
         "input": query,
     }
-    try:
-        resp = requests.post(
-            OPENAI_RESPONSES_URL, headers=headers, json=payload, timeout=60
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as e:
-        print(f"OpenAI Responses API error for web search: {e}", file=sys.stderr)
+    resp = _openai_request_with_retry("POST", OPENAI_RESPONSES_URL, headers, payload, timeout=60)
+    if resp is None:
         return None
+    data = resp.json()
 
     summary_text = ""
     source_urls: list[str] = []
@@ -406,9 +451,17 @@ def research_companies(
             }
 
     results: dict[str, CompanyResearch] = {}
-    total = len(companies)
+    # Cap the number of companies to research
+    company_items = list(companies.items())
+    if len(company_items) > MAX_COMPANIES_TO_RESEARCH:
+        print(
+            f"Capping company research at {MAX_COMPANIES_TO_RESEARCH} of {len(company_items)} companies",
+            file=sys.stderr,
+        )
+        company_items = company_items[:MAX_COMPANIES_TO_RESEARCH]
+    total = len(company_items)
 
-    for idx, (key, info) in enumerate(companies.items(), 1):
+    for idx, (key, info) in enumerate(company_items, 1):
         name = info["name"]
         state = info["state"]
         website = info["website"]
@@ -536,6 +589,15 @@ def generate_award_descriptions(
     if not awards:
         return descriptions
 
+    # Cap the number of awards to describe
+    awards_to_describe = awards
+    if len(awards) > MAX_AWARDS_TO_DESCRIBE:
+        print(
+            f"Capping award descriptions at {MAX_AWARDS_TO_DESCRIBE} of {len(awards)} awards",
+            file=sys.stderr,
+        )
+        awards_to_describe = awards[:MAX_AWARDS_TO_DESCRIBE]
+
     system = (
         "You summarize SBIR/STTR awards in plain language. "
         "For each award, write 2-3 sentences explaining what the project does "
@@ -549,8 +611,8 @@ def generate_award_descriptions(
         'to its description string. Example: {"1": "Description.", "2": "Description."}'
     )
 
-    for batch_start in range(0, len(awards), DESCRIPTION_BATCH_SIZE):
-        batch = awards[batch_start : batch_start + DESCRIPTION_BATCH_SIZE]
+    for batch_start in range(0, len(awards_to_describe), DESCRIPTION_BATCH_SIZE):
+        batch = awards_to_describe[batch_start : batch_start + DESCRIPTION_BATCH_SIZE]
         digests = []
         for i, a in enumerate(batch):
             idx = batch_start + i + 1
@@ -568,7 +630,7 @@ def generate_award_descriptions(
 
         batch_label = f"{batch_start + 1}-{batch_start + len(batch)}"
         print(
-            f"Generating descriptions for awards {batch_label} of {len(awards)}...",
+            f"Generating descriptions for awards {batch_label} of {len(awards_to_describe)}...",
             file=sys.stderr,
         )
         raw = _openai_chat(api_key, system, user)
@@ -675,7 +737,7 @@ def generate_markdown(
     lines.append("| Agency | Awards |")
     lines.append("|--------|--------|")
     for agency, count in sorted(agencies.items(), key=lambda x: -x[1]):
-        lines.append(f"| {agency} | {count} |")
+        lines.append(f"| {_escape_md_cell(agency)} | {count} |")
     lines.append("")
 
     # Breakdown by program/phase
@@ -688,7 +750,7 @@ def generate_markdown(
         key = (str(a.get("Program", "Unknown")), str(a.get("Phase", "Unknown")))
         program_phase[key] = program_phase.get(key, 0) + 1
     for (program, phase), count in sorted(program_phase.items(), key=lambda x: -x[1]):
-        lines.append(f"| {program} | {phase} | {count} |")
+        lines.append(f"| {_escape_md_cell(program)} | {_escape_md_cell(phase)} | {count} |")
     lines.append("")
 
     # Individual awards
@@ -717,7 +779,7 @@ def generate_markdown(
         # Look up company research
         cr = None
         if company_research:
-            cr = company_research.get(company.upper())
+            cr = company_research.get(company.strip().upper())
 
         # Award header
         lines.append(f"### {i + 1}. {title}")
@@ -736,22 +798,22 @@ def generate_markdown(
         lines.append("")
         lines.append("| Field | Value |")
         lines.append("|-------|-------|")
-        lines.append(f"| **Company** | {company} |")
+        lines.append(f"| **Company** | {_escape_md_cell(company)} |")
         lines.append(f"| **Award Date** | {date} |")
         lines.append(f"| **Amount** | {amount} |")
-        lines.append(f"| **Agency** | {agency} |")
-        lines.append(f"| **Program** | {program} |")
-        lines.append(f"| **Phase** | {phase} |")
+        lines.append(f"| **Agency** | {_escape_md_cell(agency)} |")
+        lines.append(f"| **Program** | {_escape_md_cell(program)} |")
+        lines.append(f"| **Phase** | {_escape_md_cell(phase)} |")
         if state:
-            lines.append(f"| **State** | {state} |")
+            lines.append(f"| **State** | {_escape_md_cell(state)} |")
         if contract:
-            lines.append(f"| **Contract** | `{contract}` |")
+            lines.append(f"| **Contract** | `{_escape_md_cell(contract)}` |")
         if pi_name:
-            lines.append(f"| **PI** | {pi_name} |")
+            lines.append(f"| **PI** | {_escape_md_cell(pi_name)} |")
         if solicitation:
-            lines.append(f"| **Solicitation** | `{solicitation}` |")
+            lines.append(f"| **Solicitation** | `{_escape_md_cell(solicitation)}` |")
         if topic_code:
-            lines.append(f"| **Topic Code** | `{topic_code}` |")
+            lines.append(f"| **Topic Code** | `{_escape_md_cell(topic_code)}` |")
         lines.append("")
         lines.append("</details>")
         lines.append("")
@@ -796,6 +858,11 @@ def main():
         action="store_true",
         help="Skip AI-generated summaries even if OPENAI_API_KEY is set",
     )
+    parser.add_argument(
+        "--no-company-research",
+        action="store_true",
+        help="Skip web-based company research (still generates synopsis and descriptions)",
+    )
     args = parser.parse_args()
 
     awards, freshness_warnings = fetch_weekly_awards(days=args.days)
@@ -807,7 +874,8 @@ def main():
     api_key = os.environ.get("OPENAI_API_KEY", "")
 
     if api_key and not args.no_ai:
-        company_info = research_companies(api_key, awards)
+        if not args.no_company_research:
+            company_info = research_companies(api_key, awards)
         synopsis = generate_weekly_synopsis(api_key, awards, args.days, company_info)
         descriptions = generate_award_descriptions(api_key, awards, company_info)
     elif not api_key and not args.no_ai:

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -5,9 +5,11 @@ Downloads the SBIR bulk CSV from SBIR.gov and filters for awards
 whose Proposal Award Date falls within the past 7 days, then outputs a
 markdown summary with links to SBIR.gov, solicitations, and USAspending.
 
-When OPENAI_API_KEY is set, uses the OpenAI API to generate:
-- A two-paragraph synopsis of all weekly award activity (top of report)
-- A brief plain-language description for each award
+When OPENAI_API_KEY is set, uses the OpenAI API to:
+- Search the web for public info on each awardee company
+- Generate a two-paragraph synopsis of all weekly award activity
+- Generate a brief description per award (informed by the abstract,
+  solicitation, USAspending data, and company research)
 
 Usage:
     python scripts/data/weekly_awards_report.py
@@ -21,6 +23,7 @@ import io
 import json
 import os
 import sys
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta, UTC
 from urllib.parse import quote
 
@@ -33,11 +36,30 @@ SBIR_AWARD_SEARCH_URL = "https://www.sbir.gov/sbirsearch/award/all"
 SBIR_SOLICITATION_URL = "https://www.sbir.gov/sbirsearch/topic/default"
 USASPENDING_SEARCH_URL = "https://www.usaspending.gov/search"
 
-OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 OPENAI_MODEL = "gpt-4.1-mini"
 
 # Batch size for per-award descriptions (awards per API call)
 DESCRIPTION_BATCH_SIZE = 10
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CompanyResearch:
+    """Results of web research on an awardee company."""
+
+    summary: str
+    source_urls: list[str] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Parsing and URL helpers
+# ---------------------------------------------------------------------------
 
 
 def parse_award_date(date_str: str) -> datetime | None:
@@ -147,16 +169,127 @@ def _openai_chat(api_key: str, system: str, user: str) -> str | None:
     }
     try:
         resp = requests.post(
-            OPENAI_API_URL, headers=headers, json=payload, timeout=120
+            OPENAI_CHAT_URL, headers=headers, json=payload, timeout=120
         )
         resp.raise_for_status()
         return resp.json()["choices"][0]["message"]["content"].strip()
     except Exception as e:
-        print(f"OpenAI API error: {e}", file=sys.stderr)
+        print(f"OpenAI Chat API error: {e}", file=sys.stderr)
         return None
 
 
-def _award_digest(award: dict) -> str:
+def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
+    """Use the OpenAI Responses API with web_search_preview to research a company.
+
+    Returns a CompanyResearch with a text summary and source URLs extracted
+    from the response annotations.
+    """
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "model": OPENAI_MODEL,
+        "tools": [{"type": "web_search_preview"}],
+        "instructions": (
+            "You are a research assistant gathering public information about "
+            "companies that receive SBIR/STTR federal awards. Provide a concise "
+            "2-3 sentence summary covering: what the company does, its size/stage, "
+            "notable products or contracts, and any previous SBIR/STTR history. "
+            "Cite your sources."
+        ),
+        "input": query,
+    }
+    try:
+        resp = requests.post(
+            OPENAI_RESPONSES_URL, headers=headers, json=payload, timeout=60
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as e:
+        print(f"OpenAI Responses API error for web search: {e}", file=sys.stderr)
+        return None
+
+    # Extract text and source URLs from the response
+    summary_text = ""
+    source_urls: list[str] = []
+
+    for output_item in data.get("output", []):
+        if output_item.get("type") == "message":
+            for content_block in output_item.get("content", []):
+                if content_block.get("type") == "output_text":
+                    summary_text = content_block.get("text", "")
+                    # Extract URLs from annotations
+                    for annotation in content_block.get("annotations", []):
+                        url = annotation.get("url", "")
+                        if url and url not in source_urls:
+                            source_urls.append(url)
+
+    if not summary_text:
+        return None
+
+    return CompanyResearch(summary=summary_text, source_urls=source_urls)
+
+
+def research_companies(
+    api_key: str, awards: list[dict]
+) -> dict[str, CompanyResearch]:
+    """Research each unique awardee company via web search.
+
+    Returns a dict mapping normalized company name to CompanyResearch.
+    Results are cached per company so duplicates aren't searched twice.
+    """
+    # Collect unique companies with their state and website for better search
+    companies: dict[str, dict] = {}
+    for a in awards:
+        name = a.get("Company", "").strip()
+        if not name:
+            continue
+        key = name.upper()
+        if key not in companies:
+            companies[key] = {
+                "name": name,
+                "state": a.get("State", ""),
+                "website": a.get("Company Website", ""),
+            }
+
+    results: dict[str, CompanyResearch] = {}
+    total = len(companies)
+
+    for idx, (key, info) in enumerate(companies.items(), 1):
+        name = info["name"]
+        state = info["state"]
+        website = info["website"]
+
+        # Build a targeted search query
+        query_parts = [f'"{name}"']
+        if state:
+            query_parts.append(state)
+        query_parts.append("SBIR company")
+        if website:
+            query_parts.append(f"site:{website}")
+
+        query = (
+            f"Find public information about {name}"
+            + (f" based in {state}" if state else "")
+            + ". They are an SBIR/STTR federal award recipient."
+            + (f" Their website is {website}." if website else "")
+            + " What does this company do? How large are they? "
+            + "What is their technology focus? Any notable contracts or previous SBIR awards?"
+        )
+
+        print(
+            f"Researching company {idx}/{total}: {name}...",
+            file=sys.stderr,
+        )
+        research = _openai_web_search(api_key, query)
+        if research:
+            results[key] = research
+
+    return results
+
+
+def _award_digest(award: dict, company_research: CompanyResearch | None = None) -> str:
     """Build a compact text digest of an award for LLM context."""
     parts = [
         f"Title: {award.get('Award Title', 'N/A')}",
@@ -191,10 +324,24 @@ def _award_digest(award: dict) -> str:
     solicitation_url = build_solicitation_url(award)
     if solicitation_url:
         parts.append(f"Solicitation Reference: {solicitation_url}")
+
+    # Include company research if available
+    if company_research:
+        parts.append(f"Company Background (from web research): {company_research.summary}")
+        if company_research.source_urls:
+            parts.append(
+                "Company Sources: " + ", ".join(company_research.source_urls[:5])
+            )
+
     return "\n".join(parts)
 
 
-def generate_weekly_synopsis(api_key: str, awards: list[dict], days: int) -> str | None:
+def generate_weekly_synopsis(
+    api_key: str,
+    awards: list[dict],
+    days: int,
+    company_research: dict[str, CompanyResearch] | None = None,
+) -> str | None:
     """Generate a two-paragraph synopsis of all weekly award activity."""
     if not awards:
         return None
@@ -214,7 +361,10 @@ def generate_weekly_synopsis(api_key: str, awards: list[dict], days: int) -> str
     # Include up to 50 award digests for context
     digests = []
     for i, a in enumerate(awards[:50]):
-        digests.append(f"[{i+1}] {_award_digest(a)}")
+        cr = None
+        if company_research:
+            cr = company_research.get(a.get("Company", "").strip().upper())
+        digests.append(f"[{i+1}] {_award_digest(a, cr)}")
     digest_block = "\n\n".join(digests)
     if len(awards) > 50:
         digest_block += f"\n\n... and {len(awards) - 50} additional awards."
@@ -223,7 +373,8 @@ def generate_weekly_synopsis(api_key: str, awards: list[dict], days: int) -> str
         "You are an analyst writing a concise executive briefing about weekly "
         "SBIR/STTR federal small business innovation award activity. "
         "Write in a professional, informative tone. Do not use markdown headers. "
-        "Do not use bullet points. Write exactly two paragraphs."
+        "Do not use bullet points. Write exactly two paragraphs. "
+        "Incorporate relevant context about the awardee companies when provided."
     )
     user = (
         f"Write a two-paragraph synopsis of this week's SBIR/STTR award activity.\n\n"
@@ -239,13 +390,15 @@ def generate_weekly_synopsis(api_key: str, awards: list[dict], days: int) -> str
 
 
 def generate_award_descriptions(
-    api_key: str, awards: list[dict]
+    api_key: str,
+    awards: list[dict],
+    company_research: dict[str, CompanyResearch] | None = None,
 ) -> dict[int, str]:
     """Generate a brief description for each award using batched API calls.
 
-    The LLM receives each award's abstract, solicitation context, and
-    USAspending reference so the description is informed by the full
-    award context.
+    The LLM receives each award's abstract, solicitation context,
+    USAspending reference, and company web research so the description
+    is informed by the full award context.
 
     Returns a dict mapping award index (0-based) to description text.
     """
@@ -256,10 +409,12 @@ def generate_award_descriptions(
     system = (
         "You summarize SBIR/STTR awards in plain language. "
         "For each award, write 2-3 sentences explaining what the project does "
-        "and why it matters. Use the abstract, solicitation context, and "
-        "associated federal spending data to inform your description. "
-        "Be specific about the technology and its intended application. "
-        "Avoid generic filler.\n\n"
+        "and why it matters. Use the abstract, solicitation context, "
+        "associated federal spending data, and company background research "
+        "to inform your description. Reference relevant company context "
+        "(e.g. their expertise, previous work, or market position) when it "
+        "adds value. Be specific about the technology and its intended "
+        "application. Avoid generic filler.\n\n"
         "Respond with a JSON object mapping the award number (as a string key) "
         'to its description string. Example: {"1": "Description.", "2": "Description."}'
     )
@@ -269,13 +424,16 @@ def generate_award_descriptions(
         digests = []
         for i, a in enumerate(batch):
             idx = batch_start + i + 1
-            digests.append(f"[{idx}] {_award_digest(a)}")
+            cr = None
+            if company_research:
+                cr = company_research.get(a.get("Company", "").strip().upper())
+            digests.append(f"[{idx}] {_award_digest(a, cr)}")
 
         user = (
             "Generate a brief plain-language description for each award below. "
             "Each description should convey the technology, its application, "
-            "and the significance of the federal investment. "
-            "Respond ONLY with a JSON object.\n\n" + "\n\n".join(digests)
+            "the significance of the federal investment, and relevant company "
+            "context. Respond ONLY with a JSON object.\n\n" + "\n\n".join(digests)
         )
 
         batch_label = f"{batch_start + 1}-{batch_start + len(batch)}"
@@ -315,6 +473,7 @@ def generate_markdown(
     days: int,
     synopsis: str | None = None,
     descriptions: dict[int, str] | None = None,
+    company_research: dict[str, CompanyResearch] | None = None,
 ) -> str:
     """Generate markdown report from filtered awards."""
     now = datetime.now(UTC)
@@ -417,6 +576,11 @@ def generate_markdown(
         solicitation_url = build_solicitation_url(a)
         usaspending_url = build_usaspending_url(a)
 
+        # Look up company research
+        cr = None
+        if company_research:
+            cr = company_research.get(company.upper())
+
         # Award header
         lines.append(f"### {i + 1}. {title}")
         lines.append("")
@@ -454,14 +618,19 @@ def generate_markdown(
         lines.append("</details>")
         lines.append("")
 
-        # Reference links
-        lines.append("**References:** ")
+        # Reference links — award, solicitation, USAspending, and company sources
         link_parts = [f"[SBIR.gov Award]({sbir_url})"]
         if solicitation_url:
             link_parts.append(f"[Solicitation]({solicitation_url})")
         if usaspending_url:
             link_parts.append(f"[USAspending]({usaspending_url})")
-        lines.append(" | ".join(link_parts))
+        if cr and cr.source_urls:
+            for url in cr.source_urls[:3]:
+                # Derive a short label from the domain
+                domain = url.split("//")[-1].split("/")[0].replace("www.", "")
+                link_parts.append(f"[{domain}]({url})")
+
+        lines.append("**References:** " + " | ".join(link_parts))
         lines.append("")
 
     lines.append(
@@ -494,13 +663,21 @@ def main():
 
     awards = fetch_weekly_awards(days=args.days)
 
-    # Generate AI descriptions if API key is available
+    # Generate AI content if API key is available
     synopsis = None
     descriptions = None
+    company_info: dict[str, CompanyResearch] | None = None
     api_key = os.environ.get("OPENAI_API_KEY", "")
+
     if api_key and not args.no_ai:
-        synopsis = generate_weekly_synopsis(api_key, awards, args.days)
-        descriptions = generate_award_descriptions(api_key, awards)
+        # Step 1: Research companies via web search
+        company_info = research_companies(api_key, awards)
+
+        # Step 2: Generate synopsis (with company context)
+        synopsis = generate_weekly_synopsis(api_key, awards, args.days, company_info)
+
+        # Step 3: Generate per-award descriptions (with company context)
+        descriptions = generate_award_descriptions(api_key, awards, company_info)
     elif not api_key and not args.no_ai:
         print(
             "OPENAI_API_KEY not set - skipping AI summaries. "
@@ -509,7 +686,11 @@ def main():
         )
 
     report = generate_markdown(
-        awards, days=args.days, synopsis=synopsis, descriptions=descriptions
+        awards,
+        days=args.days,
+        synopsis=synopsis,
+        descriptions=descriptions,
+        company_research=company_info,
     )
 
     if args.output:

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -2,8 +2,8 @@
 """Generate a weekly SBIR awards report in markdown.
 
 Downloads the SBIR bulk CSV from SBIR.gov and filters for awards
-whose Award Date falls within the past 7 days, then outputs a
-markdown summary.
+whose Proposal Award Date falls within the past 7 days, then outputs a
+markdown summary with links to SBIR.gov, solicitations, and USAspending.
 
 Usage:
     python scripts/data/weekly_awards_report.py
@@ -15,10 +15,16 @@ import csv
 import io
 import sys
 from datetime import datetime, timedelta, UTC
+from urllib.parse import quote
 
 import requests
 
 SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+
+# URL templates for external links
+SBIR_AWARD_SEARCH_URL = "https://www.sbir.gov/sbirsearch/award/all"
+SBIR_SOLICITATION_URL = "https://www.sbir.gov/sbirsearch/topic/default"
+USASPENDING_SEARCH_URL = "https://www.usaspending.gov/search"
 
 
 def parse_award_date(date_str: str) -> datetime | None:
@@ -46,13 +52,13 @@ def fetch_weekly_awards(days: int = 7) -> list[dict]:
     reader = csv.DictReader(io.StringIO(response.text))
     awards = []
     for row in reader:
-        award_date = parse_award_date(row.get("Award Date", ""))
+        award_date = parse_award_date(row.get("Proposal Award Date", ""))
         if award_date and award_date >= cutoff:
             awards.append(row)
 
     # Sort by date descending, then by amount descending
     def sort_key(a):
-        dt = parse_award_date(a.get("Award Date", "")) or datetime.min
+        dt = parse_award_date(a.get("Proposal Award Date", "")) or datetime.min
         try:
             amount = float(a.get("Award Amount", "0").replace(",", "").replace("$", ""))
         except (ValueError, AttributeError):
@@ -76,13 +82,56 @@ def format_amount(amount_str: str) -> str:
         return amount_str or "N/A"
 
 
+def build_sbir_award_url(award: dict) -> str:
+    """Build a link to the SBIR.gov award search page for this award.
+
+    Uses the contract number as a keyword search on SBIR.gov's award listing.
+    """
+    contract = award.get("Contract", "").strip()
+    if contract:
+        return f"{SBIR_AWARD_SEARCH_URL}/{quote(contract)}"
+    # Fall back to company name search
+    company = award.get("Company", "").strip()
+    if company:
+        return f"{SBIR_AWARD_SEARCH_URL}/{quote(company)}"
+    return SBIR_AWARD_SEARCH_URL
+
+
+def build_solicitation_url(award: dict) -> str | None:
+    """Build a link to the SBIR.gov solicitation/topic page.
+
+    Links to the SBIR.gov topic search using the solicitation number.
+    Returns None if no solicitation info is available.
+    """
+    solicitation = award.get("Solicitation Number", "").strip()
+    topic_code = award.get("Topic Code", "").strip()
+
+    if solicitation:
+        return f"{SBIR_SOLICITATION_URL}?keyword={quote(solicitation)}"
+    if topic_code:
+        return f"{SBIR_SOLICITATION_URL}?keyword={quote(topic_code)}"
+    return None
+
+
+def build_usaspending_url(award: dict) -> str | None:
+    """Build a link to USAspending.gov search for this award's contract.
+
+    Returns None if no contract number is available.
+    """
+    contract = award.get("Contract", "").strip()
+    if not contract:
+        return None
+    search_term = quote(contract)
+    return f'{USASPENDING_SEARCH_URL}?form_fields={{"search_term":"{search_term}"}}'
+
+
 def generate_markdown(awards: list[dict], days: int) -> str:
     """Generate markdown report from filtered awards."""
     now = datetime.now(UTC)
     cutoff = now - timedelta(days=days)
 
     lines = []
-    lines.append(f"# SBIR Weekly Awards Report")
+    lines.append("# SBIR Weekly Awards Report")
     lines.append("")
     lines.append(
         f"**Period:** {cutoff.strftime('%B %d, %Y')} - {now.strftime('%B %d, %Y')}"
@@ -120,8 +169,8 @@ def generate_markdown(awards: list[dict], days: int) -> str:
 
     lines.append("## Summary")
     lines.append("")
-    lines.append(f"| Metric | Value |")
-    lines.append(f"|--------|-------|")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
     lines.append(f"| Total Awards | {len(awards)} |")
     lines.append(f"| Total Funding | {format_amount(str(total_amount))} |")
     lines.append(
@@ -153,31 +202,67 @@ def generate_markdown(awards: list[dict], days: int) -> str:
         lines.append(f"| {program} | {phase} | {count} |")
     lines.append("")
 
-    # Awards table
+    # Awards list with links
     lines.append("## Awards")
     lines.append("")
-    lines.append("| Date | Company | Award Title | Agency | Program | Phase | Amount | State |")
-    lines.append("|------|---------|-------------|--------|---------|-------|--------|-------|")
 
-    for a in awards:
-        date = a.get("Award Date", "")
+    for i, a in enumerate(awards, 1):
+        date = a.get("Proposal Award Date", "")
         company = a.get("Company", "")
         title = a.get("Award Title", "")
-        # Truncate long titles for table readability
-        if len(title) > 80:
-            title = title[:77] + "..."
         agency = a.get("Agency", "")
         program = a.get("Program", "")
         phase = a.get("Phase", "")
         amount = format_amount(a.get("Award Amount", ""))
         state = a.get("State", "")
-        lines.append(
-            f"| {date} | {company} | {title} | {agency} | {program} | {phase} | {amount} | {state} |"
-        )
+        contract = a.get("Contract", "").strip()
+        solicitation = a.get("Solicitation Number", "").strip()
+        topic_code = a.get("Topic Code", "").strip()
+        pi_name = a.get("PI Name", "").strip()
 
-    lines.append("")
+        # Build links
+        sbir_url = build_sbir_award_url(a)
+        solicitation_url = build_solicitation_url(a)
+        usaspending_url = build_usaspending_url(a)
+
+        # Award header with title linked to SBIR.gov
+        lines.append(f"### {i}. [{title}]({sbir_url})")
+        lines.append("")
+
+        # Details table
+        lines.append("| Field | Value |")
+        lines.append("|-------|-------|")
+        lines.append(f"| **Company** | {company} |")
+        lines.append(f"| **Award Date** | {date} |")
+        lines.append(f"| **Amount** | {amount} |")
+        lines.append(f"| **Agency** | {agency} |")
+        lines.append(f"| **Program** | {program} |")
+        lines.append(f"| **Phase** | {phase} |")
+        if state:
+            lines.append(f"| **State** | {state} |")
+        if contract:
+            lines.append(f"| **Contract** | `{contract}` |")
+        if pi_name:
+            lines.append(f"| **PI** | {pi_name} |")
+        if solicitation:
+            lines.append(f"| **Solicitation** | `{solicitation}` |")
+        if topic_code:
+            lines.append(f"| **Topic Code** | `{topic_code}` |")
+
+        # Links
+        link_parts = [f"[SBIR.gov Award]({sbir_url})"]
+        if solicitation_url:
+            link_parts.append(f"[Solicitation]({solicitation_url})")
+        if usaspending_url:
+            link_parts.append(f"[USAspending]({usaspending_url})")
+
+        lines.append("")
+        lines.append(" | ".join(link_parts))
+        lines.append("")
+
     lines.append(
-        f"---\n*Generated on {now.strftime('%Y-%m-%d %H:%M UTC')} from [SBIR.gov](https://www.sbir.gov) bulk data.*"
+        f"---\n*Generated on {now.strftime('%Y-%m-%d %H:%M UTC')} from "
+        f"[SBIR.gov]({SBIR_AWARDS_URL}) bulk data.*"
     )
     return "\n".join(lines)
 


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs every Monday at 10 AM UTC
(after the data-refresh downloads fresh SBIR data at 9 AM). Downloads
the SBIR.gov bulk CSV, filters for awards from the past 7 days, and
generates a markdown report with summary stats by agency/program/phase
and a full awards table. The report is posted to the job summary and
uploaded as an artifact. Can also be triggered manually with a custom
lookback period.

https://claude.ai/code/session_01VUksBJFqYdhfFu28SXKLfM