### PR TITLE
Add company and PI diligence analysis to weekly awards report

### DIFF
--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -42,6 +42,7 @@ try:
     from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
     from sbir_etl.utils.cloud_storage import find_latest_sbir_awards, get_s3_bucket_from_env
     from sbir_etl.utils.date_utils import parse_date as _parse_date
+    from sbir_etl.utils.text_normalization import normalize_name as _normalize_name
 
     _HAS_SBIR_ETL = True
 except ImportError:
@@ -62,6 +63,26 @@ except ImportError:
             except ValueError:
                 continue
         return None
+
+    def _normalize_name(name, *, remove_suffixes=False, **_kwargs):  # type: ignore[misc]
+        """Minimal fallback company name normalizer."""
+        import re as _re
+
+        if not name:
+            return ""
+        s = str(name).strip().lower()
+        s = _re.sub(r"[^\w\s]", " ", s)
+        if remove_suffixes:
+            s = _re.sub(
+                r"\b(incorporated|incorporation|inc|corp|corporation|llc|ltd|limited|co|company)\b",
+                "",
+                s,
+            )
+        else:
+            s = _re.sub(r"\b(incorporated|incorporation)\b", "inc", s)
+            s = _re.sub(r"\b(company|co)\b", "company", s)
+            s = _re.sub(r"\b(limited|ltd)\b", "ltd", s)
+        return _re.sub(r"\s+", " ", s).strip()
 
 # URL templates for external links
 SBIR_AWARD_SEARCH_URL = "https://www.sbir.gov/sbirsearch/award/all"
@@ -274,6 +295,119 @@ def fetch_weekly_awards(days: int = 7) -> tuple[list[dict], list[str]]:
         print(f"WARNING: {w}", file=sys.stderr)
 
     return awards, freshness_warnings
+
+
+# ---------------------------------------------------------------------------
+# Data cleaning & deduplication
+# ---------------------------------------------------------------------------
+
+VALID_PHASES = {"Phase I", "Phase II", "Phase III"}
+VALID_PROGRAMS = {"SBIR", "STTR"}
+
+
+def _company_key(award: dict) -> str:
+    """Return a normalized company key for grouping.
+
+    Uses _normalized_company if the cleaning pass has run, otherwise
+    falls back to upper-cased raw name.
+    """
+    norm = award.get("_normalized_company", "")
+    if norm:
+        return norm
+    return str(award.get("Company", "")).strip().upper()
+
+
+def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
+    """Validate, normalize, and deduplicate weekly awards.
+
+    Runs the sbir_etl validation and normalization pipeline (with graceful
+    fallback) against the raw award list:
+
+    1. **Validate** — drop records with invalid phase, non-numeric amount,
+       or missing company name.
+    2. **Normalize** — standardize company names using normalize_name() so
+       that "ACME, Inc." and "ACME INCORPORATED" map to the same entity.
+       Original names are preserved; a ``_normalized_company`` key is added.
+    3. **Deduplicate** — remove exact duplicates by Contract number (the
+       most reliable unique identifier in the SBIR CSV).
+
+    Returns:
+        (cleaned_awards, stats) where stats is a dict with counts of
+        records removed at each stage.
+    """
+    stats: dict = {
+        "input": len(awards),
+        "invalid_phase": 0,
+        "invalid_amount": 0,
+        "missing_company": 0,
+        "duplicates": 0,
+    }
+
+    cleaned: list[dict] = []
+
+    for a in awards:
+        # Validate company name
+        company = str(a.get("Company", "")).strip()
+        if not company:
+            stats["missing_company"] += 1
+            continue
+
+        # Validate phase
+        phase = str(a.get("Phase", "")).strip()
+        if phase and phase not in VALID_PHASES:
+            stats["invalid_phase"] += 1
+            continue
+
+        # Validate award amount (must be numeric and positive)
+        amount_raw = str(a.get("Award Amount", "")).replace(",", "").replace("$", "").strip()
+        if amount_raw:
+            try:
+                amount_val = float(amount_raw)
+                if amount_val <= 0:
+                    stats["invalid_amount"] += 1
+                    continue
+            except (ValueError, TypeError):
+                stats["invalid_amount"] += 1
+                continue
+
+        # Normalize company name for downstream grouping
+        a["_normalized_company"] = _normalize_name(company, remove_suffixes=True)
+
+        cleaned.append(a)
+
+    # Deduplicate by Contract number (most reliable SBIR award identifier)
+    seen_contracts: set[str] = set()
+    deduped: list[dict] = []
+
+    for a in cleaned:
+        contract = str(a.get("Contract", "")).strip()
+        if contract:
+            if contract in seen_contracts:
+                stats["duplicates"] += 1
+                continue
+            seen_contracts.add(contract)
+        deduped.append(a)
+
+    stats["output"] = len(deduped)
+    stats["total_removed"] = stats["input"] - stats["output"]
+
+    if stats["total_removed"] > 0:
+        print(
+            f"Data cleaning: {stats['input']} → {stats['output']} awards "
+            f"(removed {stats['total_removed']}: "
+            f"{stats['invalid_phase']} invalid phase, "
+            f"{stats['invalid_amount']} invalid amount, "
+            f"{stats['missing_company']} missing company, "
+            f"{stats['duplicates']} duplicates)",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"Data cleaning: {stats['input']} awards, all valid",
+            file=sys.stderr,
+        )
+
+    return deduped, stats
 
 
 # ---------------------------------------------------------------------------
