### PR TITLE
DRY evaluation + shared script reporting helpers (Phase 1)

### DIFF
--- a/docs/data/weekly-sbir-report-dry-evaluation.md
+++ b/docs/data/weekly-sbir-report-dry-evaluation.md
@@ -1,0 +1,136 @@
+# Weekly SBIR Report DRY Re-evaluation
+
+## Scope Reviewed
+
+This review compares the weekly reporting path (`scripts/data/weekly_awards_report.py` and `.github/workflows/weekly-awards-report.yml`) to the rest of SBIR ETL/reporting code paths, especially:
+
+- Dagster ingestion assets (`packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py`)
+- Weekly refresh and validation scripts (`scripts/data/awards_refresh_validation.py`, `scripts/data/run_sbir_ingestion_checks.py`, `scripts/data/run_neo4j_sbir_load.py`)
+- Existing weekly data checks documentation (`docs/data/sbir-weekly-checks.md`)
+
+## Current Functional Positioning
+
+1. **Weekly report is a parallel reporting lane, not the canonical ETL lane.**
+   - `weekly_awards_report.py` performs its own source resolution and filtering for recent awards.
+   - The ingestion scripts/assets independently materialize and validate the same source dataset for ETL and downstream loading.
+
+2. **The report script is monolithic and responsibility-heavy.**
+   - `scripts/data/weekly_awards_report.py` is 4,613 LOC and defines 72 functions.
+   - It bundles data access, validation/dedup, enrichment lookups, LLM synthesis, URL building, and markdown rendering in one module.
+
+## Redundancy Findings
+
+### 1) Duplicate SBIR dataset access and freshness patterns
+
+**Where duplicated now**
+- Weekly report resolves S3 vs direct-download and checks freshness (`_resolve_csv_path`, `_check_data_freshness`, `fetch_weekly_awards`).
+- Refresh validation script separately handles source URL metadata, row counts, schema checks, and summary generation.
+- Download script has separate download/retry/hash/change-detection behavior.
+
+**Why this violates DRY**
+- Multiple components independently encode “how to get SBIR awards CSV” and “how fresh is it”.
+- Changes in source reliability or metadata policy need edits in multiple scripts.
+
+**Share-code opportunity**
+- Extract a shared `sbir_etl.reporting.sbir_source` utility:
+  - `resolve_awards_source()` (S3-first/fallback logic)
+  - `check_awards_freshness()` (key-date + max-award-date policy)
+  - `compute_dataset_fingerprint()` (size/hash/date)
+- Both weekly report and refresh-validation can consume this.
+
+### 2) Overlapping validation/normalization with ingestion assets
+
+**Where duplicated now**
+- Weekly report uses its own `clean_and_dedup_awards` path.
+- Dagster ingestion assets already define canonical structural quality filters and coercion/dedup behavior in `_apply_quality_filters`, followed by validation asset logic.
+
+**Risk introduced**
+- Weekly report “cleaned” dataset can drift from validated ETL dataset.
+- Any updates to validation semantics may land in assets but not report logic (or vice versa).
+
+**Share-code opportunity**
+- Introduce a shared “SBIR award normalization contract” helper module (pure functions) consumed by both asset code and weekly reporting.
+- Weekly report should either:
+  1) invoke reusable normalization/validation functions from ETL layer, or
+  2) optionally consume `validated_sbir_awards` output artifact when available.
+
+### 3) Repeated Dagster output serialization and markdown summary scaffolding
+
+**Where duplicated now**
+- `_serialize_metadata` exists in both `run_sbir_ingestion_checks.py` and `run_neo4j_sbir_load.py` with identical behavior.
+- Several scripts hand-roll near-identical markdown “metric table + sections” patterns.
+
+**Share-code opportunity**
+- Add `scripts/data/_reporting_common.py` (or `sbir_etl/reporting/common.py`) with:
+  - `serialize_dagster_metadata()`
+  - `render_metric_table(title, rows)`
+  - `write_gha_outputs(dict[str, Path | str])`
+
+### 4) Weekly report workflow is detached from weekly validation workflow outputs
+
+**Where duplicated now**
+- Weekly report workflow runs standalone and regenerates data selection/cleaning logic.
+- Weekly checks documentation describes ingestion validation and enrichment artifacts in `reports/awards_data_refresh/`, but report generation does not consume those artifacts.
+
+**Share-code opportunity**
+- Use a single weekly SBIR “prepared awards” artifact contract (validated CSV + metadata JSON).
+- Have the weekly report consume this artifact first; only fall back to direct source resolution if artifact is missing.
+
+### 5) URL construction helpers are local to weekly report
+
+**Where duplicated now**
+- `build_sbir_award_url`, `build_solicitation_url`, `build_usaspending_url` are local helpers.
+- Other scripts and docs reference the same external systems but cannot reuse URL-building behavior.
+
+**Share-code opportunity**
+- Move URL builders to a shared `sbir_etl/reporting/links.py` utility and reuse across markdown outputs.
+
+## Recommended DRY Refactor (Phased)
+
+### Phase 1 (low risk, immediate)
+
+1. Create `scripts/data/common/reporting_io.py` (or `sbir_etl/reporting/common.py`) for:
+   - Dagster metadata serialization
+   - Markdown metric table helper
+   - GitHub output-file writer
+2. Replace local duplicates in:
+   - `run_sbir_ingestion_checks.py`
+   - `run_neo4j_sbir_load.py`
+   - `awards_refresh_validation.py` (markdown helper portions)
+
+**Expected impact**: remove repeated utility code with no behavioral change.
+
+### Phase 2 (medium risk)
+
+1. Extract source + freshness logic from `weekly_awards_report.py` into a shared source utility.
+2. Repoint `weekly_awards_report.py` and `awards_refresh_validation.py` to that shared logic.
+3. Add unit tests for freshness policy boundaries (e.g., stale by `days+3`, stale by `days+14`).
+
+**Expected impact**: one policy for source/freshness handling across report + refresh paths.
+
+### Phase 3 (higher value)
+
+1. Split `weekly_awards_report.py` into packages:
+   - `weekly_report/source.py`
+   - `weekly_report/cleaning.py`
+   - `weekly_report/enrichment.py`
+   - `weekly_report/rendering.py`
+2. Replace local cleaning path with shared ETL normalization/validation functions.
+3. Define `WeeklyReportInput` dataclass backed by validated awards artifact + optional enrichments.
+
+**Expected impact**: lower maintenance risk, easier testing, and clearer alignment with canonical ETL outputs.
+
+## Priority Ranking
+
+1. **P1:** Shared metadata serialization + markdown helpers (quick win).
+2. **P1:** Shared source/freshness utility across weekly report + refresh validation.
+3. **P2:** Align weekly cleaning/validation semantics with ingestion assets.
+4. **P2:** Make weekly report consume validated weekly artifact contract by default.
+5. **P3:** Full modular decomposition of `weekly_awards_report.py`.
+
+## Definition of Done for DRY Improvements
+
+- A change to SBIR source resolution/freshness policy is implemented in exactly one module.
+- Weekly report and weekly ingestion checks agree on record eligibility/validation semantics.
+- Shared utility functions replace duplicate `_serialize_metadata` and markdown scaffolding.
+- Weekly report has an artifact-first mode that reuses validated ETL outputs.

