### PR TITLE
Wire sync API wrappers into weekly report

### DIFF
--- a/sbir_etl/enrichers/sam_gov/client.py
+++ b/sbir_etl/enrichers/sam_gov/client.py
@@ -125,6 +125,7 @@ class SAMGovAPIClient(BaseAsyncAPIClient):
         *,
         legal_business_name: str | None = None,
         duns: str | None = None,
+        registration_status: str | None = None,
         limit: int = 10,
     ) -> list[dict[str, Any]]:
         """Search for entities by name or DUNS.
@@ -132,6 +133,7 @@ class SAMGovAPIClient(BaseAsyncAPIClient):
         Args:
             legal_business_name: Legal business name to search
             duns: DUNS number (legacy identifier)
+            registration_status: Filter by registration status (e.g. ``"A"`` for active)
             limit: Maximum number of results
 
         Returns:
@@ -142,6 +144,8 @@ class SAMGovAPIClient(BaseAsyncAPIClient):
             params["legalBusinessName"] = legal_business_name
         if duns:
             params["duns"] = duns
+        if registration_status:
+            params["registrationStatus"] = registration_status
 
         try:
             response = await self._make_request("GET", "/entities", params=params)

--- a/sbir_etl/enrichers/sync_wrappers.py
+++ b/sbir_etl/enrichers/sync_wrappers.py
@@ -74,6 +74,31 @@ class SyncUSAspendingClient:
             )
         )
 
+    def search_awards(
+        self,
+        filters: dict[str, Any],
+        fields: list[str],
+        page: int = 1,
+        limit: int = 100,
+        sort: str | None = "Award Amount",
+        order: str | None = "desc",
+    ) -> dict[str, Any]:
+        return run_sync(
+            self._client.search_awards(
+                filters, fields, page=page, limit=limit, sort=sort, order=order
+            )
+        )
+
+    def search_recipients(
+        self, keyword: str, limit: int = 5
+    ) -> list[dict[str, Any]]:
+        return run_sync(self._client.search_recipients(keyword, limit))
+
+    def get_recipient_profile(
+        self, recipient_id: str, year: str = "all"
+    ) -> dict[str, Any] | None:
+        return run_sync(self._client.get_recipient_profile(recipient_id, year))
+
     def fetch_award_details(self, award_id: str) -> dict[str, Any] | None:
         return run_sync(self._client.fetch_award_details(award_id))
 

--- a/sbir_etl/enrichers/sync_wrappers.py
+++ b/sbir_etl/enrichers/sync_wrappers.py
@@ -123,10 +123,14 @@ class SyncSAMGovClient:
         *,
         legal_business_name: str | None = None,
         duns: str | None = None,
+        registration_status: str | None = None,
         limit: int = 10,
     ) -> list[dict[str, Any]]:
         return run_sync(
             self._client.search_entities(
-                legal_business_name=legal_business_name, duns=duns, limit=limit
+                legal_business_name=legal_business_name,
+                duns=duns,
+                registration_status=registration_status,
+                limit=limit,
             )
         )

--- a/sbir_etl/enrichers/usaspending/client.py
+++ b/sbir_etl/enrichers/usaspending/client.py
@@ -413,7 +413,7 @@ class USAspendingAPIClient(BaseAsyncAPIClient):
                 params={"year": year},
             )
         except APIError as e:
-            if "404" in str(e) or "not found" in str(e).lower():
+            if e.details.get("http_status") == 404:
                 logger.debug(f"Recipient profile not found: {recipient_id}")
                 return None
             raise

--- a/sbir_etl/enrichers/usaspending/client.py
+++ b/sbir_etl/enrichers/usaspending/client.py
@@ -351,6 +351,73 @@ class USAspendingAPIClient(BaseAsyncAPIClient):
             params=payload,
         )
 
+    async def search_awards(
+        self,
+        filters: dict[str, Any],
+        fields: list[str],
+        page: int = 1,
+        limit: int = 100,
+        sort: str | None = "Award Amount",
+        order: str | None = "desc",
+    ) -> dict[str, Any]:
+        """Search the spending_by_award endpoint."""
+        payload: dict[str, Any] = {
+            "filters": filters,
+            "fields": fields,
+            "page": page,
+            "limit": limit,
+        }
+        if sort:
+            payload["sort"] = sort
+        if order:
+            payload["order"] = order
+
+        return await self._make_request(
+            "POST",
+            "/search/spending_by_award/",
+            params=payload,
+        )
+
+    async def search_recipients(
+        self,
+        keyword: str,
+        limit: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Search for recipients by keyword (name or UEI).
+
+        Returns the results list from POST /recipient/.
+        """
+        payload = {"keyword": keyword, "limit": limit}
+        response = await self._make_request(
+            "POST",
+            "/recipient/",
+            params=payload,
+        )
+        return response.get("results", [])
+
+    async def get_recipient_profile(
+        self,
+        recipient_id: str,
+        year: str = "all",
+    ) -> dict[str, Any] | None:
+        """Fetch a full recipient profile by hash ID.
+
+        Args:
+            recipient_id: The recipient hash from :meth:`search_recipients`.
+            year: Fiscal year or ``"all"`` for lifetime totals.
+        """
+        try:
+            return await self._make_request(
+                "GET",
+                f"/recipient/{recipient_id}/",
+                params={"year": year},
+            )
+        except APIError as e:
+            if "404" in str(e) or "not found" in str(e).lower():
+                logger.debug(f"Recipient profile not found: {recipient_id}")
+                return None
+            raise
+
     async def fetch_award_details(self, award_id: str) -> dict[str, Any] | None:
         """Fetch detailed award information for PSC fallbacks."""
         try:

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -134,6 +134,13 @@ try:
 except ImportError:
     _HAS_BEA_MAPPER = False
 
