### PR TITLE
Add data source provenance fields to ingested records

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/sam_gov_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sam_gov_ingestion.py
@@ -40,6 +40,7 @@ def _import_sam_gov_entities(
 
     # PRIMARY: Try S3 parquet file first
     parquet_path = None
+    s3_parquet_url = None
     s3_bucket = get_s3_bucket_from_env()
 
     if s3_bucket and sam_config.use_s3_first:
@@ -143,9 +144,10 @@ def _import_sam_gov_entities(
     )
 
     # Stamp data source provenance on every record
+    # Prefer the original S3 URL over the resolved temp/cache path
     ingested_at = datetime.now(timezone.utc)
     df["data_source"] = "sam.gov"
-    df["data_source_url"] = str(parquet_path)
+    df["data_source_url"] = str(s3_parquet_url or parquet_path)
     df["ingested_at"] = ingested_at
 
     # Create metadata

--- a/packages/sbir-analytics/sbir_analytics/assets/sam_gov_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sam_gov_ingestion.py
@@ -6,6 +6,7 @@ Data Source Priority:
 3. FAIL: If both sources fail
 """
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -140,6 +141,12 @@ def _import_sam_gov_entities(
             "source": "parquet",
         },
     )
+
+    # Stamp data source provenance on every record
+    ingested_at = datetime.now(timezone.utc)
+    df["data_source"] = "sam.gov"
+    df["data_source_url"] = str(parquet_path)
+    df["ingested_at"] = ingested_at
 
     # Create metadata
     metadata: dict[str, Any] = {

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -300,6 +301,12 @@ def raw_sbir_awards(context: AssetExecutionContext) -> Output[pd.DataFrame]:
 
     # Apply column normalization
     df = df.rename(columns=column_normalization_map)
+
+    # Stamp data source provenance on every record
+    ingested_at = datetime.now(timezone.utc)
+    df["data_source"] = "sbir.gov"
+    df["data_source_url"] = str(extractor.csv_path)
+    df["ingested_at"] = ingested_at
 
     # Update metadata to reflect normalized columns
     metadata["normalized_columns"] = MetadataValue.json(list(df.columns))

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py
@@ -303,9 +303,11 @@ def raw_sbir_awards(context: AssetExecutionContext) -> Output[pd.DataFrame]:
     df = df.rename(columns=column_normalization_map)
 
     # Stamp data source provenance on every record
+    # Prefer the original S3 URL over the resolved temp/cache path
     ingested_at = datetime.now(timezone.utc)
+    source_url = sbir_config.csv_path_s3 or str(extractor.csv_path)
     df["data_source"] = "sbir.gov"
-    df["data_source_url"] = str(extractor.csv_path)
+    df["data_source_url"] = str(source_url)
     df["ingested_at"] = ingested_at
 
     # Update metadata to reflect normalized columns

--- a/packages/sbir-analytics/sbir_analytics/assets/usaspending_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/usaspending_ingestion.py
@@ -7,6 +7,7 @@ Data Source Priority:
 """
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -150,6 +151,12 @@ def _import_usaspending_table(
         },
     )
 