--- a/docs/data/weekly-sbir-report-dry-evaluation.md
+++ b/docs/data/weekly-sbir-report-dry-evaluation.md
@@ -4,9 +4,26 @@
 
 This review compares the weekly reporting path (`scripts/data/weekly_awards_report.py` and `.github/workflows/weekly-awards-report.yml`) to the rest of SBIR ETL/reporting code paths, especially:
 
+- Enricher infrastructure (`sbir_etl/enrichers/`)
 - Dagster ingestion assets (`packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py`)
 - Weekly refresh and validation scripts (`scripts/data/awards_refresh_validation.py`, `scripts/data/run_sbir_ingestion_checks.py`, `scripts/data/run_neo4j_sbir_load.py`)
 - Existing weekly data checks documentation (`docs/data/sbir-weekly-checks.md`)
+
+## Already Resolved (PRs #229, #231, #232)
+
+The following redundancies were identified and resolved in prior work:
+
+| Item | Resolution | PR |
+|---|---|---|
+| USAspending award type grouping (inline reimplementation) | Imported `build_award_type_groups` with fallback | #229 |
+| Patent record parsing duplication | Extracted to public `parse_patent_record()` in patentsview.py | #229 |
+| Zero rate limiting on external API calls | All 6 endpoints use shared `RateLimiter` | #229 |
+| Uncontrolled OpenAI concurrency | Shared semaphore (`OPENAI_MAX_CONCURRENT=4`) | #229 |
+| No sync access to async enricher clients | `SyncUSAspendingClient` / `SyncSAMGovClient` created and wired in | #231 |
+| SAM.gov missing `registrationStatus` filter | Added `registration_status` param to `SAMGovAPIClient.search_entities()` | #231 |
+| Hardcoded SBIR ALN set in `_is_sbir_award_type()` | Delegates to `classify_sbir_award()` from `sbir_etl.models.sbir_identification` | #232 |
+| FPDS fallback code inline in script | Extracted to `sbir_etl/enrichers/fpds_atom.py` (`FPDSAtomClient`) | #232 |
+| USAspending contract descriptions using raw httpx | Wired to `SyncUSAspendingClient.search_awards()` | #232 |
 
 ## Current Functional Positioning
 
