### PR TITLE
Refactor award ID classification and add retry logic to downloads

### DIFF
--- a/sbir_etl/enrichers/company_categorization.py
+++ b/sbir_etl/enrichers/company_categorization.py
@@ -33,6 +33,7 @@ from loguru import logger
 
 from sbir_etl.config.loader import get_config
 from sbir_etl.enrichers.usaspending import USAspendingAPIClient
+from sbir_etl.enrichers.usaspending.client import CONTRACT_TYPE_CODES
 from sbir_etl.exceptions import APIError, RateLimitError
 from sbir_etl.extractors.usaspending import DuckDBUSAspendingExtractor
 from sbir_etl.utils.async_tools import run_sync
@@ -636,7 +637,7 @@ def retrieve_company_contracts_api(
 
     # Build search filters using AdvancedFilterObject
     filters: dict[str, Any] = {
-        "award_type_codes": ["A", "B", "C", "D"],  # Contract awards only
+        "award_type_codes": CONTRACT_TYPE_CODES,  # Contract awards only
     }
 
     # Add recipient search - recipient_search_text searches across name, UEI, and DUNS
@@ -827,7 +828,7 @@ def retrieve_company_contracts_api(
             )
             # Try searching by company name - use name variations for better matching
             name_filters = {
-                "award_type_codes": ["A", "B", "C", "D"],
+                "award_type_codes": CONTRACT_TYPE_CODES,
             }
 
             # Generate name variations for better matching
@@ -1314,7 +1315,7 @@ def retrieve_sbir_awards_api(
 
     # Build search filters
     filters: dict[str, Any] = {
-        "award_type_codes": ["A", "B", "C", "D"],
+        "award_type_codes": CONTRACT_TYPE_CODES,
     }
 
     recipient_search_terms = []

--- a/sbir_etl/enrichers/company_categorization.py
+++ b/sbir_etl/enrichers/company_categorization.py
@@ -637,7 +637,7 @@ def retrieve_company_contracts_api(
 
     # Build search filters using AdvancedFilterObject
     filters: dict[str, Any] = {
-        "award_type_codes": CONTRACT_TYPE_CODES,  # Contract awards only
+        "award_type_codes": list(CONTRACT_TYPE_CODES),  # Contract awards only
     }
 
     # Add recipient search - recipient_search_text searches across name, UEI, and DUNS
@@ -828,7 +828,7 @@ def retrieve_company_contracts_api(
             )
             # Try searching by company name - use name variations for better matching
             name_filters = {
-                "award_type_codes": CONTRACT_TYPE_CODES,
+                "award_type_codes": list(CONTRACT_TYPE_CODES),
             }
 
             # Generate name variations for better matching
@@ -1315,7 +1315,7 @@ def retrieve_sbir_awards_api(
 
     # Build search filters
     filters: dict[str, Any] = {
-        "award_type_codes": CONTRACT_TYPE_CODES,
+        "award_type_codes": list(CONTRACT_TYPE_CODES),
     }
 
     recipient_search_terms = []

--- a/sbir_etl/enrichers/usaspending/client.py
+++ b/sbir_etl/enrichers/usaspending/client.py
@@ -25,8 +25,8 @@ from ..base_client import BaseAsyncAPIClient
 # Award type code groups — USAspending requires separate requests for
 # contracts (procurement) vs. assistance (grants/cooperative agreements).
 # ------------------------------------------------------------------
-CONTRACT_TYPE_CODES: list[str] = ["A", "B", "C", "D"]
-ASSISTANCE_TYPE_CODES: list[str] = ["02", "03", "04", "05"]
+CONTRACT_TYPE_CODES: tuple[str, ...] = ("A", "B", "C", "D")
+ASSISTANCE_TYPE_CODES: tuple[str, ...] = ("02", "03", "04", "05")
 
 
 def classify_award_id(award_id: str) -> str:
@@ -89,12 +89,12 @@ def build_award_type_groups(
 
     groups: list[tuple[list[str], str, list[str]]] = []
     if piids:
-        groups.append((piids, "contracts", CONTRACT_TYPE_CODES))
+        groups.append((piids, "contracts", list(CONTRACT_TYPE_CODES)))
     if fains:
-        groups.append((fains, "assistance", ASSISTANCE_TYPE_CODES))
+        groups.append((fains, "assistance", list(ASSISTANCE_TYPE_CODES)))
     for uid in unknown:
-        groups.append(([uid], "contracts", CONTRACT_TYPE_CODES))
-        groups.append(([uid], "assistance", ASSISTANCE_TYPE_CODES))
+        groups.append(([uid], "contracts", list(CONTRACT_TYPE_CODES)))
+        groups.append(([uid], "assistance", list(ASSISTANCE_TYPE_CODES)))
     return groups
 
 

--- a/sbir_etl/enrichers/usaspending/client.py
+++ b/sbir_etl/enrichers/usaspending/client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,82 @@ from ...config.loader import get_config
 from ...exceptions import APIError
 from ...models.enrichment import EnrichmentFreshnessRecord
 from ..base_client import BaseAsyncAPIClient
+
+# ------------------------------------------------------------------
+# Award type code groups — USAspending requires separate requests for
+# contracts (procurement) vs. assistance (grants/cooperative agreements).
+# ------------------------------------------------------------------
+CONTRACT_TYPE_CODES: list[str] = ["A", "B", "C", "D"]
+ASSISTANCE_TYPE_CODES: list[str] = ["02", "03", "04", "05"]
+
+
+def classify_award_id(award_id: str) -> str:
+    """Classify an SBIR award/contract identifier as PIID, FAIN, or unknown.
+
+    Uses format heuristics derived from DoD PIIDs and DOE FAINs:
+    - DoD PIIDs: 2-letter agency prefix + digits + dash patterns (e.g. FA2541-26-C-B005)
+    - DOE/agency FAINs: DE-AR, DE-SC prefixes (grants)
+    - Pure numeric: agency internal IDs (e.g. NSF "2516905") — ambiguous
+
+    Args:
+        award_id: The contract/award identifier string.
+
+    Returns:
+        One of ``"piid"``, ``"fain"``, or ``"unknown"``.
+    """
+    s = award_id.strip()
+    if not s:
+        return "unknown"
+    if re.match(r"^DE-", s, re.IGNORECASE):
+        return "fain"
+    if re.match(r"^[A-Z]{2}\d", s):
+        return "piid"
+    return "unknown"
+
+
+def build_award_type_groups(
+    award_ids: list[str],
+) -> list[tuple[list[str], str, list[str]]]:
+    """Split award IDs into typed request groups for USAspending queries.
+
+    Contracts (PIIDs) are queried with ``CONTRACT_TYPE_CODES``, financial
+    assistance (FAINs) with ``ASSISTANCE_TYPE_CODES``, and unknown IDs are
+    tried against both.
+
+    Args:
+        award_ids: Raw award/contract identifier strings.
+
+    Returns:
+        List of ``(ids, group_name, award_type_codes)`` tuples ready for
+        USAspending API calls.
+    """
+    piids: list[str] = []
+    fains: list[str] = []
+    unknown: list[str] = []
+
+    seen: set[str] = set()
+    for raw in award_ids:
+        aid = raw.strip()
+        if not aid or aid in seen:
+            continue
+        seen.add(aid)
+        kind = classify_award_id(aid)
+        if kind == "piid":
+            piids.append(aid)
+        elif kind == "fain":
+            fains.append(aid)
+        else:
+            unknown.append(aid)
+
+    groups: list[tuple[list[str], str, list[str]]] = []
+    if piids:
+        groups.append((piids, "contracts", CONTRACT_TYPE_CODES))
+    if fains:
+        groups.append((fains, "assistance", ASSISTANCE_TYPE_CODES))
+    for uid in unknown:
+        groups.append(([uid], "contracts", CONTRACT_TYPE_CODES))
+        groups.append(([uid], "assistance", ASSISTANCE_TYPE_CODES))
+    return groups
 
 
 

--- a/sbir_etl/extractors/solicitation.py
+++ b/sbir_etl/extractors/solicitation.py
@@ -105,6 +105,10 @@ class SolicitationExtractor:
 
         response = self.client.get(url, params=params)
 
+        # Raise httpx.HTTPStatusError for transient failures so tenacity retries them.
+        if response.status_code in (429, 500, 502, 503, 504):
+            response.raise_for_status()
+
         if response.status_code != 200:
             raise APIError(
                 f"SBIR.gov API returned {response.status_code}: {response.text[:200]}",

--- a/sbir_etl/extractors/solicitation.py
+++ b/sbir_etl/extractors/solicitation.py
@@ -21,8 +21,11 @@ from ..exceptions import APIError
 
 try:
     import httpx
+
+    _RETRYABLE_HTTPX = (httpx.HTTPStatusError, httpx.TimeoutException, httpx.TransportError)
 except ImportError:
     httpx = None  # type: ignore[assignment]
+    _RETRYABLE_HTTPX = (Exception,)  # type: ignore[assignment]  # fallback when httpx absent
 
 SBIR_GOV_API_BASE = "https://api.www.sbir.gov/public/api"
 
@@ -69,7 +72,7 @@ class SolicitationExtractor:
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
-        retry=retry_if_exception_type(Exception),
+        retry=retry_if_exception_type(_RETRYABLE_HTTPX),
         reraise=True,
     )
     def _query_solicitations(

--- a/sbir_etl/transformers/bea_api_client.py
+++ b/sbir_etl/transformers/bea_api_client.py
@@ -77,7 +77,9 @@ class BEAApiClient:
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
-        retry=retry_if_exception_type(httpx.HTTPStatusError),
+        retry=retry_if_exception_type(
+            (httpx.HTTPStatusError, httpx.TimeoutException, httpx.TransportError)
+        ),
         reraise=True,
     )
     def _request(self, params: dict[str, str]) -> dict[str, Any]:

--- a/sbir_etl/utils/text_normalization.py
+++ b/sbir_etl/utils/text_normalization.py
@@ -113,6 +113,26 @@ def normalize_company_name(name: str | None) -> str:
     return normalize_name(name, remove_suffixes=False)
 
 
+def pluralize_col_key(col: str) -> str:
+    """Convert a column name to a pluralized dict key.
+
+    Lowercases, replaces spaces with underscores, and applies basic English
+    pluralization (``y`` → ``ies``, otherwise append ``s``).
+
+    Examples:
+        >>> pluralize_col_key("Company")
+        'companies'
+        >>> pluralize_col_key("Phase")
+        'phases'
+        >>> pluralize_col_key("Agency")
+        'agencies'
+    """
+    key = col.lower().replace(" ", "_")
+    if key.endswith("y"):
+        return key[:-1] + "ies"
+    return key + "s"
+
+
 def normalize_recipient_name(name: str | None) -> str:
     """Normalize a recipient name (removes all suffixes).
 

--- a/scripts/data/download_sbir.py
+++ b/scripts/data/download_sbir.py
@@ -14,11 +14,28 @@ from datetime import datetime, UTC
 
 import boto3
 import requests
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 try:
     from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
 except ImportError:
     SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
+
+
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=2, max=30),
+    retry=retry_if_exception_type(
+        (requests.ConnectionError, requests.Timeout, requests.exceptions.HTTPError)
+    ),
+    reraise=True,
+)
+def _download_with_retry(url: str) -> requests.Response:
+    """Download with retry on transient network errors."""
+    resp = requests.get(url, stream=True, timeout=300)
+    if resp.status_code in (429, 500, 502, 503, 504):
+        resp.raise_for_status()  # triggers retry via HTTPError
+    return resp
 
 
 def download_sbir_awards(s3_bucket: str) -> dict:
@@ -27,8 +44,8 @@ def download_sbir_awards(s3_bucket: str) -> dict:
 
     s3 = boto3.client("s3")
 
-    # Download file
-    response = requests.get(SBIR_AWARDS_URL, stream=True, timeout=300)
+    # Download file (retry on transient network / server errors)
+    response = _download_with_retry(SBIR_AWARDS_URL)
     response.raise_for_status()
 
     content_length = int(response.headers.get("content-length", 0))

--- a/scripts/data/download_sbir.py
+++ b/scripts/data/download_sbir.py
@@ -34,6 +34,7 @@ def _download_with_retry(url: str) -> requests.Response:
     """Download with retry on transient network errors."""
     resp = requests.get(url, stream=True, timeout=300)
     if resp.status_code in (429, 500, 502, 503, 504):
+        resp.close()
         resp.raise_for_status()  # triggers retry via HTTPError
     return resp
 

--- a/scripts/data/run_benchmark_analysis.py
+++ b/scripts/data/run_benchmark_analysis.py
@@ -44,11 +44,26 @@ from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL
 def download_from_sbir_gov(dest: Path) -> Path:
     """Download latest SBIR awards CSV from sbir.gov."""
     import requests
+    from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2, min=2, max=30),
+        retry=retry_if_exception_type(
+            (requests.ConnectionError, requests.Timeout, requests.exceptions.HTTPError)
+        ),
+        reraise=True,
+    )
+    def _get(url: str) -> requests.Response:
+        resp = requests.get(url, stream=True, timeout=300)
+        if resp.status_code in (429, 500, 502, 503, 504):
+            resp.raise_for_status()
+        return resp
 
     url = SBIR_AWARDS_CSV_URL
     print(f"Downloading SBIR awards from: {url}")
 
-    response = requests.get(url, stream=True, timeout=300)
+    response = _get(url)
     response.raise_for_status()
 
     size = int(response.headers.get("content-length", 0))

--- a/scripts/data/run_benchmark_analysis.py
+++ b/scripts/data/run_benchmark_analysis.py
@@ -57,6 +57,7 @@ def download_from_sbir_gov(dest: Path) -> Path:
     def _get(url: str) -> requests.Response:
         resp = requests.get(url, stream=True, timeout=300)
         if resp.status_code in (429, 500, 502, 503, 504):
+            resp.close()
             resp.raise_for_status()
         return resp
 

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -44,6 +44,7 @@ try:
     from sbir_etl.utils.cloud_storage import find_latest_sbir_awards, get_s3_bucket_from_env
     from sbir_etl.utils.date_utils import parse_date as _parse_date
     from sbir_etl.utils.text_normalization import normalize_name as _normalize_name
+    from sbir_etl.utils.text_normalization import pluralize_col_key as _pluralize_col_key
     from sbir_etl.validators.sbir_awards import validate_sbir_award_record as _validate_record
 
     _HAS_SBIR_ETL = True
@@ -67,6 +68,13 @@ except ImportError:
         return None
 
     _validate_record = None  # type: ignore[assignment]
+
+    def _pluralize_col_key(col: str) -> str:  # type: ignore[misc]
+        """Fallback pluralizer when sbir_etl is unavailable."""
+        key = col.lower().replace(" ", "_")
+        if key.endswith("y"):
+            return key[:-1] + "ies"
+        return key + "s"
 
     def _normalize_name(name, *, remove_suffixes=False, **_kwargs):  # type: ignore[misc]
         """Minimal fallback company name normalizer."""
@@ -487,15 +495,8 @@ def _resolve_shared_extractor(
     return source, extractor, table
 
 
-def _pluralize_col_key(col: str) -> str:
-    """Convert a column name to a pluralized dict key.
-
-    'Company' -> 'companies', 'Phase' -> 'phases', etc.
-    """
-    key = col.lower().replace(" ", "_")
-    if key.endswith("y"):
-        return key[:-1] + "ies"
-    return key + "s"
+# _pluralize_col_key is imported from sbir_etl.utils.text_normalization
+# (with a fallback defined in the ImportError block above).
 
 
 def _build_history_from_df(
@@ -2537,53 +2538,52 @@ def fetch_usaspending_contract_descriptions(
     Returns a dict keyed by contract number with the award description text.
     Used as supplementary LLM context when solicitation topic data is unavailable.
     """
-    import re as _re
     import time as _t
 
-    # Classify award IDs by likely type based on format:
-    # - DoD PIIDs: letter prefix + digits + dash patterns (e.g. FA2541-26-C-B005)
-    # - DOE/agency FAINs: DE-AR, DE-SC prefixes (grants)
-    # - Pure numeric: agency internal IDs (e.g. NSF "2516905") — try both types
-    piids: list[str] = []   # Likely procurement contracts
-    fains: list[str] = []   # Likely financial assistance (grants)
-    unknown: list[str] = [] # Try both
-    for a in awards:
-        c = str(a.get("Contract", "")).strip()
-        if not c or c in piids or c in fains or c in unknown:
-            continue
-        if _re.match(r"^DE-", c, _re.IGNORECASE):
-            fains.append(c)
-        elif _re.match(r"^[A-Z]{2}\d", c):
-            piids.append(c)  # DoD PIID pattern
-        elif c.isdigit():
-            unknown.append(c)  # Bare numeric — could be either
-        else:
-            unknown.append(c)
+    # Use shared award-ID classification when available, inline fallback otherwise.
+    try:
+        from sbir_etl.enrichers.usaspending.client import build_award_type_groups
+    except ImportError:
+        import re as _re
 
-    all_ids = piids + fains + unknown
-    if not all_ids:
+        def build_award_type_groups(ids):  # type: ignore[misc]
+            piids, fains, unknown = [], [], []
+            seen: set[str] = set()
+            for raw in ids:
+                s = raw.strip()
+                if not s or s in seen:
+                    continue
+                seen.add(s)
+                if _re.match(r"^DE-", s, _re.IGNORECASE):
+                    fains.append(s)
+                elif _re.match(r"^[A-Z]{2}\d", s):
+                    piids.append(s)
+                else:
+                    unknown.append(s)
+            groups = []
+            if piids:
+                groups.append((piids, "contracts", ["A", "B", "C", "D"]))
+            if fains:
+                groups.append((fains, "assistance", ["02", "03", "04", "05"]))
+            for uid in unknown:
+                groups.append(([uid], "contracts", ["A", "B", "C", "D"]))
+                groups.append(([uid], "assistance", ["02", "03", "04", "05"]))
+            return groups
+
+    raw_ids = [str(a.get("Contract", "")).strip() for a in awards]
+    raw_ids = [c for c in raw_ids if c]
+    if not raw_ids:
         return {}
 
-    _debug(
-        f"USAspending contract desc: {len(piids)} PIIDs, "
-        f"{len(fains)} FAINs, {len(unknown)} unknown"
-    )
+    requests_to_make = build_award_type_groups(raw_ids)
+    all_ids = list({aid for ids, _, _ in requests_to_make for aid in ids})
+
+    _debug(f"USAspending contract desc: {len(all_ids)} IDs in {len(requests_to_make)} groups")
     print(
         f"Fetching {len(all_ids)} contract descriptions from USAspending...",
         file=sys.stderr,
     )
     results: dict[str, str] = {}
-
-    # Build targeted requests: PIIDs→contracts, FAINs→assistance, unknown→both
-    requests_to_make: list[tuple[list[str], str, list[str]]] = []
-    if piids:
-        requests_to_make.append((piids, "contracts", ["A", "B", "C", "D"]))
-    if fains:
-        requests_to_make.append((fains, "assistance", ["02", "03", "04", "05"]))
-    for uid in unknown:
-        # Try as contract first, then assistance
-        requests_to_make.append(([uid], "contracts", ["A", "B", "C", "D"]))
-        requests_to_make.append(([uid], "assistance", ["02", "03", "04", "05"]))
 
     try:
         with httpx.Client(timeout=30) as client:

--- a/scripts/setup_congressional_districts.py
+++ b/scripts/setup_congressional_districts.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pandas as pd
 import requests
 from loguru import logger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 
 # HUD ZIP-to-Congressional District crosswalk
@@ -47,9 +48,23 @@ def download_hud_crosswalk(output_dir: Path, force: bool = False) -> Path:
     logger.info("Downloading HUD ZIP-to-Congressional District crosswalk...")
     logger.info(f"Source: {HUD_DIRECT_DOWNLOAD}")
 
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2, min=2, max=30),
+        retry=retry_if_exception_type(
+            (requests.ConnectionError, requests.Timeout, requests.exceptions.HTTPError)
+        ),
+        reraise=True,
+    )
+    def _download(url: str) -> requests.Response:
+        resp = requests.get(url, timeout=60)
+        if resp.status_code in (429, 500, 502, 503, 504):
+            resp.raise_for_status()
+        return resp
+
     try:
         # Try direct download of Excel file
-        response = requests.get(HUD_DIRECT_DOWNLOAD, timeout=60)
+        response = _download(HUD_DIRECT_DOWNLOAD)
         response.raise_for_status()
 
         # Save as Excel temporarily

--- a/tests/unit/test_usaspending_api_client.py
+++ b/tests/unit/test_usaspending_api_client.py
@@ -11,7 +11,13 @@ import pytest
 pytestmark = pytest.mark.fast
 from httpx import TimeoutException
 
-from sbir_etl.enrichers.usaspending.client import USAspendingAPIClient
+from sbir_etl.enrichers.usaspending.client import (
+    ASSISTANCE_TYPE_CODES,
+    CONTRACT_TYPE_CODES,
+    USAspendingAPIClient,
+    build_award_type_groups,
+    classify_award_id,
+)
 from sbir_etl.exceptions import APIError as USAspendingAPIError
 from sbir_etl.exceptions import RateLimitError as USAspendingRateLimitError
 from sbir_etl.models.enrichment import EnrichmentFreshnessRecord, EnrichmentStatus
@@ -405,3 +411,95 @@ class TestStateManagement:
         api_client.save_state(test_state)
 
         assert api_client.state_file.exists()
+
+
+class TestClassifyAwardId:
+    """Tests for classify_award_id helper."""
+
+    def test_dod_piid(self):
+        assert classify_award_id("FA2541-26-C-B005") == "piid"
+
+    def test_two_letter_prefix_digit(self):
+        assert classify_award_id("HQ0034-22-C-0001") == "piid"
+
+    def test_doe_fain(self):
+        assert classify_award_id("DE-AR0001234") == "fain"
+
+    def test_doe_fain_lowercase(self):
+        assert classify_award_id("de-sc001") == "fain"
+
+    def test_bare_numeric(self):
+        assert classify_award_id("2516905") == "unknown"
+
+    def test_empty_string(self):
+        assert classify_award_id("") == "unknown"
+
+    def test_whitespace(self):
+        assert classify_award_id("   ") == "unknown"
+
+    def test_other_mixed(self):
+        assert classify_award_id("SOME-RANDOM") == "unknown"
+
+
+class TestBuildAwardTypeGroups:
+    """Tests for build_award_type_groups helper."""
+
+    def test_piids_grouped(self):
+        groups = build_award_type_groups(["FA2541-26-C-B005", "HQ0034-22-C-0001"])
+        assert len(groups) == 1
+        ids, name, codes = groups[0]
+        assert name == "contracts"
+        assert set(ids) == {"FA2541-26-C-B005", "HQ0034-22-C-0001"}
+        assert codes == list(CONTRACT_TYPE_CODES)
+
+    def test_fains_grouped(self):
+        groups = build_award_type_groups(["DE-AR0001234", "DE-SC001"])
+        assert len(groups) == 1
+        ids, name, codes = groups[0]
+        assert name == "assistance"
+        assert codes == list(ASSISTANCE_TYPE_CODES)
+
+    def test_unknown_generates_both(self):
+        groups = build_award_type_groups(["2516905"])
+        assert len(groups) == 2
+        assert groups[0][1] == "contracts"
+        assert groups[1][1] == "assistance"
+
+    def test_mixed_inputs(self):
+        groups = build_award_type_groups(["FA2541-26-C-B005", "DE-SC001", "999"])
+        # 1 piid group + 1 fain group + 2 unknown groups (999 tried as both)
+        assert len(groups) == 4
+        group_names = [g[1] for g in groups]
+        assert group_names.count("contracts") == 2  # piids + unknown-as-contract
+        assert group_names.count("assistance") == 2  # fains + unknown-as-assistance
+
+    def test_deduplicates(self):
+        groups = build_award_type_groups(["FA2541-26-C-B005", "FA2541-26-C-B005"])
+        assert len(groups) == 1
+        assert len(groups[0][0]) == 1
+
+    def test_empty_input(self):
+        assert build_award_type_groups([]) == []
+
+    def test_blank_strings_skipped(self):
+        groups = build_award_type_groups(["", "  ", "FA2541-26-C-B005"])
+        assert len(groups) == 1
+        assert groups[0][0] == ["FA2541-26-C-B005"]
+
+    def test_returns_mutable_lists(self):
+        """Returned code lists should be mutable copies, not the module constants."""
+        groups = build_award_type_groups(["FA2541-26-C-B005"])
+        codes = groups[0][2]
+        assert isinstance(codes, list)
+        codes.append("X")  # should not affect the constant
+        assert "X" not in CONTRACT_TYPE_CODES
+
+
+class TestTypeCodeConstants:
+    """Verify module-level constants are immutable."""
+
+    def test_contract_codes_are_tuples(self):
+        assert isinstance(CONTRACT_TYPE_CODES, tuple)
+
+    def test_assistance_codes_are_tuples(self):
+        assert isinstance(ASSISTANCE_TYPE_CODES, tuple)

--- a/tests/unit/utils/test_text_normalization.py
+++ b/tests/unit/utils/test_text_normalization.py
@@ -17,6 +17,7 @@ from sbir_etl.utils.text_normalization import (
     normalize_company_name,
     normalize_name,
     normalize_recipient_name,
+    pluralize_col_key,
 )
 
 
@@ -338,3 +339,35 @@ class TestComparisonScenarios:
         name2 = normalize_name("Beta Systems", remove_suffixes=True)
 
         assert name1 != name2
+
+
+class TestPluralizeColKey:
+    """Tests for pluralize_col_key helper."""
+
+    def test_y_ending(self):
+        """'y' ending becomes 'ies'."""
+        assert pluralize_col_key("Company") == "companies"
+        assert pluralize_col_key("Agency") == "agencies"
+
+    def test_regular_ending(self):
+        """Non-y ending appends 's'."""
+        assert pluralize_col_key("Phase") == "phases"
+        assert pluralize_col_key("Award") == "awards"
+
+    def test_spaces_replaced(self):
+        """Spaces become underscores."""
+        assert pluralize_col_key("Award Type") == "award_types"
+
+    def test_lowercased(self):
+        """Input is lowercased."""
+        assert pluralize_col_key("COMPANY") == "companies"
+        assert pluralize_col_key("Phase") == "phases"
+
+    def test_empty_string(self):
+        """Empty string appends 's'."""
+        assert pluralize_col_key("") == "s"
+
+    def test_single_char(self):
+        """Single character works."""
+        assert pluralize_col_key("x") == "xs"
+        assert pluralize_col_key("y") == "ies"


### PR DESCRIPTION
## Description

This PR consolidates award ID classification logic and improves resilience of external data downloads through retry mechanisms.

### Key Changes

1. **Extract award ID classification to shared module** (`sbir_etl/enrichers/usaspending/client.py`)
   - Moved `classify_award_id()` and `build_award_type_groups()` functions to a dedicated module for reuse
   - Defines constants `CONTRACT_TYPE_CODES` and `ASSISTANCE_TYPE_CODES` for USAspending API queries
   - Reduces code duplication between `weekly_awards_report.py` and other consumers

2. **Move `pluralize_col_key()` to text normalization module** (`sbir_etl/utils/text_normalization.py`)
   - Extracted from `weekly_awards_report.py` to a public utility function
   - Maintains fallback implementation in `weekly_awards_report.py` for when `sbir_etl` is unavailable
   - Improves code organization and reusability

3. **Add retry logic to external downloads**
   - `scripts/data/download_sbir.py`: Added `_download_with_retry()` with exponential backoff for SBIR awards CSV
   - `scripts/data/run_benchmark_analysis.py`: Added retry decorator to `_get()` for sbir.gov downloads
   - `scripts/setup_congressional_districts.py`: Added retry decorator to `_download()` for HUD crosswalk
   - All retry 3 times with exponential backoff (2–30s) on connection errors, timeouts, and server errors (429, 5xx)

4. **Improve HTTP error handling in API clients**
   - `sbir_etl/extractors/solicitation.py`: Narrowed retry condition from all `Exception` to specific httpx exceptions
   - `sbir_etl/transformers/bea_api_client.py`: Extended retry to include `TimeoutException` and `TransportError`
   - `sbir_etl/enrichers/company_categorization.py`: Use shared `CONTRACT_TYPE_CODES` constant

## Type of Change

- [x] Refactoring (non-breaking change which improves code organization)
- [x] Enhancement (adds retry resilience to downloads)

## Testing

- Existing unit tests pass with refactored functions
- Retry logic uses standard `tenacity` library patterns already in use elsewhere in the codebase
- Award ID classification logic is unchanged; only relocated for reuse
- Fallback implementations ensure backward compatibility when `sbir_etl` module is unavailable

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed for correctness
- [x] No new warnings introduced
- [x] Backward compatibility maintained via fallback implementations
- [x] Shared constants reduce magic numbers in API calls

https://claude.ai/code/session_01KQWw3mGLdGFP7ShsQy7a7Y