+    # Stamp data source provenance on every record
+    ingested_at = datetime.now(timezone.utc)
+    sample_df["data_source"] = "usaspending"
+    sample_df["data_source_url"] = str(dump_path) if dump_path else "usaspending_api"
+    sample_df["ingested_at"] = ingested_at
+
     metadata = {
         "table_name": table_info.get("table_name"),
         "row_count": table_info.get("row_count"),
@@ -220,6 +227,14 @@ def raw_usaspending_recipients(context: AssetExecutionContext) -> Output[pd.Data
             df[col] = None
 
     context.log.info(f"Loaded {len(df)} recipient records with columns: {list(df.columns)}")
+
+    # Stamp data source provenance (if not already stamped by _import_usaspending_table)
+    if "data_source" not in df.columns:
+        ingested_at = datetime.now(timezone.utc)
+        source_url = parquet_url if parquet_url else "usaspending_dump"
+        df["data_source"] = "usaspending"
+        df["data_source_url"] = str(source_url)
+        df["ingested_at"] = ingested_at
 
     metadata = {
         "num_records": len(df),

--- a/packages/sbir-analytics/sbir_analytics/assets/usaspending_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/usaspending_ingestion.py
@@ -151,10 +151,13 @@ def _import_usaspending_table(
         },
     )
 
-    # Stamp data source provenance on every record
+    # Stamp data source provenance on the returned DataFrame
+    # Note: _import_usaspending_table returns a sample (limit=100) per the existing
+    # query_awards call above. Provenance is stamped on whatever this function returns.
     ingested_at = datetime.now(timezone.utc)
+    source_url = str(dump_path) if dump_path else "usaspending_api"
     sample_df["data_source"] = "usaspending"
-    sample_df["data_source_url"] = str(dump_path) if dump_path else "usaspending_api"
+    sample_df["data_source_url"] = source_url
     sample_df["ingested_at"] = ingested_at
 
     metadata = {
@@ -190,6 +193,7 @@ def raw_usaspending_recipients(context: AssetExecutionContext) -> Output[pd.Data
 
     s3_bucket = get_s3_bucket_from_env()
     df = None
+    parquet_url = None
 
     # PRIORITY 1: Try parquet extract (fast, ~500MB)
     if s3_bucket:

--- a/sbir_etl/models/award.py
+++ b/sbir_etl/models/award.py
@@ -1,6 +1,6 @@
 """Pydantic models for SBIR award data."""
 
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 
 from pydantic import (
@@ -157,6 +157,20 @@ class Award(BaseModel):
 
     # Additional tracking / metadata
     award_year: int | None = Field(None, description="Award year as integer")
+
+    # Data source provenance
+    data_source: str | None = Field(
+        None,
+        description="Original data source system (e.g., 'sbir.gov', 'usaspending', 'sam.gov')",
+    )
+    data_source_url: str | None = Field(
+        None,
+        description="URL or path of the source file (e.g., S3 URI, local CSV path)",
+    )
+    ingested_at: datetime | None = Field(
+        None,
+        description="UTC timestamp when this record was ingested into the pipeline",
+    )
 
     # --- Validators ---
 
@@ -791,6 +805,11 @@ class RawAward(BaseModel):
     # Accept numeric strings for number_of_employees (e.g., "1,234") — coercion happens in to_award()
     number_of_employees: str | int | None = None
     company_website: str | None = None
+
+    # Data source provenance
+    data_source: str | None = None
+    data_source_url: str | None = None
+    ingested_at: datetime | None = None
 
     def to_award(self) -> "Award":
         """Convert this RawAward into a validated Award instance.

--- a/sbir_etl/models/award.py
+++ b/sbir_etl/models/award.py
@@ -1,6 +1,6 @@
 """Pydantic models for SBIR award data."""
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from typing import Any
 
 from pydantic import (
@@ -173,6 +173,18 @@ class Award(BaseModel):
     )
 
     # --- Validators ---
+
+    @field_validator("ingested_at", mode="before")
+    @classmethod
+    def validate_ingested_at_utc(cls, v: Any) -> datetime | None:
+        """Ensure ingested_at is timezone-aware UTC. Naive datetimes are assumed UTC."""
+        if v is None:
+            return None
+        if isinstance(v, datetime):
+            if v.tzinfo is None:
+                return v.replace(tzinfo=timezone.utc)
+            return v.astimezone(timezone.utc)
+        return v
 
     @field_validator("award_amount", mode="before")
     @classmethod


### PR DESCRIPTION
Every raw record now carries `data_source`, `data_source_url`, and
`ingested_at` columns stamped at extraction time. This closes the
provenance gap where enrichment metadata tracked source/timestamp but
the original ingest records did not.

- Add fields to RawAward and Award models
- Stamp SBIR records with source "sbir.gov" + CSV path
- Stamp USAspending records with source "usaspending" + dump/parquet path
- Stamp SAM.gov records with source "sam.gov" + parquet path

https://claude.ai/code/session_011qu3oavjj6n57Hrh8KPWfK