@@ -14,103 +31,107 @@ This review compares the weekly reporting path (`scripts/data/weekly_awards_repo
    - `weekly_awards_report.py` performs its own source resolution and filtering for recent awards.
    - The ingestion scripts/assets independently materialize and validate the same source dataset for ETL and downstream loading.
 
-2. **The report script is monolithic and responsibility-heavy.**
-   - `scripts/data/weekly_awards_report.py` is 4,613 LOC and defines 72 functions.
+2. **The report script is monolithic but increasingly delegates to the library.**
+   - `scripts/data/weekly_awards_report.py` is ~4,600 LOC and defines ~70 functions.
    - It bundles data access, validation/dedup, enrichment lookups, LLM synthesis, URL building, and markdown rendering in one module.
+   - Enrichment calls now route through `sbir_etl` sync wrappers when the library is installed.
 
-## Redundancy Findings
+## Remaining Redundancy Findings
 
 ### 1) Duplicate SBIR dataset access and freshness patterns
 
 **Where duplicated now**
 - Weekly report resolves S3 vs direct-download and checks freshness (`_resolve_csv_path`, `_check_data_freshness`, `fetch_weekly_awards`).
 - Refresh validation script separately handles source URL metadata, row counts, schema checks, and summary generation.
-- Download script has separate download/retry/hash/change-detection behavior.
-
-**Why this violates DRY**
-- Multiple components independently encode “how to get SBIR awards CSV” and “how fresh is it”.
-- Changes in source reliability or metadata policy need edits in multiple scripts.
 
 **Share-code opportunity**
 - Extract a shared `sbir_etl.reporting.sbir_source` utility:
   - `resolve_awards_source()` (S3-first/fallback logic)
   - `check_awards_freshness()` (key-date + max-award-date policy)
-  - `compute_dataset_fingerprint()` (size/hash/date)
 - Both weekly report and refresh-validation can consume this.
 
 ### 2) Overlapping validation/normalization with ingestion assets
 
 **Where duplicated now**
-- Weekly report uses its own `clean_and_dedup_awards` path.
-- Dagster ingestion assets already define canonical structural quality filters and coercion/dedup behavior in `_apply_quality_filters`, followed by validation asset logic.
+- Weekly report uses `clean_and_dedup_awards()` which delegates to library validators (`validate_sbir_award_record`, `normalize_name`) but adds its own dedup logic.
+- Dagster ingestion assets define canonical structural quality filters in `_apply_quality_filters`.
 
 **Risk introduced**
-- Weekly report “cleaned” dataset can drift from validated ETL dataset.
-- Any updates to validation semantics may land in assets but not report logic (or vice versa).
+- Weekly report "cleaned" dataset can drift from validated ETL dataset.
 
 **Share-code opportunity**
-- Introduce a shared “SBIR award normalization contract” helper module (pure functions) consumed by both asset code and weekly reporting.
-- Weekly report should either:
-  1) invoke reusable normalization/validation functions from ETL layer, or
-  2) optionally consume `validated_sbir_awards` output artifact when available.
+- Introduce shared normalization/validation functions consumed by both asset code and weekly reporting.
+- Weekly report could optionally consume `validated_sbir_awards` output artifact when available.
 
 ### 3) Repeated Dagster output serialization and markdown summary scaffolding
 
 **Where duplicated now**
-- `_serialize_metadata` exists in both `run_sbir_ingestion_checks.py` and `run_neo4j_sbir_load.py` with identical behavior.
-- Several scripts hand-roll near-identical markdown “metric table + sections” patterns.
+- `_serialize_metadata` existed identically in `run_sbir_ingestion_checks.py` and `run_neo4j_sbir_load.py`.
+- Several scripts hand-rolled near-identical markdown metric table patterns.
 
-**Share-code opportunity**
-- Add `scripts/data/_reporting_common.py` (or `sbir_etl/reporting/common.py`) with:
+**Resolution (this PR)**
+- Shared helpers in `sbir_etl/utils/reporting/script_helpers.py`:
   - `serialize_dagster_metadata()`
   - `render_metric_table(title, rows)`
-  - `write_gha_outputs(dict[str, Path | str])`
+  - `write_gha_outputs()`
+- Duplicate code removed from 3 scripts.
 
-### 4) Weekly report workflow is detached from weekly validation workflow outputs
+### 4) Weekly report workflow detached from validation workflow outputs
 
 **Where duplicated now**
 - Weekly report workflow runs standalone and regenerates data selection/cleaning logic.
 - Weekly checks documentation describes ingestion validation and enrichment artifacts in `reports/awards_data_refresh/`, but report generation does not consume those artifacts.
 
 **Share-code opportunity**
-- Use a single weekly SBIR “prepared awards” artifact contract (validated CSV + metadata JSON).
+- Use a single weekly SBIR "prepared awards" artifact contract (validated CSV + metadata JSON).
 - Have the weekly report consume this artifact first; only fall back to direct source resolution if artifact is missing.
 
-### 5) URL construction helpers are local to weekly report
+### 5) Missing library enrichers for ORCID and Semantic Scholar
 
 **Where duplicated now**
-- `build_sbir_award_url`, `build_solicitation_url`, `build_usaspending_url` are local helpers.
-- Other scripts and docs reference the same external systems but cannot reuse URL-building behavior.
+- `lookup_pi_orcid()` (~130 LOC) and `lookup_pi_publications()` (~110 LOC) are inline in the script with no library equivalent.
 
 **Share-code opportunity**
-- Move URL builders to a shared `sbir_etl/reporting/links.py` utility and reuse across markdown outputs.
+- Extract to `sbir_etl/enrichers/orcid_client.py` and `sbir_etl/enrichers/semantic_scholar.py` if academic/PI enrichment is in scope for other consumers.
+
+### 6) OpenAI client inline in script
+
+**Where duplicated now**
+- `_openai_request_with_retry()`, `_openai_chat()`, `_openai_web_search()` (~130 LOC) with retry, semaphore, and token tracking — no library equivalent.
+
+**Share-code opportunity**
+- Extract to `sbir_etl/enrichers/openai_client.py` if other pipeline stages need LLM calls.
 
 ## Recommended DRY Refactor (Phased)
 
-### Phase 1 (low risk, immediate)
+### Phase 1 (low risk, immediate) — done
 
-1. Create `scripts/data/common/reporting_io.py` (or `sbir_etl/reporting/common.py`) for:
+1. Standardize shared reporting helpers in `sbir_etl/utils/reporting/script_helpers.py` for:
    - Dagster metadata serialization
    - Markdown metric table helper
    - GitHub output-file writer
 2. Replace local duplicates in:
    - `run_sbir_ingestion_checks.py`
    - `run_neo4j_sbir_load.py`
-   - `awards_refresh_validation.py` (markdown helper portions)
+   - `awards_refresh_validation.py`
 
-**Expected impact**: remove repeated utility code with no behavioral change.
+**Status**: completed in this PR.
 
 ### Phase 2 (medium risk)
 
 1. Extract source + freshness logic from `weekly_awards_report.py` into a shared source utility.
 2. Repoint `weekly_awards_report.py` and `awards_refresh_validation.py` to that shared logic.
-3. Add unit tests for freshness policy boundaries (e.g., stale by `days+3`, stale by `days+14`).
+3. Add unit tests for freshness policy boundaries.
 
-**Expected impact**: one policy for source/freshness handling across report + refresh paths.
+### Phase 3 (higher value, if academic enrichment is in scope)
 
-### Phase 3 (higher value)
+1. Extract ORCID and Semantic Scholar clients to library enricher modules.
+2. Extract OpenAI client to library enricher module.
+3. Define shared dataclasses for PI research records.
 
-1. Split `weekly_awards_report.py` into packages:
+### Phase 4 (structural)
+
+1. Split `weekly_awards_report.py` into submodules:
    - `weekly_report/source.py`
    - `weekly_report/cleaning.py`
    - `weekly_report/enrichment.py`
@@ -118,15 +139,14 @@ This review compares the weekly reporting path (`scripts/data/weekly_awards_repo
 2. Replace local cleaning path with shared ETL normalization/validation functions.
 3. Define `WeeklyReportInput` dataclass backed by validated awards artifact + optional enrichments.
 
-**Expected impact**: lower maintenance risk, easier testing, and clearer alignment with canonical ETL outputs.
-
 ## Priority Ranking
 
-1. **P1:** Shared metadata serialization + markdown helpers (quick win).
-2. **P1:** Shared source/freshness utility across weekly report + refresh validation.
-3. **P2:** Align weekly cleaning/validation semantics with ingestion assets.
-4. **P2:** Make weekly report consume validated weekly artifact contract by default.
-5. **P3:** Full modular decomposition of `weekly_awards_report.py`.
+1. **P0 (done):** Enricher-level DRY — sync wrappers, rate limiting, FPDS client, SBIR identification (PRs #229, #231, #232).
+2. **P1 (done):** Shared metadata serialization + markdown helpers (this PR).
+3. **P1:** Shared source/freshness utility across weekly report + refresh validation.
+4. **P2:** Align weekly cleaning/validation semantics with ingestion assets.
+5. **P2:** Extract ORCID, Semantic Scholar, OpenAI clients to library.
+6. **P3:** Full modular decomposition of `weekly_awards_report.py`.
 
 ## Definition of Done for DRY Improvements
 

--- a/sbir_etl/utils/reporting/__init__.py
+++ b/sbir_etl/utils/reporting/__init__.py
@@ -1,6 +1,10 @@
 """Statistical reporting utilities for pipeline analysis."""
 
-from .script_helpers import render_metric_table, serialize_dagster_metadata, write_gha_outputs
+from .script_helpers import (
+    render_metric_table,
+    serialize_dagster_metadata,
+    write_gha_outputs,
+)
 
 __all__ = [
     "render_metric_table",

--- a/sbir_etl/utils/reporting/__init__.py
+++ b/sbir_etl/utils/reporting/__init__.py
@@ -1,1 +1,9 @@
 """Statistical reporting utilities for pipeline analysis."""
+
+from .script_helpers import render_metric_table, serialize_dagster_metadata, write_gha_outputs
+
+__all__ = [
+    "render_metric_table",
+    "serialize_dagster_metadata",
+    "write_gha_outputs",
+]

--- a/sbir_etl/utils/reporting/script_helpers.py
+++ b/sbir_etl/utils/reporting/script_helpers.py
@@ -1,0 +1,48 @@
+"""Shared helpers for lightweight script reporting output.
+
+These utilities are intentionally minimal and dependency-light so that
+standalone scripts under ``scripts/data`` can share formatting and I/O
+behavior without duplicating helper logic.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+def serialize_dagster_metadata(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert Dagster metadata values to JSON-serializable plain values."""
+    result: dict[str, Any] = {}
+    for key, value in metadata.items():
+        # Dagster metadata values expose the real value via a `.value` attribute.
+        result[key] = value.value if hasattr(value, "value") else value
+    return result
+
+
+def _escape_md_cell(value: Any) -> str:
+    """Escape markdown table cell content."""
+    return str(value).replace("|", "\\|")
+
+
+def render_metric_table(title: str, rows: list[tuple[str, Any]]) -> str:
+    """Render a standard markdown metric table section."""
+    lines = [
+        f"# {title}",
+        "",
+        "| Metric | Value |",
+        "| --- | --- |",
+    ]
+    for metric, value in rows:
+        lines.append(f"| {_escape_md_cell(metric)} | {_escape_md_cell(value)} |")
+    return "\n".join(lines)
+
+
+def write_gha_outputs(gha_output: Path | None, outputs: Mapping[str, Any]) -> None:
+    """Append key-value outputs to a GitHub Actions output file."""
+    if gha_output is None:
+        return
+    with gha_output.open("a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")

--- a/scripts/data/awards_refresh_validation.py
+++ b/scripts/data/awards_refresh_validation.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from typing import Any
 from collections.abc import Iterable, Sequence
 
+from sbir_etl.utils.reporting import render_metric_table, write_gha_outputs
+
 
 try:
     from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as DEFAULT_SOURCE_URL
@@ -125,18 +127,19 @@ def render_summary_markdown(metadata: dict[str, Any], warnings: Iterable[str]) -
     size_mb = bytes_total / (1024 * 1024)
     schema_status = "match" if metadata["schema"]["matches_expected"] else "drift"
     lines = [
-        "# SBIR awards dataset refresh",
-        "",
-        "| Metric | Value |",
-        "| --- | --- |",
-        f"| Source URL | {metadata['source_url']} |",
-        f"| Downloaded (UTC) | {metadata['refreshed_at_utc']} |",
-        f"| SHA-256 | `{metadata['sha256']}` |",
-        f"| File size | {bytes_total:,} bytes ({size_mb:.2f} MiB) |",
-        f"| Row count | {metadata['row_count']:,} |",
-        f"| Row delta | {row_delta_str} ({row_delta_pct_str}) |",
-        f"| Column count | {metadata['column_count']} |",
-        f"| Schema status | {schema_status} |",
+        render_metric_table(
+            "SBIR awards dataset refresh",
+            [
+                ("Source URL", metadata["source_url"]),
+                ("Downloaded (UTC)", metadata["refreshed_at_utc"]),
+                ("SHA-256", f"`{metadata['sha256']}`"),
+                ("File size", f"{bytes_total:,} bytes ({size_mb:.2f} MiB)"),
+                ("Row count", f"{metadata['row_count']:,}"),
+                ("Row delta", f"{row_delta_str} ({row_delta_pct_str})"),
+                ("Column count", metadata["column_count"]),
+                ("Schema status", schema_status),
+            ],
+        ),
         "",
     ]
     warnings = list(warnings)
@@ -223,12 +226,13 @@ def main() -> int:
         args.summary_path.parent.mkdir(parents=True, exist_ok=True)
         args.summary_path.write_text(summary_markdown, encoding="utf-8")
 
-    if args.gha_output:
-        with args.gha_output.open("a", encoding="utf-8") as fp:
-            fp.write(f"metadata_path={metadata_path}\n")
-            fp.write(f"latest_metadata_path={latest_json_path}\n")
-            if args.summary_path:
-                fp.write(f"summary_path={args.summary_path}\n")
+    outputs: dict[str, Path | str] = {
+        "metadata_path": metadata_path,
+        "latest_metadata_path": latest_json_path,
+    }
+    if args.summary_path:
+        outputs["summary_path"] = args.summary_path
+    write_gha_outputs(args.gha_output, outputs)
 
     print(f"Wrote metadata to {metadata_path}")
     if args.summary_path:

--- a/scripts/data/run_neo4j_sbir_load.py
+++ b/scripts/data/run_neo4j_sbir_load.py
@@ -13,6 +13,11 @@ import pandas as pd
 from dagster import build_asset_context
 
 import sbir_analytics.assets.sbir_neo4j_loading as loading_module
+from sbir_etl.utils.reporting import (
+    render_metric_table,
+    serialize_dagster_metadata,
+    write_gha_outputs,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -52,46 +57,30 @@ def _output_metadata(output: Any) -> dict[str, Any]:
     return getattr(output, "metadata", {}) or {}
 
 
-def _serialize_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
-    """Convert Dagster metadata values to JSON-serializable plain values."""
-    result = {}
-    for key, value in metadata.items():
-        # Dagster metadata values have a 'value' attribute containing the actual data
-        if hasattr(value, "value"):
-            result[key] = value.value
-        else:
-            result[key] = value
-    return result
-
-
 def render_markdown_summary(load_result: dict[str, Any]) -> str:
     """Render Neo4j load results as markdown."""
-    lines = [
-        "# Neo4j SBIR Awards Load",
-        "",
-        f"**Status:** {load_result.get('status', 'unknown')}",
-        "",
-        "| Metric | Value |",
-        "| --- | --- |",
-    ]
+    rows: list[tuple[str, Any]] = [("Status", load_result.get("status", "unknown"))]
 
     if load_result.get("status") == "success":
-        lines.append(f"| Awards loaded | {load_result.get('awards_loaded', 0)} |")
-        lines.append(f"| Awards updated | {load_result.get('awards_updated', 0)} |")
-        lines.append(f"| Companies loaded | {load_result.get('companies_loaded', 0)} |")
-        lines.append(f"| Companies updated | {load_result.get('companies_updated', 0)} |")
-        lines.append(f"| Researchers loaded | {load_result.get('researchers_loaded', 0)} |")
-        lines.append(f"| Researchers updated | {load_result.get('researchers_updated', 0)} |")
-        lines.append(f"| Institutions loaded | {load_result.get('institutions_loaded', 0)} |")
-        lines.append(f"| Institutions updated | {load_result.get('institutions_updated', 0)} |")
-        lines.append(f"| Relationships created | {load_result.get('relationships_created', 0)} |")
-        lines.append(f"| Errors | {load_result.get('errors', 0)} |")
-        lines.append(f"| Duration (seconds) | {load_result.get('duration_seconds', 0):.2f} |")
+        rows.extend(
+            [
+                ("Awards loaded", load_result.get("awards_loaded", 0)),
+                ("Awards updated", load_result.get("awards_updated", 0)),
+                ("Companies loaded", load_result.get("companies_loaded", 0)),
+                ("Companies updated", load_result.get("companies_updated", 0)),
+                ("Researchers loaded", load_result.get("researchers_loaded", 0)),
+                ("Researchers updated", load_result.get("researchers_updated", 0)),
+                ("Institutions loaded", load_result.get("institutions_loaded", 0)),
+                ("Institutions updated", load_result.get("institutions_updated", 0)),
+                ("Relationships created", load_result.get("relationships_created", 0)),
+                ("Errors", load_result.get("errors", 0)),
+                ("Duration (seconds)", f"{load_result.get('duration_seconds', 0):.2f}"),
+            ]
+        )
     else:
         reason = load_result.get("reason") or load_result.get("error", "unknown")
-        lines.append(f"| Reason | {reason} |")
-
-    return "\n".join(lines)
+        rows.append(("Reason", reason))
+    return render_metric_table("Neo4j SBIR Awards Load", rows)
 
 
 def main() -> int:
@@ -122,7 +111,9 @@ def main() -> int:
     metrics_json_path = args.output_dir / "neo4j_load_metrics.json"
     with metrics_json_path.open("w", encoding="utf-8") as f:
         json.dump(
-            {"result": load_result, "metadata": _serialize_metadata(load_metadata)}, f, indent=2
+            {"result": load_result, "metadata": serialize_dagster_metadata(load_metadata)},
+            f,
+            indent=2,
         )
         f.write("\n")
 
@@ -131,11 +122,14 @@ def main() -> int:
     summary_md = render_markdown_summary(load_result)
     summary_md_path.write_text(summary_md, encoding="utf-8")
 
-    if args.gha_output:
-        with args.gha_output.open("a", encoding="utf-8") as f:
-            f.write(f"neo4j_load_metrics_json={metrics_json_path}\n")
-            f.write(f"neo4j_load_summary_md={summary_md_path}\n")
-            f.write(f"neo4j_load_status={load_result.get('status', 'unknown')}\n")
+    write_gha_outputs(
+        args.gha_output,
+        {
+            "neo4j_load_metrics_json": metrics_json_path,
+            "neo4j_load_summary_md": summary_md_path,
+            "neo4j_load_status": load_result.get("status", "unknown"),
+        },
+    )
 
     # Run asset check
     check_result = loading_module.neo4j_sbir_awards_load_check(neo4j_sbir_awards=load_result)

--- a/scripts/data/run_sbir_ingestion_checks.py
+++ b/scripts/data/run_sbir_ingestion_checks.py
@@ -14,6 +14,11 @@ import pandas as pd
 from dagster import build_asset_context
 
 import sbir_analytics.assets.sbir_ingestion as assets_module
+from sbir_etl.utils.reporting import (
+    render_metric_table,
+    serialize_dagster_metadata,
+    write_gha_outputs,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -79,33 +84,22 @@ def _output_metadata(output: Any) -> dict[str, Any]:
     return getattr(output, "metadata", {}) or {}
 
 
-def _serialize_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
-    """Convert Dagster metadata values to JSON-serializable plain values."""
-    result = {}
-    for key, value in metadata.items():
-        # Dagster metadata values have a 'value' attribute containing the actual data
-        if hasattr(value, "value"):
-            result[key] = value.value
-        else:
-            result[key] = value
-    return result
-
-
 def render_markdown_summary(
     raw_meta: dict[str, Any], validated_meta: dict[str, Any], report: dict[str, Any]
 ) -> str:
     lines = [
-        "# SBIR ingestion validation",
-        "",
-        "| Metric | Value |",
-        "| --- | --- |",
-        f"| Raw records | {raw_meta.get('num_records', 'N/A')} |",
-        f"| Raw columns | {raw_meta.get('num_columns', 'N/A')} |",
-        f"| Validation pass rate | {validated_meta.get('pass_rate', 'N/A')} |",
-        f"| Passed records | {validated_meta.get('passed_records', 'N/A')} |",
-        f"| Failed records | {validated_meta.get('failed_records', 'N/A')} |",
-        f"| Validation status | {validated_meta.get('validation_status', 'N/A')} |",
-        f"| Report total issues | {len(report.get('issues', []))} |",
+        render_metric_table(
+            "SBIR ingestion validation",
+            [
+                ("Raw records", raw_meta.get("num_records", "N/A")),
+                ("Raw columns", raw_meta.get("num_columns", "N/A")),
+                ("Validation pass rate", validated_meta.get("pass_rate", "N/A")),
+                ("Passed records", validated_meta.get("passed_records", "N/A")),
+                ("Failed records", validated_meta.get("failed_records", "N/A")),
+                ("Validation status", validated_meta.get("validation_status", "N/A")),
+                ("Report total issues", len(report.get("issues", []))),
+            ],
+        ),
         "",
         "## Issues by severity",
         "",
@@ -163,12 +157,16 @@ def main() -> int:
     report_json_path = args.report_json or (args.output_dir / "sbir_validation_report.json")
     summary_md_path = args.summary_md or (args.output_dir / "ingestion_summary.md")
 
+    raw_metadata_serialized = serialize_dagster_metadata(raw_metadata)
+    validated_metadata_serialized = serialize_dagster_metadata(validated_metadata)
+    report_metadata_serialized = serialize_dagster_metadata(report_metadata)
+
     with raw_meta_path.open("w", encoding="utf-8") as handle:
-        json.dump({"metadata": _serialize_metadata(raw_metadata)}, handle, indent=2)
+        json.dump({"metadata": raw_metadata_serialized}, handle, indent=2)
         handle.write("\n")
 
     with validated_meta_path.open("w", encoding="utf-8") as handle:
-        json.dump({"metadata": _serialize_metadata(validated_metadata)}, handle, indent=2)
+        json.dump({"metadata": validated_metadata_serialized}, handle, indent=2)
         handle.write("\n")
 
     # Save validated DataFrame as CSV for downstream use (e.g., Neo4j loading)
@@ -176,24 +174,27 @@ def main() -> int:
 
     with report_json_path.open("w", encoding="utf-8") as handle:
         json.dump(
-            {"report": report_dict, "metadata": _serialize_metadata(report_metadata)},
+            {"report": report_dict, "metadata": report_metadata_serialized},
             handle,
             indent=2,
         )
         handle.write("\n")
 
     summary_md = render_markdown_summary(
-        _serialize_metadata(raw_metadata), _serialize_metadata(validated_metadata), report_dict
+        raw_metadata_serialized, validated_metadata_serialized, report_dict
     )
     summary_md_path.write_text(summary_md, encoding="utf-8")
 
-    if args.gha_output:
-        with args.gha_output.open("a", encoding="utf-8") as handle:
-            handle.write(f"raw_metadata_path={raw_meta_path}\n")
-            handle.write(f"validated_metadata_path={validated_meta_path}\n")
-            handle.write(f"validated_csv_path={validated_csv_path}\n")
-            handle.write(f"validation_report_path={report_json_path}\n")
-            handle.write(f"ingestion_summary_path={summary_md_path}\n")
+    write_gha_outputs(
+        args.gha_output,
+        {
+            "raw_metadata_path": raw_meta_path,
+            "validated_metadata_path": validated_meta_path,
+            "validated_csv_path": validated_csv_path,
+            "validation_report_path": report_json_path,
+            "ingestion_summary_path": summary_md_path,
+        },
+    )
 
     # If validation failed, exit non-zero to alert workflow.
     if report_dict.get("passed") is False:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,19 @@
+# PR 202 Follow-up Fixes
+
+- [x] Review previously identified issue and likely Copilot review fallout from workflow consolidation
+- [x] Update code/docs that still reference deleted `run-ml-jobs.yml`
+- [x] Update deployment docs to use consolidated `etl-pipeline.yml` dispatch inputs
+- [x] Verify no stale workflow references remain
+
+## Review Notes
+
+Implemented follow-up fixes for PR #202 consolidation:
+- Updated `definitions_ml.py` docstring to point to `.github/workflows/etl-pipeline.yml`.
+- Updated deployment docs to use ETL Pipeline workflow, correct dispatch input names, and current schedule/env examples.
+- Updated AWS Batch deployment doc to use ETL Pipeline dispatch instructions.
+
+---
+
 # Weekly SBIR Report DRY Re-evaluation — Phase 1
 
 - [x] Create shared reporting helper utilities for script-level reporting concerns
@@ -14,7 +30,3 @@ Completed Phase 1 implementation with no runtime behavior changes to pipeline se
   - Markdown metric-table rendering
   - GitHub Actions output-file writing
 - Updated three SBIR scripts to consume shared helpers and remove duplicated utility logic.
-- Validation results:
-  - `python -m compileall` passed for all touched Python files.
-  - `ruff check` passed on all touched Python files.
-  - `uv run ruff check` could not complete due external dependency download/network tunnel failure in this environment.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,13 +1,15 @@
-# PR 202 Follow-up Fixes
+# Weekly SBIR Report DRY Re-evaluation
 
-- [x] Review previously identified issue and likely Copilot review fallout from workflow consolidation
-- [x] Update code/docs that still reference deleted `run-ml-jobs.yml`
-- [x] Update deployment docs to use consolidated `etl-pipeline.yml` dispatch inputs
-- [x] Verify no stale workflow references remain
+- [x] Inventory weekly SBIR report functionality and workflow integration points
+- [x] Compare weekly report logic against SBIR ETL ingestion and reporting scripts
+- [x] Identify concrete redundancy hot spots and code-sharing opportunities
+- [x] Draft a refactor plan that preserves behavior while reducing duplication
 
 ## Review Notes
 
-Implemented follow-up fixes for PR #202 consolidation:
-- Updated `definitions_ml.py` docstring to point to `.github/workflows/etl-pipeline.yml`.
-- Updated deployment docs to use ETL Pipeline workflow, correct dispatch input names, and current schedule/env examples.
-- Updated AWS Batch deployment doc to use ETL Pipeline dispatch instructions.
+Completed a focused architecture review of `scripts/data/weekly_awards_report.py` relative to:
+- SBIR extraction/validation assets in `packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py`
+- SBIR refresh/validation scripts under `scripts/data/`
+- Reporting workflows in `.github/workflows/`
+
+Documented findings and a phased DRY refactor approach in `docs/data/weekly-sbir-report-dry-evaluation.md`.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,15 +1,20 @@
-# Weekly SBIR Report DRY Re-evaluation
+# Weekly SBIR Report DRY Re-evaluation — Phase 1
 
-- [x] Inventory weekly SBIR report functionality and workflow integration points
-- [x] Compare weekly report logic against SBIR ETL ingestion and reporting scripts
-- [x] Identify concrete redundancy hot spots and code-sharing opportunities
-- [x] Draft a refactor plan that preserves behavior while reducing duplication
+- [x] Create shared reporting helper utilities for script-level reporting concerns
+- [x] Refactor `run_sbir_ingestion_checks.py` to use shared helpers
+- [x] Refactor `run_neo4j_sbir_load.py` to use shared helpers
+- [x] Refactor `awards_refresh_validation.py` markdown summary assembly to shared helpers
+- [x] Run targeted validation checks and document results
 
 ## Review Notes
 
-Completed a focused architecture review of `scripts/data/weekly_awards_report.py` relative to:
-- SBIR extraction/validation assets in `packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py`
-- SBIR refresh/validation scripts under `scripts/data/`
-- Reporting workflows in `.github/workflows/`
-
-Documented findings and a phased DRY refactor approach in `docs/data/weekly-sbir-report-dry-evaluation.md`.
+Completed Phase 1 implementation with no runtime behavior changes to pipeline semantics:
+- Added shared helpers in `sbir_etl/utils/reporting/script_helpers.py` for:
+  - Dagster metadata serialization
+  - Markdown metric-table rendering
+  - GitHub Actions output-file writing
+- Updated three SBIR scripts to consume shared helpers and remove duplicated utility logic.
+- Validation results:
+  - `python -m compileall` passed for all touched Python files.
+  - `ruff check` passed on all touched Python files.
+  - `uv run ruff check` could not complete due external dependency download/network tunnel failure in this environment.

--- a/tests/unit/utils/test_script_helpers.py
+++ b/tests/unit/utils/test_script_helpers.py
@@ -1,0 +1,107 @@
+"""Tests for sbir_etl.utils.reporting.script_helpers."""
+
+import pytest
+
+from sbir_etl.utils.reporting.script_helpers import (
+    render_metric_table,
+    serialize_dagster_metadata,
+    write_gha_outputs,
+)
+
+pytestmark = pytest.mark.fast
+
+
+# ==================== serialize_dagster_metadata ====================
+
+
+class TestSerializeDagsterMetadata:
+    def test_extracts_value_attribute(self):
+        class DagsterValue:
+            def __init__(self, v):
+                self.value = v
+
+        meta = {"count": DagsterValue(42), "rate": DagsterValue(0.95)}
+        result = serialize_dagster_metadata(meta)
+        assert result == {"count": 42, "rate": 0.95}
+
+    def test_passes_through_plain_values(self):
+        meta = {"name": "test", "count": 100}
+        result = serialize_dagster_metadata(meta)
+        assert result == {"name": "test", "count": 100}
+
+    def test_mixed_dagster_and_plain(self):
+        class DagsterValue:
+            def __init__(self, v):
+                self.value = v
+
+        meta = {"dag": DagsterValue("wrapped"), "plain": "unwrapped"}
+        result = serialize_dagster_metadata(meta)
+        assert result == {"dag": "wrapped", "plain": "unwrapped"}
+
+    def test_empty_metadata(self):
+        assert serialize_dagster_metadata({}) == {}
+
+
+# ==================== render_metric_table ====================
+
+
+class TestRenderMetricTable:
+    def test_basic_table(self):
+        result = render_metric_table("Test Report", [("Records", 100), ("Rate", "95%")])
+        lines = result.split("\n")
+        assert lines[0] == "# Test Report"
+        assert "| Records | 100 |" in result
+        assert "| Rate | 95% |" in result
+
+    def test_escapes_pipes(self):
+        result = render_metric_table("T", [("a|b", "c|d")])
+        assert r"a\|b" in result
+        assert r"c\|d" in result
+
+    def test_empty_rows(self):
+        result = render_metric_table("Empty", [])
+        assert "# Empty" in result
+        assert "| Metric | Value |" in result
+
+    def test_header_structure(self):
+        result = render_metric_table("Title", [("k", "v")])
+        lines = result.split("\n")
+        assert lines[0] == "# Title"
+        assert lines[1] == ""
+        assert lines[2] == "| Metric | Value |"
+        assert lines[3] == "| --- | --- |"
+        assert lines[4] == "| k | v |"
+
+
+# ==================== write_gha_outputs ====================
+
+
+class TestWriteGhaOutputs:
+    def test_writes_key_value_pairs(self, tmp_path):
+        output_file = tmp_path / "output.txt"
+        write_gha_outputs(output_file, {"key1": "val1", "key2": "val2"})
+
+        content = output_file.read_text()
+        assert "key1=val1\n" in content
+        assert "key2=val2\n" in content
+
+    def test_appends_to_existing(self, tmp_path):
+        output_file = tmp_path / "output.txt"
+        output_file.write_text("existing=line\n")
+        write_gha_outputs(output_file, {"new": "value"})
+
+        content = output_file.read_text()
+        assert content.startswith("existing=line\n")
+        assert "new=value\n" in content
+
+    def test_none_path_is_noop(self):
+        # Should not raise
+        write_gha_outputs(None, {"key": "val"})
+
+    def test_path_values_stringified(self, tmp_path):
+        output_file = tmp_path / "output.txt"
+        write_gha_outputs(output_file, {"path": tmp_path / "file.json"})
+
+        content = output_file.read_text()
+        assert "path=" in content
+        assert "file.json" in content


### PR DESCRIPTION
## Summary

- **Evaluation doc** identifying DRY opportunities between the weekly SBIR report and the rest of the ETL/reporting codebase, updated to reflect work already completed in PRs #229, #231, #232
- **Shared script helpers** (`sbir_etl/utils/reporting/script_helpers.py`) replacing duplicate Dagster metadata serialization, markdown metric tables, and GHA output writing across 3 operational scripts
- **12 unit tests** for the new helpers

## What changed

| File | Change |
|---|---|
| `docs/data/weekly-sbir-report-dry-evaluation.md` | DRY evaluation doc with phased refactor plan, updated for current state |
| `sbir_etl/utils/reporting/script_helpers.py` | New shared helpers: `serialize_dagster_metadata`, `render_metric_table`, `write_gha_outputs` |
| `sbir_etl/utils/reporting/__init__.py` | Re-exports new helpers |
| `scripts/data/run_sbir_ingestion_checks.py` | Uses shared helpers, removes duplicate `_serialize_metadata` |
| `scripts/data/run_neo4j_sbir_load.py` | Uses shared helpers, removes duplicate `_serialize_metadata` + `render_markdown_summary` |
| `scripts/data/awards_refresh_validation.py` | Uses shared helpers for metric table + GHA outputs |
| `tasks/todo.md` | Appends Phase 1 checklist (preserves PR #202 content) |
| `tests/unit/utils/test_script_helpers.py` | 12 unit tests |

## Context

This PR complements the enricher-level DRY work in PRs #229, #231, #232 by addressing a different axis of redundancy: the operational scripts (`run_sbir_ingestion_checks.py`, `run_neo4j_sbir_load.py`, `awards_refresh_validation.py`) that shared identical utility code. The evaluation doc maps remaining opportunities (source/freshness unification, ORCID/Semantic Scholar extraction, report modularization) into future phases.

## Test plan

- [x] All files compile
- [x] 12 unit tests for script_helpers pass
- [ ] CI passes on refactored scripts

https://claude.ai/code/session_01D8ws9MmBT6yXZzXSzMnWYw