### PR TITLE
Wire remaining sync wrappers, extract FPDS client, delegate SBIR identification

### DIFF
--- a/sbir_etl/enrichers/fpds_atom.py
+++ b/sbir_etl/enrichers/fpds_atom.py
@@ -198,9 +198,23 @@ class FPDSAtomClient:
         self,
         rate_limiter: Any | None = None,
         timeout: int = 30,
+        http_client: httpx.Client | None = None,
     ) -> None:
         self._limiter = rate_limiter
         self._timeout = timeout
+        self._client = http_client or httpx.Client(timeout=timeout)
+        self._owns_client = http_client is None
+
+    def close(self) -> None:
+        """Close the underlying HTTP client (if owned by this instance)."""
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> "FPDSAtomClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
 
     def _wait(self) -> None:
         if self._limiter is not None:
@@ -211,8 +225,7 @@ class FPDSAtomClient:
         for attempt in range(MAX_RETRIES):
             self._wait()
             try:
-                with httpx.Client(timeout=self._timeout) as client:
-                    resp = client.get(FPDS_ATOM_URL, params=params)
+                resp = self._client.get(FPDS_ATOM_URL, params=params)
                 if resp.status_code in (429, 500, 502, 503, 504):
                     wait = RETRY_BACKOFF_BASE ** (attempt + 1)
                     logger.debug(

--- a/sbir_etl/enrichers/fpds_atom.py
+++ b/sbir_etl/enrichers/fpds_atom.py
@@ -1,0 +1,341 @@
+"""FPDS Atom Feed client for real-time federal procurement data.
+
+The FPDS (Federal Procurement Data System) Atom Feed at
+``https://www.fpds.gov/ezsearch/LATEST`` provides public, real-time access
+to federal contract records.  Unlike USAspending (which lags weeks/months),
+FPDS updates within 3 days of contract action.
+
+Key data available via FPDS Atom:
+- Contract descriptions (``descriptionOfContractRequirement``)
+- SBIR/STTR research codes (Element 10Q: SR1–SR3, ST1–ST3)
+- Vendor information (name, UEI, CAGE, DUNS)
+- PSC and NAICS codes
+- Contract values and dates
+- Competition type and solicitation info
+
+No API key is required — the Atom feed is fully public.
+
+Usage::
+
+    from sbir_etl.enrichers.fpds_atom import FPDSAtomClient
+
+    client = FPDSAtomClient()
+    record = client.search_by_piid("FA2541-26-C-B005")
+    if record:
+        print(record.description)
+        print(record.research_code)  # e.g. "SR1" for SBIR Phase I
+
+    descs = client.get_descriptions(["FA2541-26-C-B005", "FA9550-26-C-B001"])
+"""
+
+from __future__ import annotations
+
+import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from loguru import logger
+
+FPDS_ATOM_URL = "https://www.fpds.gov/ezsearch/LATEST"
+ATOM_NS = {"atom": "http://www.w3.org/2005/Atom"}
+
+# Maximum retries for transient errors (429, 5xx)
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2  # seconds
+
+
+@dataclass
+class FPDSRecord:
+    """Parsed FPDS contract record from the Atom feed."""
+
+    piid: str
+    description: str | None = None
+    research_code: str | None = None
+    vendor_name: str | None = None
+    vendor_uei: str | None = None
+    vendor_duns: str | None = None
+    vendor_cage: str | None = None
+    psc_code: str | None = None
+    naics_code: str | None = None
+    agency_name: str | None = None
+    awarding_office: str | None = None
+    obligated_amount: float | None = None
+    signed_date: str | None = None
+    completion_date: str | None = None
+    solicitation_id: str | None = None
+    competition_type: str | None = None
+    raw_xml: str | None = field(default=None, repr=False)
+
+
+def _find_local(element: ET.Element, local_name: str) -> ET.Element | None:
+    """Find a descendant element by local name, ignoring XML namespaces.
+
+    Python's ElementTree doesn't support XPath ``local-name()``, so we
+    iterate and strip namespace prefixes manually.
+    """
+    for el in element.iter():
+        # Tag may be ``{namespace}localName`` or just ``localName``
+        tag = el.tag
+        if "}" in tag:
+            tag = tag.split("}", 1)[1]
+        if tag == local_name:
+            return el
+    return None
+
+
+def _text(element: ET.Element, local_name: str) -> str | None:
+    """Extract text from a descendant element by local name."""
+    el = _find_local(element, local_name)
+    if el is not None and el.text:
+        return el.text.strip()
+    return None
+
+
+def _attr(element: ET.Element, local_name: str, attr: str = "description") -> str | None:
+    """Extract an attribute value from a descendant element by local name."""
+    el = _find_local(element, local_name)
+    if el is not None:
+        return el.get(attr)
+    return None
+
+
+def _parse_entry(entry: ET.Element, piid: str) -> FPDSRecord:
+    """Parse an Atom ``<entry>`` element into an :class:`FPDSRecord`.
+
+    Extracts fields from the inner FPDS XML nested inside
+    ``<atom:content>``, falling back to Atom-level elements where needed.
+    """
+    content_el = entry.find("atom:content", ATOM_NS)
+    if content_el is None:
+        # Minimal record from Atom-level data only
+        title = entry.findtext("atom:title", default=None, namespaces=ATOM_NS)
+        return FPDSRecord(piid=piid, description=title)
+
+    # Description: try FPDS-specific field first, then generic
+    desc = _text(content_el, "descriptionOfContractRequirement")
+    if not desc:
+        desc = _text(content_el, "description")
+    if not desc:
+        title_el = entry.find("atom:title", ATOM_NS)
+        if title_el is not None and title_el.text:
+            desc = title_el.text.strip()
+
+    # SBIR/STTR research code (Element 10Q)
+    research_code = _text(content_el, "research")
+
+    # Vendor information
+    vendor_name = _text(content_el, "vendorName")
+    vendor_uei = _text(content_el, "UEINumber") or _text(content_el, "entityIdentifier")
+    vendor_duns = _text(content_el, "DUNSNumber")
+    vendor_cage = _text(content_el, "cageCode")
+
+    # Classification
+    psc_code = _text(content_el, "productOrServiceCode")
+    naics_code = _text(content_el, "principalNAICSCode")
+
+    # Agency
+    agency_name = _text(content_el, "agencyID")
+    if not agency_name:
+        agency_name = _attr(content_el, "agencyID", "name")
+    awarding_office = _text(content_el, "contractingOfficeAgencyID")
+    if not awarding_office:
+        awarding_office = _attr(content_el, "contractingOfficeAgencyID", "name")
+
+    # Financial
+    amount_str = _text(content_el, "obligatedAmount")
+    obligated_amount = None
+    if amount_str:
+        try:
+            obligated_amount = float(amount_str)
+        except ValueError:
+            pass
+
+    # Dates
+    signed_date = _text(content_el, "signedDate")
+    completion_date = _text(content_el, "ultimateCompletionDate")
+
+    # Solicitation and competition
+    solicitation_id = _text(content_el, "solicitationID")
+    competition_type = _text(content_el, "extentCompeted")
+    if not competition_type:
+        competition_type = _attr(content_el, "extentCompeted", "description")
+
+    return FPDSRecord(
+        piid=piid,
+        description=desc,
+        research_code=research_code,
+        vendor_name=vendor_name,
+        vendor_uei=vendor_uei,
+        vendor_duns=vendor_duns,
+        vendor_cage=vendor_cage,
+        psc_code=psc_code,
+        naics_code=naics_code,
+        agency_name=agency_name,
+        awarding_office=awarding_office,
+        obligated_amount=obligated_amount,
+        signed_date=signed_date,
+        completion_date=completion_date,
+        solicitation_id=solicitation_id,
+        competition_type=competition_type,
+    )
+
+
+class FPDSAtomClient:
+    """Client for querying the FPDS Atom Feed.
+
+    Uses synchronous httpx with retry logic and rate limiting.
+    Thread-safe when used with a shared :class:`RateLimiter`.
+
+    Args:
+        rate_limiter: Optional rate limiter (e.g. from ``patentsview.RateLimiter``).
+            If ``None``, no rate limiting is applied.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        rate_limiter: Any | None = None,
+        timeout: int = 30,
+    ) -> None:
+        self._limiter = rate_limiter
+        self._timeout = timeout
+
+    def _wait(self) -> None:
+        if self._limiter is not None:
+            self._limiter.wait_if_needed()
+
+    def _get(self, params: dict[str, Any]) -> httpx.Response | None:
+        """Make a GET request with retry logic for transient errors."""
+        for attempt in range(MAX_RETRIES):
+            self._wait()
+            try:
+                with httpx.Client(timeout=self._timeout) as client:
+                    resp = client.get(FPDS_ATOM_URL, params=params)
+                if resp.status_code in (429, 500, 502, 503, 504):
+                    wait = RETRY_BACKOFF_BASE ** (attempt + 1)
+                    logger.debug(
+                        f"FPDS returned {resp.status_code}, retrying in {wait}s "
+                        f"(attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
+                    time.sleep(wait)
+                    continue
+                if resp.status_code != 200:
+                    logger.debug(f"FPDS returned {resp.status_code}")
+                    return None
+                return resp
+            except httpx.HTTPError as e:
+                wait = RETRY_BACKOFF_BASE ** (attempt + 1)
+                logger.debug(f"FPDS request error: {e}, retrying in {wait}s")
+                time.sleep(wait)
+        return None
+
+    def _parse_response(self, resp: httpx.Response, piid: str) -> FPDSRecord | None:
+        """Parse an FPDS Atom response into a record."""
+        try:
+            root = ET.fromstring(resp.text)
+        except (ET.ParseError, UnicodeDecodeError) as e:
+            logger.debug(f"FPDS XML parse error for {piid}: {e}")
+            return None
+
+        entry = root.find("atom:entry", ATOM_NS)
+        if entry is None:
+            return None
+
+        return _parse_entry(entry, piid)
+
+    def search_by_piid(self, piid: str) -> FPDSRecord | None:
+        """Search for a contract by PIID (Procurement Instrument Identifier).
+
+        Queries both ``PIID`` and ``REF_IDV_PIID`` to catch task orders
+        under indefinite-delivery contracts.
+
+        Returns:
+            Parsed :class:`FPDSRecord` or ``None`` if not found.
+        """
+        query = f'PIID:"{piid}" OR REF_IDV_PIID:"{piid}"'
+        resp = self._get({"q": query, "s": 0, "num": 1})
+        if resp is None:
+            return None
+        return self._parse_response(resp, piid)
+
+    def search_by_vendor(
+        self, name: str | None = None, uei: str | None = None, limit: int = 10
+    ) -> list[FPDSRecord]:
+        """Search for contracts by vendor name or UEI.
+
+        Args:
+            name: Vendor name to search.
+            uei: Unique Entity Identifier.
+            limit: Maximum results to return.
+
+        Returns:
+            List of :class:`FPDSRecord` objects.
+        """
+        parts = []
+        if uei:
+            parts.append(f'VENDOR_UEI_NUMBER:"{uei}"')
+        if name:
+            parts.append(f'VENDOR_FULL_NAME:"{name}"')
+        if not parts:
+            return []
+
+        query = " OR ".join(parts)
+        resp = self._get({"q": query, "s": 0, "num": limit})
+        if resp is None:
+            return []
+
+        try:
+            root = ET.fromstring(resp.text)
+        except (ET.ParseError, UnicodeDecodeError) as e:
+            logger.debug(f"FPDS XML parse error for vendor search: {e}")
+            return []
+
+        records = []
+        for entry in root.findall("atom:entry", ATOM_NS):
+            # Extract PIID from entry for the record
+            content = entry.find("atom:content", ATOM_NS)
+            piid = _text(content, "PIID") if content is not None else None
+            piid = piid or "unknown"
+            records.append(_parse_entry(entry, piid))
+
+        return records
+
+    def get_description(self, piid: str) -> str | None:
+        """Get just the contract description for a PIID.
+
+        Convenience method — delegates to :meth:`search_by_piid`.
+        """
+        record = self.search_by_piid(piid)
+        return record.description if record else None
+
+    def get_research_code(self, piid: str) -> str | None:
+        """Get the FPDS SBIR/STTR research code for a PIID.
+
+        Returns codes like ``"SR1"`` (SBIR Phase I), ``"ST2"`` (STTR Phase II),
+        or ``None`` if not an SBIR/STTR contract.
+        """
+        record = self.search_by_piid(piid)
+        return record.research_code if record else None
+
+    def get_descriptions(self, piids: list[str]) -> dict[str, str]:
+        """Batch-fetch descriptions for multiple PIIDs.
+
+        Args:
+            piids: List of contract PIIDs.
+
+        Returns:
+            Dict mapping PIID to description text.
+        """
+        results: dict[str, str] = {}
+        for piid in piids:
+            if piid in results:
+                continue
+            record = self.search_by_piid(piid)
+            if record and record.description:
+                desc = record.description
+                if len(desc) > 500:
+                    desc = desc[:500] + "..."
+                results[piid] = desc
+        return results

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -141,6 +141,13 @@ try:
 except ImportError:
     _HAS_SYNC_CLIENTS = False
 
+try:
+    from sbir_etl.enrichers.fpds_atom import FPDSAtomClient
+
+    _HAS_FPDS_CLIENT = True
+except ImportError:
+    _HAS_FPDS_CLIENT = False
+
 
 # ---------------------------------------------------------------------------
 # Debug mode — toggled by --debug CLI flag
@@ -2893,21 +2900,32 @@ def _fetch_fpds_descriptions(
 ) -> dict[str, str]:
     """Fetch contract descriptions from FPDS Atom Feed (public, no API key).
 
-    Queries ``https://www.fpds.gov/ezsearch/LATEST`` for each contract ID
-    and extracts the ``<description>`` element from the Atom XML response.
-    Used as a fallback when USAspending is unavailable (503 / 422).
+    Uses :class:`FPDSAtomClient` when the library is available; falls back
+    to inline httpx + XML parsing for standalone operation.
 
     Only accepts contract PIIDs — assistance FAINs (e.g. DE-*) are not
     indexed in FPDS and should be filtered out before calling this function.
     """
+    if not contract_ids:
+        return {}
+
+    _debug(f"FPDS: querying {len(contract_ids)} contract IDs")
+
+    if _HAS_FPDS_CLIENT:
+        fpds = FPDSAtomClient(rate_limiter=_usaspending_limiter)
+        try:
+            results = fpds.get_descriptions(contract_ids)
+        except Exception as e:
+            print(f"FPDS error: {e}", file=sys.stderr)
+            results = {}
+        _debug(f"FPDS: {len(results)}/{len(contract_ids)} descriptions found")
+        return results
+
+    # Inline fallback for standalone operation (no sbir_etl)
     import time as _t
     import xml.etree.ElementTree as ET
 
     results: dict[str, str] = {}
-    if not contract_ids:
-        return results
-
-    _debug(f"FPDS fallback: querying {len(contract_ids)} contract IDs")
     try:
         with httpx.Client(timeout=30) as client:
             for cid in contract_ids:
@@ -2916,69 +2934,48 @@ def _fetch_fpds_descriptions(
                 query = f'PIID:"{cid}" OR REF_IDV_PIID:"{cid}"'
                 for attempt in range(3):
                     try:
+                        _usaspending_limiter.wait_if_needed()
                         resp = client.get(
                             FPDS_ATOM_SEARCH_URL,
                             params={"q": query, "s": 0, "num": 1},
                         )
                         if resp.status_code in (429, 500, 502, 503, 504):
                             wait = 2 ** (attempt + 1)
-                            _debug(
-                                f"FPDS [{cid}] returned {resp.status_code}, "
-                                f"retrying in {wait}s"
-                            )
+                            _debug(f"FPDS [{cid}] returned {resp.status_code}, retrying in {wait}s")
                             _t.sleep(wait)
                             continue
                         if resp.status_code != 200:
-                            _debug(f"FPDS [{cid}] returned {resp.status_code}")
                             break
 
                         root = ET.fromstring(resp.text)
-                        # Atom namespace
                         ns = {"atom": "http://www.w3.org/2005/Atom"}
                         entry = root.find("atom:entry", ns)
                         if entry is None:
-                            _debug(f"FPDS [{cid}]: no entry in response")
                             break
 
-                        # The Atom <content> element contains inner FPDS XML.
-                        # Use namespace-agnostic local-name matching so we
-                        # don't break if the FPDS namespace URI changes.
                         content_el = entry.find("atom:content", ns)
                         desc = None
                         if content_el is not None:
-                            for local_name in [
-                                "descriptionOfContractRequirement",
-                                "description",
-                            ]:
-                                match = content_el.find(
-                                    f".//*[local-name()='{local_name}']"
-                                )
+                            for local_name in ("descriptionOfContractRequirement", "description"):
+                                match = content_el.find(f".//*[local-name()='{local_name}']")
                                 if match is not None and match.text:
                                     desc = match.text.strip()
                                     break
-
-                        # Fallback: use Atom <title>
                         if not desc:
                             title_el = entry.find("atom:title", ns)
                             if title_el is not None and title_el.text:
                                 desc = title_el.text.strip()
-
                         if desc:
                             if len(desc) > 500:
                                 desc = desc[:500] + "..."
                             results[cid] = desc
-                            _debug(f"FPDS [{cid}]: found description ({len(desc)} chars)")
-                        else:
-                            _debug(f"FPDS [{cid}]: entry found but no description text")
                         break
                     except (httpx.HTTPError, ET.ParseError, UnicodeDecodeError) as e:
-                        wait = 2 ** (attempt + 1)
-                        _debug(f"FPDS [{cid}] error: {e}, retrying in {wait}s")
-                        _t.sleep(wait)
+                        _t.sleep(2 ** (attempt + 1))
     except Exception as e:
         print(f"FPDS fallback error: {e}", file=sys.stderr)
 
-    _debug(f"FPDS fallback: {len(results)}/{len(contract_ids)} descriptions found")
+    _debug(f"FPDS: {len(results)}/{len(contract_ids)} descriptions found")
     return results
 
 

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -2912,12 +2912,12 @@ def _fetch_fpds_descriptions(
     _debug(f"FPDS: querying {len(contract_ids)} contract IDs")
 
     if _HAS_FPDS_CLIENT:
-        fpds = FPDSAtomClient(rate_limiter=_usaspending_limiter)
-        try:
-            results = fpds.get_descriptions(contract_ids)
-        except Exception as e:
-            print(f"FPDS error: {e}", file=sys.stderr)
-            results = {}
+        with FPDSAtomClient(rate_limiter=_usaspending_limiter) as fpds:
+            try:
+                results = fpds.get_descriptions(contract_ids)
+            except Exception as e:
+                print(f"FPDS error: {e}", file=sys.stderr)
+                results = {}
         _debug(f"FPDS: {len(results)}/{len(contract_ids)} descriptions found")
         return results
 
@@ -2957,9 +2957,12 @@ def _fetch_fpds_descriptions(
                         desc = None
                         if content_el is not None:
                             for local_name in ("descriptionOfContractRequirement", "description"):
-                                match = content_el.find(f".//*[local-name()='{local_name}']")
-                                if match is not None and match.text:
-                                    desc = match.text.strip()
+                                for el in content_el.iter():
+                                    tag = el.tag.split("}", 1)[-1] if "}" in el.tag else el.tag
+                                    if tag == local_name and el.text:
+                                        desc = el.text.strip()
+                                        break
+                                if desc:
                                     break
                         if not desc:
                             title_el = entry.find("atom:title", ns)

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1137,24 +1137,30 @@ def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
 
 
 def _is_sbir_award_type(description: str, cfda: str) -> bool:
-    """Heuristic to identify SBIR/STTR awards in USAspending results.
+    """Identify SBIR/STTR awards using ALN numbers and description keywords.
 
-    Uses CFDA/ALN numbers and description keywords. Mirrors the logic in
-    sbir_etl.models.sbir_identification but without the heavy import.
+    Delegates to :func:`sbir_etl.models.sbir_identification.classify_sbir_award`
+    when the library is available; falls back to a minimal inline heuristic.
     """
-    # Known SBIR/STTR Assistance Listing Numbers (subset of the most common)
-    sbir_alns = {
+    try:
+        from sbir_etl.models.sbir_identification import classify_sbir_award
+
+        result = classify_sbir_award(cfda_number=cfda, description=description)
+        return result is not None
+    except ImportError:
+        pass
+
+    # Fallback for standalone operation
+    _sbir_alns = {
         "10.212", "12.910", "12.911", "81.049", "43.002", "43.003",
         "47.041", "47.084", "66.511", "66.512", "97.077", "20.701",
         "84.133",
-        # HHS/NIH common ones
         "93.855", "93.856", "93.859", "93.837", "93.847", "93.853",
         "93.865", "93.866", "93.867", "93.879", "93.242", "93.273",
         "93.279", "93.395", "93.393", "93.394", "93.396", "93.399",
     }
-    if cfda and cfda.strip() in sbir_alns:
+    if cfda and cfda.strip() in _sbir_alns:
         return True
-    # Keyword heuristic on description
     desc_upper = description.upper()
     if "SBIR" in desc_upper or "STTR" in desc_upper:
         return True
@@ -3034,73 +3040,112 @@ def fetch_usaspending_contract_descriptions(
     # so the FPDS fallback only fires for actual USAspending outages.
     failed_ids: set[str] = set()
 
-    try:
-        with httpx.Client(timeout=30) as client:
+    desc_fields = ["Award ID", "Description", "Awarding Agency", "Award Type"]
+
+    def _extract_descriptions(data: dict) -> None:
+        """Extract descriptions from a USAspending response into results."""
+        for r in data.get("results", []):
+            aid = str(r.get("Award ID", "")).strip()
+            desc = str(r.get("Description", "")).strip()
+            if aid and desc and aid not in results:
+                if len(desc) > 500:
+                    desc = desc[:500] + "..."
+                results[aid] = desc
+
+    if _HAS_SYNC_CLIENTS:
+        usa = SyncUSAspendingClient()
+        try:
             for ids, group_name, codes in requests_to_make:
                 quoted = [f'"{c}"' for c in ids]
-                payload = {
-                    "filters": {
-                        "award_ids": quoted,
-                        "award_type_codes": codes,
-                    },
-                    "fields": ["Award ID", "Description", "Awarding Agency", "Award Type"],
-                    "page": 1,
-                    "limit": len(ids),
-                }
+                filters = {"award_ids": quoted, "award_type_codes": codes}
                 _debug(
                     f"USAspending contract desc: {group_name} "
                     f"({len(ids)} IDs: {ids[:3]})"
                 )
-                # Try spending_by_award first, fall back to spending_by_transaction
-                # if the search endpoint is down (503).
-                endpoints = [
-                    "search/spending_by_award",
-                    "search/spending_by_transaction",
-                ]
                 data = None
-                for endpoint in endpoints:
-                    for attempt in range(2):
+                # Try spending_by_award, then spending_by_transaction
+                for method in ("search_awards", "search_transactions"):
+                    try:
                         _usaspending_limiter.wait_if_needed()
-                        resp = client.post(
-                            f"{USASPENDING_API_URL}/{endpoint}/",
-                            json=payload,
+                        data = getattr(usa, method)(
+                            filters=filters,
+                            fields=desc_fields,
+                            limit=len(ids),
+                            sort=None,
+                            order=None,
                         )
-                        if resp.status_code in (429, 500, 502, 503, 504):
-                            wait = 2 ** (attempt + 1)
-                            _debug(
-                                f"USAspending {endpoint}/{group_name} "
-                                f"returned {resp.status_code}, retrying in {wait}s"
-                            )
-                            _t.sleep(wait)
-                            continue
-                        if resp.status_code != 200:
-                            _debug(
-                                f"USAspending {endpoint}/{group_name} "
-                                f"returned {resp.status_code}"
-                            )
-                            break
-                        data = resp.json()
                         break
-                    if data is not None:
-                        break
-                    _debug(
-                        f"USAspending {endpoint} failed for {group_name}, "
-                        f"trying next endpoint"
-                    )
+                    except Exception as e:
+                        _debug(f"USAspending {method}/{group_name} failed: {e}")
+                        continue
                 if data is None:
                     failed_ids.update(ids)
                     continue
-                for r in data.get("results", []):
-                    aid = str(r.get("Award ID", "")).strip()
-                    desc = str(r.get("Description", "")).strip()
-                    if aid and desc and aid not in results:
-                        if len(desc) > 500:
-                            desc = desc[:500] + "..."
-                        results[aid] = desc
-    except Exception as e:
-        # Total failure — treat all remaining IDs as failed.
-        failed_ids.update(cid for cid in all_ids if cid not in results)
-        print(f"USAspending contract desc error: {e}", file=sys.stderr)
+                _extract_descriptions(data)
+        except Exception as e:
+            failed_ids.update(cid for cid in all_ids if cid not in results)
+            print(f"USAspending contract desc error: {e}", file=sys.stderr)
+        finally:
+            usa.close()
+    else:
+        try:
+            with httpx.Client(timeout=30) as client:
+                for ids, group_name, codes in requests_to_make:
+                    quoted = [f'"{c}"' for c in ids]
+                    payload = {
+                        "filters": {
+                            "award_ids": quoted,
+                            "award_type_codes": codes,
+                        },
+                        "fields": desc_fields,
+                        "page": 1,
+                        "limit": len(ids),
+                    }
+                    _debug(
+                        f"USAspending contract desc: {group_name} "
+                        f"({len(ids)} IDs: {ids[:3]})"
+                    )
+                    endpoints = [
+                        "search/spending_by_award",
+                        "search/spending_by_transaction",
+                    ]
+                    data = None
+                    for endpoint in endpoints:
+                        for attempt in range(2):
+                            _usaspending_limiter.wait_if_needed()
+                            resp = client.post(
+                                f"{USASPENDING_API_URL}/{endpoint}/",
+                                json=payload,
+                            )
+                            if resp.status_code in (429, 500, 502, 503, 504):
+                                wait = 2 ** (attempt + 1)
+                                _debug(
+                                    f"USAspending {endpoint}/{group_name} "
+                                    f"returned {resp.status_code}, retrying in {wait}s"
+                                )
+                                _t.sleep(wait)
+                                continue
+                            if resp.status_code != 200:
+                                _debug(
+                                    f"USAspending {endpoint}/{group_name} "
+                                    f"returned {resp.status_code}"
+                                )
+                                break
+                            data = resp.json()
+                            break
+                        if data is not None:
+                            break
+                        _debug(
+                            f"USAspending {endpoint} failed for {group_name}, "
+                            f"trying next endpoint"
+                        )
+                    if data is None:
+                        failed_ids.update(ids)
+                        continue
+                    _extract_descriptions(data)
+        except Exception as e:
+            failed_ids.update(cid for cid in all_ids if cid not in results)
+            print(f"USAspending contract desc error: {e}", file=sys.stderr)
 
     # FPDS Atom Feed fallback for contract PIIDs that failed at USAspending.
     # FPDS only indexes procurement contracts (PIIDs), not assistance FAINs

--- a/tests/unit/enrichers/test_fpds_atom.py
+++ b/tests/unit/enrichers/test_fpds_atom.py
@@ -3,7 +3,6 @@
 import xml.etree.ElementTree as ET
 from unittest.mock import Mock, patch
 
-import httpx
 import pytest
 
 from sbir_etl.enrichers.fpds_atom import (
@@ -12,7 +11,6 @@ from sbir_etl.enrichers.fpds_atom import (
     FPDSRecord,
     _find_local,
     _parse_entry,
-    _text,
 )
 
 pytestmark = pytest.mark.fast
@@ -218,22 +216,28 @@ class TestFPDSAtomClient:
         assert result["TEST"].endswith("...")
         assert len(result["TEST"]) == 503  # 500 + "..."
 
+    def test_context_manager(self):
+        mock_http = Mock()
+        with FPDSAtomClient(http_client=mock_http) as client:
+            assert client._client is mock_http
+        # Owned client would be closed; injected client is not
+        mock_http.close.assert_not_called()
+
+    def test_close_owns_client(self):
+        client = FPDSAtomClient()
+        assert client._owns_client is True
+        client.close()
+
     def test_rate_limiter_called(self):
         limiter = Mock()
-        client = FPDSAtomClient(rate_limiter=limiter)
-
+        mock_http = Mock()
         mock_resp = Mock()
         mock_resp.status_code = 200
         mock_resp.text = EMPTY_FEED
+        mock_http.get.return_value = mock_resp
 
-        with patch("sbir_etl.enrichers.fpds_atom.httpx.Client") as mock_client_cls:
-            mock_http = Mock()
-            mock_http.get.return_value = mock_resp
-            mock_http.__enter__ = Mock(return_value=mock_http)
-            mock_http.__exit__ = Mock(return_value=False)
-            mock_client_cls.return_value = mock_http
-
-            client.search_by_piid("TEST")
+        client = FPDSAtomClient(rate_limiter=limiter, http_client=mock_http)
+        client.search_by_piid("TEST")
 
         limiter.wait_if_needed.assert_called()
 

--- a/tests/unit/enrichers/test_fpds_atom.py
+++ b/tests/unit/enrichers/test_fpds_atom.py
@@ -1,0 +1,251 @@
+"""Tests for FPDS Atom Feed client."""
+
+import xml.etree.ElementTree as ET
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from sbir_etl.enrichers.fpds_atom import (
+    ATOM_NS,
+    FPDSAtomClient,
+    FPDSRecord,
+    _find_local,
+    _parse_entry,
+    _text,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ==================== Sample XML ====================
+
+SAMPLE_ATOM_ENTRY = """\
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>SBIR PHASE I: Advanced Sensor</title>
+    <content type="application/xml">
+      <award xmlns:ns1="https://www.fpds.gov/FPDS">
+        <ns1:PIID>FA2541-26-C-B005</ns1:PIID>
+        <ns1:descriptionOfContractRequirement>Develop advanced sensor</ns1:descriptionOfContractRequirement>
+        <ns1:research>SR1</ns1:research>
+        <ns1:vendorName>Acme Corp</ns1:vendorName>
+        <ns1:UEINumber>ABC123DEF456</ns1:UEINumber>
+        <ns1:productOrServiceCode>AC12</ns1:productOrServiceCode>
+        <ns1:principalNAICSCode>541715</ns1:principalNAICSCode>
+        <ns1:obligatedAmount>150000.00</ns1:obligatedAmount>
+        <ns1:signedDate>2026-01-15</ns1:signedDate>
+        <ns1:ultimateCompletionDate>2027-01-15</ns1:ultimateCompletionDate>
+        <ns1:solicitationID>SOL-001</ns1:solicitationID>
+      </award>
+    </content>
+  </entry>
+</feed>"""
+
+EMPTY_FEED = '<feed xmlns="http://www.w3.org/2005/Atom"></feed>'
+
+TITLE_ONLY_ENTRY = """\
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <entry>
+    <title>Contract title as fallback</title>
+  </entry>
+</feed>"""
+
+
+# ==================== Parsing Tests ====================
+
+
+class TestFindLocal:
+    def test_finds_namespaced_element(self):
+        xml = '<root><ns:child xmlns:ns="http://example.com">text</ns:child></root>'
+        root = ET.fromstring(xml)
+        el = _find_local(root, "child")
+        assert el is not None
+        assert el.text == "text"
+
+    def test_finds_unnamespaced_element(self):
+        xml = "<root><child>text</child></root>"
+        root = ET.fromstring(xml)
+        el = _find_local(root, "child")
+        assert el is not None
+        assert el.text == "text"
+
+    def test_returns_none_for_missing(self):
+        xml = "<root><other>text</other></root>"
+        root = ET.fromstring(xml)
+        assert _find_local(root, "child") is None
+
+
+class TestParseEntry:
+    @pytest.fixture
+    def entry(self):
+        root = ET.fromstring(SAMPLE_ATOM_ENTRY)
+        return root.find("atom:entry", ATOM_NS)
+
+    def test_extracts_description(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.description == "Develop advanced sensor"
+
+    def test_extracts_research_code(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.research_code == "SR1"
+
+    def test_extracts_vendor_info(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.vendor_name == "Acme Corp"
+        assert record.vendor_uei == "ABC123DEF456"
+
+    def test_extracts_classification(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.psc_code == "AC12"
+        assert record.naics_code == "541715"
+
+    def test_extracts_financial(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.obligated_amount == 150000.0
+
+    def test_extracts_dates(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.signed_date == "2026-01-15"
+        assert record.completion_date == "2027-01-15"
+
+    def test_extracts_solicitation(self, entry):
+        record = _parse_entry(entry, "FA2541-26-C-B005")
+        assert record.solicitation_id == "SOL-001"
+
+    def test_title_fallback_when_no_content(self):
+        root = ET.fromstring(TITLE_ONLY_ENTRY)
+        entry = root.find("atom:entry", ATOM_NS)
+        record = _parse_entry(entry, "TEST-001")
+        assert record.description == "Contract title as fallback"
+        assert record.research_code is None
+
+    def test_empty_feed_returns_none_from_client(self):
+        root = ET.fromstring(EMPTY_FEED)
+        entry = root.find("atom:entry", ATOM_NS)
+        assert entry is None  # No entry to parse
+
+
+# ==================== Client Tests ====================
+
+
+class TestFPDSAtomClient:
+    def test_default_config(self):
+        client = FPDSAtomClient()
+        assert client._timeout == 30
+        assert client._limiter is None
+
+    def test_custom_config(self):
+        limiter = Mock()
+        client = FPDSAtomClient(rate_limiter=limiter, timeout=60)
+        assert client._timeout == 60
+        assert client._limiter is limiter
+
+    def test_search_by_piid_success(self):
+        client = FPDSAtomClient()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.text = SAMPLE_ATOM_ENTRY
+
+        with patch.object(client, "_get", return_value=mock_resp):
+            record = client.search_by_piid("FA2541-26-C-B005")
+
+        assert record is not None
+        assert record.description == "Develop advanced sensor"
+        assert record.research_code == "SR1"
+
+    def test_search_by_piid_not_found(self):
+        client = FPDSAtomClient()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.text = EMPTY_FEED
+
+        with patch.object(client, "_get", return_value=mock_resp):
+            record = client.search_by_piid("NONEXISTENT")
+
+        assert record is None
+
+    def test_search_by_piid_api_failure(self):
+        client = FPDSAtomClient()
+
+        with patch.object(client, "_get", return_value=None):
+            record = client.search_by_piid("FA2541-26-C-B005")
+
+        assert record is None
+
+    def test_get_description(self):
+        client = FPDSAtomClient()
+        mock_record = FPDSRecord(piid="TEST", description="Test description")
+
+        with patch.object(client, "search_by_piid", return_value=mock_record):
+            desc = client.get_description("TEST")
+
+        assert desc == "Test description"
+
+    def test_get_research_code(self):
+        client = FPDSAtomClient()
+        mock_record = FPDSRecord(piid="TEST", research_code="SR2")
+
+        with patch.object(client, "search_by_piid", return_value=mock_record):
+            code = client.get_research_code("TEST")
+
+        assert code == "SR2"
+
+    def test_get_descriptions_batch(self):
+        client = FPDSAtomClient()
+        records = {
+            "PIID-1": FPDSRecord(piid="PIID-1", description="Desc 1"),
+            "PIID-2": FPDSRecord(piid="PIID-2", description="Desc 2"),
+            "PIID-3": FPDSRecord(piid="PIID-3", description=None),
+        }
+
+        def mock_search(piid):
+            return records.get(piid)
+
+        with patch.object(client, "search_by_piid", side_effect=mock_search):
+            result = client.get_descriptions(["PIID-1", "PIID-2", "PIID-3"])
+
+        assert result == {"PIID-1": "Desc 1", "PIID-2": "Desc 2"}
+
+    def test_get_descriptions_truncates_long(self):
+        client = FPDSAtomClient()
+        long_desc = "x" * 600
+        mock_record = FPDSRecord(piid="TEST", description=long_desc)
+
+        with patch.object(client, "search_by_piid", return_value=mock_record):
+            result = client.get_descriptions(["TEST"])
+
+        assert result["TEST"].endswith("...")
+        assert len(result["TEST"]) == 503  # 500 + "..."
+
+    def test_rate_limiter_called(self):
+        limiter = Mock()
+        client = FPDSAtomClient(rate_limiter=limiter)
+
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.text = EMPTY_FEED
+
+        with patch("sbir_etl.enrichers.fpds_atom.httpx.Client") as mock_client_cls:
+            mock_http = Mock()
+            mock_http.get.return_value = mock_resp
+            mock_http.__enter__ = Mock(return_value=mock_http)
+            mock_http.__exit__ = Mock(return_value=False)
+            mock_client_cls.return_value = mock_http
+
+            client.search_by_piid("TEST")
+
+        limiter.wait_if_needed.assert_called()
+
+    def test_search_by_vendor_with_uei(self):
+        client = FPDSAtomClient()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.text = SAMPLE_ATOM_ENTRY
+
+        with patch.object(client, "_get", return_value=mock_resp) as mock_get:
+            records = client.search_by_vendor(uei="ABC123DEF456")
+
+        assert len(records) == 1
+        call_args = mock_get.call_args[0][0]
+        assert "VENDOR_UEI_NUMBER" in call_args["q"]


### PR DESCRIPTION
## Summary

- **Wire `SyncUSAspendingClient` into `fetch_usaspending_contract_descriptions()`** — the last function still using raw httpx for USAspending calls
- **Replace hardcoded SBIR ALN set** with `classify_sbir_award()` from `sbir_etl.models.sbir_identification`, which has the authoritative 31-ALN set plus FPDS research code and description-based classification
- **Extract FPDS Atom Feed client** to `sbir_etl/enrichers/fpds_atom.py` as a first-class enricher with `FPDSAtomClient` and `FPDSRecord`
- **23 new FPDS unit tests**, 8 USAspending client tests from prior commit (707 total pass)

## FPDS Atom Client

New `sbir_etl/enrichers/fpds_atom.py` provides reusable access to FPDS real-time data:

| Method | Returns | Use case |
|---|---|---|
| `search_by_piid(piid)` | `FPDSRecord` | Full contract record with all fields |
| `search_by_vendor(name, uei)` | `list[FPDSRecord]` | Company contract portfolio |
| `get_description(piid)` | `str` | Contract description text |
| `get_research_code(piid)` | `str` | SBIR/STTR Element 10Q (SR1-SR3, ST1-ST3) |
| `get_descriptions(piids)` | `dict[str, str]` | Batch description fetch |

FPDS updates within 3 days of contract action (vs weeks for USAspending), making it valuable for transition detection, weekly reports, and company categorization beyond just fallback.

## Test plan

- [x] All files compile
- [x] FPDS record parsing verified with namespaced XML (23 tests)
- [x] `classify_sbir_award()` integration verified (31 ALNs + description heuristics)
- [x] 707 unit tests pass (2 pre-existing failures)
- [ ] End-to-end report generation

https://claude.ai/code/session_01D8ws9MmBT6yXZzXSzMnWYw