+try:
+    from sbir_etl.enrichers.sync_wrappers import SyncSAMGovClient, SyncUSAspendingClient
+
+    _HAS_SYNC_CLIENTS = True
+except ImportError:
+    _HAS_SYNC_CLIENTS = False
+
 
 # ---------------------------------------------------------------------------
 # Debug mode — toggled by --debug CLI flag
@@ -1225,35 +1232,60 @@ def _usaspending_autocomplete(company_name: str) -> dict[str, str] | None:
     _debug(f"USAspending autocomplete: {len(unique)} name variations for '{company_name}'")
 
     best_candidate = None
-    with httpx.Client(timeout=15) as client:
-        for idx, name in enumerate(unique, 1):
-            try:
-                _usaspending_limiter.wait_if_needed()
-                resp = client.post(
-                    f"{USASPENDING_API_URL}/autocomplete/recipient/",
-                    json={"search_text": name, "limit": 5},
-                )
-                if resp.status_code != 200:
-                    continue
-                results = resp.json().get("results", [])
-                if not results:
-                    continue
 
-                match = results[0]
-                matched_name = match.get("legal_business_name", "")
-                matched_uei = match.get("uei")
-
-                if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
-                    _debug(
-                        f"USAspending autocomplete matched '{company_name}' "
-                        f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
+    # Use shared sync client when available (gets rate limiting + retry from
+    # the library); fall back to raw httpx for standalone operation.
+    if _HAS_SYNC_CLIENTS:
+        usa = SyncUSAspendingClient()
+        try:
+            for idx, name in enumerate(unique, 1):
+                try:
+                    data = usa.autocomplete_recipient(name, limit=5)
+                    results = data.get("results", [])
+                    if not results:
+                        continue
+                    match = results[0]
+                    matched_name = match.get("legal_business_name", "")
+                    matched_uei = match.get("uei")
+                    if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
+                        _debug(
+                            f"USAspending autocomplete matched '{company_name}' "
+                            f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
+                        )
+                        return {"uei": matched_uei, "name": matched_name}
+                    if matched_name and best_candidate is None:
+                        best_candidate = {"uei": matched_uei, "name": matched_name}
+                except Exception:
+                    continue
+        finally:
+            usa.close()
+    else:
+        with httpx.Client(timeout=15) as client:
+            for idx, name in enumerate(unique, 1):
+                try:
+                    _usaspending_limiter.wait_if_needed()
+                    resp = client.post(
+                        f"{USASPENDING_API_URL}/autocomplete/recipient/",
+                        json={"search_text": name, "limit": 5},
                     )
-                    return {"uei": matched_uei, "name": matched_name}
-
-                if matched_name and best_candidate is None:
-                    best_candidate = {"uei": matched_uei, "name": matched_name}
-            except Exception:
-                continue
+                    if resp.status_code != 200:
+                        continue
+                    results = resp.json().get("results", [])
+                    if not results:
+                        continue
+                    match = results[0]
+                    matched_name = match.get("legal_business_name", "")
+                    matched_uei = match.get("uei")
+                    if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
+                        _debug(
+                            f"USAspending autocomplete matched '{company_name}' "
+                            f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
+                        )
+                        return {"uei": matched_uei, "name": matched_name}
+                    if matched_name and best_candidate is None:
+                        best_candidate = {"uei": matched_uei, "name": matched_name}
+                except Exception:
+                    continue
 
     if best_candidate:
         _debug(f"USAspending autocomplete: best candidate for '{company_name}' → '{best_candidate['name']}' (no UEI)")
@@ -1296,37 +1328,60 @@ def _usaspending_search(
     all_results: list[dict] = []
     _debug(
         f"USAspending query for '{company_name}' ({label}='{search_text}'): "
-        f"POST {USASPENDING_API_URL}/search/spending_by_award/"
+        f"POST /search/spending_by_award/"
     )
-    try:
-        with httpx.Client(timeout=30) as client:
+
+    if _HAS_SYNC_CLIENTS:
+        usa = SyncUSAspendingClient()
+        try:
             for group_name, codes in type_groups:
-                _usaspending_limiter.wait_if_needed()
-                payload = {
-                    "filters": {
-                        "award_type_codes": codes,
-                        "recipient_search_text": [search_text],
-                    },
-                    "fields": fields,
-                    "page": 1,
-                    "limit": 50,
-                    "sort": "Award Amount",
-                    "order": "desc",
-                }
-                resp = client.post(
-                    f"{USASPENDING_API_URL}/search/spending_by_award/",
-                    json=payload,
-                )
-                if resp.status_code != 200:
-                    _debug(f"USAspending [{company_name}] {label}/{group_name} returned {resp.status_code}")
+                try:
+                    data = usa.search_awards(
+                        filters={
+                            "award_type_codes": codes,
+                            "recipient_search_text": [search_text],
+                        },
+                        fields=fields,
+                        limit=50,
+                    )
+                    group_results = data.get("results", [])
+                    _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
+                    all_results.extend(group_results)
+                except Exception as e:
+                    _debug(f"USAspending [{company_name}] {label}/{group_name} error: {e}")
                     continue
-                data = resp.json()
-                group_results = data.get("results", [])
-                _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
-                all_results.extend(group_results)
-    except Exception as e:
-        _debug(f"USAspending [{company_name}] {label} error: {e}")
-        return None
+        finally:
+            usa.close()
+    else:
+        try:
+            with httpx.Client(timeout=30) as client:
+                for group_name, codes in type_groups:
+                    _usaspending_limiter.wait_if_needed()
+                    payload = {
+                        "filters": {
+                            "award_type_codes": codes,
+                            "recipient_search_text": [search_text],
+                        },
+                        "fields": fields,
+                        "page": 1,
+                        "limit": 50,
+                        "sort": "Award Amount",
+                        "order": "desc",
+                    }
+                    resp = client.post(
+                        f"{USASPENDING_API_URL}/search/spending_by_award/",
+                        json=payload,
+                    )
+                    if resp.status_code != 200:
+                        _debug(f"USAspending [{company_name}] {label}/{group_name} returned {resp.status_code}")
+                        continue
+                    data = resp.json()
+                    group_results = data.get("results", [])
+                    _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
+                    all_results.extend(group_results)
+        except Exception as e:
+            _debug(f"USAspending [{company_name}] {label} error: {e}")
+            return None
 
     _debug(f"USAspending [{company_name} via {label}]: {len(all_results)} total results")
     return all_results if all_results else None
@@ -1564,51 +1619,85 @@ def lookup_usaspending_recipient(
     search_terms.append(company_name)
 
     recipient_id = None
-    for term in search_terms:
-        _debug(f"USAspending recipient search: keyword='{term}'")
+
+    if _HAS_SYNC_CLIENTS:
+        usa = SyncUSAspendingClient()
+        try:
+            for term in search_terms:
+                _debug(f"USAspending recipient search: keyword='{term}'")
+                try:
+                    results = usa.search_recipients(term, limit=5)
+                    if results:
+                        recipient_id = results[0].get("id")
+                        _debug(
+                            f"USAspending recipient matched '{term}' → "
+                            f"'{results[0].get('name')}' id={recipient_id}"
+                        )
+                        break
+                except Exception as e:
+                    _debug(f"USAspending recipient search error for '{term}': {e}")
+                    continue
+
+            if not recipient_id:
+                _debug(f"USAspending recipient: no match for '{company_name}'")
+                return None
+
+            # Step 2: Fetch the full profile
+            _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
+            try:
+                profile = usa.get_recipient_profile(recipient_id)
+            except Exception as e:
+                _debug(f"USAspending recipient profile error: {e}")
+                return None
+            if not profile:
+                return None
+        finally:
+            usa.close()
+    else:
+        for term in search_terms:
+            _debug(f"USAspending recipient search: keyword='{term}'")
+            try:
+                _usaspending_limiter.wait_if_needed()
+                with httpx.Client(timeout=15) as client:
+                    resp = client.post(
+                        f"{USASPENDING_API_URL}/recipient/",
+                        json={"keyword": term, "limit": 5},
+                    )
+                    if resp.status_code != 200:
+                        _debug(f"USAspending recipient search returned {resp.status_code}")
+                        continue
+                    data = resp.json()
+                    results = data.get("results", [])
+                    if results:
+                        recipient_id = results[0].get("id")
+                        _debug(
+                            f"USAspending recipient matched '{term}' → "
+                            f"'{results[0].get('name')}' id={recipient_id}"
+                        )
+                        break
+            except Exception as e:
+                _debug(f"USAspending recipient search error for '{term}': {e}")
+                continue
+
+        if not recipient_id:
+            _debug(f"USAspending recipient: no match for '{company_name}'")
+            return None
+
+        _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
         try:
             _usaspending_limiter.wait_if_needed()
             with httpx.Client(timeout=15) as client:
-                resp = client.post(
-                    f"{USASPENDING_API_URL}/recipient/",
-                    json={"keyword": term, "limit": 5},
+                resp = client.get(
+                    f"{USASPENDING_API_URL}/recipient/{recipient_id}/",
+                    params={"year": "all"},
                 )
                 if resp.status_code != 200:
-                    _debug(f"USAspending recipient search returned {resp.status_code}")
-                    continue
-                data = resp.json()
-                results = data.get("results", [])
-                if results:
-                    recipient_id = results[0].get("id")
-                    _debug(
-                        f"USAspending recipient matched '{term}' → "
-                        f"'{results[0].get('name')}' id={recipient_id}"
-                    )
-                    break
+                    _debug(f"USAspending recipient profile returned {resp.status_code}")
+                    return None
+                profile = resp.json()
         except Exception as e:
-            _debug(f"USAspending recipient search error for '{term}': {e}")
-            continue
-
-    if not recipient_id:
-        _debug(f"USAspending recipient: no match for '{company_name}'")
-        return None
-
-    # Step 2: Fetch the full profile
-    _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
-    try:
-        _usaspending_limiter.wait_if_needed()
-        with httpx.Client(timeout=15) as client:
-            resp = client.get(
-                f"{USASPENDING_API_URL}/recipient/{recipient_id}/",
-                params={"year": "all"},
-            )
-            if resp.status_code != 200:
-                _debug(f"USAspending recipient profile returned {resp.status_code}")
-                return None
-            profile = resp.json()
-    except Exception as e:
-        _debug(f"USAspending recipient profile error: {e}")
-        return None
+            _debug(f"USAspending recipient profile error: {e}")
+            return None
 
     location = profile.get("location") or {}
 
@@ -1715,57 +1804,87 @@ def lookup_sam_entity(
     if not api_key:
         return None
 
-    headers = {"X-Api-Key": api_key, "Accept": "application/json"}
-
-    def _try_query(params: dict) -> dict | None:
-        _debug(f"SAM.gov query for '{company_name}': GET {SAM_GOV_API_URL} params={params}")
-        import time
-
-        for attempt in range(3):
-            try:
-                _sam_gov_limiter.wait_if_needed()
-                with httpx.Client(timeout=30) as client:
-                    resp = client.get(SAM_GOV_API_URL, headers=headers, params=params)
-                    _debug_response(f"SAM.gov [{company_name}]", resp)
-                    if resp.status_code == 429:
-                        wait = 2 ** (attempt + 1)
-                        _debug(f"SAM.gov [{company_name}]: rate limited, retrying in {wait}s")
-                        time.sleep(wait)
-                        continue
-                    if resp.status_code != 200:
-                        return None
-                    data = resp.json()
-                    results = data.get("entityData", data.get("results", []))
-                    result_count = len(results) if isinstance(results, list) else (1 if results else 0)
-                    _debug(f"SAM.gov [{company_name}]: {result_count} entities in response")
-                    if isinstance(results, list) and results:
-                        return results[0]
-                    if isinstance(results, dict):
-                        return results
-                    return None
-            except Exception as e:
-                if attempt < 2:
-                    wait = 2 ** (attempt + 1)
-                    _debug(f"SAM.gov [{company_name}]: request error ({e}), retrying in {wait}s")
-                    time.sleep(wait)
-                    continue
-                print(f"SAM.gov API error: {e}", file=sys.stderr)
-                return None
-        return None
-
     entity = None
 
-    # Try UEI first (most reliable)
-    if uei:
-        entity = _try_query({"ueiSAM": uei})
+    if _HAS_SYNC_CLIENTS:
+        sam = SyncSAMGovClient()
+        try:
+            # Try UEI first (most reliable)
+            if uei:
+                _debug(f"SAM.gov [{company_name}]: lookup by UEI={uei}")
+                try:
+                    entity = sam.get_entity_by_uei(uei)
+                except Exception as e:
+                    _debug(f"SAM.gov [{company_name}]: UEI lookup error: {e}")
 
-    # Try CAGE code
-    if not entity and cage:
-        entity = _try_query({"cageCode": cage})
+            # Try CAGE code
+            if not entity and cage:
+                _debug(f"SAM.gov [{company_name}]: lookup by CAGE={cage}")
+                try:
+                    entity = sam.get_entity_by_cage(cage)
+                except Exception as e:
+                    _debug(f"SAM.gov [{company_name}]: CAGE lookup error: {e}")
 
-    # Fall back to name search
-    if not entity and company_name:
-        entity = _try_query({"legalBusinessName": company_name, "registrationStatus": "A"})
+            # Fall back to name search
+            if not entity and company_name:
+                _debug(f"SAM.gov [{company_name}]: name search")
+                try:
+                    results = sam.search_entities(legal_business_name=company_name, limit=1)
+                    entity = results[0] if results else None
+                except Exception as e:
+                    _debug(f"SAM.gov [{company_name}]: name search error: {e}")
+        finally:
+            sam.close()
+    else:
+        headers = {"X-Api-Key": api_key, "Accept": "application/json"}
+
+        def _try_query(params: dict) -> dict | None:
+            _debug(f"SAM.gov query for '{company_name}': GET {SAM_GOV_API_URL} params={params}")
+            import time
+
+            for attempt in range(3):
+                try:
+                    _sam_gov_limiter.wait_if_needed()
+                    with httpx.Client(timeout=30) as client:
+                        resp = client.get(SAM_GOV_API_URL, headers=headers, params=params)
+                        _debug_response(f"SAM.gov [{company_name}]", resp)
+                        if resp.status_code == 429:
+                            wait = 2 ** (attempt + 1)
+                            _debug(f"SAM.gov [{company_name}]: rate limited, retrying in {wait}s")
+                            time.sleep(wait)
+                            continue
+                        if resp.status_code != 200:
+                            return None
+                        data = resp.json()
+                        results = data.get("entityData", data.get("results", []))
+                        result_count = len(results) if isinstance(results, list) else (1 if results else 0)
+                        _debug(f"SAM.gov [{company_name}]: {result_count} entities in response")
+                        if isinstance(results, list) and results:
+                            return results[0]
+                        if isinstance(results, dict):
+                            return results
+                        return None
+                except Exception as e:
+                    if attempt < 2:
+                        wait = 2 ** (attempt + 1)
+                        _debug(f"SAM.gov [{company_name}]: request error ({e}), retrying in {wait}s")
+                        time.sleep(wait)
+                        continue
+                    print(f"SAM.gov API error: {e}", file=sys.stderr)
+                    return None
+            return None
+
+        # Try UEI first (most reliable)
+        if uei:
+            entity = _try_query({"ueiSAM": uei})
+
+        # Try CAGE code
+        if not entity and cage:
+            entity = _try_query({"cageCode": cage})
+
+        # Fall back to name search
+        if not entity and company_name:
+            entity = _try_query({"legalBusinessName": company_name, "registrationStatus": "A"})
 
     if not entity:
         # Always log — helps diagnose silent failures in CI

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1240,6 +1240,7 @@ def _usaspending_autocomplete(company_name: str) -> dict[str, str] | None:
         try:
             for idx, name in enumerate(unique, 1):
                 try:
+                    _usaspending_limiter.wait_if_needed()
                     data = usa.autocomplete_recipient(name, limit=5)
                     results = data.get("results", [])
                     if not results:
@@ -1336,6 +1337,7 @@ def _usaspending_search(
         try:
             for group_name, codes in type_groups:
                 try:
+                    _usaspending_limiter.wait_if_needed()
                     data = usa.search_awards(
                         filters={
                             "award_type_codes": codes,
@@ -1626,6 +1628,7 @@ def lookup_usaspending_recipient(
             for term in search_terms:
                 _debug(f"USAspending recipient search: keyword='{term}'")
                 try:
+                    _usaspending_limiter.wait_if_needed()
                     results = usa.search_recipients(term, limit=5)
                     if results:
                         recipient_id = results[0].get("id")
@@ -1645,6 +1648,7 @@ def lookup_usaspending_recipient(
             # Step 2: Fetch the full profile
             _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
             try:
+                _usaspending_limiter.wait_if_needed()
                 profile = usa.get_recipient_profile(recipient_id)
             except Exception as e:
                 _debug(f"USAspending recipient profile error: {e}")
@@ -1813,6 +1817,7 @@ def lookup_sam_entity(
             if uei:
                 _debug(f"SAM.gov [{company_name}]: lookup by UEI={uei}")
                 try:
+                    _sam_gov_limiter.wait_if_needed()
                     entity = sam.get_entity_by_uei(uei)
                 except Exception as e:
                     _debug(f"SAM.gov [{company_name}]: UEI lookup error: {e}")
@@ -1821,6 +1826,7 @@ def lookup_sam_entity(
             if not entity and cage:
                 _debug(f"SAM.gov [{company_name}]: lookup by CAGE={cage}")
                 try:
+                    _sam_gov_limiter.wait_if_needed()
                     entity = sam.get_entity_by_cage(cage)
                 except Exception as e:
                     _debug(f"SAM.gov [{company_name}]: CAGE lookup error: {e}")
@@ -1829,7 +1835,12 @@ def lookup_sam_entity(
             if not entity and company_name:
                 _debug(f"SAM.gov [{company_name}]: name search")
                 try:
-                    results = sam.search_entities(legal_business_name=company_name, limit=1)
+                    _sam_gov_limiter.wait_if_needed()
+                    results = sam.search_entities(
+                        legal_business_name=company_name,
+                        registration_status="A",
+                        limit=1,
+                    )
                     entity = results[0] if results else None
                 except Exception as e:
                     _debug(f"SAM.gov [{company_name}]: name search error: {e}")

--- a/tests/unit/enrichers/usaspending/test_client.py
+++ b/tests/unit/enrichers/usaspending/test_client.py
@@ -822,3 +822,142 @@ class TestEdgeCases:
         finally:
             # Restore permissions for cleanup
             readonly_dir.chmod(0o755)
+
+
+# ==================== New Endpoint Method Tests ====================
+
+
+class TestSearchAwards:
+    """Tests for the search_awards() method."""
+
+    @pytest.mark.asyncio
+    async def test_search_awards_calls_correct_endpoint(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": [{"Award ID": "FA123"}]}
+        mock_response.raise_for_status = Mock()
+        mock_http_client.post.return_value = mock_response
+
+        result = await client.search_awards(
+            filters={"award_type_codes": ["A", "B"]},
+            fields=["Award ID", "Description"],
+            limit=10,
+        )
+
+        assert result == {"results": [{"Award ID": "FA123"}]}
+        call_args = mock_http_client.post.call_args
+        assert "/search/spending_by_award/" in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_search_awards_default_sort(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = Mock()
+        mock_http_client.post.return_value = mock_response
+
+        await client.search_awards(
+            filters={"award_type_codes": ["A"]},
+            fields=["Award ID"],
+        )
+
+        call_kwargs = mock_http_client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        assert payload["sort"] == "Award Amount"
+        assert payload["order"] == "desc"
+
+
+class TestSearchRecipients:
+    """Tests for the search_recipients() method."""
+
+    @pytest.mark.asyncio
+    async def test_search_recipients_returns_results_list(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "results": [
+                {"id": "abc-hash", "name": "Acme Corp"},
+                {"id": "def-hash", "name": "Acme Inc"},
+            ]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_http_client.post.return_value = mock_response
+
+        results = await client.search_recipients("Acme", limit=5)
+
+        assert len(results) == 2
+        assert results[0]["id"] == "abc-hash"
+
+    @pytest.mark.asyncio
+    async def test_search_recipients_empty(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = Mock()
+        mock_http_client.post.return_value = mock_response
+
+        results = await client.search_recipients("NonExistent")
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_search_recipients_calls_correct_endpoint(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"results": []}
+        mock_response.raise_for_status = Mock()
+        mock_http_client.post.return_value = mock_response
+
+        await client.search_recipients("test", limit=3)
+
+        call_args = mock_http_client.post.call_args
+        assert "/recipient/" in str(call_args)
+        payload = call_args.kwargs.get("json") or call_args[1].get("json")
+        assert payload["keyword"] == "test"
+        assert payload["limit"] == 3
+
+
+class TestGetRecipientProfile:
+    """Tests for the get_recipient_profile() method."""
+
+    @pytest.mark.asyncio
+    async def test_get_recipient_profile_success(self, client, mock_http_client):
+        profile_data = {
+            "name": "Acme Corp",
+            "uei": "ABC123",
+            "total_transaction_amount": 5000000,
+        }
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = profile_data
+        mock_response.raise_for_status = Mock()
+        mock_http_client.get.return_value = mock_response
+
+        result = await client.get_recipient_profile("abc-hash")
+
+        assert result == profile_data
+        call_args = mock_http_client.get.call_args
+        assert "/recipient/abc-hash/" in str(call_args)
+
+    @pytest.mark.asyncio
+    async def test_get_recipient_profile_404_returns_none(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.text = "Not found"
+        error = httpx.HTTPStatusError("404", request=Mock(), response=mock_response)
+        mock_http_client.get.side_effect = error
+
+        result = await client.get_recipient_profile("nonexistent-hash")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_recipient_profile_500_raises(self, client, mock_http_client):
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        error = httpx.HTTPStatusError("500", request=Mock(), response=mock_response)
+        mock_http_client.get.side_effect = error
+
+        with pytest.raises(APIError):
+            await client.get_recipient_profile("some-hash")


### PR DESCRIPTION
## Summary

- **Wire `SyncUSAspendingClient` and `SyncSAMGovClient`** into the weekly report's 4 main API functions, replacing raw `httpx.Client()` calls with the library's shared infrastructure (rate limiting, tenacity retry, error hierarchy)
- **Add 3 new async methods** to `USAspendingAPIClient` and their sync facades: `search_awards()`, `search_recipients()`, `get_recipient_profile()`
- **Preserve standalone operation** — all 4 functions fall back to raw httpx when `sbir_etl` is not installed

## Functions refactored

| Function | Before | After (with sbir_etl) |
|---|---|---|
| `_usaspending_autocomplete()` | Raw httpx POST to `/autocomplete/recipient/` | `SyncUSAspendingClient.autocomplete_recipient()` |
| `_usaspending_search()` | Raw httpx POST to `/search/spending_by_award/` | `SyncUSAspendingClient.search_awards()` |
| `lookup_usaspending_recipient()` | Raw httpx POST+GET to `/recipient/` | `SyncUSAspendingClient.search_recipients()` + `.get_recipient_profile()` |
| `lookup_sam_entity()` | Raw httpx GET with manual retry loop | `SyncSAMGovClient.get_entity_by_uei/cage/search_entities()` |

Script orchestration logic preserved in all cases (name variation generation, type group splitting, UEI→CAGE→name cascade).

## Test plan

- [x] All files compile
- [x] Sync wrapper methods verified present
- [x] 676 unit tests pass (2 pre-existing failures unrelated)
- [ ] End-to-end report generation with `OPENAI_API_KEY`

https://claude.ai/code/session_01D8ws9MmBT6yXZzXSzMnWYw