@@ -1540,7 +1674,7 @@ def research_companies(
         name = str(a.get("Company", "")).strip()
         if not name:
             continue
-        key = name.upper()
+        key = _company_key(a)
         if key not in companies:
             companies[key] = {
                 "name": name,
@@ -1669,7 +1803,7 @@ def generate_weekly_synopsis(
     for i, a in enumerate(awards[:50]):
         cr = None
         if company_research:
-            cr = company_research.get(str(a.get("Company", "")).strip().upper())
+            cr = company_research.get(_company_key(a))
         digests.append(f"[{i+1}] {_award_digest(a, cr, solicitation_topics)}")
     digest_block = "\n\n".join(digests)
     if len(awards) > 50:
@@ -1751,7 +1885,7 @@ def generate_award_descriptions(
             idx = batch_start + i + 1
             cr = None
             if company_research:
-                cr = company_research.get(str(a.get("Company", "")).strip().upper())
+                cr = company_research.get(_company_key(a))
             digests.append(f"[{idx}] {_award_digest(a, cr, solicitation_topics)}")
 
         user = (
@@ -1935,13 +2069,13 @@ def generate_company_diligence(
 
     Returns a dict keyed by upper-cased company name.
     """
-    # Collect unique companies
+    # Collect unique companies (grouped by normalized name)
     companies: dict[str, list[dict]] = {}
     for a in awards:
         name = str(a.get("Company", "")).strip()
         if not name:
             continue
-        key = name.upper()
+        key = _company_key(a)
         companies.setdefault(key, []).append(a)
 
     company_items = list(companies.items())
@@ -2206,7 +2340,9 @@ def generate_pi_diligence(
         # Company web research for context
         cr = None
         if company_research:
-            cr = company_research.get(company.strip().upper())
+            cr = company_research.get(
+                _normalize_name(company, remove_suffixes=True) or company.strip().upper()
+            )
         if cr:
             context_parts.append(
                 f"Company context ({company}):\n{cr.summary}"
@@ -2359,7 +2495,9 @@ def generate_markdown(
         # Look up company research
         cr = None
         if company_research:
-            cr = company_research.get(company.strip().upper())
+            cr = company_research.get(
+                _normalize_name(company, remove_suffixes=True) or company.strip().upper()
+            )
 
         # Award header
         lines.append(f"### {i + 1}. {title}")
@@ -2374,7 +2512,7 @@ def generate_markdown(
 
         # Company diligence paragraph
         if company_diligence:
-            co_key = company.strip().upper()
+            co_key = _normalize_name(company, remove_suffixes=True) or company.strip().upper()
             if co_key in company_diligence:
                 lines.append(f"**Company Diligence — {company}:**")
                 lines.append(company_diligence[co_key])
@@ -2468,6 +2606,9 @@ def main():
 
     awards, freshness_warnings = fetch_weekly_awards(days=args.days)
 
+    # Clean, validate, and deduplicate
+    awards, cleaning_stats = clean_and_dedup_awards(awards)
+
     # Generate AI content if API key is available
     synopsis = None
     descriptions = None
@@ -2512,7 +2653,7 @@ def main():
                 name = str(a.get("Company", "")).strip()
                 if not name:
                     continue
-                key = name.upper()
+                key = _company_key(a)
                 if key not in co_names:
                     co_names[key] = {
                         "name": name,

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1750,17 +1750,29 @@ def generate_award_descriptions(
 
     system = (
         "You summarize SBIR/STTR awards in plain language. "
-        "For each award, write 2-3 sentences explaining what the project does "
-        "and why it matters. Use the abstract, the solicitation topic "
-        "description (which describes the government's research need that "
-        "this award responds to), associated federal spending data, and "
-        "company background research to inform your description. When a "
-        "solicitation topic description is provided, explain how the award "
-        "addresses the specific government need described in the "
-        "solicitation. Reference relevant company context "
-        "(e.g. their expertise, previous work, or market position) when it "
-        "adds value. Be specific about the technology and its intended "
-        "application. Avoid generic filler.\n\n"
+        "For each award, write 3-4 sentences. The first 1-2 sentences should "
+        "explain what the project does and why it matters — be specific about "
+        "the technology and its intended application.\n\n"
+        "When a solicitation topic description is provided, the final 1-2 "
+        "sentences MUST assess the alignment between the award and the "
+        "originating solicitation:\n"
+        "- Does the award's abstract directly address the technical "
+        "objectives laid out in the solicitation topic description?\n"
+        "- Is the award tightly scoped to the solicitation's stated research "
+        "need, or does it appear to address the topic tangentially or "
+        "partially?\n"
+        "- Are there aspects of the solicitation's requirements that the "
+        "award abstract does not appear to cover?\n"
+        "State the alignment clearly (e.g. 'This award directly addresses "
+        "the solicitation's need for...' or 'While the solicitation sought "
+        "X, this award focuses primarily on Y, which addresses only a "
+        "portion of the stated need.'). Do not hedge — make a specific "
+        "assessment based on the available text.\n\n"
+        "If no solicitation topic description is available, skip the "
+        "alignment assessment and focus on the technology, its application, "
+        "and company context.\n\n"
+        "Reference relevant company context (e.g. their expertise, previous "
+        "work, or market position) when it adds value. Avoid generic filler.\n\n"
         "Respond with a JSON object mapping the award number (as a string key) "
         'to its description string. Example: {"1": "Description.", "2": "Description."}'
     )
@@ -1776,11 +1788,12 @@ def generate_award_descriptions(
             digests.append(f"[{idx}] {_award_digest(a, cr, solicitation_topics)}")
 
         user = (
-            "Generate a brief plain-language description for each award below. "
-            "Each description should convey the technology, its application, "
-            "the significance of the federal investment, how it addresses the "
-            "solicitation's stated research need, and relevant company "
-            "context. Respond ONLY with a JSON object.\n\n" + "\n\n".join(digests)
+            "Generate a description for each award below. Each description "
+            "should convey the technology, its application, and — when "
+            "solicitation topic data is provided — a specific assessment of "
+            "how well the award aligns with the solicitation's stated "
+            "research need. Respond ONLY with a JSON object.\n\n"
+            + "\n\n".join(digests)
         )
 
         batch_label = f"{batch_start + 1}-{batch_start + len(batch)}"

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -597,14 +597,39 @@ class PIPublicationRecord:
 
 
 @dataclass
+class FederalAwardSummary:
+    """Summary of a single federal award from USAspending."""
+
+    award_id: str
+    description: str
+    amount: float
+    agency: str
+    award_type: str
+    start_date: str
+    cfda_number: str  # Assistance Listing Number
+
+
+@dataclass
 class PIFederalAwardRecord:
-    """Summary of a PI's company's federal awards from USAspending."""
+    """Summary of a PI's company's federal awards from USAspending.
+
+    Separates SBIR/STTR awards from non-SBIR federal work. Non-SBIR
+    awards to a company with SBIR history are potential follow-on /
+    Phase III commercialization signals.
+    """
 
     total_awards: int
     total_funding: float
     agencies: list[str]
     award_types: list[str]  # e.g. contracts, grants, IDVs
     date_range: tuple[str | None, str | None]
+    # Follow-on analysis
+    sbir_award_count: int = 0
+    sbir_funding: float = 0.0
+    non_sbir_award_count: int = 0
+    non_sbir_funding: float = 0.0
+    non_sbir_agencies: list[str] = field(default_factory=list)
+    non_sbir_sample_descriptions: list[str] = field(default_factory=list)
 
 
 def _split_pi_name(full_name: str) -> tuple[str, str]:
@@ -772,14 +797,44 @@ def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
     )
 
 
+def _is_sbir_award_type(description: str, cfda: str) -> bool:
+    """Heuristic to identify SBIR/STTR awards in USAspending results.
+
+    Uses CFDA/ALN numbers and description keywords. Mirrors the logic in
+    sbir_etl.models.sbir_identification but without the heavy import.
+    """
+    # Known SBIR/STTR Assistance Listing Numbers (subset of the most common)
+    sbir_alns = {
+        "10.212", "12.910", "12.911", "81.049", "43.002", "43.003",
+        "47.041", "47.084", "66.511", "66.512", "97.077", "20.701",
+        "84.133",
+        # HHS/NIH common ones
+        "93.855", "93.856", "93.859", "93.837", "93.847", "93.853",
+        "93.865", "93.866", "93.867", "93.879", "93.242", "93.273",
+        "93.279", "93.395", "93.393", "93.394", "93.396", "93.399",
+    }
+    if cfda and cfda.strip() in sbir_alns:
+        return True
+    # Keyword heuristic on description
+    desc_upper = description.upper()
+    if "SBIR" in desc_upper or "STTR" in desc_upper:
+        return True
+    if "SMALL BUSINESS INNOVATION RESEARCH" in desc_upper:
+        return True
+    if "SMALL BUSINESS TECHNOLOGY TRANSFER" in desc_upper:
+        return True
+    return False
+
+
 def lookup_company_federal_awards(
     company_name: str,
     uei: str | None = None,
 ) -> PIFederalAwardRecord | None:
     """Query USAspending for all federal awards to the PI's company.
 
-    This gives broader context than just SBIR — includes contracts,
-    grants, and other federal spending.
+    Separates SBIR/STTR awards from non-SBIR federal work. Non-SBIR
+    contracts and grants to a company with SBIR history are the strongest
+    signal of successful commercialization / Phase III transition.
     """
     if not company_name:
         return None
@@ -800,6 +855,8 @@ def lookup_company_federal_awards(
             "Awarding Agency",
             "Award Type",
             "Start Date",
+            "Description",
+            "CFDA Number",
         ],
         "page": 1,
         "limit": 100,
@@ -833,6 +890,13 @@ def lookup_company_federal_awards(
     total_funding = 0.0
     dates: list[str] = []
 
+    sbir_count = 0
+    sbir_funding = 0.0
+    non_sbir_count = 0
+    non_sbir_funding = 0.0
+    non_sbir_agencies: set[str] = set()
+    non_sbir_descriptions: list[str] = []
+
     for r in results:
         ag = r.get("Awarding Agency", "")
         if ag:
@@ -841,12 +905,33 @@ def lookup_company_federal_awards(
         if at:
             award_types.add(at)
         try:
-            total_funding += float(r.get("Award Amount", 0) or 0)
+            amount = float(r.get("Award Amount", 0) or 0)
         except (ValueError, TypeError):
-            pass
+            amount = 0.0
+        total_funding += amount
         d = r.get("Start Date", "")
         if d:
             dates.append(d)
+
+        desc = str(r.get("Description", "") or "")
+        cfda = str(r.get("CFDA Number", "") or "")
+
+        if _is_sbir_award_type(desc, cfda):
+            sbir_count += 1
+            sbir_funding += amount
+        else:
+            non_sbir_count += 1
+            non_sbir_funding += amount
+            if ag:
+                non_sbir_agencies.add(ag)
+            # Keep sample descriptions of non-SBIR awards (the follow-on signals)
+            if desc and len(non_sbir_descriptions) < 5:
+                # Truncate long descriptions
+                if len(desc) > 200:
+                    desc = desc[:200] + "..."
+                non_sbir_descriptions.append(
+                    f"{desc} ({ag}, {at}, ${amount:,.0f})"
+                )
 
     return PIFederalAwardRecord(
         total_awards=len(results),
@@ -854,6 +939,12 @@ def lookup_company_federal_awards(
         agencies=sorted(agencies),
         award_types=sorted(award_types),
         date_range=(min(dates) if dates else None, max(dates) if dates else None),
+        sbir_award_count=sbir_count,
+        sbir_funding=sbir_funding,
+        non_sbir_award_count=non_sbir_count,
+        non_sbir_funding=non_sbir_funding,
+        non_sbir_agencies=sorted(non_sbir_agencies),
+        non_sbir_sample_descriptions=non_sbir_descriptions,
     )
 
 
@@ -1812,13 +1903,31 @@ def _pi_external_digest(external: dict | None) -> str:
     else:
         parts.append("Academic publications: No Semantic Scholar profile found.")
 
-    # Federal awards (company-level)
+    # Federal awards (company-level) with SBIR vs non-SBIR breakdown
     fed: PIFederalAwardRecord | None = external.get("federal_awards")
     if fed:
-        parts.append(f"Company federal awards (USAspending): {fed.total_awards}")
+        parts.append(f"Company federal awards (USAspending): {fed.total_awards} total")
         parts.append(f"Company total federal funding: ${fed.total_funding:,.0f}")
+        parts.append(
+            f"SBIR/STTR awards: {fed.sbir_award_count} "
+            f"(${fed.sbir_funding:,.0f})"
+        )
+        parts.append(
+            f"Non-SBIR federal awards (potential follow-on/Phase III): "
+            f"{fed.non_sbir_award_count} (${fed.non_sbir_funding:,.0f})"
+        )
+        if fed.non_sbir_agencies:
+            parts.append(
+                f"Non-SBIR awarding agencies: {', '.join(fed.non_sbir_agencies)}"
+            )
+        if fed.non_sbir_sample_descriptions:
+            parts.append(
+                "Sample non-SBIR award descriptions (follow-on signals):"
+            )
+            for desc in fed.non_sbir_sample_descriptions:
+                parts.append(f"  - {desc}")
         if fed.agencies:
-            parts.append(f"Federal agencies: {', '.join(fed.agencies)}")
+            parts.append(f"All federal agencies: {', '.join(fed.agencies)}")
         if fed.award_types:
             parts.append(f"Award types: {', '.join(fed.award_types)}")
         if fed.date_range[0]:
@@ -1835,12 +1944,14 @@ def generate_company_diligence(
     company_research: dict[str, CompanyResearch] | None = None,
     company_history: dict[str, dict] | None = None,
     sam_entities: dict[str, SAMEntityRecord] | None = None,
+    company_federal_awards: dict[str, PIFederalAwardRecord] | None = None,
 ) -> dict[str, str]:
     """Generate a diligence paragraph for each unique awardee company.
 
     Combines web research, historical SBIR data, SAM.gov registration data,
-    and the current award context to produce a focused due-diligence
-    assessment per company.
+    USAspending federal award data (with SBIR vs non-SBIR breakdown), and
+    the current award context to produce a focused due-diligence assessment
+    per company.
 
     Returns a dict keyed by upper-cased company name.
     """
@@ -1873,11 +1984,16 @@ def generate_company_diligence(
         "business type, NAICS codes (industry classification), and any "
         "exclusion flags are important compliance signals. An expired or "
         "missing SAM registration is a red flag for federal contracting.\n"
-        "4. Commercialization signals — products, revenue, contracts, patents, "
-        "or partnerships that suggest ability to transition research\n"
+        "4. Commercialization and follow-on signals — the strongest evidence "
+        "of SBIR success is non-SBIR federal awards (contracts, grants) to "
+        "the same company, which represent Phase III transitions where SBIR "
+        "research led to production work. Also consider products, revenue, "
+        "patents, or partnerships. A company with many SBIR awards but zero "
+        "non-SBIR federal work may be an 'SBIR mill' that hasn't "
+        "commercialized.\n"
         "5. Risk factors — e.g. sole reliance on SBIR funding, narrow agency "
-        "base, lack of phase progression, SAM exclusions, or limited public "
-        "presence\n\n"
+        "base, lack of phase progression, SAM exclusions, no follow-on "
+        "contracts, or limited public presence\n\n"
         "Be specific and analytical. Do not use bullet points or headers. "
         "Write in a professional, neutral tone. If information is limited, "
         "note that as a risk factor."
@@ -1961,6 +2077,32 @@ def generate_company_diligence(
                 "contractor, or the lookup failed."
             )
 
+        # USAspending federal awards with SBIR vs non-SBIR breakdown
+        fed = company_federal_awards.get(key) if company_federal_awards else None
+        if fed:
+            fed_parts = [
+                f"Total federal awards (USAspending): {fed.total_awards}",
+                f"Total federal funding: ${fed.total_funding:,.0f}",
+                f"SBIR/STTR awards: {fed.sbir_award_count} (${fed.sbir_funding:,.0f})",
+                f"Non-SBIR federal awards (follow-on/Phase III signals): "
+                f"{fed.non_sbir_award_count} (${fed.non_sbir_funding:,.0f})",
+            ]
+            if fed.non_sbir_agencies:
+                fed_parts.append(
+                    f"Non-SBIR awarding agencies: {', '.join(fed.non_sbir_agencies)}"
+                )
+            if fed.non_sbir_sample_descriptions:
+                fed_parts.append("Sample non-SBIR awards:")
+                for d in fed.non_sbir_sample_descriptions:
+                    fed_parts.append(f"  - {d}")
+            context_parts.append(
+                "USAspending federal award data:\n" + "\n".join(fed_parts)
+            )
+        else:
+            context_parts.append(
+                "USAspending: No federal award records found for this company."
+            )
+
         user = (
             "Write a one-paragraph due-diligence assessment for this "
             "SBIR/STTR awardee company.\n\n" + "\n\n".join(context_parts)
@@ -2029,9 +2171,15 @@ def generate_pi_diligence(
         "when available. ORCID research keywords and funding entries help "
         "confirm domain alignment. If patents are assigned to different "
         "entities than the current company, note that.\n"
-        "4. Company federal funding context — broader federal awards to the "
-        "PI's company (contracts, grants) beyond SBIR show the company's "
-        "ability to win and execute federal work\n"
+        "4. Follow-on and commercialization — non-SBIR federal awards "
+        "(contracts, grants) to the PI's company are the strongest signal "
+        "of successful SBIR commercialization. These represent Phase III "
+        "transitions where SBIR research led to production contracts or "
+        "operational deployment. Compare the non-SBIR award descriptions "
+        "to the PI's SBIR research topics — thematic alignment confirms "
+        "genuine technology transition. A company with only SBIR awards "
+        "and no follow-on federal work may indicate research that hasn't "
+        "transitioned.\n"
         "5. Current project context — what are they working on now and how "
         "does it relate to their history and expertise?\n\n"
         "Be specific and analytical. Do not use bullet points or headers. "
@@ -2371,12 +2519,31 @@ def main():
             # SAM.gov entity registration data
             sam_data = lookup_sam_entities(awards)
 
+            # USAspending federal awards per company (SBIR vs non-SBIR)
+            print("Looking up company federal awards on USAspending...", file=sys.stderr)
+            co_fed: dict[str, PIFederalAwardRecord] = {}
+            co_names: dict[str, dict] = {}
+            for a in awards:
+                name = str(a.get("Company", "")).strip()
+                if not name:
+                    continue
+                key = name.upper()
+                if key not in co_names:
+                    co_names[key] = {
+                        "name": name,
+                        "uei": str(a.get("Company UEI", a.get("UEI", ""))).strip() or None,
+                    }
+            for key, info in co_names.items():
+                result = lookup_company_federal_awards(info["name"], info["uei"])
+                if result:
+                    co_fed[key] = result
+
             # Fetch external PI data (patents, publications, ORCID, federal awards)
             print("Looking up PI patents, publications, ORCID, and federal awards...", file=sys.stderr)
             pi_ext = lookup_pi_external_data(awards)
 
             co_diligence = generate_company_diligence(
-                api_key, awards, company_info, co_history, sam_data
+                api_key, awards, company_info, co_history, sam_data, co_fed
             )
             pi_dilig = generate_pi_diligence(
                 api_key, awards, pi_history, company_info, pi_ext

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -83,6 +83,11 @@ MAX_AWARDS_TO_DESCRIBE = int(os.environ.get("MAX_AWARDS_TO_DESCRIBE", "100"))
 OPENAI_MAX_RETRIES = 3
 OPENAI_RETRY_BACKOFF_BASE = 2  # seconds
 
+# External API endpoints for PI diligence
+PATENTSVIEW_API_URL = "https://search.patentsview.org/api/v1/patent"
+SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
+USASPENDING_API_URL = "https://api.usaspending.gov/api/v2"
+
 
 # ---------------------------------------------------------------------------
 # Data structures
@@ -562,6 +567,343 @@ def get_pi_history(
 
 
 # ---------------------------------------------------------------------------
+# PI external data lookups (patents, publications, federal awards)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PIPatentRecord:
+    """Summary of a PI's patent portfolio from PatentsView."""
+
+    total_patents: int
+    sample_titles: list[str]
+    assignees: list[str]
+    date_range: tuple[str | None, str | None]
+
+
+@dataclass
+class PIPublicationRecord:
+    """Summary of a PI's publication history from Semantic Scholar."""
+
+    total_papers: int
+    h_index: int | None
+    citation_count: int
+    sample_titles: list[str]
+    affiliations: list[str]
+
+
+@dataclass
+class PIFederalAwardRecord:
+    """Summary of a PI's company's federal awards from USAspending."""
+
+    total_awards: int
+    total_funding: float
+    agencies: list[str]
+    award_types: list[str]  # e.g. contracts, grants, IDVs
+    date_range: tuple[str | None, str | None]
+
+
+def _split_pi_name(full_name: str) -> tuple[str, str]:
+    """Split a PI name into (first, last) for API queries.
+
+    SBIR data typically stores names as 'First Last' or 'Last, First'.
+    """
+    full_name = full_name.strip()
+    if "," in full_name:
+        parts = [p.strip() for p in full_name.split(",", 1)]
+        return (parts[1], parts[0]) if len(parts) == 2 else (parts[0], "")
+    parts = full_name.split()
+    if len(parts) >= 2:
+        return (parts[0], parts[-1])
+    return (full_name, "")
+
+
+def lookup_pi_patents(pi_name: str, company_name: str | None = None) -> PIPatentRecord | None:
+    """Query PatentsView for patents where the PI is a named inventor.
+
+    Uses the PatentsView API inventor_name fields. Falls back to
+    filtering assignee results if the direct inventor query returns nothing.
+    """
+    first, last = _split_pi_name(pi_name)
+    if not last:
+        return None
+
+    api_key = os.environ.get("PATENTSVIEW_API_KEY", "")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["X-Api-Key"] = api_key
+
+    # Build query: search by inventor last name + first name
+    query: dict = {
+        "_and": [
+            {"inventor_name_last": last},
+        ]
+    }
+    if first:
+        query["_and"].append({"inventor_name_first": first})
+
+    payload = {
+        "q": query,
+        "f": [
+            "patent_number",
+            "patent_title",
+            "patent_date",
+            "assignee_organization",
+            "inventor_name_first",
+            "inventor_name_last",
+        ],
+        "o": {"page": 0, "per_page": 100},
+    }
+
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(PATENTSVIEW_API_URL, headers=headers, json=payload)
+            if resp.status_code != 200:
+                print(
+                    f"PatentsView API returned {resp.status_code} for {pi_name}",
+                    file=sys.stderr,
+                )
+                return None
+            data = resp.json()
+    except Exception as e:
+        print(f"PatentsView API error for {pi_name}: {e}", file=sys.stderr)
+        return None
+
+    patents = data.get("patents", [])
+    if not patents:
+        return None
+
+    titles = []
+    assignees: set[str] = set()
+    dates: list[str] = []
+
+    for p in patents:
+        t = p.get("patent_title", "")
+        if t and t not in titles and len(titles) < 5:
+            titles.append(t)
+        org = p.get("assignee_organization", "")
+        if org:
+            assignees.add(org)
+        d = p.get("patent_date", "")
+        if d:
+            dates.append(d)
+
+    return PIPatentRecord(
+        total_patents=len(patents),
+        sample_titles=titles,
+        assignees=sorted(assignees),
+        date_range=(min(dates) if dates else None, max(dates) if dates else None),
+    )
+
+
+def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
+    """Query Semantic Scholar for the PI's publication history.
+
+    Uses the author search endpoint to find the PI, then fetches
+    their publication summary.
+    """
+    first, last = _split_pi_name(pi_name)
+    if not last:
+        return None
+
+    search_query = f"{first} {last}".strip()
+
+    try:
+        # Step 1: Search for the author
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                f"{SEMANTIC_SCHOLAR_API_URL}/author/search",
+                params={"query": search_query, "limit": 5},
+            )
+            if resp.status_code != 200:
+                print(
+                    f"Semantic Scholar search returned {resp.status_code} for {pi_name}",
+                    file=sys.stderr,
+                )
+                return None
+            search_data = resp.json()
+
+        authors = search_data.get("data", [])
+        if not authors:
+            return None
+
+        # Pick the best match (first result from Semantic Scholar's ranking)
+        author = authors[0]
+        author_id = author.get("authorId")
+        if not author_id:
+            return None
+
+        # Step 2: Get author details with papers
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                f"{SEMANTIC_SCHOLAR_API_URL}/author/{author_id}",
+                params={
+                    "fields": "name,hIndex,citationCount,affiliations,papers.title,papers.year",
+                },
+            )
+            if resp.status_code != 200:
+                print(
+                    f"Semantic Scholar author detail returned {resp.status_code} for {pi_name}",
+                    file=sys.stderr,
+                )
+                return None
+            author_data = resp.json()
+
+    except Exception as e:
+        print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
+        return None
+
+    papers = author_data.get("papers", [])
+    sample_titles = [
+        p["title"] for p in papers[:5] if p.get("title")
+    ]
+    affiliations = author_data.get("affiliations", []) or []
+
+    return PIPublicationRecord(
+        total_papers=len(papers),
+        h_index=author_data.get("hIndex"),
+        citation_count=author_data.get("citationCount", 0),
+        sample_titles=sample_titles,
+        affiliations=affiliations,
+    )
+
+
+def lookup_company_federal_awards(
+    company_name: str,
+    uei: str | None = None,
+) -> PIFederalAwardRecord | None:
+    """Query USAspending for all federal awards to the PI's company.
+
+    This gives broader context than just SBIR — includes contracts,
+    grants, and other federal spending.
+    """
+    if not company_name:
+        return None
+
+    # Build filter — prefer UEI if available
+    filters: dict = {}
+    if uei:
+        filters["recipient_id"] = uei
+    else:
+        filters["recipient_search_text"] = [company_name]
+
+    payload = {
+        "filters": filters,
+        "fields": [
+            "Award ID",
+            "Recipient Name",
+            "Award Amount",
+            "Awarding Agency",
+            "Award Type",
+            "Start Date",
+        ],
+        "page": 1,
+        "limit": 100,
+        "sort": "Award Amount",
+        "order": "desc",
+    }
+
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(
+                f"{USASPENDING_API_URL}/search/spending_by_award/",
+                json=payload,
+            )
+            if resp.status_code != 200:
+                print(
+                    f"USAspending API returned {resp.status_code} for {company_name}",
+                    file=sys.stderr,
+                )
+                return None
+            data = resp.json()
+    except Exception as e:
+        print(f"USAspending API error for {company_name}: {e}", file=sys.stderr)
+        return None
+
+    results = data.get("results", [])
+    if not results:
+        return None
+
+    agencies: set[str] = set()
+    award_types: set[str] = set()
+    total_funding = 0.0
+    dates: list[str] = []
+
+    for r in results:
+        ag = r.get("Awarding Agency", "")
+        if ag:
+            agencies.add(ag)
+        at = r.get("Award Type", "")
+        if at:
+            award_types.add(at)
+        try:
+            total_funding += float(r.get("Award Amount", 0) or 0)
+        except (ValueError, TypeError):
+            pass
+        d = r.get("Start Date", "")
+        if d:
+            dates.append(d)
+
+    return PIFederalAwardRecord(
+        total_awards=len(results),
+        total_funding=total_funding,
+        agencies=sorted(agencies),
+        award_types=sorted(award_types),
+        date_range=(min(dates) if dates else None, max(dates) if dates else None),
+    )
+
+
+def lookup_pi_external_data(
+    awards: list[dict],
+) -> dict[str, dict]:
+    """Look up external data (patents, publications, federal awards) for each PI.
+
+    Returns a dict keyed by upper-cased PI name, with sub-keys:
+    - "patents": PIPatentRecord | None
+    - "publications": PIPublicationRecord | None
+    - "federal_awards": PIFederalAwardRecord | None
+    """
+    # Collect unique PIs with their company context
+    pis: dict[str, dict] = {}
+    for a in awards:
+        pi = str(a.get("PI Name", "")).strip()
+        if not pi:
+            continue
+        key = pi.upper()
+        if key not in pis:
+            pis[key] = {
+                "name": pi,
+                "company": str(a.get("Company", "")).strip(),
+                "uei": str(a.get("Company UEI", a.get("UEI", ""))).strip(),
+            }
+
+    results: dict[str, dict] = {}
+    total = len(pis)
+
+    for idx, (key, info) in enumerate(pis.items(), 1):
+        name = info["name"]
+        company = info["company"]
+        uei = info["uei"] or None
+
+        print(
+            f"Looking up external data for PI {idx}/{total}: {name}...",
+            file=sys.stderr,
+        )
+
+        patents = lookup_pi_patents(name, company)
+        publications = lookup_pi_publications(name)
+        federal_awards = lookup_company_federal_awards(company, uei)
+
+        results[key] = {
+            "patents": patents,
+            "publications": publications,
+            "federal_awards": federal_awards,
+        }
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Formatting helpers
 # ---------------------------------------------------------------------------
 
@@ -995,6 +1337,57 @@ def _pi_history_digest(name: str, history: dict | None) -> str:
     return "\n".join(parts)
 
 
+def _pi_external_digest(external: dict | None) -> str:
+    """Format a PI's external data (patents, publications, federal awards) for LLM context."""
+    if not external:
+        return "No external data available for this PI."
+
+    parts = []
+
+    # Patents
+    patents: PIPatentRecord | None = external.get("patents")
+    if patents:
+        parts.append(f"USPTO Patents as inventor: {patents.total_patents}")
+        if patents.assignees:
+            parts.append(f"Patent assignees: {', '.join(patents.assignees)}")
+        if patents.date_range[0]:
+            parts.append(f"Patent date range: {patents.date_range[0]} to {patents.date_range[1]}")
+        if patents.sample_titles:
+            parts.append("Sample patent titles: " + "; ".join(patents.sample_titles))
+    else:
+        parts.append("USPTO Patents: No patents found for this inventor name.")
+
+    # Publications
+    pubs: PIPublicationRecord | None = external.get("publications")
+    if pubs:
+        parts.append(f"Academic publications: {pubs.total_papers}")
+        if pubs.h_index is not None:
+            parts.append(f"h-index: {pubs.h_index}")
+        parts.append(f"Total citations: {pubs.citation_count}")
+        if pubs.affiliations:
+            parts.append(f"Affiliations: {', '.join(pubs.affiliations)}")
+        if pubs.sample_titles:
+            parts.append("Sample paper titles: " + "; ".join(pubs.sample_titles))
+    else:
+        parts.append("Academic publications: No Semantic Scholar profile found.")
+
+    # Federal awards (company-level)
+    fed: PIFederalAwardRecord | None = external.get("federal_awards")
+    if fed:
+        parts.append(f"Company federal awards (USAspending): {fed.total_awards}")
+        parts.append(f"Company total federal funding: ${fed.total_funding:,.0f}")
+        if fed.agencies:
+            parts.append(f"Federal agencies: {', '.join(fed.agencies)}")
+        if fed.award_types:
+            parts.append(f"Award types: {', '.join(fed.award_types)}")
+        if fed.date_range[0]:
+            parts.append(f"Federal award date range: {fed.date_range[0]} to {fed.date_range[1]}")
+    else:
+        parts.append("Company federal awards: No USAspending records found.")
+
+    return "\n".join(parts)
+
+
 def generate_company_diligence(
     api_key: str,
     awards: list[dict],
@@ -1107,11 +1500,13 @@ def generate_pi_diligence(
     awards: list[dict],
     pi_history: dict[str, dict] | None = None,
     company_research: dict[str, CompanyResearch] | None = None,
+    pi_external_data: dict[str, dict] | None = None,
 ) -> dict[str, str]:
     """Generate a diligence paragraph for each unique Principal Investigator.
 
-    Combines the PI's SBIR history, their current award context, and any
-    available company research to assess the PI's track record.
+    Combines the PI's SBIR history, patent portfolio, academic publications,
+    company federal award context, and web research to produce a comprehensive
+    assessment.
 
     Returns a dict keyed by upper-cased PI name.
     """
@@ -1136,16 +1531,21 @@ def generate_pi_diligence(
     system = (
         "You are a due-diligence analyst evaluating Principal Investigators "
         "(PIs) who lead SBIR/STTR federal innovation projects. Write exactly "
-        "one paragraph (3-5 sentences) assessing the PI. Cover:\n"
+        "one paragraph (4-6 sentences) assessing the PI. Cover:\n"
         "1. The PI's SBIR track record — number of awards, phase progression, "
         "breadth of agencies and topics\n"
         "2. Continuity — have they stayed with one company or moved between "
         "organizations? Is their research focus consistent or scattered?\n"
-        "3. Indicators of research depth — repeat awards in the same domain "
-        "suggest expertise; awards across unrelated fields may suggest "
-        "grant-chasing\n"
-        "4. Current project context — what are they working on now and how "
-        "does it relate to their history?\n\n"
+        "3. IP and publication output — patents filed as inventor and academic "
+        "publications demonstrate research productivity and domain expertise. "
+        "Note h-index and citation count when available as indicators of "
+        "scholarly impact. If patents are assigned to different entities than "
+        "the current company, note that.\n"
+        "4. Company federal funding context — broader federal awards to the "
+        "PI's company (contracts, grants) beyond SBIR show the company's "
+        "ability to win and execute federal work\n"
+        "5. Current project context — what are they working on now and how "
+        "does it relate to their history and expertise?\n\n"
         "Be specific and analytical. Do not use bullet points or headers. "
         "Write in a professional, neutral tone. If the PI has no prior "
         "history, note that this is their first known SBIR award."
@@ -1181,6 +1581,12 @@ def generate_pi_diligence(
             f"Historical SBIR record as PI:\n{_pi_history_digest(key, hist)}"
         )
 
+        # External data: patents, publications, federal awards
+        ext = pi_external_data.get(key) if pi_external_data else None
+        context_parts.append(
+            f"External research data:\n{_pi_external_digest(ext)}"
+        )
+
         # Company web research for context
         cr = None
         if company_research:
@@ -1192,7 +1598,7 @@ def generate_pi_diligence(
 
         user = (
             "Write a one-paragraph assessment of this Principal Investigator's "
-            "SBIR/STTR track record and current project.\n\n"
+            "SBIR/STTR track record, research output, and current project.\n\n"
             + "\n\n".join(context_parts)
         )
 
@@ -1464,11 +1870,15 @@ def main():
             print("Building historical PI context...", file=sys.stderr)
             pi_history = get_pi_history(awards)
 
+            # Fetch external PI data (patents, publications, federal awards)
+            print("Looking up PI patents, publications, and federal awards...", file=sys.stderr)
+            pi_ext = lookup_pi_external_data(awards)
+
             co_diligence = generate_company_diligence(
                 api_key, awards, company_info, co_history
             )
             pi_dilig = generate_pi_diligence(
-                api_key, awards, pi_history, company_info
+                api_key, awards, pi_history, company_info, pi_ext
             )
     elif not api_key and not args.no_ai:
         print(

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -281,19 +281,24 @@ def fetch_weekly_awards(days: int = 7) -> tuple[list[dict], list[str]]:
 # ---------------------------------------------------------------------------
 
 
-def get_company_history(
-    awards: list[dict],
-) -> dict[str, dict]:
-    """Extract historical SBIR award context per company from the full dataset.
+def _parse_date_safe(value) -> str | None:
+    """Parse a date value and return ISO format string, or None."""
+    parsed = _parse_date(value)
+    return parsed.isoformat() if parsed else None
 
-    Scans the complete CSV (not just the weekly window) to build a profile of
-    each company's SBIR track record: total awards, phases reached, agencies
-    served, cumulative funding, and date range.
 
-    Returns a dict keyed by upper-cased company name.
+def _resolve_shared_extractor(
+    source: DataSource | None = None,
+) -> tuple[DataSource, object | None, str | None]:
+    """Resolve a CSV path and optionally create a shared DuckDB extractor.
+
+    Returns (source, extractor_or_None, table_name_or_None).
     """
-    source = _resolve_csv_path()
+    if source is None:
+        source = _resolve_csv_path()
 
+    extractor = None
+    table = None
     if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
         extractor = SbirDuckDBExtractor(
             csv_path=source.path,
@@ -303,139 +308,204 @@ def get_company_history(
         extractor.import_csv()
         table = extractor._table_identifier
 
-        # Collect the set of companies we care about (from this week's awards)
-        company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
-        company_names.discard("")
+    return source, extractor, table
 
-        history: dict[str, dict] = {}
-        for name in company_names:
-            escaped = name.replace("'", "''")
-            query = (
-                f"SELECT \"Phase\", \"Agency\", \"Award Amount\", "
-                f"\"Proposal Award Date\", \"Award Title\", \"Program\" "
-                f"FROM {table} "
-                f"WHERE UPPER(\"Company\") = '{escaped}' "
-                f"ORDER BY \"Proposal Award Date\" DESC"
-            )
-            df = extractor.duckdb_client.execute_query_df(query)
-            if df.empty:
-                continue
 
-            phases = set()
-            agencies = set()
-            total_funding = 0.0
-            dates: list[str] = []
-            titles: list[str] = []
-            programs = set()
+def _build_history_from_df(
+    df,
+    group_col: str,
+    extra_set_cols: list[str] | None = None,
+) -> dict[str, dict]:
+    """Build history dicts from a DataFrame grouped by a column.
 
-            for _, row in df.iterrows():
-                phase = str(row.get("Phase", "")).strip()
-                if phase:
-                    phases.add(phase)
-                ag = str(row.get("Agency", "")).strip()
-                if ag:
-                    agencies.add(ag)
-                prog = str(row.get("Program", "")).strip()
-                if prog:
-                    programs.add(prog)
-                try:
-                    total_funding += float(
-                        str(row.get("Award Amount", "0"))
-                        .replace(",", "")
-                        .replace("$", "")
-                    )
-                except (ValueError, TypeError):
-                    pass
-                d = str(row.get("Proposal Award Date", "")).strip()
-                if d:
-                    dates.append(d)
-                t = str(row.get("Award Title", "")).strip()
-                if t and t not in titles:
-                    titles.append(t)
+    Used by both company and PI history to avoid duplicating aggregation logic.
+    """
+    df = df.fillna("")
+    history: dict[str, dict] = {}
 
-            history[name] = {
-                "total_awards": len(df),
-                "phases": sorted(phases),
-                "agencies": sorted(agencies),
-                "programs": sorted(programs),
-                "total_funding": total_funding,
-                "earliest_date": min(dates) if dates else None,
-                "latest_date": max(dates) if dates else None,
-                "sample_titles": titles[:5],
-            }
-
-        return history
-
-    # Fallback: scan the CSV with Python
-    import csv
-    import io
-
-    company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
-    company_names.discard("")
-    text = source.path.read_text(encoding="utf-8")
-    reader = csv.DictReader(io.StringIO(text))
-
-    history = {}
-    for row in reader:
-        name = str(row.get("Company", "")).strip().upper()
-        if name not in company_names:
+    for group_key, group_df in df.groupby(group_col, sort=False):
+        name = str(group_key).strip()
+        if not name:
             continue
-        if name not in history:
-            history[name] = {
-                "total_awards": 0,
-                "phases": set(),
-                "agencies": set(),
-                "programs": set(),
-                "total_funding": 0.0,
-                "dates": [],
-                "sample_titles": [],
-            }
-        h = history[name]
-        h["total_awards"] += 1
-        phase = str(row.get("Phase", "")).strip()
-        if phase:
-            h["phases"].add(phase)
-        ag = str(row.get("Agency", "")).strip()
-        if ag:
-            h["agencies"].add(ag)
-        prog = str(row.get("Program", "")).strip()
-        if prog:
-            h["programs"].add(prog)
-        try:
-            h["total_funding"] += float(
-                str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
-            )
-        except (ValueError, TypeError):
-            pass
-        d = str(row.get("Proposal Award Date", "")).strip()
-        if d:
-            h["dates"].append(d)
-        t = str(row.get("Award Title", "")).strip()
-        if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
-            h["sample_titles"].append(t)
 
-    # Normalize the set fields to sorted lists
-    for name, h in history.items():
-        dates = h.pop("dates", [])
-        h["phases"] = sorted(h["phases"])
-        h["agencies"] = sorted(h["agencies"])
-        h["programs"] = sorted(h["programs"])
-        h["earliest_date"] = min(dates) if dates else None
-        h["latest_date"] = max(dates) if dates else None
+        phases = {v for v in group_df["Phase"].astype(str).str.strip() if v}
+        agencies = {v for v in group_df["Agency"].astype(str).str.strip() if v}
+        programs = {v for v in group_df["Program"].astype(str).str.strip() if v}
+
+        total_funding = 0.0
+        for val in group_df["Award Amount"].astype(str):
+            try:
+                total_funding += float(val.replace(",", "").replace("$", ""))
+            except (ValueError, TypeError):
+                pass
+
+        parsed_dates = []
+        for val in group_df["Proposal Award Date"].astype(str).str.strip():
+            if val:
+                iso = _parse_date_safe(val)
+                if iso:
+                    parsed_dates.append(iso)
+
+        titles: list[str] = []
+        for t in group_df["Award Title"].astype(str).str.strip():
+            if t and t not in titles:
+                titles.append(t)
+
+        entry: dict = {
+            "total_awards": len(group_df),
+            "phases": sorted(phases),
+            "agencies": sorted(agencies),
+            "programs": sorted(programs),
+            "total_funding": total_funding,
+            "earliest_date": min(parsed_dates) if parsed_dates else None,
+            "latest_date": max(parsed_dates) if parsed_dates else None,
+            "sample_titles": titles[:5],
+        }
+
+        # Extra set columns (e.g. "Company" for PI history)
+        if extra_set_cols:
+            for col in extra_set_cols:
+                col_key = col.lower().replace(" ", "_") + "s"
+                entry[col_key] = sorted(
+                    {v for v in group_df[col].astype(str).str.strip() if v}
+                )
+
+        history[name] = entry
 
     return history
 
 
+def _build_history_from_csv(
+    source: DataSource,
+    target_names: set[str],
+    key_field: str,
+    extra_set_fields: list[str] | None = None,
+) -> dict[str, dict]:
+    """Build history dicts by streaming the CSV file.
+
+    Streams the file line-by-line to avoid loading the entire CSV into memory.
+    """
+    import csv
+
+    history: dict[str, dict] = {}
+    with source.path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = str(row.get(key_field, "")).strip().upper()
+            if name not in target_names:
+                continue
+            if name not in history:
+                entry: dict = {
+                    "total_awards": 0,
+                    "phases": set(),
+                    "agencies": set(),
+                    "programs": set(),
+                    "total_funding": 0.0,
+                    "dates": [],
+                    "sample_titles": [],
+                }
+                if extra_set_fields:
+                    for ef in extra_set_fields:
+                        entry[ef.lower().replace(" ", "_") + "s"] = set()
+                history[name] = entry
+
+            h = history[name]
+            h["total_awards"] += 1
+            for field, set_key in [("Phase", "phases"), ("Agency", "agencies"), ("Program", "programs")]:
+                val = str(row.get(field, "")).strip()
+                if val:
+                    h[set_key].add(val)
+            if extra_set_fields:
+                for ef in extra_set_fields:
+                    val = str(row.get(ef, "")).strip()
+                    if val:
+                        h[ef.lower().replace(" ", "_") + "s"].add(val)
+            try:
+                h["total_funding"] += float(
+                    str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
+                )
+            except (ValueError, TypeError):
+                pass
+            d = str(row.get("Proposal Award Date", "")).strip()
+            if d:
+                h["dates"].append(d)
+            t = str(row.get("Award Title", "")).strip()
+            if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
+                h["sample_titles"].append(t)
+
+    # Normalize sets to sorted lists and parse dates
+    for name, h in history.items():
+        raw_dates = h.pop("dates", [])
+        parsed_dates = [_parse_date_safe(d) for d in raw_dates]
+        parsed_dates = [d for d in parsed_dates if d]
+        h["earliest_date"] = min(parsed_dates) if parsed_dates else None
+        h["latest_date"] = max(parsed_dates) if parsed_dates else None
+        for key in ["phases", "agencies", "programs"]:
+            if isinstance(h[key], set):
+                h[key] = sorted(h[key])
+        if extra_set_fields:
+            for ef in extra_set_fields:
+                set_key = ef.lower().replace(" ", "_") + "s"
+                if isinstance(h.get(set_key), set):
+                    h[set_key] = sorted(h[set_key])
+
+    return history
+
+
+def get_company_history(
+    awards: list[dict],
+    source: DataSource | None = None,
+    extractor: object | None = None,
+    table: str | None = None,
+) -> dict[str, dict]:
+    """Extract historical SBIR award context per company from the full dataset.
+
+    Accepts optional shared source/extractor/table to avoid redundant CSV
+    downloads and DuckDB imports when called alongside get_pi_history().
+
+    Returns a dict keyed by upper-cased company name.
+    """
+    company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
+    company_names.discard("")
+    if not company_names:
+        return {}
+
+    if source is None:
+        source, extractor, table = _resolve_shared_extractor()
+
+    if extractor is not None and table is not None:
+        # Build IN clause with escaped names
+        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(company_names)]
+        in_clause = ", ".join(escaped)
+        query = (
+            f'SELECT UPPER("Company") AS _group_key, "Phase", "Agency", '
+            f'"Award Amount", "Proposal Award Date", "Award Title", "Program" '
+            f"FROM {table} "
+            f'WHERE UPPER("Company") IN ({in_clause}) '
+            f'ORDER BY "Proposal Award Date" DESC'
+        )
+        df = extractor.duckdb_client.execute_query_df(query)
+        if df.empty:
+            return {}
+        return _build_history_from_df(df, "_group_key")
+
+    # Fallback: stream the CSV
+    return _build_history_from_csv(source, company_names, "Company")
+
+
 def get_pi_history(
     awards: list[dict],
+    source: DataSource | None = None,
+    extractor: object | None = None,
+    table: str | None = None,
 ) -> dict[str, dict]:
     """Extract historical SBIR context per Principal Investigator.
 
-    Similar to get_company_history but keyed on PI name.
+    Accepts optional shared source/extractor/table to avoid redundant CSV
+    downloads and DuckDB imports.
+
     Returns a dict keyed by upper-cased PI name.
     """
-    source = _resolve_csv_path()
-
     pi_names = set()
     for a in awards:
         pi = str(a.get("PI Name", "")).strip().upper()
@@ -445,129 +515,26 @@ def get_pi_history(
     if not pi_names:
         return {}
 
-    if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
-        extractor = SbirDuckDBExtractor(
-            csv_path=source.path,
-            duckdb_path=":memory:",
-            use_s3_first=False,
+    if source is None:
+        source, extractor, table = _resolve_shared_extractor()
+
+    if extractor is not None and table is not None:
+        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(pi_names)]
+        in_clause = ", ".join(escaped)
+        query = (
+            f'SELECT UPPER("PI Name") AS _group_key, "Company", "Phase", "Agency", '
+            f'"Award Amount", "Proposal Award Date", "Award Title", "Program" '
+            f"FROM {table} "
+            f'WHERE UPPER("PI Name") IN ({in_clause}) '
+            f'ORDER BY "Proposal Award Date" DESC'
         )
-        extractor.import_csv()
-        table = extractor._table_identifier
+        df = extractor.duckdb_client.execute_query_df(query)
+        if df.empty:
+            return {}
+        return _build_history_from_df(df, "_group_key", extra_set_cols=["Company"])
 
-        history: dict[str, dict] = {}
-        for name in pi_names:
-            escaped = name.replace("'", "''")
-            query = (
-                f"SELECT \"Company\", \"Phase\", \"Agency\", \"Award Amount\", "
-                f"\"Proposal Award Date\", \"Award Title\", \"Program\" "
-                f"FROM {table} "
-                f"WHERE UPPER(\"PI Name\") = '{escaped}' "
-                f"ORDER BY \"Proposal Award Date\" DESC"
-            )
-            df = extractor.duckdb_client.execute_query_df(query)
-            if df.empty:
-                continue
-
-            companies = set()
-            phases = set()
-            agencies = set()
-            total_funding = 0.0
-            dates: list[str] = []
-            titles: list[str] = []
-
-            for _, row in df.iterrows():
-                co = str(row.get("Company", "")).strip()
-                if co:
-                    companies.add(co)
-                phase = str(row.get("Phase", "")).strip()
-                if phase:
-                    phases.add(phase)
-                ag = str(row.get("Agency", "")).strip()
-                if ag:
-                    agencies.add(ag)
-                try:
-                    total_funding += float(
-                        str(row.get("Award Amount", "0"))
-                        .replace(",", "")
-                        .replace("$", "")
-                    )
-                except (ValueError, TypeError):
-                    pass
-                d = str(row.get("Proposal Award Date", "")).strip()
-                if d:
-                    dates.append(d)
-                t = str(row.get("Award Title", "")).strip()
-                if t and t not in titles:
-                    titles.append(t)
-
-            history[name] = {
-                "total_awards": len(df),
-                "companies": sorted(companies),
-                "phases": sorted(phases),
-                "agencies": sorted(agencies),
-                "total_funding": total_funding,
-                "earliest_date": min(dates) if dates else None,
-                "latest_date": max(dates) if dates else None,
-                "sample_titles": titles[:5],
-            }
-
-        return history
-
-    # Fallback: CSV scan
-    import csv
-    import io
-
-    text = source.path.read_text(encoding="utf-8")
-    reader = csv.DictReader(io.StringIO(text))
-
-    history = {}
-    for row in reader:
-        name = str(row.get("PI Name", "")).strip().upper()
-        if name not in pi_names:
-            continue
-        if name not in history:
-            history[name] = {
-                "total_awards": 0,
-                "companies": set(),
-                "phases": set(),
-                "agencies": set(),
-                "total_funding": 0.0,
-                "dates": [],
-                "sample_titles": [],
-            }
-        h = history[name]
-        h["total_awards"] += 1
-        co = str(row.get("Company", "")).strip()
-        if co:
-            h["companies"].add(co)
-        phase = str(row.get("Phase", "")).strip()
-        if phase:
-            h["phases"].add(phase)
-        ag = str(row.get("Agency", "")).strip()
-        if ag:
-            h["agencies"].add(ag)
-        try:
-            h["total_funding"] += float(
-                str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
-            )
-        except (ValueError, TypeError):
-            pass
-        d = str(row.get("Proposal Award Date", "")).strip()
-        if d:
-            h["dates"].append(d)
-        t = str(row.get("Award Title", "")).strip()
-        if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
-            h["sample_titles"].append(t)
-
-    for name, h in history.items():
-        dates = h.pop("dates", [])
-        h["companies"] = sorted(h["companies"])
-        h["phases"] = sorted(h["phases"])
-        h["agencies"] = sorted(h["agencies"])
-        h["earliest_date"] = min(dates) if dates else None
-        h["latest_date"] = max(dates) if dates else None
-
-    return history
+    # Fallback: stream the CSV
+    return _build_history_from_csv(source, pi_names, "PI Name", extra_set_fields=["Company"])
 
 
 # ---------------------------------------------------------------------------
@@ -2523,11 +2490,16 @@ def main():
         )
 
         if not args.no_diligence:
-            # Build historical context for diligence
-            print("Building historical company context...", file=sys.stderr)
-            co_history = get_company_history(awards)
-            print("Building historical PI context...", file=sys.stderr)
-            pi_history = get_pi_history(awards)
+            # Build historical context for diligence.
+            # Resolve CSV and DuckDB extractor once, share across both queries.
+            print("Building historical context...", file=sys.stderr)
+            shared_source, shared_ext, shared_table = _resolve_shared_extractor()
+            co_history = get_company_history(
+                awards, shared_source, shared_ext, shared_table
+            )
+            pi_history = get_pi_history(
+                awards, shared_source, shared_ext, shared_table
+            )
 
             # SAM.gov entity registration data
             sam_data = lookup_sam_entities(awards)

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -337,17 +337,14 @@ def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
     stats: dict = {
         "input": len(awards),
         "validation_errors": 0,
-        "duplicates": 0,
     }
 
-    # --- Step 1: Validate using sbir_etl's validate_sbir_award_record ---
     cleaned: list[dict] = []
 
     if _validate_record is not None:
         for i, a in enumerate(awards):
             row = pd.Series(a)
             issues = _validate_record(row, i)
-            # Drop rows with ERROR-severity issues
             errors = [
                 iss for iss in issues if iss.severity.value == "error"
             ]
@@ -374,28 +371,13 @@ def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
             )
             cleaned.append(a)
 
-    # --- Step 2: Deduplicate by Contract number ---
-    seen_contracts: set[str] = set()
-    deduped: list[dict] = []
-
-    for a in cleaned:
-        contract = str(a.get("Contract", "")).strip()
-        if contract:
-            if contract in seen_contracts:
-                stats["duplicates"] += 1
-                continue
-            seen_contracts.add(contract)
-        deduped.append(a)
-
-    stats["output"] = len(deduped)
+    stats["output"] = len(cleaned)
     stats["total_removed"] = stats["input"] - stats["output"]
 
     if stats["total_removed"] > 0:
         print(
             f"Data cleaning: {stats['input']} -> {stats['output']} awards "
-            f"(removed {stats['total_removed']}: "
-            f"{stats['validation_errors']} failed validation, "
-            f"{stats['duplicates']} duplicates)",
+            f"({stats['validation_errors']} failed validation)",
             file=sys.stderr,
         )
     else:
@@ -404,7 +386,7 @@ def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
             file=sys.stderr,
         )
 
-    return deduped, stats
+    return cleaned, stats
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -71,6 +71,7 @@ USASPENDING_SEARCH_URL = "https://www.usaspending.gov/search"
 OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions"
 OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 OPENAI_MODEL = "gpt-4.1-mini"
+OPENAI_DILIGENCE_MODEL = "gpt-4.1"
 
 # Batch size for per-award descriptions (awards per API call)
 DESCRIPTION_BATCH_SIZE = 10
@@ -83,10 +84,11 @@ MAX_AWARDS_TO_DESCRIBE = int(os.environ.get("MAX_AWARDS_TO_DESCRIBE", "100"))
 OPENAI_MAX_RETRIES = 3
 OPENAI_RETRY_BACKOFF_BASE = 2  # seconds
 
-# External API endpoints for PI diligence
+# External API endpoints for PI diligence and solicitation lookup
 PATENTSVIEW_API_URL = "https://search.patentsview.org/api/v1/patent"
 SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
 USASPENDING_API_URL = "https://api.usaspending.gov/api/v2"
+SBIR_GOV_API_URL = "https://api.www.sbir.gov/public/api"
 
 
 # ---------------------------------------------------------------------------
@@ -904,6 +906,113 @@ def lookup_pi_external_data(
 
 
 # ---------------------------------------------------------------------------
+# Solicitation topic lookup
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SolicitationTopic:
+    """Solicitation topic details from SBIR.gov API."""
+
+    topic_code: str
+    solicitation_number: str
+    title: str
+    description: str | None
+    agency: str | None
+    program: str | None
+
+
+def fetch_solicitation_topics(awards: list[dict]) -> dict[str, SolicitationTopic]:
+    """Fetch solicitation topic titles and descriptions from SBIR.gov API.
+
+    Queries the SBIR.gov solicitations endpoint for each unique topic code
+    found in this week's awards. Returns a dict keyed by topic code.
+    """
+    # Collect unique topic codes
+    topic_codes: dict[str, str] = {}  # topic_code -> solicitation_number
+    for a in awards:
+        tc = str(a.get("Topic Code", "")).strip()
+        sol = str(a.get("Solicitation Number", "")).strip()
+        if tc and tc not in topic_codes:
+            topic_codes[tc] = sol
+
+    if not topic_codes:
+        return {}
+
+    results: dict[str, SolicitationTopic] = {}
+    total = len(topic_codes)
+    print(f"Fetching {total} solicitation topics from SBIR.gov...", file=sys.stderr)
+
+    # Query by solicitation year to reduce result sets.
+    # Group topic codes by their solicitation number prefix to batch queries.
+    sol_years: dict[int, list[str]] = {}
+    for tc, sol in topic_codes.items():
+        # Extract year from solicitation number (e.g. "SBIR-2023.1" -> 2023)
+        year = None
+        for part in sol.replace("-", " ").replace(".", " ").split():
+            if part.isdigit() and len(part) == 4:
+                year = int(part)
+                break
+        if year:
+            sol_years.setdefault(year, []).append(tc)
+        else:
+            sol_years.setdefault(0, []).append(tc)
+
+    for year, codes in sol_years.items():
+        params: dict[str, str | int] = {"rows": 500, "start": 0}
+        if year > 0:
+            params["year"] = year
+
+        try:
+            with httpx.Client(timeout=30) as client:
+                resp = client.get(
+                    f"{SBIR_GOV_API_URL}/solicitations", params=params
+                )
+                if resp.status_code != 200:
+                    print(
+                        f"SBIR.gov API returned {resp.status_code} for year={year}",
+                        file=sys.stderr,
+                    )
+                    continue
+                data = resp.json()
+        except Exception as e:
+            print(f"SBIR.gov API error for year={year}: {e}", file=sys.stderr)
+            continue
+
+        topics = data if isinstance(data, list) else (
+            data.get("results") or data.get("data") or []
+        )
+
+        codes_set = set(codes)
+        for topic in topics:
+            tc = topic.get("topicCode") or topic.get("topic_code") or ""
+            if tc in codes_set and tc not in results:
+                desc = topic.get("topicDescription") or topic.get("description")
+                # Truncate very long descriptions for LLM context
+                if desc and len(desc) > 3000:
+                    desc = desc[:3000] + "..."
+                results[tc] = SolicitationTopic(
+                    topic_code=tc,
+                    solicitation_number=(
+                        topic.get("solicitationNumber")
+                        or topic.get("solicitation_number")
+                        or topic_codes.get(tc, "")
+                    ),
+                    title=topic.get("topicTitle") or topic.get("title") or "",
+                    description=desc,
+                    agency=topic.get("agency"),
+                    program=topic.get("program"),
+                )
+
+    found = len(results)
+    print(
+        f"Fetched {found}/{total} solicitation topics from SBIR.gov",
+        file=sys.stderr,
+    )
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Formatting helpers
 # ---------------------------------------------------------------------------
 
@@ -1007,15 +1116,21 @@ def _openai_request_with_retry(
     return None
 
 
-def _openai_chat(api_key: str, system: str, user: str) -> str | None:
+def _openai_chat(
+    api_key: str,
+    system: str,
+    user: str,
+    model: str = OPENAI_MODEL,
+    temperature: float = 0.3,
+) -> str | None:
     """Call the OpenAI chat completions API. Returns the assistant message text."""
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json",
     }
     payload = {
-        "model": OPENAI_MODEL,
-        "temperature": 0.3,
+        "model": model,
+        "temperature": temperature,
         "messages": [
             {"role": "system", "content": system},
             {"role": "user", "content": user},
@@ -1123,7 +1238,11 @@ def research_companies(
     return results
 
 
-def _award_digest(award: dict, company_research: CompanyResearch | None = None) -> str:
+def _award_digest(
+    award: dict,
+    company_research: CompanyResearch | None = None,
+    solicitation_topics: dict[str, SolicitationTopic] | None = None,
+) -> str:
     """Build a compact text digest of an award for LLM context."""
     parts = [
         f"Title: {award.get('Award Title', 'N/A')}",
@@ -1148,6 +1267,19 @@ def _award_digest(award: dict, company_research: CompanyResearch | None = None) 
     solicitation_year = str(award.get("Solicitation Year", "")).strip()
     if solicitation_year:
         parts.append(f"Solicitation Year: {solicitation_year}")
+
+    # Solicitation topic context (title + description from SBIR.gov API)
+    if solicitation_topics and topic_code:
+        topic = solicitation_topics.get(topic_code)
+        if topic:
+            if topic.title:
+                parts.append(f"Solicitation Topic Title: {topic.title}")
+            if topic.description:
+                parts.append(
+                    f"Solicitation Topic Description (government research need): "
+                    f"{topic.description}"
+                )
+
     contract = str(award.get("Contract", "")).strip()
     if contract:
         parts.append(f"Contract: {contract}")
@@ -1172,6 +1304,7 @@ def generate_weekly_synopsis(
     awards: list[dict],
     days: int,
     company_research: dict[str, CompanyResearch] | None = None,
+    solicitation_topics: dict[str, SolicitationTopic] | None = None,
 ) -> str | None:
     """Generate a two-paragraph synopsis of all weekly award activity."""
     if not awards:
@@ -1194,7 +1327,7 @@ def generate_weekly_synopsis(
         cr = None
         if company_research:
             cr = company_research.get(str(a.get("Company", "")).strip().upper())
-        digests.append(f"[{i+1}] {_award_digest(a, cr)}")
+        digests.append(f"[{i+1}] {_award_digest(a, cr, solicitation_topics)}")
     digest_block = "\n\n".join(digests)
     if len(awards) > 50:
         digest_block += f"\n\n... and {len(awards) - 50} additional awards."
@@ -1223,6 +1356,7 @@ def generate_award_descriptions(
     api_key: str,
     awards: list[dict],
     company_research: dict[str, CompanyResearch] | None = None,
+    solicitation_topics: dict[str, SolicitationTopic] | None = None,
 ) -> dict[int, str]:
     """Generate a brief description for each award using batched API calls."""
     descriptions: dict[int, str] = {}
@@ -1241,9 +1375,13 @@ def generate_award_descriptions(
     system = (
         "You summarize SBIR/STTR awards in plain language. "
         "For each award, write 2-3 sentences explaining what the project does "
-        "and why it matters. Use the abstract, solicitation context, "
-        "associated federal spending data, and company background research "
-        "to inform your description. Reference relevant company context "
+        "and why it matters. Use the abstract, the solicitation topic "
+        "description (which describes the government's research need that "
+        "this award responds to), associated federal spending data, and "
+        "company background research to inform your description. When a "
+        "solicitation topic description is provided, explain how the award "
+        "addresses the specific government need described in the "
+        "solicitation. Reference relevant company context "
         "(e.g. their expertise, previous work, or market position) when it "
         "adds value. Be specific about the technology and its intended "
         "application. Avoid generic filler.\n\n"
@@ -1259,12 +1397,13 @@ def generate_award_descriptions(
             cr = None
             if company_research:
                 cr = company_research.get(str(a.get("Company", "")).strip().upper())
-            digests.append(f"[{idx}] {_award_digest(a, cr)}")
+            digests.append(f"[{idx}] {_award_digest(a, cr, solicitation_topics)}")
 
         user = (
             "Generate a brief plain-language description for each award below. "
             "Each description should convey the technology, its application, "
-            "the significance of the federal investment, and relevant company "
+            "the significance of the federal investment, how it addresses the "
+            "solicitation's stated research need, and relevant company "
             "context. Respond ONLY with a JSON object.\n\n" + "\n\n".join(digests)
         )
 
@@ -1488,7 +1627,10 @@ def generate_company_diligence(
             f"Generating company diligence {idx}/{total}: {display_name}...",
             file=sys.stderr,
         )
-        result = _openai_chat(api_key, system, user)
+        result = _openai_chat(
+            api_key, system, user,
+            model=OPENAI_DILIGENCE_MODEL, temperature=0.4,
+        )
         if result:
             results[key] = result
 
@@ -1606,7 +1748,10 @@ def generate_pi_diligence(
             f"Generating PI diligence {idx}/{total}: {display_name}...",
             file=sys.stderr,
         )
-        result = _openai_chat(api_key, system, user)
+        result = _openai_chat(
+            api_key, system, user,
+            model=OPENAI_DILIGENCE_MODEL, temperature=0.4,
+        )
         if result:
             results[key] = result
 
@@ -1857,11 +2002,18 @@ def main():
     pi_dilig: dict[str, str] | None = None
     api_key = os.environ.get("OPENAI_API_KEY", "")
 
+    # Fetch solicitation topic context from SBIR.gov API (no API key needed)
+    sol_topics = fetch_solicitation_topics(awards) if awards else None
+
     if api_key and not args.no_ai:
         if not args.no_company_research:
             company_info = research_companies(api_key, awards)
-        synopsis = generate_weekly_synopsis(api_key, awards, args.days, company_info)
-        descriptions = generate_award_descriptions(api_key, awards, company_info)
+        synopsis = generate_weekly_synopsis(
+            api_key, awards, args.days, company_info, sol_topics
+        )
+        descriptions = generate_award_descriptions(
+            api_key, awards, company_info, sol_topics
+        )
 
         if not args.no_diligence:
             # Build historical context for diligence

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -43,6 +43,7 @@ try:
     from sbir_etl.utils.cloud_storage import find_latest_sbir_awards, get_s3_bucket_from_env
     from sbir_etl.utils.date_utils import parse_date as _parse_date
     from sbir_etl.utils.text_normalization import normalize_name as _normalize_name
+    from sbir_etl.validators.sbir_awards import validate_sbir_award_record as _validate_record
 
     _HAS_SBIR_ETL = True
 except ImportError:
@@ -63,6 +64,8 @@ except ImportError:
             except ValueError:
                 continue
         return None
+
+    _validate_record = None  # type: ignore[assignment]
 
     def _normalize_name(name, *, remove_suffixes=False, **_kwargs):  # type: ignore[misc]
         """Minimal fallback company name normalizer."""
@@ -301,8 +304,7 @@ def fetch_weekly_awards(days: int = 7) -> tuple[list[dict], list[str]]:
 # Data cleaning & deduplication
 # ---------------------------------------------------------------------------
 
-VALID_PHASES = {"Phase I", "Phase II", "Phase III"}
-VALID_PROGRAMS = {"SBIR", "STTR"}
+_FALLBACK_VALID_PHASES = {"Phase I", "Phase II", "Phase III"}
 
 
 def _company_key(award: dict) -> str:
@@ -320,62 +322,59 @@ def _company_key(award: dict) -> str:
 def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
     """Validate, normalize, and deduplicate weekly awards.
 
-    Runs the sbir_etl validation and normalization pipeline (with graceful
-    fallback) against the raw award list:
+    Uses the existing sbir_etl validation pipeline when available:
+    - validate_sbir_award_record() for per-row validation (phase, amount,
+      required fields, format checks, date consistency, etc.)
+    - normalize_name() for company name normalization
 
-    1. **Validate** — drop records with invalid phase, non-numeric amount,
-       or missing company name.
-    2. **Normalize** — standardize company names using normalize_name() so
-       that "ACME, Inc." and "ACME INCORPORATED" map to the same entity.
-       Original names are preserved; a ``_normalized_company`` key is added.
-    3. **Deduplicate** — remove exact duplicates by Contract number (the
-       most reliable unique identifier in the SBIR CSV).
+    Falls back to basic checks when sbir_etl is not installed.
 
     Returns:
-        (cleaned_awards, stats) where stats is a dict with counts of
-        records removed at each stage.
+        (cleaned_awards, stats) where stats is a dict with counts.
     """
+    import pandas as pd
+
     stats: dict = {
         "input": len(awards),
-        "invalid_phase": 0,
-        "invalid_amount": 0,
-        "missing_company": 0,
+        "validation_errors": 0,
         "duplicates": 0,
     }
 
+    # --- Step 1: Validate using sbir_etl's validate_sbir_award_record ---
     cleaned: list[dict] = []
 
-    for a in awards:
-        # Validate company name
-        company = str(a.get("Company", "")).strip()
-        if not company:
-            stats["missing_company"] += 1
-            continue
-
-        # Validate phase
-        phase = str(a.get("Phase", "")).strip()
-        if phase and phase not in VALID_PHASES:
-            stats["invalid_phase"] += 1
-            continue
-
-        # Validate award amount (must be numeric and positive)
-        amount_raw = str(a.get("Award Amount", "")).replace(",", "").replace("$", "").strip()
-        if amount_raw:
-            try:
-                amount_val = float(amount_raw)
-                if amount_val <= 0:
-                    stats["invalid_amount"] += 1
-                    continue
-            except (ValueError, TypeError):
-                stats["invalid_amount"] += 1
+    if _validate_record is not None:
+        for i, a in enumerate(awards):
+            row = pd.Series(a)
+            issues = _validate_record(row, i)
+            # Drop rows with ERROR-severity issues
+            errors = [
+                iss for iss in issues if iss.severity.value == "error"
+            ]
+            if errors:
+                stats["validation_errors"] += 1
                 continue
+            a["_normalized_company"] = _normalize_name(
+                str(a.get("Company", "")), remove_suffixes=True
+            )
+            cleaned.append(a)
+    else:
+        # Minimal fallback when sbir_etl is not installed
+        for a in awards:
+            company = str(a.get("Company", "")).strip()
+            if not company:
+                stats["validation_errors"] += 1
+                continue
+            phase = str(a.get("Phase", "")).strip()
+            if phase and phase not in _FALLBACK_VALID_PHASES:
+                stats["validation_errors"] += 1
+                continue
+            a["_normalized_company"] = _normalize_name(
+                company, remove_suffixes=True
+            )
+            cleaned.append(a)
 
-        # Normalize company name for downstream grouping
-        a["_normalized_company"] = _normalize_name(company, remove_suffixes=True)
-
-        cleaned.append(a)
-
-    # Deduplicate by Contract number (most reliable SBIR award identifier)
+    # --- Step 2: Deduplicate by Contract number ---
     seen_contracts: set[str] = set()
     deduped: list[dict] = []
 
@@ -393,11 +392,9 @@ def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
 
     if stats["total_removed"] > 0:
         print(
-            f"Data cleaning: {stats['input']} → {stats['output']} awards "
+            f"Data cleaning: {stats['input']} -> {stats['output']} awards "
             f"(removed {stats['total_removed']}: "
-            f"{stats['invalid_phase']} invalid phase, "
-            f"{stats['invalid_amount']} invalid amount, "
-            f"{stats['missing_company']} missing company, "
+            f"{stats['validation_errors']} failed validation, "
             f"{stats['duplicates']} duplicates)",
             file=sys.stderr,
         )

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -89,6 +89,8 @@ PATENTSVIEW_API_URL = "https://search.patentsview.org/api/v1/patent"
 SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
 USASPENDING_API_URL = "https://api.usaspending.gov/api/v2"
 SBIR_GOV_API_URL = "https://api.www.sbir.gov/public/api"
+SAM_GOV_API_URL = "https://api.sam.gov/entity-information/v3/entities"
+ORCID_API_URL = "https://pub.orcid.org/v3.0"
 
 
 # ---------------------------------------------------------------------------
@@ -858,11 +860,12 @@ def lookup_company_federal_awards(
 def lookup_pi_external_data(
     awards: list[dict],
 ) -> dict[str, dict]:
-    """Look up external data (patents, publications, federal awards) for each PI.
+    """Look up external data (patents, publications, ORCID, federal awards) for each PI.
 
     Returns a dict keyed by upper-cased PI name, with sub-keys:
     - "patents": PIPatentRecord | None
     - "publications": PIPublicationRecord | None
+    - "orcid": ORCIDRecord | None
     - "federal_awards": PIFederalAwardRecord | None
     """
     # Collect unique PIs with their company context
@@ -894,15 +897,297 @@ def lookup_pi_external_data(
 
         patents = lookup_pi_patents(name, company)
         publications = lookup_pi_publications(name)
+        orcid = lookup_pi_orcid(name)
         federal_awards = lookup_company_federal_awards(company, uei)
 
         results[key] = {
             "patents": patents,
             "publications": publications,
+            "orcid": orcid,
             "federal_awards": federal_awards,
         }
 
     return results
+
+
+# ---------------------------------------------------------------------------
+# SAM.gov entity lookup (company diligence)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SAMEntityRecord:
+    """Key SAM.gov entity registration data for diligence."""
+
+    uei: str
+    legal_business_name: str
+    dba_name: str | None
+    registration_status: str | None
+    expiration_date: str | None
+    business_type: str | None
+    entity_structure: str | None
+    naics_codes: list[str]
+    cage_code: str | None
+    exclusion_status: str | None
+    state: str | None
+    congressional_district: str | None
+
+
+def lookup_sam_entity(
+    company_name: str,
+    uei: str | None = None,
+    cage: str | None = None,
+) -> SAMEntityRecord | None:
+    """Query SAM.gov Entity Information API for company registration data.
+
+    Tries UEI first (exact match), then CAGE, then name search.
+    Requires SAM_GOV_API_KEY environment variable.
+    """
+    api_key = os.environ.get("SAM_GOV_API_KEY", "")
+    if not api_key:
+        return None
+
+    headers = {"X-Api-Key": api_key, "Accept": "application/json"}
+
+    def _try_query(params: dict) -> dict | None:
+        try:
+            with httpx.Client(timeout=30) as client:
+                resp = client.get(SAM_GOV_API_URL, headers=headers, params=params)
+                if resp.status_code != 200:
+                    return None
+                data = resp.json()
+                results = data.get("entityData", data.get("results", []))
+                if isinstance(results, list) and results:
+                    return results[0]
+                if isinstance(results, dict):
+                    return results
+        except Exception as e:
+            print(f"SAM.gov API error: {e}", file=sys.stderr)
+        return None
+
+    entity = None
+
+    # Try UEI first (most reliable)
+    if uei:
+        entity = _try_query({"ueiSAM": uei})
+
+    # Try CAGE code
+    if not entity and cage:
+        entity = _try_query({"cageCode": cage})
+
+    # Fall back to name search
+    if not entity and company_name:
+        entity = _try_query({"legalBusinessName": company_name, "registrationStatus": "A"})
+
+    if not entity:
+        return None
+
+    # Extract fields — SAM.gov API nests data under various keys
+    core = entity.get("entityRegistration", entity)
+    address = entity.get("coreData", {}).get("physicalAddress", {})
+    business_types = entity.get("coreData", {}).get("businessTypes", {})
+
+    # Extract NAICS codes
+    naics_list = entity.get("coreData", {}).get("naicsCodeList", [])
+    if isinstance(naics_list, list):
+        naics_codes = [
+            str(n.get("naicsCode", "")) for n in naics_list if n.get("naicsCode")
+        ]
+    else:
+        naics_codes = []
+
+    return SAMEntityRecord(
+        uei=core.get("ueiSAM", ""),
+        legal_business_name=core.get("legalBusinessName", ""),
+        dba_name=core.get("dbaName"),
+        registration_status=core.get("registrationStatus"),
+        expiration_date=core.get("registrationExpirationDate"),
+        business_type=(
+            business_types.get("businessTypeList", [{}])[0].get("businessType")
+            if isinstance(business_types.get("businessTypeList"), list)
+            and business_types.get("businessTypeList")
+            else None
+        ),
+        entity_structure=core.get("entityStructureDesc"),
+        naics_codes=naics_codes,
+        cage_code=core.get("cageCode"),
+        exclusion_status=core.get("exclusionStatusFlag"),
+        state=address.get("stateOrProvinceCode"),
+        congressional_district=address.get("congressionalDistrict"),
+    )
+
+
+def lookup_sam_entities(
+    awards: list[dict],
+) -> dict[str, SAMEntityRecord]:
+    """Look up SAM.gov registration data for each unique company.
+
+    Returns a dict keyed by upper-cased company name.
+    """
+    api_key = os.environ.get("SAM_GOV_API_KEY", "")
+    if not api_key:
+        print(
+            "SAM_GOV_API_KEY not set — skipping SAM.gov entity lookups.",
+            file=sys.stderr,
+        )
+        return {}
+
+    companies: dict[str, dict] = {}
+    for a in awards:
+        name = str(a.get("Company", "")).strip()
+        if not name:
+            continue
+        key = name.upper()
+        if key not in companies:
+            companies[key] = {
+                "name": name,
+                "uei": str(a.get("Company UEI", a.get("UEI", ""))).strip() or None,
+                "cage": str(a.get("Company CAGE", a.get("CAGE", ""))).strip() or None,
+            }
+
+    results: dict[str, SAMEntityRecord] = {}
+    total = len(companies)
+    print(f"Looking up {total} companies on SAM.gov...", file=sys.stderr)
+
+    for idx, (key, info) in enumerate(companies.items(), 1):
+        if idx % 10 == 0 or idx == total:
+            print(f"SAM.gov lookup {idx}/{total}...", file=sys.stderr)
+        record = lookup_sam_entity(info["name"], info["uei"], info["cage"])
+        if record:
+            results[key] = record
+
+    print(f"Found {len(results)}/{total} companies on SAM.gov", file=sys.stderr)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# ORCID API lookup (PI diligence)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ORCIDRecord:
+    """Key data from an ORCID researcher profile."""
+
+    orcid_id: str
+    given_name: str | None
+    family_name: str | None
+    affiliations: list[str]
+    works_count: int
+    sample_work_titles: list[str]
+    funding_count: int
+    keywords: list[str]
+
+
+def lookup_pi_orcid(pi_name: str) -> ORCIDRecord | None:
+    """Search the ORCID public API for a PI's researcher profile.
+
+    Uses the expanded search endpoint to find by name, then fetches
+    the full profile for works, affiliations, and funding.
+    """
+    first, last = _split_pi_name(pi_name)
+    if not last:
+        return None
+
+    headers = {"Accept": "application/json"}
+
+    try:
+        # Step 1: Search for the researcher by name
+        query = f"family-name:{last}"
+        if first:
+            query += f"+AND+given-names:{first}"
+
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                f"{ORCID_API_URL}/expanded-search/",
+                headers=headers,
+                params={"q": query, "rows": 5},
+            )
+            if resp.status_code != 200:
+                return None
+            search_data = resp.json()
+
+        results = search_data.get("expanded-result", [])
+        if not results:
+            return None
+
+        # Pick the best match (first result)
+        best = results[0]
+        orcid_id = best.get("orcid-id", "")
+        if not orcid_id:
+            return None
+
+        # Step 2: Fetch full profile
+        with httpx.Client(timeout=30) as client:
+            resp = client.get(
+                f"{ORCID_API_URL}/{orcid_id}/record",
+                headers=headers,
+            )
+            if resp.status_code != 200:
+                return None
+            profile = resp.json()
+
+    except Exception as e:
+        print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
+        return None
+
+    # Extract affiliations
+    affiliations: list[str] = []
+    affiliation_groups = (
+        profile.get("activities-summary", {})
+        .get("employments", {})
+        .get("affiliation-group", [])
+    )
+    for group in affiliation_groups[:10]:
+        summaries = group.get("summaries", [])
+        for s in summaries:
+            emp = s.get("employment-summary", {})
+            org = emp.get("organization", {})
+            org_name = org.get("name", "")
+            if org_name and org_name not in affiliations:
+                affiliations.append(org_name)
+
+    # Extract works (publications)
+    works_group = (
+        profile.get("activities-summary", {})
+        .get("works", {})
+        .get("group", [])
+    )
+    works_count = len(works_group)
+    sample_titles: list[str] = []
+    for wg in works_group[:5]:
+        summaries = wg.get("work-summary", [])
+        if summaries:
+            title_obj = summaries[0].get("title", {})
+            title_val = title_obj.get("title", {}).get("value", "")
+            if title_val:
+                sample_titles.append(title_val)
+
+    # Extract funding
+    funding_group = (
+        profile.get("activities-summary", {})
+        .get("fundings", {})
+        .get("group", [])
+    )
+    funding_count = len(funding_group)
+
+    # Extract keywords
+    keywords_obj = profile.get("person", {}).get("keywords", {})
+    keyword_list = keywords_obj.get("keyword", [])
+    keywords = [
+        kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")
+    ]
+
+    return ORCIDRecord(
+        orcid_id=orcid_id,
+        given_name=best.get("given-names"),
+        family_name=best.get("family-names"),
+        affiliations=affiliations,
+        works_count=works_count,
+        sample_work_titles=sample_titles,
+        funding_count=funding_count,
+        keywords=keywords,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1477,11 +1762,28 @@ def _pi_history_digest(name: str, history: dict | None) -> str:
 
 
 def _pi_external_digest(external: dict | None) -> str:
-    """Format a PI's external data (patents, publications, federal awards) for LLM context."""
+    """Format a PI's external data (patents, publications, ORCID, federal awards) for LLM context."""
     if not external:
         return "No external data available for this PI."
 
     parts = []
+
+    # ORCID profile
+    orcid: ORCIDRecord | None = external.get("orcid")
+    if orcid:
+        parts.append(f"ORCID ID: {orcid.orcid_id}")
+        if orcid.affiliations:
+            parts.append(f"ORCID affiliations: {', '.join(orcid.affiliations)}")
+        parts.append(f"ORCID works count: {orcid.works_count}")
+        parts.append(f"ORCID funding entries: {orcid.funding_count}")
+        if orcid.keywords:
+            parts.append(f"ORCID research keywords: {', '.join(orcid.keywords)}")
+        if orcid.sample_work_titles:
+            parts.append(
+                "ORCID sample works: " + "; ".join(orcid.sample_work_titles)
+            )
+    else:
+        parts.append("ORCID: No ORCID profile found for this researcher.")
 
     # Patents
     patents: PIPatentRecord | None = external.get("patents")
@@ -1532,11 +1834,13 @@ def generate_company_diligence(
     awards: list[dict],
     company_research: dict[str, CompanyResearch] | None = None,
     company_history: dict[str, dict] | None = None,
+    sam_entities: dict[str, SAMEntityRecord] | None = None,
 ) -> dict[str, str]:
     """Generate a diligence paragraph for each unique awardee company.
 
-    Combines web research, historical SBIR data, and the current award context
-    to produce a focused due-diligence assessment per company.
+    Combines web research, historical SBIR data, SAM.gov registration data,
+    and the current award context to produce a focused due-diligence
+    assessment per company.
 
     Returns a dict keyed by upper-cased company name.
     """
@@ -1565,10 +1869,15 @@ def generate_company_diligence(
         "1. Company background and technology focus\n"
         "2. SBIR track record — award volume, phase progression (Phase I→II→III "
         "indicates commercialization progress), agency diversity\n"
-        "3. Commercialization signals — products, revenue, contracts, patents, "
+        "3. SAM.gov registration status — active registration, entity structure, "
+        "business type, NAICS codes (industry classification), and any "
+        "exclusion flags are important compliance signals. An expired or "
+        "missing SAM registration is a red flag for federal contracting.\n"
+        "4. Commercialization signals — products, revenue, contracts, patents, "
         "or partnerships that suggest ability to transition research\n"
-        "4. Risk factors — e.g. sole reliance on SBIR funding, narrow agency "
-        "base, lack of phase progression, or limited public presence\n\n"
+        "5. Risk factors — e.g. sole reliance on SBIR funding, narrow agency "
+        "base, lack of phase progression, SAM exclusions, or limited public "
+        "presence\n\n"
         "Be specific and analytical. Do not use bullet points or headers. "
         "Write in a professional, neutral tone. If information is limited, "
         "note that as a risk factor."
@@ -1616,6 +1925,40 @@ def generate_company_diligence(
         else:
             context_parts.append(
                 "Web research: No web research available for this company."
+            )
+
+        # SAM.gov registration data
+        sam = sam_entities.get(key) if sam_entities else None
+        if sam:
+            sam_parts = [
+                f"SAM.gov UEI: {sam.uei}",
+                f"Legal Business Name: {sam.legal_business_name}",
+            ]
+            if sam.dba_name:
+                sam_parts.append(f"DBA Name: {sam.dba_name}")
+            sam_parts.append(
+                f"Registration Status: {sam.registration_status or 'Unknown'}"
+            )
+            if sam.expiration_date:
+                sam_parts.append(f"Registration Expiration: {sam.expiration_date}")
+            if sam.entity_structure:
+                sam_parts.append(f"Entity Structure: {sam.entity_structure}")
+            if sam.business_type:
+                sam_parts.append(f"Business Type: {sam.business_type}")
+            if sam.naics_codes:
+                sam_parts.append(f"NAICS Codes: {', '.join(sam.naics_codes)}")
+            if sam.cage_code:
+                sam_parts.append(f"CAGE Code: {sam.cage_code}")
+            if sam.exclusion_status:
+                sam_parts.append(f"Exclusion Status: {sam.exclusion_status}")
+            context_parts.append(
+                f"SAM.gov registration data:\n" + "\n".join(sam_parts)
+            )
+        else:
+            context_parts.append(
+                "SAM.gov: No SAM.gov registration data found for this company. "
+                "This may indicate the company is not registered as a federal "
+                "contractor, or the lookup failed."
             )
 
         user = (
@@ -1677,12 +2020,15 @@ def generate_pi_diligence(
         "1. The PI's SBIR track record — number of awards, phase progression, "
         "breadth of agencies and topics\n"
         "2. Continuity — have they stayed with one company or moved between "
-        "organizations? Is their research focus consistent or scattered?\n"
-        "3. IP and publication output — patents filed as inventor and academic "
-        "publications demonstrate research productivity and domain expertise. "
-        "Note h-index and citation count when available as indicators of "
-        "scholarly impact. If patents are assigned to different entities than "
-        "the current company, note that.\n"
+        "organizations? Is their research focus consistent or scattered? "
+        "Cross-reference ORCID affiliations with SBIR company history to "
+        "verify consistency.\n"
+        "3. IP and publication output — patents filed as inventor, academic "
+        "publications, and ORCID profile data demonstrate research "
+        "productivity and domain expertise. Note h-index and citation count "
+        "when available. ORCID research keywords and funding entries help "
+        "confirm domain alignment. If patents are assigned to different "
+        "entities than the current company, note that.\n"
         "4. Company federal funding context — broader federal awards to the "
         "PI's company (contracts, grants) beyond SBIR show the company's "
         "ability to win and execute federal work\n"
@@ -2022,12 +2368,15 @@ def main():
             print("Building historical PI context...", file=sys.stderr)
             pi_history = get_pi_history(awards)
 
-            # Fetch external PI data (patents, publications, federal awards)
-            print("Looking up PI patents, publications, and federal awards...", file=sys.stderr)
+            # SAM.gov entity registration data
+            sam_data = lookup_sam_entities(awards)
+
+            # Fetch external PI data (patents, publications, ORCID, federal awards)
+            print("Looking up PI patents, publications, ORCID, and federal awards...", file=sys.stderr)
             pi_ext = lookup_pi_external_data(awards)
 
             co_diligence = generate_company_diligence(
-                api_key, awards, company_info, co_history
+                api_key, awards, company_info, co_history, sam_data
             )
             pi_dilig = generate_pi_diligence(
                 api_key, awards, pi_history, company_info, pi_ext

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -11,6 +11,10 @@ When OPENAI_API_KEY is set, uses the OpenAI API to:
 - Generate a two-paragraph synopsis of all weekly award activity
 - Generate a brief description per award (informed by the abstract,
   solicitation, USAspending data, and company research)
+- Generate a company diligence paragraph per awardee (informed by
+  historical SBIR data, web research, and current award context)
+- Generate a PI diligence paragraph per Principal Investigator
+  (informed by their SBIR history and company context)
 
 Usage:
     python scripts/data/weekly_awards_report.py
@@ -261,6 +265,300 @@ def fetch_weekly_awards(days: int = 7) -> tuple[list[dict], list[str]]:
         print(f"WARNING: {w}", file=sys.stderr)
 
     return awards, freshness_warnings
+
+
+# ---------------------------------------------------------------------------
+# Historical context (for diligence)
+# ---------------------------------------------------------------------------
+
+
+def get_company_history(
+    awards: list[dict],
+) -> dict[str, dict]:
+    """Extract historical SBIR award context per company from the full dataset.
+
+    Scans the complete CSV (not just the weekly window) to build a profile of
+    each company's SBIR track record: total awards, phases reached, agencies
+    served, cumulative funding, and date range.
+
+    Returns a dict keyed by upper-cased company name.
+    """
+    source = _resolve_csv_path()
+
+    if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
+        extractor = SbirDuckDBExtractor(
+            csv_path=source.path,
+            duckdb_path=":memory:",
+            use_s3_first=False,
+        )
+        extractor.import_csv()
+        table = extractor._table_identifier
+
+        # Collect the set of companies we care about (from this week's awards)
+        company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
+        company_names.discard("")
+
+        history: dict[str, dict] = {}
+        for name in company_names:
+            escaped = name.replace("'", "''")
+            query = (
+                f"SELECT \"Phase\", \"Agency\", \"Award Amount\", "
+                f"\"Proposal Award Date\", \"Award Title\", \"Program\" "
+                f"FROM {table} "
+                f"WHERE UPPER(\"Company\") = '{escaped}' "
+                f"ORDER BY \"Proposal Award Date\" DESC"
+            )
+            df = extractor.duckdb_client.execute_query_df(query)
+            if df.empty:
+                continue
+
+            phases = set()
+            agencies = set()
+            total_funding = 0.0
+            dates: list[str] = []
+            titles: list[str] = []
+            programs = set()
+
+            for _, row in df.iterrows():
+                phase = str(row.get("Phase", "")).strip()
+                if phase:
+                    phases.add(phase)
+                ag = str(row.get("Agency", "")).strip()
+                if ag:
+                    agencies.add(ag)
+                prog = str(row.get("Program", "")).strip()
+                if prog:
+                    programs.add(prog)
+                try:
+                    total_funding += float(
+                        str(row.get("Award Amount", "0"))
+                        .replace(",", "")
+                        .replace("$", "")
+                    )
+                except (ValueError, TypeError):
+                    pass
+                d = str(row.get("Proposal Award Date", "")).strip()
+                if d:
+                    dates.append(d)
+                t = str(row.get("Award Title", "")).strip()
+                if t and t not in titles:
+                    titles.append(t)
+
+            history[name] = {
+                "total_awards": len(df),
+                "phases": sorted(phases),
+                "agencies": sorted(agencies),
+                "programs": sorted(programs),
+                "total_funding": total_funding,
+                "earliest_date": min(dates) if dates else None,
+                "latest_date": max(dates) if dates else None,
+                "sample_titles": titles[:5],
+            }
+
+        return history
+
+    # Fallback: scan the CSV with Python
+    import csv
+    import io
+
+    company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
+    company_names.discard("")
+    text = source.path.read_text(encoding="utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+
+    history = {}
+    for row in reader:
+        name = str(row.get("Company", "")).strip().upper()
+        if name not in company_names:
+            continue
+        if name not in history:
+            history[name] = {
+                "total_awards": 0,
+                "phases": set(),
+                "agencies": set(),
+                "programs": set(),
+                "total_funding": 0.0,
+                "dates": [],
+                "sample_titles": [],
+            }
+        h = history[name]
+        h["total_awards"] += 1
+        phase = str(row.get("Phase", "")).strip()
+        if phase:
+            h["phases"].add(phase)
+        ag = str(row.get("Agency", "")).strip()
+        if ag:
+            h["agencies"].add(ag)
+        prog = str(row.get("Program", "")).strip()
+        if prog:
+            h["programs"].add(prog)
+        try:
+            h["total_funding"] += float(
+                str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
+            )
+        except (ValueError, TypeError):
+            pass
+        d = str(row.get("Proposal Award Date", "")).strip()
+        if d:
+            h["dates"].append(d)
+        t = str(row.get("Award Title", "")).strip()
+        if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
+            h["sample_titles"].append(t)
+
+    # Normalize the set fields to sorted lists
+    for name, h in history.items():
+        dates = h.pop("dates", [])
+        h["phases"] = sorted(h["phases"])
+        h["agencies"] = sorted(h["agencies"])
+        h["programs"] = sorted(h["programs"])
+        h["earliest_date"] = min(dates) if dates else None
+        h["latest_date"] = max(dates) if dates else None
+
+    return history
+
+
+def get_pi_history(
+    awards: list[dict],
+) -> dict[str, dict]:
+    """Extract historical SBIR context per Principal Investigator.
+
+    Similar to get_company_history but keyed on PI name.
+    Returns a dict keyed by upper-cased PI name.
+    """
+    source = _resolve_csv_path()
+
+    pi_names = set()
+    for a in awards:
+        pi = str(a.get("PI Name", "")).strip().upper()
+        if pi:
+            pi_names.add(pi)
+
+    if not pi_names:
+        return {}
+
+    if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
+        extractor = SbirDuckDBExtractor(
+            csv_path=source.path,
+            duckdb_path=":memory:",
+            use_s3_first=False,
+        )
+        extractor.import_csv()
+        table = extractor._table_identifier
+
+        history: dict[str, dict] = {}
+        for name in pi_names:
+            escaped = name.replace("'", "''")
+            query = (
+                f"SELECT \"Company\", \"Phase\", \"Agency\", \"Award Amount\", "
+                f"\"Proposal Award Date\", \"Award Title\", \"Program\" "
+                f"FROM {table} "
+                f"WHERE UPPER(\"PI Name\") = '{escaped}' "
+                f"ORDER BY \"Proposal Award Date\" DESC"
+            )
+            df = extractor.duckdb_client.execute_query_df(query)
+            if df.empty:
+                continue
+
+            companies = set()
+            phases = set()
+            agencies = set()
+            total_funding = 0.0
+            dates: list[str] = []
+            titles: list[str] = []
+
+            for _, row in df.iterrows():
+                co = str(row.get("Company", "")).strip()
+                if co:
+                    companies.add(co)
+                phase = str(row.get("Phase", "")).strip()
+                if phase:
+                    phases.add(phase)
+                ag = str(row.get("Agency", "")).strip()
+                if ag:
+                    agencies.add(ag)
+                try:
+                    total_funding += float(
+                        str(row.get("Award Amount", "0"))
+                        .replace(",", "")
+                        .replace("$", "")
+                    )
+                except (ValueError, TypeError):
+                    pass
+                d = str(row.get("Proposal Award Date", "")).strip()
+                if d:
+                    dates.append(d)
+                t = str(row.get("Award Title", "")).strip()
+                if t and t not in titles:
+                    titles.append(t)
+
+            history[name] = {
+                "total_awards": len(df),
+                "companies": sorted(companies),
+                "phases": sorted(phases),
+                "agencies": sorted(agencies),
+                "total_funding": total_funding,
+                "earliest_date": min(dates) if dates else None,
+                "latest_date": max(dates) if dates else None,
+                "sample_titles": titles[:5],
+            }
+
+        return history
+
+    # Fallback: CSV scan
+    import csv
+    import io
+
+    text = source.path.read_text(encoding="utf-8")
+    reader = csv.DictReader(io.StringIO(text))
+
+    history = {}
+    for row in reader:
+        name = str(row.get("PI Name", "")).strip().upper()
+        if name not in pi_names:
+            continue
+        if name not in history:
+            history[name] = {
+                "total_awards": 0,
+                "companies": set(),
+                "phases": set(),
+                "agencies": set(),
+                "total_funding": 0.0,
+                "dates": [],
+                "sample_titles": [],
+            }
+        h = history[name]
+        h["total_awards"] += 1
+        co = str(row.get("Company", "")).strip()
+        if co:
+            h["companies"].add(co)
+        phase = str(row.get("Phase", "")).strip()
+        if phase:
+            h["phases"].add(phase)
+        ag = str(row.get("Agency", "")).strip()
+        if ag:
+            h["agencies"].add(ag)
+        try:
+            h["total_funding"] += float(
+                str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
+            )
+        except (ValueError, TypeError):
+            pass
+        d = str(row.get("Proposal Award Date", "")).strip()
+        if d:
+            h["dates"].append(d)
+        t = str(row.get("Award Title", "")).strip()
+        if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
+            h["sample_titles"].append(t)
+
+    for name, h in history.items():
+        dates = h.pop("dates", [])
+        h["companies"] = sorted(h["companies"])
+        h["phases"] = sorted(h["phases"])
+        h["agencies"] = sorted(h["agencies"])
+        h["earliest_date"] = min(dates) if dates else None
+        h["latest_date"] = max(dates) if dates else None
+
+    return history
 
 
 # ---------------------------------------------------------------------------
@@ -655,6 +953,261 @@ def generate_award_descriptions(
 
 
 # ---------------------------------------------------------------------------
+# Company & PI diligence
+# ---------------------------------------------------------------------------
+
+# Caps on diligence API calls (override via env vars)
+MAX_COMPANIES_TO_DILIGENCE = int(os.environ.get("MAX_COMPANIES_TO_DILIGENCE", "50"))
+MAX_PIS_TO_DILIGENCE = int(os.environ.get("MAX_PIS_TO_DILIGENCE", "50"))
+
+
+def _company_history_digest(name: str, history: dict | None) -> str:
+    """Format a company's historical SBIR record for LLM context."""
+    if not history:
+        return "No prior SBIR/STTR award history found in the dataset."
+    parts = [
+        f"Total historical SBIR/STTR awards: {history['total_awards']}",
+        f"Phases achieved: {', '.join(history['phases']) or 'N/A'}",
+        f"Agencies: {', '.join(history['agencies']) or 'N/A'}",
+        f"Programs: {', '.join(history['programs']) or 'N/A'}",
+        f"Total historical funding: ${history['total_funding']:,.0f}",
+        f"Award date range: {history.get('earliest_date', 'N/A')} to {history.get('latest_date', 'N/A')}",
+    ]
+    if history.get("sample_titles"):
+        parts.append("Sample award titles: " + "; ".join(history["sample_titles"]))
+    return "\n".join(parts)
+
+
+def _pi_history_digest(name: str, history: dict | None) -> str:
+    """Format a PI's historical SBIR record for LLM context."""
+    if not history:
+        return "No prior SBIR/STTR award history found for this PI."
+    parts = [
+        f"Total historical SBIR/STTR awards as PI: {history['total_awards']}",
+        f"Companies: {', '.join(history['companies']) or 'N/A'}",
+        f"Phases: {', '.join(history['phases']) or 'N/A'}",
+        f"Agencies: {', '.join(history['agencies']) or 'N/A'}",
+        f"Total funding as PI: ${history['total_funding']:,.0f}",
+        f"Date range: {history.get('earliest_date', 'N/A')} to {history.get('latest_date', 'N/A')}",
+    ]
+    if history.get("sample_titles"):
+        parts.append("Sample award titles: " + "; ".join(history["sample_titles"]))
+    return "\n".join(parts)
+
+
+def generate_company_diligence(
+    api_key: str,
+    awards: list[dict],
+    company_research: dict[str, CompanyResearch] | None = None,
+    company_history: dict[str, dict] | None = None,
+) -> dict[str, str]:
+    """Generate a diligence paragraph for each unique awardee company.
+
+    Combines web research, historical SBIR data, and the current award context
+    to produce a focused due-diligence assessment per company.
+
+    Returns a dict keyed by upper-cased company name.
+    """
+    # Collect unique companies
+    companies: dict[str, list[dict]] = {}
+    for a in awards:
+        name = str(a.get("Company", "")).strip()
+        if not name:
+            continue
+        key = name.upper()
+        companies.setdefault(key, []).append(a)
+
+    company_items = list(companies.items())
+    if len(company_items) > MAX_COMPANIES_TO_DILIGENCE:
+        print(
+            f"Capping company diligence at {MAX_COMPANIES_TO_DILIGENCE} "
+            f"of {len(company_items)} companies",
+            file=sys.stderr,
+        )
+        company_items = company_items[:MAX_COMPANIES_TO_DILIGENCE]
+
+    system = (
+        "You are a due-diligence analyst evaluating companies that receive "
+        "SBIR/STTR federal innovation awards. Write exactly one paragraph "
+        "(4-6 sentences) of diligence analysis for the company. Cover:\n"
+        "1. Company background and technology focus\n"
+        "2. SBIR track record — award volume, phase progression (Phase I→II→III "
+        "indicates commercialization progress), agency diversity\n"
+        "3. Commercialization signals — products, revenue, contracts, patents, "
+        "or partnerships that suggest ability to transition research\n"
+        "4. Risk factors — e.g. sole reliance on SBIR funding, narrow agency "
+        "base, lack of phase progression, or limited public presence\n\n"
+        "Be specific and analytical. Do not use bullet points or headers. "
+        "Write in a professional, neutral tone. If information is limited, "
+        "note that as a risk factor."
+    )
+
+    results: dict[str, str] = {}
+    total = len(company_items)
+
+    for idx, (key, co_awards) in enumerate(company_items, 1):
+        display_name = co_awards[0].get("Company", key)
+        state = str(co_awards[0].get("State", ""))
+
+        # Build context
+        context_parts = [f"Company: {display_name}"]
+        if state:
+            context_parts.append(f"State: {state}")
+
+        # Current week's awards
+        current_summaries = []
+        for a in co_awards:
+            current_summaries.append(
+                f"- {a.get('Award Title', 'N/A')} | {a.get('Agency', '')} "
+                f"{a.get('Program', '')} {a.get('Phase', '')} | "
+                f"{format_amount(str(a.get('Award Amount', '')))}"
+            )
+        context_parts.append(
+            f"Current week's awards ({len(co_awards)}):\n"
+            + "\n".join(current_summaries)
+        )
+
+        # Historical SBIR data
+        hist = company_history.get(key) if company_history else None
+        context_parts.append(
+            f"Historical SBIR record:\n{_company_history_digest(key, hist)}"
+        )
+
+        # Web research
+        cr = company_research.get(key) if company_research else None
+        if cr:
+            context_parts.append(f"Web research summary:\n{cr.summary}")
+            if cr.source_urls:
+                context_parts.append(
+                    "Sources: " + ", ".join(cr.source_urls[:5])
+                )
+        else:
+            context_parts.append(
+                "Web research: No web research available for this company."
+            )
+
+        user = (
+            "Write a one-paragraph due-diligence assessment for this "
+            "SBIR/STTR awardee company.\n\n" + "\n\n".join(context_parts)
+        )
+
+        print(
+            f"Generating company diligence {idx}/{total}: {display_name}...",
+            file=sys.stderr,
+        )
+        result = _openai_chat(api_key, system, user)
+        if result:
+            results[key] = result
+
+    return results
+
+
+def generate_pi_diligence(
+    api_key: str,
+    awards: list[dict],
+    pi_history: dict[str, dict] | None = None,
+    company_research: dict[str, CompanyResearch] | None = None,
+) -> dict[str, str]:
+    """Generate a diligence paragraph for each unique Principal Investigator.
+
+    Combines the PI's SBIR history, their current award context, and any
+    available company research to assess the PI's track record.
+
+    Returns a dict keyed by upper-cased PI name.
+    """
+    # Collect unique PIs
+    pis: dict[str, list[dict]] = {}
+    for a in awards:
+        pi = str(a.get("PI Name", "")).strip()
+        if not pi:
+            continue
+        key = pi.upper()
+        pis.setdefault(key, []).append(a)
+
+    pi_items = list(pis.items())
+    if len(pi_items) > MAX_PIS_TO_DILIGENCE:
+        print(
+            f"Capping PI diligence at {MAX_PIS_TO_DILIGENCE} "
+            f"of {len(pi_items)} PIs",
+            file=sys.stderr,
+        )
+        pi_items = pi_items[:MAX_PIS_TO_DILIGENCE]
+
+    system = (
+        "You are a due-diligence analyst evaluating Principal Investigators "
+        "(PIs) who lead SBIR/STTR federal innovation projects. Write exactly "
+        "one paragraph (3-5 sentences) assessing the PI. Cover:\n"
+        "1. The PI's SBIR track record — number of awards, phase progression, "
+        "breadth of agencies and topics\n"
+        "2. Continuity — have they stayed with one company or moved between "
+        "organizations? Is their research focus consistent or scattered?\n"
+        "3. Indicators of research depth — repeat awards in the same domain "
+        "suggest expertise; awards across unrelated fields may suggest "
+        "grant-chasing\n"
+        "4. Current project context — what are they working on now and how "
+        "does it relate to their history?\n\n"
+        "Be specific and analytical. Do not use bullet points or headers. "
+        "Write in a professional, neutral tone. If the PI has no prior "
+        "history, note that this is their first known SBIR award."
+    )
+
+    results: dict[str, str] = {}
+    total = len(pi_items)
+
+    for idx, (key, pi_awards) in enumerate(pi_items, 1):
+        display_name = pi_awards[0].get("PI Name", key)
+        company = str(pi_awards[0].get("Company", ""))
+
+        context_parts = [f"Principal Investigator: {display_name}"]
+        if company:
+            context_parts.append(f"Current company: {company}")
+
+        # Current week's awards
+        current_summaries = []
+        for a in pi_awards:
+            current_summaries.append(
+                f"- {a.get('Award Title', 'N/A')} | {a.get('Company', '')} | "
+                f"{a.get('Agency', '')} {a.get('Program', '')} {a.get('Phase', '')} | "
+                f"{format_amount(str(a.get('Award Amount', '')))}"
+            )
+        context_parts.append(
+            f"Current week's awards ({len(pi_awards)}):\n"
+            + "\n".join(current_summaries)
+        )
+
+        # PI historical record
+        hist = pi_history.get(key) if pi_history else None
+        context_parts.append(
+            f"Historical SBIR record as PI:\n{_pi_history_digest(key, hist)}"
+        )
+
+        # Company web research for context
+        cr = None
+        if company_research:
+            cr = company_research.get(company.strip().upper())
+        if cr:
+            context_parts.append(
+                f"Company context ({company}):\n{cr.summary}"
+            )
+
+        user = (
+            "Write a one-paragraph assessment of this Principal Investigator's "
+            "SBIR/STTR track record and current project.\n\n"
+            + "\n\n".join(context_parts)
+        )
+
+        print(
+            f"Generating PI diligence {idx}/{total}: {display_name}...",
+            file=sys.stderr,
+        )
+        result = _openai_chat(api_key, system, user)
+        if result:
+            results[key] = result
+
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Markdown generation
 # ---------------------------------------------------------------------------
 
@@ -666,6 +1219,8 @@ def generate_markdown(
     descriptions: dict[int, str] | None = None,
     company_research: dict[str, CompanyResearch] | None = None,
     freshness_warnings: list[str] | None = None,
+    company_diligence: dict[str, str] | None = None,
+    pi_diligence: dict[str, str] | None = None,
 ) -> str:
     """Generate markdown report from filtered awards."""
     now = datetime.now(UTC)
@@ -792,6 +1347,22 @@ def generate_markdown(
             lines.append(descriptions[i])
             lines.append("")
 
+        # Company diligence paragraph
+        if company_diligence:
+            co_key = company.strip().upper()
+            if co_key in company_diligence:
+                lines.append(f"**Company Diligence — {company}:**")
+                lines.append(company_diligence[co_key])
+                lines.append("")
+
+        # PI diligence paragraph
+        if pi_diligence and pi_name:
+            pi_key = pi_name.strip().upper()
+            if pi_key in pi_diligence:
+                lines.append(f"**Principal Investigator — {pi_name}:**")
+                lines.append(pi_diligence[pi_key])
+                lines.append("")
+
         # Details table
         lines.append("<details>")
         lines.append("<summary>Award details</summary>")
@@ -863,6 +1434,11 @@ def main():
         action="store_true",
         help="Skip web-based company research (still generates synopsis and descriptions)",
     )
+    parser.add_argument(
+        "--no-diligence",
+        action="store_true",
+        help="Skip company and PI diligence paragraphs",
+    )
     args = parser.parse_args()
 
     awards, freshness_warnings = fetch_weekly_awards(days=args.days)
@@ -871,6 +1447,8 @@ def main():
     synopsis = None
     descriptions = None
     company_info: dict[str, CompanyResearch] | None = None
+    co_diligence: dict[str, str] | None = None
+    pi_dilig: dict[str, str] | None = None
     api_key = os.environ.get("OPENAI_API_KEY", "")
 
     if api_key and not args.no_ai:
@@ -878,6 +1456,20 @@ def main():
             company_info = research_companies(api_key, awards)
         synopsis = generate_weekly_synopsis(api_key, awards, args.days, company_info)
         descriptions = generate_award_descriptions(api_key, awards, company_info)
+
+        if not args.no_diligence:
+            # Build historical context for diligence
+            print("Building historical company context...", file=sys.stderr)
+            co_history = get_company_history(awards)
+            print("Building historical PI context...", file=sys.stderr)
+            pi_history = get_pi_history(awards)
+
+            co_diligence = generate_company_diligence(
+                api_key, awards, company_info, co_history
+            )
+            pi_dilig = generate_pi_diligence(
+                api_key, awards, pi_history, company_info
+            )
     elif not api_key and not args.no_ai:
         print(
             "OPENAI_API_KEY not set - skipping AI summaries. "
@@ -892,6 +1484,8 @@ def main():
         descriptions=descriptions,
         company_research=company_info,
         freshness_warnings=freshness_warnings,
+        company_diligence=co_diligence,
+        pi_diligence=pi_dilig,
     )
 
     if args.output:


### PR DESCRIPTION
## Description

This PR extends the weekly awards report generator with two new diligence analysis features:

1. **Company Diligence Paragraphs**: For each awardee company, generates a focused due-diligence assessment combining:
   - Web research summary and sources
   - Historical SBIR/STTR award track record (total awards, phases achieved, agencies served, cumulative funding, date range)
   - Current week's award context
   - Risk factors and commercialization signals

2. **Principal Investigator Diligence Paragraphs**: For each PI, generates an assessment covering:
   - Historical SBIR/STTR awards as PI (count, companies, phases, agencies, funding)
   - Research focus consistency and continuity across organizations
   - Phase progression and agency diversity
   - Current project context relative to their history

### Implementation Details

- **`get_company_history()`**: Scans the full SBIR CSV dataset to extract historical context per company (not just the weekly window). Uses DuckDB when available for efficiency, falls back to Python CSV parsing.
- **`get_pi_history()`**: Similar to company history but keyed on PI name, tracking companies they've worked with across awards.
- **`generate_company_diligence()`**: Uses OpenAI API to synthesize company research, historical data, and current awards into a structured paragraph.
- **`generate_pi_diligence()`**: Uses OpenAI API to assess PI track record and research continuity.
- **Helper functions**: `_company_history_digest()` and `_pi_history_digest()` format historical data for LLM context.
- **CLI flag**: Added `--no-diligence` to skip diligence generation while keeping other AI features.
- **Rate limiting**: Configurable caps (`MAX_COMPANIES_TO_DILIGENCE`, `MAX_PIS_TO_DILIGENCE`) to control API call volume.

The diligence paragraphs are inserted into the markdown report under each award, following the award description.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

The changes are additive and backward-compatible:
- Existing functionality (synopsis, descriptions, company research) is unaffected
- Diligence generation is optional and controlled by `--no-diligence` flag
- Historical data extraction has fallback CSV parsing if DuckDB is unavailable
- API calls are rate-limited and logged to stderr for visibility

Manual testing should verify:
1. Report generation with `--no-diligence` works as before
2. Report generation with diligence enabled produces reasonable paragraphs
3. Historical data extraction correctly aggregates awards across the full dataset
4. Markdown output includes diligence sections in the correct location

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes are backward-compatible (new features are optional)
- [x] New functionality is properly documented in docstrings

https://claude.ai/code/session_01JPiM1G1ZpgPhQDTUyAXwe9