### PR TITLE
Use actions/setup-python@v5 in composite action

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
### Motivation
- Ensure the composite action remains compatible and stable by pinning the Python setup action to `actions/setup-python@v5` instead of `@v6`.

### Description
- Replaced `uses: actions/setup-python@v6` with `uses: actions/setup-python@v5` in `.github/actions/setup-python-uv/action.yml`.

### Testing
- Executed the repository CI workflow that exercises the composite action and the job containing the Python setup step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfc16e690c83229c8ee0b6830337e3)