### PR TITLE
P1+P2: Shared source/freshness, extract clients, enhance SolicitationExtractor

### DIFF
--- a/sbir_etl/enrichers/openai_client.py
+++ b/sbir_etl/enrichers/openai_client.py
@@ -1,0 +1,229 @@
+"""OpenAI API client with retry, concurrency control, and token tracking.
+
+Provides a thin wrapper around the OpenAI Chat Completions and Responses
+APIs with:
+
+- Exponential-backoff retry on 429 and 5xx errors
+- Configurable concurrency semaphore for thread-pool safety
+- Token usage logging via loguru
+
+Usage::
+
+    from sbir_etl.enrichers.openai_client import OpenAIClient
+
+    client = OpenAIClient(api_key="sk-...")
+    text = client.chat("You are helpful.", "Summarize this award.")
+
+    research = client.web_search("Find info about Acme Corp SBIR recipient")
+    if research:
+        print(research.summary, research.source_urls)
+
+    client.close()
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from loguru import logger
+
+OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions"
+OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
+
+DEFAULT_MODEL = "gpt-4.1-mini"
+DEFAULT_DILIGENCE_MODEL = "gpt-4.1"
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2  # seconds
+
+
+@dataclass
+class WebSearchResult:
+    """Result from an OpenAI web search query."""
+
+    summary: str
+    source_urls: list[str] = field(default_factory=list)
+
+
+class OpenAIClient:
+    """Synchronous OpenAI API client with retry and concurrency control.
+
+    Args:
+        api_key: OpenAI API key.
+        max_concurrent: Maximum concurrent requests across threads.
+            Controls the semaphore size. Default 4.
+        timeout: HTTP request timeout in seconds.
+        model: Default model for chat and web search.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        max_concurrent: int = 4,
+        timeout: int = 120,
+        model: str = DEFAULT_MODEL,
+    ) -> None:
+        self._api_key = api_key
+        self._model = model
+        self._timeout = timeout
+        self._semaphore = threading.Semaphore(max_concurrent)
+        self._client = httpx.Client(timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "OpenAIClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _request(
+        self,
+        method: str,
+        url: str,
+        payload: dict[str, Any],
+        timeout: int | None = None,
+    ) -> httpx.Response | None:
+        """Make an API request with semaphore + retry."""
+        effective_timeout = timeout or self._timeout
+        model_name = payload.get("model", "unknown")
+
+        for attempt in range(MAX_RETRIES + 1):
+            self._semaphore.acquire()
+            try:
+                resp = self._client.request(
+                    method, url, headers=self._headers(), json=payload,
+                    timeout=effective_timeout,
+                )
+            finally:
+                self._semaphore.release()
+
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < MAX_RETRIES:
+                    wait = RETRY_BACKOFF_BASE ** (attempt + 1)
+                    logger.debug(
+                        f"OpenAI {model_name} returned {resp.status_code}, "
+                        f"retrying in {wait}s (attempt {attempt + 1}/{MAX_RETRIES})"
+                    )
+                    time.sleep(wait)
+                    continue
+
+            try:
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPStatusError:
+                if attempt < MAX_RETRIES:
+                    continue
+                logger.warning(
+                    f"OpenAI API error after {MAX_RETRIES} retries: {resp.status_code}"
+                )
+                return None
+
+        return None
+
+    def chat(
+        self,
+        system: str,
+        user: str,
+        model: str | None = None,
+        temperature: float = 0.3,
+    ) -> str | None:
+        """Call the Chat Completions API.
+
+        Args:
+            system: System message content.
+            user: User message content.
+            model: Model override (defaults to client's model).
+            temperature: Sampling temperature.
+
+        Returns:
+            Assistant message text, or ``None`` on failure.
+        """
+        payload = {
+            "model": model or self._model,
+            "temperature": temperature,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+        }
+        resp = self._request("POST", OPENAI_CHAT_URL, payload)
+        if resp is None:
+            return None
+
+        try:
+            data = resp.json()
+            content = data["choices"][0]["message"]["content"].strip()
+            usage = data.get("usage", {})
+            logger.debug(
+                f"OpenAI chat: {len(content)} chars | "
+                f"tokens: prompt={usage.get('prompt_tokens', '?')} "
+                f"completion={usage.get('completion_tokens', '?')} "
+                f"total={usage.get('total_tokens', '?')}"
+            )
+            return content
+        except (KeyError, IndexError) as e:
+            logger.warning(f"OpenAI Chat unexpected response: {e}")
+            return None
+
+    def web_search(
+        self,
+        query: str,
+        instructions: str | None = None,
+        model: str | None = None,
+    ) -> WebSearchResult | None:
+        """Call the Responses API with web_search_preview tool.
+
+        Args:
+            query: The search query / input text.
+            instructions: System-level instructions for the search.
+            model: Model override.
+
+        Returns:
+            :class:`WebSearchResult` with summary and source URLs, or ``None``.
+        """
+        default_instructions = (
+            "You are a research assistant gathering public information about "
+            "companies that receive SBIR/STTR federal awards. Provide a concise "
+            "2-3 sentence summary covering: what the company does, its size/stage, "
+            "notable products or contracts, and any previous SBIR/STTR history. "
+            "Cite your sources."
+        )
+        payload = {
+            "model": model or self._model,
+            "tools": [{"type": "web_search_preview"}],
+            "instructions": instructions or default_instructions,
+            "input": query,
+        }
+        resp = self._request("POST", OPENAI_RESPONSES_URL, payload, timeout=60)
+        if resp is None:
+            return None
+
+        data = resp.json()
+        summary_text = ""
+        source_urls: list[str] = []
+
+        for output_item in data.get("output", []):
+            if output_item.get("type") == "message":
+                for content_block in output_item.get("content", []):
+                    if content_block.get("type") == "output_text":
+                        summary_text = content_block.get("text", "")
+                        for annotation in content_block.get("annotations", []):
+                            url = annotation.get("url", "")
+                            if url and url not in source_urls:
+                                source_urls.append(url)
+
+        if not summary_text:
+            return None
+
+        return WebSearchResult(summary=summary_text, source_urls=source_urls)

--- a/sbir_etl/enrichers/orcid_client.py
+++ b/sbir_etl/enrichers/orcid_client.py
@@ -1,0 +1,204 @@
+"""ORCID public API client for researcher profile lookups.
+
+Queries the `ORCID public API <https://pub.orcid.org/>`_ to find
+researcher profiles and extract affiliations, works, funding, and
+keywords.
+
+No API key is required for basic access.  Set ``ORCID_ACCESS_TOKEN``
+for higher rate limits (generate via client credentials grant with a
+free ORCID Public API application).
+
+Usage::
+
+    from sbir_etl.enrichers.orcid_client import ORCIDClient
+
+    client = ORCIDClient()
+    record = client.lookup("Jane Smith")
+    if record:
+        print(record.orcid_id, record.works_count)
+    client.close()
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from loguru import logger
+
+ORCID_API_URL = "https://pub.orcid.org/v3.0"
+
+
+@dataclass
+class ORCIDRecord:
+    """Key data from an ORCID researcher profile."""
+
+    orcid_id: str
+    given_name: str | None = None
+    family_name: str | None = None
+    affiliations: list[str] = field(default_factory=list)
+    works_count: int = 0
+    sample_work_titles: list[str] = field(default_factory=list)
+    funding_count: int = 0
+    keywords: list[str] = field(default_factory=list)
+
+
+def _parse_profile(orcid_id: str, search_result: dict, profile: dict) -> ORCIDRecord:
+    """Parse an ORCID profile response into an :class:`ORCIDRecord`."""
+    # Affiliations
+    affiliations: list[str] = []
+    affiliation_groups = (
+        profile.get("activities-summary", {})
+        .get("employments", {})
+        .get("affiliation-group", [])
+    )
+    for group in affiliation_groups[:10]:
+        for s in group.get("summaries", []):
+            org_name = (
+                s.get("employment-summary", {})
+                .get("organization", {})
+                .get("name", "")
+            )
+            if org_name and org_name not in affiliations:
+                affiliations.append(org_name)
+
+    # Works
+    works_group = (
+        profile.get("activities-summary", {})
+        .get("works", {})
+        .get("group", [])
+    )
+    sample_titles: list[str] = []
+    for wg in works_group[:5]:
+        summaries = wg.get("work-summary", [])
+        if summaries:
+            title_val = (
+                summaries[0].get("title", {}).get("title", {}).get("value", "")
+            )
+            if title_val:
+                sample_titles.append(title_val)
+
+    # Funding
+    funding_group = (
+        profile.get("activities-summary", {})
+        .get("fundings", {})
+        .get("group", [])
+    )
+
+    # Keywords
+    keyword_list = (
+        profile.get("person", {}).get("keywords", {}).get("keyword", [])
+    )
+    keywords = [kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")]
+
+    return ORCIDRecord(
+        orcid_id=orcid_id,
+        given_name=search_result.get("given-names"),
+        family_name=search_result.get("family-names"),
+        affiliations=affiliations,
+        works_count=len(works_group),
+        sample_work_titles=sample_titles,
+        funding_count=len(funding_group),
+        keywords=keywords,
+    )
+
+
+class ORCIDClient:
+    """Client for querying the ORCID public API.
+
+    Args:
+        rate_limiter: Optional rate limiter instance with ``wait_if_needed()`` method.
+        access_token: Optional OAuth token. Defaults to ``ORCID_ACCESS_TOKEN`` env var.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        rate_limiter: Any | None = None,
+        access_token: str | None = None,
+        timeout: int = 30,
+    ) -> None:
+        self._limiter = rate_limiter
+        headers: dict[str, str] = {"Accept": "application/json"}
+        token = access_token or os.environ.get("ORCID_ACCESS_TOKEN", "")
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = httpx.Client(timeout=timeout, headers=headers)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "ORCIDClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _wait(self) -> None:
+        if self._limiter is not None:
+            self._limiter.wait_if_needed()
+
+    def search(self, family_name: str, given_names: str | None = None, limit: int = 5) -> list[dict]:
+        """Search for researchers by name.
+
+        Returns list of expanded search result dicts.
+        """
+        query = f"family-name:{family_name}"
+        if given_names:
+            query += f"+AND+given-names:{given_names}"
+
+        self._wait()
+        try:
+            resp = self._client.get(
+                f"{ORCID_API_URL}/expanded-search/",
+                params={"q": query, "rows": limit},
+            )
+            if resp.status_code != 200:
+                logger.debug(f"ORCID search returned {resp.status_code}")
+                return []
+            return resp.json().get("expanded-result", []) or []
+        except httpx.HTTPError as e:
+            logger.debug(f"ORCID search error: {e}")
+            return []
+
+    def get_profile(self, orcid_id: str) -> dict | None:
+        """Fetch a full ORCID profile by ID."""
+        self._wait()
+        try:
+            resp = self._client.get(f"{ORCID_API_URL}/{orcid_id}/record")
+            if resp.status_code != 200:
+                logger.debug(f"ORCID profile {orcid_id} returned {resp.status_code}")
+                return None
+            return resp.json()
+        except httpx.HTTPError as e:
+            logger.debug(f"ORCID profile error for {orcid_id}: {e}")
+            return None
+
+    def lookup(self, name: str) -> ORCIDRecord | None:
+        """Look up a researcher's ORCID profile by full name.
+
+        Splits *name* into given/family components, searches, then
+        fetches the full profile for the best match.
+        """
+        parts = name.strip().split()
+        if not parts:
+            return None
+        family = parts[-1]
+        given = " ".join(parts[:-1]) if len(parts) > 1 else None
+
+        results = self.search(family, given)
+        if not results:
+            return None
+
+        best = results[0]
+        orcid_id = best.get("orcid-id", "")
+        if not orcid_id:
+            return None
+
+        profile = self.get_profile(orcid_id)
+        if profile is None:
+            return None
+
+        return _parse_profile(orcid_id, best, profile)

--- a/sbir_etl/enrichers/semantic_scholar.py
+++ b/sbir_etl/enrichers/semantic_scholar.py
@@ -1,0 +1,156 @@
+"""Semantic Scholar API client for researcher publication lookups.
+
+Queries the `Semantic Scholar Academic Graph API
+<https://api.semanticscholar.org/>`_ to find author profiles and
+retrieve publication statistics (h-index, citation count, paper titles,
+affiliations).
+
+No API key is required for basic access (rate limited to ~100 req/min).
+Set ``SEMANTIC_SCHOLAR_API_KEY`` for higher limits.
+
+Usage::
+
+    from sbir_etl.enrichers.semantic_scholar import SemanticScholarClient
+
+    client = SemanticScholarClient()
+    record = client.lookup_author("Jane Smith")
+    if record:
+        print(record.h_index, record.total_papers)
+    client.close()
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+from loguru import logger
+
+SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
+MAX_RETRIES = 3
+RETRY_BACKOFF_BASE = 2
+
+
+@dataclass
+class PublicationRecord:
+    """Summary of a researcher's publication history."""
+
+    total_papers: int
+    h_index: int | None
+    citation_count: int
+    sample_titles: list[str]
+    affiliations: list[str]
+
+
+class SemanticScholarClient:
+    """Client for querying the Semantic Scholar Academic Graph API.
+
+    Args:
+        rate_limiter: Optional rate limiter instance with ``wait_if_needed()`` method.
+        api_key: Optional API key. Defaults to ``SEMANTIC_SCHOLAR_API_KEY`` env var.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        rate_limiter: Any | None = None,
+        api_key: str | None = None,
+        timeout: int = 30,
+    ) -> None:
+        self._limiter = rate_limiter
+        self._timeout = timeout
+        resolved_key = api_key or os.environ.get("SEMANTIC_SCHOLAR_API_KEY", "")
+        self._headers: dict[str, str] = {}
+        if resolved_key:
+            self._headers["x-api-key"] = resolved_key
+        self._client = httpx.Client(timeout=timeout, headers=self._headers)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "SemanticScholarClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    def _wait(self) -> None:
+        if self._limiter is not None:
+            self._limiter.wait_if_needed()
+
+    def _get_with_retry(self, url: str, params: dict[str, Any] | None = None) -> dict | None:
+        """GET with retry on 429/5xx."""
+        for attempt in range(MAX_RETRIES):
+            self._wait()
+            try:
+                resp = self._client.get(url, params=params)
+                if resp.status_code == 429:
+                    wait = RETRY_BACKOFF_BASE ** (attempt + 1)
+                    logger.debug(f"Semantic Scholar 429, retrying in {wait}s")
+                    time.sleep(wait)
+                    continue
+                if resp.status_code != 200:
+                    logger.debug(f"Semantic Scholar returned {resp.status_code}")
+                    return None
+                return resp.json()
+            except httpx.HTTPError as e:
+                logger.debug(f"Semantic Scholar request error: {e}")
+                time.sleep(RETRY_BACKOFF_BASE ** (attempt + 1))
+        return None
+
+    def search_author(self, name: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Search for authors by name.
+
+        Returns list of author dicts with ``authorId``, ``name``, etc.
+        """
+        data = self._get_with_retry(
+            f"{SEMANTIC_SCHOLAR_API_URL}/author/search",
+            params={"query": name, "limit": limit},
+        )
+        if data is None:
+            return []
+        return data.get("data", [])
+
+    def get_author_details(
+        self, author_id: str
+    ) -> dict[str, Any] | None:
+        """Fetch author details including papers, h-index, and affiliations."""
+        return self._get_with_retry(
+            f"{SEMANTIC_SCHOLAR_API_URL}/author/{author_id}",
+            params={
+                "fields": "name,hIndex,citationCount,affiliations,papers.title,papers.year",
+            },
+        )
+
+    def lookup_author(self, name: str) -> PublicationRecord | None:
+        """Look up a researcher's publication profile by name.
+
+        Two-step: author search → author details with papers.
+        Returns ``None`` if no match found.
+        """
+        authors = self.search_author(name)
+        if not authors:
+            return None
+
+        author_id = authors[0].get("authorId")
+        if not author_id:
+            return None
+
+        details = self.get_author_details(author_id)
+        if details is None:
+            return None
+
+        papers = details.get("papers", [])
+        sample_titles = [p["title"] for p in papers[:5] if p.get("title")]
+        affiliations = details.get("affiliations", []) or []
+
+        return PublicationRecord(
+            total_papers=len(papers),
+            h_index=details.get("hIndex"),
+            citation_count=details.get("citationCount", 0),
+            sample_titles=sample_titles,
+            affiliations=affiliations,
+        )

--- a/sbir_etl/extractors/solicitation.py
+++ b/sbir_etl/extractors/solicitation.py
@@ -80,6 +80,7 @@ class SolicitationExtractor:
         *,
         agency: str | None = None,
         year: int | None = None,
+        keyword: str | None = None,
         start: int = 0,
         rows: int = 100,
     ) -> list[dict[str, Any]]:
@@ -88,6 +89,7 @@ class SolicitationExtractor:
         Args:
             agency: Agency abbreviation filter.
             year: Solicitation year filter.
+            keyword: Free-text keyword search (topic code or solicitation number).
             start: Pagination offset.
             rows: Results per page.
 
@@ -99,6 +101,8 @@ class SolicitationExtractor:
             params["agency"] = agency
         if year:
             params["year"] = year
+        if keyword:
+            params["keyword"] = keyword
 
         url = f"{self.base_url}/solicitations"
         logger.debug(f"SBIR.gov solicitations request: {url} params={params}")
@@ -121,6 +125,119 @@ class SolicitationExtractor:
         if isinstance(data, dict):
             return data.get("results") or data.get("data") or []
         return []
+
+    def query_by_keyword(
+        self,
+        keyword: str,
+        max_results: int = 25,
+    ) -> list[dict[str, Any]]:
+        """Search solicitations by keyword (topic code or solicitation number).
+
+        Useful for finding topics when the solicitation year is unknown.
+
+        Args:
+            keyword: Topic code, solicitation number, or free-text query.
+            max_results: Maximum results to return.
+
+        Returns:
+            List of normalized topic dicts.
+        """
+        try:
+            return self._query_solicitations(keyword=keyword, rows=max_results)
+        except Exception as e:
+            logger.debug(f"SBIR.gov keyword query failed for '{keyword}': {e}")
+            return []
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=2, min=2, max=30),
+        retry=retry_if_exception_type(_RETRYABLE_HTTPX),
+        reraise=True,
+    )
+    def _query_awards(
+        self,
+        keyword: str,
+        rows: int = 5,
+    ) -> list[dict[str, Any]]:
+        """Query SBIR.gov awards endpoint by keyword.
+
+        Used as fallback when a topic code isn't found via ``/solicitations``.
+        Award records often contain topic titles and abstracts that can
+        substitute for missing solicitation descriptions.
+
+        Args:
+            keyword: Topic code to search for.
+            rows: Maximum results.
+
+        Returns:
+            List of award dicts.
+        """
+        url = f"{self.base_url}/awards"
+        params: dict[str, str | int] = {"keyword": keyword, "rows": rows, "start": 0}
+        logger.debug(f"SBIR.gov awards fallback request: {url} params={params}")
+
+        response = self.client.get(url, params=params)
+        if response.status_code in (429, 500, 502, 503, 504):
+            response.raise_for_status()
+        if response.status_code != 200:
+            return []
+
+        data = response.json()
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return data.get("results") or data.get("data") or []
+        return []
+
+    def query_awards_for_topic(
+        self,
+        topic_code: str,
+    ) -> dict[str, Any] | None:
+        """Find topic metadata via the awards endpoint as a last resort.
+
+        Searches awards by topic code and extracts topic-level metadata
+        (title, description, agency, program) from the first matching award.
+
+        Args:
+            topic_code: The topic code to search for.
+
+        Returns:
+            Normalized topic dict with ``topic_code``, ``title``,
+            ``description``, ``agency``, ``program`` keys, or ``None``.
+        """
+        try:
+            awards = self._query_awards(topic_code)
+        except Exception as e:
+            logger.debug(f"Awards fallback failed for '{topic_code}': {e}")
+            return None
+
+        for award in awards:
+            award_tc = award.get("topicCode") or award.get("topic_code") or ""
+            if award_tc != topic_code:
+                continue
+            title = (
+                award.get("topicTitle")
+                or award.get("topic_title")
+                or award.get("awardTitle")
+                or award.get("award_title")
+                or ""
+            )
+            desc = (
+                award.get("topicDescription")
+                or award.get("topic_description")
+                or award.get("abstract")
+                or award.get("Abstract")
+                or None
+            )
+            if title or desc:
+                return {
+                    "topic_code": topic_code,
+                    "title": title,
+                    "description": desc,
+                    "agency": award.get("agency"),
+                    "program": award.get("program"),
+                }
+        return None
 
     def extract_topics(
         self,

--- a/sbir_etl/utils/cloud_storage.py
+++ b/sbir_etl/utils/cloud_storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -361,3 +362,135 @@ def find_latest_sam_gov_parquet(
     except Exception as e:
         logger.error(f"Error finding latest SAM.gov parquet: {e}")
         return None
+
+
+# ---------------------------------------------------------------------------
+# SBIR awards CSV source resolution and freshness checking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SbirAwardsSource:
+    """Metadata about a resolved SBIR awards CSV source."""
+
+    path: Path
+    origin: str  # "s3", "download", or "local"
+    s3_key_date: str | None = None
+
+
+def resolve_sbir_awards_csv(
+    download_url: str = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv",
+    local_path: Path | None = None,
+) -> SbirAwardsSource:
+    """Resolve the SBIR awards CSV: S3 first, then download, then local.
+
+    Resolution order:
+    1. S3 bucket (if ``SBIR_ANALYTICS_S3_BUCKET`` is set and contains a CSV)
+    2. Direct HTTP download from *download_url*
+    3. *local_path* if provided and exists (e.g. a previously cached copy)
+
+    Args:
+        download_url: URL to download CSV from if S3 is unavailable.
+        local_path: Optional local path to try as last resort.
+
+    Returns:
+        :class:`SbirAwardsSource` with the resolved path and origin metadata.
+
+    Raises:
+        FileNotFoundError: If no source could be resolved.
+    """
+    import re
+
+    import httpx
+
+    # 1. Try S3
+    bucket = get_s3_bucket_from_env()
+    if bucket:
+        s3_url = find_latest_sbir_awards(bucket)
+        if s3_url:
+            logger.info(f"Using S3-cached CSV: {s3_url}")
+            date_match = re.search(r"raw/awards/(\d{4}-\d{2}-\d{2})/", s3_url)
+            key_date = date_match.group(1) if date_match else None
+            return SbirAwardsSource(path=Path(s3_url), origin="s3", s3_key_date=key_date)
+
+    # 2. Download from URL
+    logger.info(f"S3 not available; downloading from {download_url}")
+    try:
+        with httpx.Client(timeout=600, follow_redirects=True) as client:
+            response = client.get(download_url)
+            response.raise_for_status()
+
+        tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
+        tmp.write_bytes(response.content)
+        size_mb = tmp.stat().st_size / 1024 / 1024
+        logger.info(f"Downloaded {size_mb:.1f} MB to {tmp}")
+        return SbirAwardsSource(path=tmp, origin="download")
+    except Exception as e:
+        logger.warning(f"Download failed: {e}")
+
+    # 3. Local fallback
+    if local_path and local_path.exists():
+        logger.info(f"Using local fallback: {local_path}")
+        return SbirAwardsSource(path=local_path, origin="local")
+
+    raise FileNotFoundError(
+        f"Could not resolve SBIR awards CSV from S3, download ({download_url}), "
+        f"or local ({local_path})"
+    )
+
+
+def check_sbir_data_freshness(
+    source: SbirAwardsSource,
+    max_award_date: str | None,
+    days: int,
+    *,
+    s3_slack_days: int = 3,
+    data_slack_days: int = 14,
+) -> list[str]:
+    """Check whether SBIR bulk data is fresh enough for a reporting window.
+
+    Runs two independent checks:
+    1. **S3 key date** — was the data-refresh workflow recent?
+    2. **Max award date in data** — is the underlying SBIR.gov dataset current?
+
+    Args:
+        source: Resolved data source with optional S3 key date.
+        max_award_date: The most recent ``Proposal Award Date`` in the dataset.
+        days: The reporting window in days (e.g. 7 for weekly).
+        s3_slack_days: Allowed slack beyond *days* for S3 key date.
+        data_slack_days: Allowed slack beyond *days* for max award date.
+
+    Returns:
+        List of warning strings (empty if data is fresh).
+    """
+    from datetime import datetime, UTC
+
+    from .date_utils import parse_date
+
+    warnings: list[str] = []
+    now = datetime.now(UTC).replace(tzinfo=None)
+
+    if source.s3_key_date:
+        key_dt = parse_date(source.s3_key_date)
+        if key_dt:
+            key_datetime = datetime(key_dt.year, key_dt.month, key_dt.day)
+            age_days = (now - key_datetime).days
+            if age_days > days + s3_slack_days:
+                warnings.append(
+                    f"S3 data is {age_days} days old (key date: {source.s3_key_date}). "
+                    f"The data-refresh workflow may have failed."
+                )
+
+    if max_award_date:
+        max_dt = parse_date(max_award_date)
+        if max_dt:
+            max_datetime = datetime(max_dt.year, max_dt.month, max_dt.day)
+            data_age = (now - max_datetime).days
+            if data_age > days + data_slack_days:
+                warnings.append(
+                    f"Most recent award in data is from {max_award_date} "
+                    f"({data_age} days ago). SBIR.gov bulk data may not have "
+                    f"been updated recently."
+                )
+
+    return warnings

--- a/sbir_etl/utils/cloud_storage.py
+++ b/sbir_etl/utils/cloud_storage.py
@@ -406,12 +406,23 @@ def resolve_sbir_awards_csv(
     # 1. Try S3
     bucket = get_s3_bucket_from_env()
     if bucket:
-        s3_url = find_latest_sbir_awards(bucket)
+        try:
+            s3_url = find_latest_sbir_awards(bucket)
+        except (ImportError, ModuleNotFoundError) as e:
+            logger.warning(
+                f"S3 lookup unavailable (missing cloud dependencies): {e}"
+            )
+            s3_url = None
         if s3_url:
             logger.info(f"Using S3-cached CSV: {s3_url}")
             date_match = re.search(r"raw/awards/(\d{4}-\d{2}-\d{2})/", s3_url)
             key_date = date_match.group(1) if date_match else None
-            return SbirAwardsSource(path=Path(s3_url), origin="s3", s3_key_date=key_date)
+            # Download S3 object to a local temp file so downstream code
+            # (DuckDB, pandas) can read it without special S3 handling.
+            local_path_resolved = resolve_data_path(s3_url)
+            return SbirAwardsSource(
+                path=local_path_resolved, origin="s3", s3_key_date=key_date
+            )
 
     # 2. Download from URL
     logger.info(f"S3 not available; downloading from {download_url}")
@@ -420,8 +431,11 @@ def resolve_sbir_awards_csv(
             response = client.get(download_url)
             response.raise_for_status()
 
-        tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
-        tmp.write_bytes(response.content)
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".csv", prefix="sbir_awards_", delete=False,
+        ) as tmp_file:
+            tmp_file.write(response.content)
+            tmp = Path(tmp_file.name)
         size_mb = tmp.stat().st_size / 1024 / 1024
         logger.info(f"Downloaded {size_mb:.1f} MB to {tmp}")
         return SbirAwardsSource(path=tmp, origin="download")

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -2151,9 +2151,9 @@ class SolicitationTopic:
 def fetch_solicitation_topics(awards: list[dict]) -> dict[str, SolicitationTopic]:
     """Fetch solicitation topic titles and descriptions from SBIR.gov API.
 
-    Uses SolicitationExtractor when available (tenacity retry, pagination).
-    Falls back to hand-rolled queries otherwise.
-    Returns a dict keyed by topic code.
+    Uses SolicitationExtractor when available (tenacity retry, pagination,
+    keyword search, awards fallback). Falls back to hand-rolled queries
+    otherwise.
     """
     # Collect unique topic codes
     topic_codes: dict[str, str] = {}  # topic_code -> solicitation_number
@@ -2170,31 +2170,53 @@ def fetch_solicitation_topics(awards: list[dict]) -> dict[str, SolicitationTopic
     total = len(topic_codes)
     print(f"Fetching {total} solicitation topics from SBIR.gov...", file=sys.stderr)
 
-    # Prefer SolicitationExtractor — handles pagination and retry internally
+    def _parse_year(sol: str) -> int | None:
+        for part in sol.replace("-", " ").replace(".", " ").split():
+            if part.isdigit() and len(part) == 4:
+                return int(part)
+        return None
+
+    def _make_topic(tc: str, sol_num: str, topic: dict) -> SolicitationTopic:
+        desc = topic.get("topicDescription") or topic.get("description")
+        if desc and len(str(desc)) > 3000:
+            desc = str(desc)[:3000] + "..."
+        return SolicitationTopic(
+            topic_code=tc,
+            solicitation_number=(
+                topic.get("solicitationNumber")
+                or topic.get("solicitation_number")
+                or sol_num
+            ),
+            title=topic.get("topicTitle") or topic.get("title") or "",
+            description=str(desc) if desc else None,
+            agency=topic.get("agency"),
+            program=topic.get("program"),
+        )
+
+    # --- Path A: SolicitationExtractor (tenacity retry + all query modes) ---
     if _HAS_SOLICITATION_EXTRACTOR:
-        _debug("Using SolicitationExtractor (tenacity retry + pagination)")
+        _debug("Using SolicitationExtractor")
         try:
             extractor = SolicitationExtractor()
             try:
-                # Extract unique years from solicitation numbers
-                years: set[int] = set()
-                for sol in topic_codes.values():
-                    for part in sol.replace("-", " ").replace(".", " ").split():
-                        if part.isdigit() and len(part) == 4:
-                            years.add(int(part))
-                            break
+                # Group topic codes by year
+                sol_years: dict[int, list[str]] = {}
+                no_year_codes: list[tuple[str, str]] = []
+                for tc, sol in topic_codes.items():
+                    year = _parse_year(sol)
+                    if year:
+                        sol_years.setdefault(year, []).append(tc)
+                    else:
+                        no_year_codes.append((tc, sol))
 
-                # Fetch topics for each year (or all if no years found)
+                # Step 1: Year-based batch queries
                 import pandas as pd
 
                 all_topics = pd.DataFrame()
-                if years:
-                    for year in years:
-                        df = extractor.extract_topics(year=year, max_results=1000)
-                        if not df.empty:
-                            all_topics = pd.concat([all_topics, df], ignore_index=True)
-                else:
-                    all_topics = extractor.extract_topics(max_results=1000)
+                for year in sol_years:
+                    df = extractor.extract_topics(year=year, max_results=1000)
+                    if not df.empty:
+                        all_topics = pd.concat([all_topics, df], ignore_index=True)
 
                 if not all_topics.empty:
                     all_topics = extractor.deduplicate_topics(all_topics)
@@ -2202,261 +2224,146 @@ def fetch_solicitation_topics(awards: list[dict]) -> dict[str, SolicitationTopic
                     for _, row in all_topics.iterrows():
                         tc = str(row.get("topic_code", "")).strip()
                         if tc in codes_set and tc not in results:
-                            desc = row.get("description")
-                            if desc and len(str(desc)) > 3000:
-                                desc = str(desc)[:3000] + "..."
+                            results[tc] = _make_topic(tc, topic_codes.get(tc, ""), row.to_dict())
+
+                # Step 2: Keyword search for no-year codes
+                for tc, sol in no_year_codes:
+                    if tc in results:
+                        continue
+                    keyword = sol if sol else tc
+                    topics = extractor.query_by_keyword(keyword)
+                    for topic in topics:
+                        found_tc = topic.get("topicCode") or topic.get("topic_code") or ""
+                        if found_tc == tc:
+                            results[tc] = _make_topic(tc, sol, topic)
+                            break
+
+                # Step 3: Awards fallback for anything still missing
+                missing = [tc for tc in topic_codes if tc not in results]
+                if missing:
+                    _debug(f"Awards fallback for {len(missing)} missing topic codes")
+                    for tc in missing:
+                        fallback = extractor.query_awards_for_topic(tc)
+                        if fallback:
                             results[tc] = SolicitationTopic(
                                 topic_code=tc,
-                                solicitation_number=str(row.get("solicitation_number", "")) or topic_codes.get(tc, ""),
-                                title=str(row.get("title", "")),
-                                description=str(desc) if desc else None,
-                                agency=str(row.get("agency", "")) or None,
-                                program=str(row.get("program", "")) or None,
+                                solicitation_number=topic_codes.get(tc, ""),
+                                title=fallback.get("title", ""),
+                                description=(
+                                    str(fallback["description"])[:3000] + "..."
+                                    if fallback.get("description") and len(str(fallback["description"])) > 3000
+                                    else fallback.get("description")
+                                ),
+                                agency=fallback.get("agency"),
+                                program=fallback.get("program"),
                             )
-                print(
-                    f"SolicitationExtractor found {len(results)}/{total} topics",
-                    file=sys.stderr,
-                )
-                if len(results) == total:
-                    return results
-                # Fall through for any missing codes
+
+                print(f"SolicitationExtractor found {len(results)}/{total} topics", file=sys.stderr)
             finally:
-                if hasattr(extractor, "close"):
-                    extractor.close()
+                extractor.close()
+            return results
         except Exception as e:
             print(f"SolicitationExtractor error: {e}, falling back to manual queries", file=sys.stderr)
 
-    # Query by solicitation year to reduce result sets.
-    # Group topic codes by their solicitation number prefix to batch queries.
-    sol_years: dict[int, list[str]] = {}
-    # Topic codes with no parseable year — query individually by keyword
-    no_year_codes: list[tuple[str, str]] = []  # (topic_code, solicitation_number)
+    # --- Path B: Inline httpx fallback (standalone mode) ---
+    sol_years_fb: dict[int, list[str]] = {}
+    no_year_codes_fb: list[tuple[str, str]] = []
     for tc, sol in topic_codes.items():
-        # Extract year from solicitation number (e.g. "SBIR-2023.1" -> 2023)
-        year = None
-        for part in sol.replace("-", " ").replace(".", " ").split():
-            if part.isdigit() and len(part) == 4:
-                year = int(part)
-                break
+        year = _parse_year(sol)
         if year:
-            sol_years.setdefault(year, []).append(tc)
+            sol_years_fb.setdefault(year, []).append(tc)
         else:
-            no_year_codes.append((tc, sol))
+            no_year_codes_fb.append((tc, sol))
 
-    # Handle topic codes with no parseable year: query by keyword (topic code
-    # or solicitation number) instead of fetching the entire unfiltered set.
     import time
 
-    for tc, sol in no_year_codes:
+    for tc, sol in no_year_codes_fb:
         keyword = sol if sol else tc
-        params: dict[str, str | int] = {"rows": 25, "start": 0, "keyword": keyword}
-        _debug(f"SBIR.gov solicitations (no year): keyword='{keyword}' for topic {tc}")
         try:
             _sbir_gov_limiter.wait_if_needed()
             with httpx.Client(timeout=30) as client:
-                resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params=params)
+                resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params={"rows": 25, "start": 0, "keyword": keyword})
                 if resp.status_code == 429:
                     time.sleep(3)
                     _sbir_gov_limiter.wait_if_needed()
-                    resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params=params)
-                _debug_response(f"SBIR.gov solicitations [keyword={keyword}]", resp)
+                    resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params={"rows": 25, "start": 0, "keyword": keyword})
                 if resp.status_code != 200:
                     continue
                 data = resp.json()
-        except Exception as e:
-            _debug(f"SBIR.gov keyword query error for {keyword}: {e}")
+        except Exception:
             continue
-
-        topics = data if isinstance(data, list) else (
-            data.get("results") or data.get("data") or []
-        )
+        topics = data if isinstance(data, list) else (data.get("results") or data.get("data") or [])
         for topic in topics:
             found_tc = topic.get("topicCode") or topic.get("topic_code") or ""
             if found_tc == tc and tc not in results:
-                desc = topic.get("topicDescription") or topic.get("description")
-                if desc and len(desc) > 3000:
-                    desc = desc[:3000] + "..."
-                results[tc] = SolicitationTopic(
-                    topic_code=tc,
-                    solicitation_number=(
-                        topic.get("solicitationNumber")
-                        or topic.get("solicitation_number")
-                        or sol
-                    ),
-                    title=topic.get("topicTitle") or topic.get("title") or "",
-                    description=desc,
-                    agency=topic.get("agency"),
-                    program=topic.get("program"),
-                )
+                results[tc] = _make_topic(tc, sol, topic)
                 break
 
-    for year, codes in sol_years.items():
-        params = {"rows": 500, "start": 0, "year": year}
-
-        _debug(
-            f"SBIR.gov solicitations query: GET {SBIR_GOV_API_URL}/solicitations "
-            f"params={params} (looking for {len(codes)} topic codes)"
-        )
-
-        # Retry with backoff on 429 (rate limit) responses
-        import time
-
+    for year, codes in sol_years_fb.items():
         data = None
         for attempt in range(3):
             try:
                 _sbir_gov_limiter.wait_if_needed()
                 with httpx.Client(timeout=30) as client:
-                    resp = client.get(
-                        f"{SBIR_GOV_API_URL}/solicitations", params=params
-                    )
-                    _debug_response(f"SBIR.gov solicitations [year={year}]", resp)
+                    resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params={"rows": 500, "start": 0, "year": year})
                     if resp.status_code == 429:
-                        wait = 2 ** (attempt + 1)
-                        print(
-                            f"SBIR.gov rate limited (429) for year={year}, "
-                            f"retrying in {wait}s (attempt {attempt + 1}/3)...",
-                            file=sys.stderr,
-                        )
-                        time.sleep(wait)
+                        time.sleep(2 ** (attempt + 1))
                         continue
                     if resp.status_code != 200:
-                        print(
-                            f"SBIR.gov API returned {resp.status_code} for year={year}",
-                            file=sys.stderr,
-                        )
                         break
                     data = resp.json()
                     break
-            except Exception as e:
-                print(f"SBIR.gov API error for year={year}: {e}", file=sys.stderr)
+            except Exception:
                 break
-
         if data is None:
             continue
-
-        topics = data if isinstance(data, list) else (
-            data.get("results") or data.get("data") or []
-        )
-        _debug(f"SBIR.gov solicitations [year={year}]: {len(topics)} topics in response")
-
+        topics = data if isinstance(data, list) else (data.get("results") or data.get("data") or [])
         codes_set = set(codes)
         for topic in topics:
             tc = topic.get("topicCode") or topic.get("topic_code") or ""
             if tc in codes_set and tc not in results:
-                desc = topic.get("topicDescription") or topic.get("description")
-                # Truncate very long descriptions for LLM context
-                if desc and len(desc) > 3000:
-                    desc = desc[:3000] + "..."
-                results[tc] = SolicitationTopic(
-                    topic_code=tc,
-                    solicitation_number=(
-                        topic.get("solicitationNumber")
-                        or topic.get("solicitation_number")
-                        or topic_codes.get(tc, "")
-                    ),
-                    title=topic.get("topicTitle") or topic.get("title") or "",
-                    description=desc,
-                    agency=topic.get("agency"),
-                    program=topic.get("program"),
-                )
+                results[tc] = _make_topic(tc, topic_codes.get(tc, ""), topic)
 
     found = len(results)
-    print(
-        f"Fetched {found}/{total} solicitation topics from SBIR.gov",
-        file=sys.stderr,
-    )
+    print(f"Fetched {found}/{total} solicitation topics from SBIR.gov", file=sys.stderr)
 
-    # --- Fallback: query the awards endpoint for any missing topic codes ---
+    # Awards fallback for missing codes
     missing_codes = [tc for tc in topic_codes if tc not in results]
     if missing_codes:
-        _debug(
-            f"Solicitation topic fallback: {len(missing_codes)} codes not found "
-            f"via /solicitations — trying /awards endpoint: {missing_codes}"
-        )
-        print(
-            f"Falling back to SBIR.gov awards API for {len(missing_codes)} "
-            f"missing topic codes...",
-            file=sys.stderr,
-        )
-        # Brief pause before hitting the same API — respect rate limits
+        print(f"Falling back to SBIR.gov awards API for {len(missing_codes)} missing topic codes...", file=sys.stderr)
         time.sleep(2)
         for tc in missing_codes:
             try:
                 _sbir_gov_limiter.wait_if_needed()
                 with httpx.Client(timeout=30) as client:
-                    resp = client.get(
-                        f"{SBIR_GOV_API_URL}/awards",
-                        params={"keyword": tc, "rows": 5, "start": 0},
-                    )
-                    _debug_response(f"SBIR.gov awards fallback [{tc}]", resp)
+                    resp = client.get(f"{SBIR_GOV_API_URL}/awards", params={"keyword": tc, "rows": 5, "start": 0})
                     if resp.status_code == 429:
-                        _debug(f"SBIR.gov awards fallback [{tc}]: rate limited, sleeping 3s")
                         time.sleep(3)
-                        # One retry after backoff
-                        resp = client.get(
-                            f"{SBIR_GOV_API_URL}/awards",
-                            params={"keyword": tc, "rows": 5, "start": 0},
-                        )
+                        resp = client.get(f"{SBIR_GOV_API_URL}/awards", params={"keyword": tc, "rows": 5, "start": 0})
                         if resp.status_code != 200:
                             continue
                     elif resp.status_code != 200:
                         continue
                     data = resp.json()
-            except Exception as e:
-                _debug(f"SBIR.gov awards fallback error for {tc}: {e}")
+            except Exception:
                 continue
-
-            award_list = data if isinstance(data, list) else (
-                data.get("results") or data.get("data") or []
-            )
-            _debug(f"SBIR.gov awards fallback [{tc}]: {len(award_list)} awards returned")
-
-            # Look for a matching award that has topic description info
+            award_list = data if isinstance(data, list) else (data.get("results") or data.get("data") or [])
             for award in award_list:
-                award_tc = (
-                    award.get("topicCode")
-                    or award.get("topic_code")
-                    or ""
-                )
+                award_tc = award.get("topicCode") or award.get("topic_code") or ""
                 if award_tc != tc:
                     continue
-                title = (
-                    award.get("topicTitle")
-                    or award.get("topic_title")
-                    or award.get("awardTitle")
-                    or award.get("award_title")
-                    or ""
-                )
-                desc = (
-                    award.get("topicDescription")
-                    or award.get("topic_description")
-                    or award.get("abstract")
-                    or award.get("Abstract")
-                    or None
-                )
+                title = award.get("topicTitle") or award.get("topic_title") or award.get("awardTitle") or award.get("award_title") or ""
+                desc = award.get("topicDescription") or award.get("topic_description") or award.get("abstract") or award.get("Abstract") or None
                 if desc and len(desc) > 3000:
                     desc = desc[:3000] + "..."
                 if title or desc:
                     results[tc] = SolicitationTopic(
-                        topic_code=tc,
-                        solicitation_number=topic_codes.get(tc, ""),
-                        title=title,
-                        description=desc,
-                        agency=award.get("agency"),
-                        program=award.get("program"),
-                    )
-                    _debug(
-                        f"Solicitation fallback matched [{tc}]: "
-                        f"title='{title[:80]}' desc_len={len(desc) if desc else 0}"
+                        topic_code=tc, solicitation_number=topic_codes.get(tc, ""),
+                        title=title, description=desc, agency=award.get("agency"), program=award.get("program"),
                     )
                     break
-
         fallback_found = len(results) - found
-        print(
-            f"Fallback recovered {fallback_found}/{len(missing_codes)} "
-            f"topic descriptions from awards API",
-            file=sys.stderr,
-        )
+        print(f"Fallback recovered {fallback_found}/{len(missing_codes)} topic descriptions from awards API", file=sys.stderr)
 
     return results
 

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -148,6 +148,30 @@ try:
 except ImportError:
     _HAS_FPDS_CLIENT = False
 
+try:
+    from sbir_etl.enrichers.semantic_scholar import (
+        PublicationRecord as _LibPublicationRecord,
+        SemanticScholarClient,
+    )
+
+    _HAS_S2_CLIENT = True
+except ImportError:
+    _HAS_S2_CLIENT = False
+
+try:
+    from sbir_etl.enrichers.orcid_client import ORCIDClient, ORCIDRecord as _LibORCIDRecord
+
+    _HAS_ORCID_CLIENT = True
+except ImportError:
+    _HAS_ORCID_CLIENT = False
+
+try:
+    from sbir_etl.enrichers.openai_client import OpenAIClient, WebSearchResult
+
+    _HAS_OPENAI_CLIENT = True
+except ImportError:
+    _HAS_OPENAI_CLIENT = False
+
 
 # ---------------------------------------------------------------------------
 # Debug mode — toggled by --debug CLI flag
@@ -1016,8 +1040,8 @@ def lookup_pi_patents(pi_name: str, company_name: str | None = None) -> PIPatent
 def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
     """Query Semantic Scholar for the PI's publication history.
 
-    Uses the author search endpoint to find the PI, then fetches
-    their publication summary.
+    Uses :class:`SemanticScholarClient` when the library is available;
+    falls back to inline httpx calls for standalone operation.
     """
     first, last = _split_pi_name(pi_name)
     if not last:
@@ -1025,17 +1049,32 @@ def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
 
     search_query = f"{first} {last}".strip()
 
-    # Optional API key for higher rate limits (free at semanticscholar.org/product/api)
+    if _HAS_S2_CLIENT:
+        with SemanticScholarClient(rate_limiter=_semantic_scholar_limiter) as s2:
+            try:
+                rec = s2.lookup_author(search_query)
+            except Exception as e:
+                print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
+                return None
+        if rec is None:
+            return None
+        return PIPublicationRecord(
+            total_papers=rec.total_papers,
+            h_index=rec.h_index,
+            citation_count=rec.citation_count,
+            sample_titles=rec.sample_titles,
+            affiliations=rec.affiliations,
+        )
+
+    # Inline fallback for standalone operation
     s2_api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY", "")
     headers: dict[str, str] = {}
     if s2_api_key:
         headers["x-api-key"] = s2_api_key
 
-    _debug(f"Semantic Scholar search for '{pi_name}': query='{search_query}' (api_key={'yes' if s2_api_key else 'no'})")
     import time
 
     try:
-        # Step 1: Search for the author (with retry on 429)
         search_data = None
         with httpx.Client(timeout=30, headers=headers) as client:
             for attempt in range(3):
@@ -1044,87 +1083,50 @@ def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
                     f"{SEMANTIC_SCHOLAR_API_URL}/author/search",
                     params={"query": search_query, "limit": 5},
                 )
-                _debug_response(f"Semantic Scholar search [{pi_name}]", resp)
                 if resp.status_code == 429:
-                    wait = 2 ** (attempt + 1)
-                    _debug(f"Semantic Scholar [{pi_name}]: rate limited, retrying in {wait}s")
-                    time.sleep(wait)
+                    time.sleep(2 ** (attempt + 1))
                     continue
                 if resp.status_code != 200:
-                    print(
-                        f"Semantic Scholar search returned {resp.status_code} for {pi_name}",
-                        file=sys.stderr,
-                    )
                     return None
                 search_data = resp.json()
                 break
-
         if search_data is None:
-            print(f"Semantic Scholar rate limited after 3 retries for {pi_name}", file=sys.stderr)
             return None
-
         authors = search_data.get("data", [])
-        _debug(f"Semantic Scholar [{pi_name}]: {len(authors)} author matches")
         if not authors:
             return None
-
-        # Pick the best match (first result from Semantic Scholar's ranking)
-        author = authors[0]
-        author_id = author.get("authorId")
-        _debug(f"Semantic Scholar [{pi_name}]: selected authorId={author_id}, name={author.get('name', 'N/A')}")
+        author_id = authors[0].get("authorId")
         if not author_id:
             return None
 
-        # Step 2: Get author details with papers (with retry on 429)
         author_data = None
         with httpx.Client(timeout=30, headers=headers) as client:
             for attempt in range(3):
                 _semantic_scholar_limiter.wait_if_needed()
                 resp = client.get(
                     f"{SEMANTIC_SCHOLAR_API_URL}/author/{author_id}",
-                    params={
-                        "fields": "name,hIndex,citationCount,affiliations,papers.title,papers.year",
-                    },
+                    params={"fields": "name,hIndex,citationCount,affiliations,papers.title,papers.year"},
                 )
-                _debug_response(f"Semantic Scholar detail [{pi_name}]", resp)
                 if resp.status_code == 429:
-                    wait = 2 ** (attempt + 1)
-                    _debug(f"Semantic Scholar detail [{pi_name}]: rate limited, retrying in {wait}s")
-                    time.sleep(wait)
+                    time.sleep(2 ** (attempt + 1))
                     continue
                 if resp.status_code != 200:
-                    print(
-                        f"Semantic Scholar author detail returned {resp.status_code} for {pi_name}",
-                        file=sys.stderr,
-                    )
                     return None
                 author_data = resp.json()
                 break
-
         if author_data is None:
-            print(f"Semantic Scholar detail rate limited after 3 retries for {pi_name}", file=sys.stderr)
             return None
-
     except Exception as e:
         print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
         return None
 
     papers = author_data.get("papers", [])
-    _debug(
-        f"Semantic Scholar [{pi_name}]: {len(papers)} papers, "
-        f"h-index={author_data.get('hIndex')}, citations={author_data.get('citationCount')}"
-    )
-    sample_titles = [
-        p["title"] for p in papers[:5] if p.get("title")
-    ]
-    affiliations = author_data.get("affiliations", []) or []
-
     return PIPublicationRecord(
         total_papers=len(papers),
         h_index=author_data.get("hIndex"),
         citation_count=author_data.get("citationCount", 0),
-        sample_titles=sample_titles,
-        affiliations=affiliations,
+        sample_titles=[p["title"] for p in papers[:5] if p.get("title")],
+        affiliations=author_data.get("affiliations", []) or [],
     )
 
 
@@ -2030,30 +2032,44 @@ class ORCIDRecord:
 def lookup_pi_orcid(pi_name: str) -> ORCIDRecord | None:
     """Search the ORCID public API for a PI's researcher profile.
 
-    Uses the expanded search endpoint to find by name, then fetches
-    the full profile for works, affiliations, and funding.
+    Uses :class:`ORCIDClient` when the library is available;
+    falls back to inline httpx calls for standalone operation.
     """
     first, last = _split_pi_name(pi_name)
     if not last:
         return None
 
-    headers = {"Accept": "application/json"}
+    if _HAS_ORCID_CLIENT:
+        with ORCIDClient(rate_limiter=_orcid_limiter) as orcid:
+            try:
+                rec = orcid.lookup(pi_name)
+            except Exception as e:
+                print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
+                return None
+        if rec is None:
+            return None
+        return ORCIDRecord(
+            orcid_id=rec.orcid_id,
+            given_name=rec.given_name,
+            family_name=rec.family_name,
+            affiliations=rec.affiliations,
+            works_count=rec.works_count,
+            sample_work_titles=rec.sample_work_titles,
+            funding_count=rec.funding_count,
+            keywords=rec.keywords,
+        )
 
-    # Optional ORCID access token for higher rate limits.
-    # Generate via client credentials grant with a free ORCID Public API key:
-    #   curl -d "client_id=APP-XXX&client_secret=XXX&grant_type=client_credentials&scope=/read-public" \
-    #        https://orcid.org/oauth/token
+    # Inline fallback for standalone operation
+    headers = {"Accept": "application/json"}
     orcid_token = os.environ.get("ORCID_ACCESS_TOKEN", "")
     if orcid_token:
         headers["Authorization"] = f"Bearer {orcid_token}"
 
     try:
-        # Step 1: Search for the researcher by name
         query = f"family-name:{last}"
         if first:
             query += f"+AND+given-names:{first}"
 
-        _debug(f"ORCID search for '{pi_name}': query='{query}' (token={'yes' if orcid_token else 'no'})")
         _orcid_limiter.wait_if_needed()
         with httpx.Client(timeout=30) as client:
             resp = client.get(
@@ -2061,94 +2077,56 @@ def lookup_pi_orcid(pi_name: str) -> ORCIDRecord | None:
                 headers=headers,
                 params={"q": query, "rows": 5},
             )
-            _debug_response(f"ORCID search [{pi_name}]", resp)
             if resp.status_code != 200:
                 return None
             search_data = resp.json()
 
         results = search_data.get("expanded-result", [])
-        _debug(f"ORCID [{pi_name}]: {len(results) if results else 0} search results")
         if not results:
             return None
-
-        # Pick the best match (first result)
         best = results[0]
         orcid_id = best.get("orcid-id", "")
-        _debug(f"ORCID [{pi_name}]: selected orcid-id={orcid_id}")
         if not orcid_id:
             return None
 
-        # Step 2: Fetch full profile
         _orcid_limiter.wait_if_needed()
         with httpx.Client(timeout=30) as client:
-            resp = client.get(
-                f"{ORCID_API_URL}/{orcid_id}/record",
-                headers=headers,
-            )
-            _debug_response(f"ORCID profile [{pi_name}]", resp)
+            resp = client.get(f"{ORCID_API_URL}/{orcid_id}/record", headers=headers)
             if resp.status_code != 200:
                 return None
             profile = resp.json()
-
     except Exception as e:
         print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
         return None
 
-    # Extract affiliations
     affiliations: list[str] = []
-    affiliation_groups = (
-        profile.get("activities-summary", {})
-        .get("employments", {})
-        .get("affiliation-group", [])
-    )
-    for group in affiliation_groups[:10]:
-        summaries = group.get("summaries", [])
-        for s in summaries:
-            emp = s.get("employment-summary", {})
-            org = emp.get("organization", {})
-            org_name = org.get("name", "")
+    for group in (profile.get("activities-summary", {}).get("employments", {}).get("affiliation-group", []))[:10]:
+        for s in group.get("summaries", []):
+            org_name = s.get("employment-summary", {}).get("organization", {}).get("name", "")
             if org_name and org_name not in affiliations:
                 affiliations.append(org_name)
 
-    # Extract works (publications)
-    works_group = (
-        profile.get("activities-summary", {})
-        .get("works", {})
-        .get("group", [])
-    )
-    works_count = len(works_group)
-    sample_titles: list[str] = []
+    works_group = profile.get("activities-summary", {}).get("works", {}).get("group", [])
+    sample_titles = []
     for wg in works_group[:5]:
         summaries = wg.get("work-summary", [])
         if summaries:
-            title_obj = summaries[0].get("title", {})
-            title_val = title_obj.get("title", {}).get("value", "")
+            title_val = summaries[0].get("title", {}).get("title", {}).get("value", "")
             if title_val:
                 sample_titles.append(title_val)
 
-    # Extract funding
-    funding_group = (
-        profile.get("activities-summary", {})
-        .get("fundings", {})
-        .get("group", [])
-    )
-    funding_count = len(funding_group)
-
-    # Extract keywords
-    keywords_obj = profile.get("person", {}).get("keywords", {})
-    keyword_list = keywords_obj.get("keyword", [])
-    keywords = [
-        kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")
-    ]
+    funding_group = profile.get("activities-summary", {}).get("fundings", {}).get("group", [])
+    keyword_list = profile.get("person", {}).get("keywords", {}).get("keyword", [])
+    keywords = [kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")]
 
     return ORCIDRecord(
         orcid_id=orcid_id,
         given_name=best.get("given-names"),
         family_name=best.get("family-names"),
         affiliations=affiliations,
-        works_count=works_count,
+        works_count=len(works_group),
         sample_work_titles=sample_titles,
-        funding_count=funding_count,
+        funding_count=len(funding_group),
         keywords=keywords,
     )
 
@@ -2673,6 +2651,25 @@ def build_usaspending_url(award: dict) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+# Lazy-initialized OpenAI client — created on first use when the library is
+# available.  Shares the concurrency semaphore with the fallback path.
+_openai_client_instance: object | None = None
+
+
+def _get_openai_client(api_key: str) -> object | None:
+    """Return (and cache) an OpenAIClient if the library is installed."""
+    global _openai_client_instance  # noqa: PLW0603
+    if not _HAS_OPENAI_CLIENT:
+        return None
+    if _openai_client_instance is None:
+        _openai_client_instance = OpenAIClient(
+            api_key=api_key,
+            max_concurrent=int(os.environ.get("OPENAI_MAX_CONCURRENT", "4")),
+            model=OPENAI_MODEL,
+        )
+    return _openai_client_instance
+
+
 def _openai_request_with_retry(
     method: str,
     url: str,
@@ -2680,16 +2677,9 @@ def _openai_request_with_retry(
     payload: dict,
     timeout: int = 120,
 ) -> httpx.Response | None:
-    """Make an OpenAI API request with retry/backoff for 429 and 5xx errors.
-
-    Acquires ``_openai_semaphore`` before sending a request so that total
-    concurrent OpenAI calls across all thread pools stays bounded (default 4,
-    configurable via ``OPENAI_MAX_CONCURRENT`` env var).
-    """
+    """Fallback: make an OpenAI API request with retry/backoff."""
     import time
 
-    model_name = payload.get("model", "unknown")
-    _debug(f"OpenAI request: {method} {url} model={model_name} timeout={timeout}")
     for attempt in range(OPENAI_MAX_RETRIES + 1):
         try:
             _openai_semaphore.acquire()
@@ -2701,11 +2691,6 @@ def _openai_request_with_retry(
             if resp.status_code == 429 or resp.status_code >= 500:
                 if attempt < OPENAI_MAX_RETRIES:
                     wait = OPENAI_RETRY_BACKOFF_BASE ** (attempt + 1)
-                    print(
-                        f"OpenAI API returned {resp.status_code}, retrying in {wait}s "
-                        f"(attempt {attempt + 1}/{OPENAI_MAX_RETRIES})...",
-                        file=sys.stderr,
-                    )
                     time.sleep(wait)
                     continue
             resp.raise_for_status()
@@ -2713,10 +2698,8 @@ def _openai_request_with_retry(
         except httpx.HTTPStatusError:
             if attempt < OPENAI_MAX_RETRIES:
                 continue
-            print(f"OpenAI API error after {OPENAI_MAX_RETRIES} retries: {resp.status_code}", file=sys.stderr)
             return None
-        except Exception as e:
-            print(f"OpenAI API request error: {e}", file=sys.stderr)
+        except Exception:
             return None
     return None
 
@@ -2733,10 +2716,17 @@ def _openai_chat(
         f"OpenAI chat: model={model} temp={temperature} "
         f"system_len={len(system)} user_len={len(user)}"
     )
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
+
+    # Prefer library client (has its own retry + semaphore)
+    oai = _get_openai_client(api_key)
+    if oai is not None:
+        result = oai.chat(system, user, model=model, temperature=temperature)
+        if result:
+            _debug(f"OpenAI chat response: {len(result)} chars")
+        return result
+
+    # Inline fallback
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     payload = {
         "model": model,
         "temperature": temperature,
@@ -2747,7 +2737,6 @@ def _openai_chat(
     }
     resp = _openai_request_with_retry("POST", OPENAI_CHAT_URL, headers, payload)
     if resp is None:
-        _debug("OpenAI chat: no response (all retries failed)")
         return None
     try:
         data = resp.json()
@@ -2762,17 +2751,23 @@ def _openai_chat(
         return content
     except (KeyError, IndexError) as e:
         print(f"OpenAI Chat API unexpected response: {e}", file=sys.stderr)
-        _debug(f"OpenAI chat raw response: {resp.text[:1000]}")
         return None
 
 
 def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
     """Use the OpenAI Responses API with web_search_preview to research a company."""
     _debug(f"OpenAI web search: query='{query[:200]}'")
-    headers = {
-        "Authorization": f"Bearer {api_key}",
-        "Content-Type": "application/json",
-    }
+
+    # Prefer library client
+    oai = _get_openai_client(api_key)
+    if oai is not None:
+        result = oai.web_search(query)
+        if result is None:
+            return None
+        return CompanyResearch(summary=result.summary, source_urls=result.source_urls)
+
+    # Inline fallback
+    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
     payload = {
         "model": OPENAI_MODEL,
         "tools": [{"type": "web_search_preview"}],
@@ -2792,7 +2787,6 @@ def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
 
     summary_text = ""
     source_urls: list[str] = []
-
     for output_item in data.get("output", []):
         if output_item.get("type") == "message":
             for content_block in output_item.get("content", []):
@@ -2804,13 +2798,7 @@ def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
                             source_urls.append(url)
 
     if not summary_text:
-        _debug("OpenAI web search: no summary text in response")
         return None
-
-    _debug(
-        f"OpenAI web search: {len(summary_text)} char summary, "
-        f"{len(source_urls)} source URLs: {source_urls[:3]}"
-    )
     return CompanyResearch(summary=summary_text, source_urls=source_urls)
 
 

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -293,87 +293,72 @@ class CompanyResearch:
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class DataSource:
-    """Metadata about the resolved CSV data source."""
+# Source resolution and freshness checking — prefer shared library functions,
+# fall back to inline implementations when sbir_etl is not installed.
+try:
+    from sbir_etl.utils.cloud_storage import (
+        SbirAwardsSource as DataSource,
+        check_sbir_data_freshness as _check_data_freshness_lib,
+        resolve_sbir_awards_csv as _resolve_csv_path_lib,
+    )
 
-    path: Path
-    origin: str  # "s3" or "download"
-    # S3 key date (e.g. "2026-04-01" from raw/awards/2026-04-01/award_data.csv)
-    s3_key_date: str | None = None
+    def _resolve_csv_path() -> DataSource:
+        source = _resolve_csv_path_lib(download_url=SBIR_AWARDS_URL)
+        print(f"Resolved CSV: {source.path} (origin={source.origin})", file=sys.stderr)
+        return source
 
+    def _check_data_freshness(
+        source: DataSource, max_award_date: str | None, days: int
+    ) -> list[str]:
+        return _check_data_freshness_lib(source, max_award_date, days)
 
-def _resolve_csv_path() -> DataSource:
-    """Resolve the SBIR CSV path: try S3 first, then download fresh.
+except ImportError:
+    from dataclasses import dataclass as _dataclass
 
-    In CI the data-refresh workflow uploads the CSV to S3 weekly, so we
-    prefer that cached copy.  Falls back to downloading directly from
-    SBIR.gov when S3 isn't configured or the file isn't found.
-    """
-    # Try S3 first (only when sbir_etl is installed)
-    if _HAS_SBIR_ETL:
-        bucket = get_s3_bucket_from_env()
-        if bucket:
-            s3_url = find_latest_sbir_awards(bucket)
-            if s3_url:
-                print(f"Using S3-cached CSV: {s3_url}", file=sys.stderr)
-                # Extract date from S3 key: raw/awards/YYYY-MM-DD/award_data.csv
-                import re
+    @_dataclass
+    class DataSource:  # type: ignore[no-redef]
+        """Metadata about the resolved CSV data source (fallback)."""
+        path: Path
+        origin: str
+        s3_key_date: str | None = None
 
-                date_match = re.search(r"raw/awards/(\d{4}-\d{2}-\d{2})/", s3_url)
-                key_date = date_match.group(1) if date_match else None
-                return DataSource(path=Path(s3_url), origin="s3", s3_key_date=key_date)
+    def _resolve_csv_path() -> DataSource:  # type: ignore[misc]
+        """Fallback source resolver for standalone operation."""
+        print(f"S3 not available; downloading from {SBIR_AWARDS_URL}...", file=sys.stderr)
+        with httpx.Client(timeout=600, follow_redirects=True) as client:
+            response = client.get(SBIR_AWARDS_URL)
+            response.raise_for_status()
+        tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
+        tmp.write_bytes(response.content)
+        print(f"Downloaded {tmp.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
+        return DataSource(path=tmp, origin="download")
 
-    # Fall back to direct download
-    print(f"S3 not available; downloading from {SBIR_AWARDS_URL}...", file=sys.stderr)
-    with httpx.Client(timeout=600, follow_redirects=True) as client:
-        response = client.get(SBIR_AWARDS_URL)
-        response.raise_for_status()
-
-    tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
-    tmp.write_bytes(response.content)
-    print(f"Downloaded {tmp.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
-    return DataSource(path=tmp, origin="download")
-
-
-def _check_data_freshness(
-    source: DataSource,
-    max_award_date: str | None,
-    days: int,
-) -> list[str]:
-    """Verify that the bulk data is fresh enough for the reporting window.
-
-    Returns a list of warning strings (empty if everything looks good).
-    """
-    warnings: list[str] = []
-    now = datetime.now(UTC).replace(tzinfo=None)
-
-    # Check 1: S3 key date — was the data-refresh recent?
-    if source.s3_key_date:
-        key_dt = _parse_date(source.s3_key_date)
-        if key_dt:
-            key_datetime = datetime(key_dt.year, key_dt.month, key_dt.day)
-            age_days = (now - key_datetime).days
-            if age_days > days + 3:  # allow a few days of slack
-                warnings.append(
-                    f"S3 data is {age_days} days old (key date: {source.s3_key_date}). "
-                    f"The data-refresh workflow may have failed."
-                )
-
-    # Check 2: max Proposal Award Date in the data — is the data itself current?
-    if max_award_date:
-        max_dt = _parse_date(max_award_date)
-        if max_dt:
-            max_datetime = datetime(max_dt.year, max_dt.month, max_dt.day)
-            data_age = (now - max_datetime).days
-            if data_age > days + 14:
-                warnings.append(
-                    f"Most recent award in data is from {max_award_date} "
-                    f"({data_age} days ago). SBIR.gov bulk data may not have "
-                    f"been updated recently."
-                )
-
-    return warnings
+    def _check_data_freshness(  # type: ignore[misc]
+        source: DataSource, max_award_date: str | None, days: int
+    ) -> list[str]:
+        """Fallback freshness checker for standalone operation."""
+        warnings: list[str] = []
+        now = datetime.now(UTC).replace(tzinfo=None)
+        if source.s3_key_date:
+            key_dt = _parse_date(source.s3_key_date)
+            if key_dt:
+                age = (now - datetime(key_dt.year, key_dt.month, key_dt.day)).days
+                if age > days + 3:
+                    warnings.append(
+                        f"S3 data is {age} days old (key date: {source.s3_key_date}). "
+                        f"The data-refresh workflow may have failed."
+                    )
+        if max_award_date:
+            max_dt = _parse_date(max_award_date)
+            if max_dt:
+                data_age = (now - datetime(max_dt.year, max_dt.month, max_dt.day)).days
+                if data_age > days + 14:
+                    warnings.append(
+                        f"Most recent award in data is from {max_award_date} "
+                        f"({data_age} days ago). SBIR.gov bulk data may not have "
+                        f"been updated recently."
+                    )
+        return warnings
 
 
 def fetch_weekly_awards(

--- a/tests/unit/enrichers/test_openai_client.py
+++ b/tests/unit/enrichers/test_openai_client.py
@@ -1,0 +1,99 @@
+"""Tests for OpenAI client."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from sbir_etl.enrichers.openai_client import OpenAIClient, WebSearchResult
+
+pytestmark = pytest.mark.fast
+
+
+class TestOpenAIClient:
+    def test_chat_success(self):
+        mock_http = Mock()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "choices": [{"message": {"content": "  Hello world  "}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        mock_resp.raise_for_status = Mock()
+        mock_http.request.return_value = mock_resp
+
+        client = OpenAIClient(api_key="test-key")
+        client._client = mock_http
+        result = client.chat("system", "user")
+
+        assert result == "Hello world"
+
+    def test_chat_failure_returns_none(self):
+        import httpx
+
+        mock_http = Mock()
+        mock_resp = Mock()
+        mock_resp.status_code = 500
+        mock_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=Mock(), response=mock_resp
+        )
+        mock_http.request.return_value = mock_resp
+
+        client = OpenAIClient(api_key="test-key", max_concurrent=1)
+        client._client = mock_http
+        # Will retry and eventually return None
+        result = client.chat("sys", "usr")
+        assert result is None
+
+    def test_web_search_success(self):
+        mock_http = Mock()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "output": [
+                {
+                    "type": "message",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": "Acme Corp is a defense tech company.",
+                            "annotations": [
+                                {"url": "https://example.com/1"},
+                                {"url": "https://example.com/2"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+        mock_resp.raise_for_status = Mock()
+        mock_http.request.return_value = mock_resp
+
+        client = OpenAIClient(api_key="test-key")
+        client._client = mock_http
+        result = client.web_search("Acme Corp SBIR")
+
+        assert result is not None
+        assert "Acme Corp" in result.summary
+        assert len(result.source_urls) == 2
+
+    def test_web_search_empty_returns_none(self):
+        mock_http = Mock()
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"output": []}
+        mock_resp.raise_for_status = Mock()
+        mock_http.request.return_value = mock_resp
+
+        client = OpenAIClient(api_key="test-key")
+        client._client = mock_http
+        assert client.web_search("query") is None
+
+    def test_context_manager(self):
+        with OpenAIClient(api_key="test") as client:
+            assert hasattr(client, "chat")
+            assert hasattr(client, "web_search")
+
+    def test_web_search_result_fields(self):
+        r = WebSearchResult(summary="test", source_urls=["url1"])
+        assert r.summary == "test"
+        assert r.source_urls == ["url1"]

--- a/tests/unit/enrichers/test_orcid_client.py
+++ b/tests/unit/enrichers/test_orcid_client.py
@@ -1,0 +1,98 @@
+"""Tests for ORCID client."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from sbir_etl.enrichers.orcid_client import ORCIDClient, ORCIDRecord, _parse_profile
+
+pytestmark = pytest.mark.fast
+
+
+SAMPLE_PROFILE = {
+    "activities-summary": {
+        "employments": {
+            "affiliation-group": [
+                {"summaries": [{"employment-summary": {"organization": {"name": "MIT"}}}]},
+                {"summaries": [{"employment-summary": {"organization": {"name": "Stanford"}}}]},
+            ]
+        },
+        "works": {
+            "group": [
+                {"work-summary": [{"title": {"title": {"value": "Paper A"}}}]},
+                {"work-summary": [{"title": {"title": {"value": "Paper B"}}}]},
+            ]
+        },
+        "fundings": {"group": [{"funding-summary": [{}]}]},
+    },
+    "person": {
+        "keywords": {"keyword": [{"content": "AI"}, {"content": "ML"}]}
+    },
+}
+
+
+class TestParseProfile:
+    def test_extracts_affiliations(self):
+        rec = _parse_profile("0000-0001", {"given-names": "Jane", "family-names": "Doe"}, SAMPLE_PROFILE)
+        assert "MIT" in rec.affiliations
+        assert "Stanford" in rec.affiliations
+
+    def test_extracts_works(self):
+        rec = _parse_profile("0000-0001", {}, SAMPLE_PROFILE)
+        assert rec.works_count == 2
+        assert "Paper A" in rec.sample_work_titles
+
+    def test_extracts_funding(self):
+        rec = _parse_profile("0000-0001", {}, SAMPLE_PROFILE)
+        assert rec.funding_count == 1
+
+    def test_extracts_keywords(self):
+        rec = _parse_profile("0000-0001", {}, SAMPLE_PROFILE)
+        assert "AI" in rec.keywords
+        assert "ML" in rec.keywords
+
+
+class TestORCIDClient:
+    def test_lookup_success(self):
+        mock_http = Mock()
+        # Search response
+        search_resp = Mock()
+        search_resp.status_code = 200
+        search_resp.json.return_value = {
+            "expanded-result": [
+                {"orcid-id": "0000-0001", "given-names": "Jane", "family-names": "Doe"}
+            ]
+        }
+        # Profile response
+        profile_resp = Mock()
+        profile_resp.status_code = 200
+        profile_resp.json.return_value = SAMPLE_PROFILE
+
+        mock_http.get.side_effect = [search_resp, profile_resp]
+
+        client = ORCIDClient()
+        client._client = mock_http
+        rec = client.lookup("Jane Doe")
+
+        assert rec is not None
+        assert rec.orcid_id == "0000-0001"
+        assert rec.works_count == 2
+
+    def test_lookup_not_found(self):
+        mock_http = Mock()
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = {"expanded-result": []}
+        mock_http.get.return_value = resp
+
+        client = ORCIDClient()
+        client._client = mock_http
+        assert client.lookup("Nobody") is None
+
+    def test_context_manager(self):
+        with ORCIDClient() as client:
+            assert hasattr(client, "lookup")
+
+    def test_orcid_record_fields(self):
+        rec = ORCIDRecord(orcid_id="0000-0001", works_count=5, funding_count=2)
+        assert rec.orcid_id == "0000-0001"

--- a/tests/unit/enrichers/test_semantic_scholar.py
+++ b/tests/unit/enrichers/test_semantic_scholar.py
@@ -1,0 +1,66 @@
+"""Tests for Semantic Scholar client."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sbir_etl.enrichers.semantic_scholar import PublicationRecord, SemanticScholarClient
+
+pytestmark = pytest.mark.fast
+
+
+class TestSemanticScholarClient:
+    def test_lookup_author_success(self):
+        mock_http = Mock()
+        # Search response
+        search_resp = Mock()
+        search_resp.status_code = 200
+        search_resp.json.return_value = {
+            "data": [{"authorId": "12345", "name": "Jane Smith"}]
+        }
+        # Detail response
+        detail_resp = Mock()
+        detail_resp.status_code = 200
+        detail_resp.json.return_value = {
+            "name": "Jane Smith",
+            "hIndex": 15,
+            "citationCount": 500,
+            "affiliations": ["MIT"],
+            "papers": [
+                {"title": "Paper 1", "year": 2024},
+                {"title": "Paper 2", "year": 2023},
+            ],
+        }
+        mock_http.get.side_effect = [search_resp, detail_resp]
+
+        client = SemanticScholarClient()
+        client._client = mock_http
+        rec = client.lookup_author("Jane Smith")
+
+        assert rec is not None
+        assert rec.h_index == 15
+        assert rec.total_papers == 2
+        assert rec.citation_count == 500
+        assert "MIT" in rec.affiliations
+
+    def test_lookup_author_not_found(self):
+        mock_http = Mock()
+        resp = Mock()
+        resp.status_code = 200
+        resp.json.return_value = {"data": []}
+        mock_http.get.return_value = resp
+
+        client = SemanticScholarClient()
+        client._client = mock_http
+        assert client.lookup_author("Nobody") is None
+
+    def test_context_manager(self):
+        with SemanticScholarClient() as client:
+            assert hasattr(client, "lookup_author")
+
+    def test_publication_record_fields(self):
+        rec = PublicationRecord(
+            total_papers=10, h_index=5, citation_count=100,
+            sample_titles=["T1"], affiliations=["Uni"]
+        )
+        assert rec.total_papers == 10

--- a/tests/unit/extractors/test_solicitation.py
+++ b/tests/unit/extractors/test_solicitation.py
@@ -1,0 +1,115 @@
+"""Tests for SolicitationExtractor."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from sbir_etl.extractors.solicitation import SolicitationExtractor
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.fixture
+def mock_client():
+    return Mock()
+
+
+@pytest.fixture
+def extractor(mock_client):
+    return SolicitationExtractor(http_client=mock_client)
+
+
+def _ok_response(data):
+    resp = Mock()
+    resp.status_code = 200
+    resp.json.return_value = data
+    return resp
+
+
+class TestQueryByKeyword:
+    def test_returns_matching_topics(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([
+            {"topicCode": "AF241-001", "topicTitle": "Sensor Fusion"},
+        ])
+        results = extractor.query_by_keyword("AF241-001")
+        assert len(results) == 1
+        assert results[0]["topicCode"] == "AF241-001"
+
+    def test_returns_empty_on_no_match(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([])
+        results = extractor.query_by_keyword("NONEXISTENT")
+        assert results == []
+
+    def test_returns_empty_on_error(self, extractor, mock_client):
+        mock_client.get.side_effect = Exception("network error")
+        results = extractor.query_by_keyword("test")
+        assert results == []
+
+
+class TestQueryAwardsForTopic:
+    def test_finds_matching_award(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([
+            {"topicCode": "AF241-001", "topicTitle": "Sensor", "abstract": "Research on sensors"},
+            {"topicCode": "AF241-002", "topicTitle": "Other"},
+        ])
+        result = extractor.query_awards_for_topic("AF241-001")
+        assert result is not None
+        assert result["topic_code"] == "AF241-001"
+        assert result["title"] == "Sensor"
+        assert result["description"] == "Research on sensors"
+
+    def test_returns_none_when_no_match(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([
+            {"topicCode": "OTHER", "topicTitle": "Unrelated"},
+        ])
+        result = extractor.query_awards_for_topic("AF241-001")
+        assert result is None
+
+    def test_returns_none_on_empty(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([])
+        result = extractor.query_awards_for_topic("AF241-001")
+        assert result is None
+
+    def test_returns_none_on_error(self, extractor, mock_client):
+        mock_client.get.side_effect = Exception("network error")
+        result = extractor.query_awards_for_topic("test")
+        assert result is None
+
+    def test_prefers_topic_description(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([
+            {
+                "topicCode": "TC1",
+                "topicTitle": "Title",
+                "topicDescription": "Full topic desc",
+                "abstract": "Award abstract",
+            },
+        ])
+        result = extractor.query_awards_for_topic("TC1")
+        assert result["description"] == "Full topic desc"
+
+    def test_falls_back_to_abstract(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response([
+            {"topicCode": "TC1", "awardTitle": "Award", "abstract": "Abstract text"},
+        ])
+        result = extractor.query_awards_for_topic("TC1")
+        assert result["description"] == "Abstract text"
+        assert result["title"] == "Award"
+
+
+class TestQuerySolicitationsKeywordParam:
+    def test_keyword_passed_to_api(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response({"results": []})
+        extractor._query_solicitations(keyword="AF241-001", rows=25)
+
+        call_kwargs = mock_client.get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["keyword"] == "AF241-001"
+
+    def test_keyword_and_year_combined(self, extractor, mock_client):
+        mock_client.get.return_value = _ok_response({"results": []})
+        extractor._query_solicitations(keyword="test", year=2025, rows=10)
+
+        call_kwargs = mock_client.get.call_args
+        params = call_kwargs.kwargs.get("params") or call_kwargs[1].get("params")
+        assert params["keyword"] == "test"
+        assert params["year"] == 2025

--- a/tests/unit/utils/test_cloud_storage.py
+++ b/tests/unit/utils/test_cloud_storage.py
@@ -7,7 +7,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 pytestmark = pytest.mark.fast
 
 from sbir_etl.utils.cloud_storage import (
@@ -180,7 +179,9 @@ class TestCheckSbirDataFreshness:
     """Tests for check_sbir_data_freshness function."""
 
     def _recent_date(self, days_ago: int = 1) -> str:
-        return (datetime.now(UTC) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+        # Use noon UTC to avoid midnight-boundary flakiness
+        ref = datetime.now(UTC).replace(hour=12, minute=0, second=0, microsecond=0)
+        return (ref - timedelta(days=days_ago)).strftime("%Y-%m-%d")
 
     def test_fresh_data_no_warnings(self):
         source = SbirAwardsSource(

--- a/tests/unit/utils/test_cloud_storage.py
+++ b/tests/unit/utils/test_cloud_storage.py
@@ -1,6 +1,7 @@
 """Unit tests for cloud storage utilities."""
 
 import os
+from datetime import datetime, timedelta, UTC
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -9,7 +10,13 @@ import pytest
 
 pytestmark = pytest.mark.fast
 
-from sbir_etl.utils.cloud_storage import build_s3_path, get_s3_bucket_from_env, resolve_data_path
+from sbir_etl.utils.cloud_storage import (
+    SbirAwardsSource,
+    build_s3_path,
+    check_sbir_data_freshness,
+    get_s3_bucket_from_env,
+    resolve_data_path,
+)
 
 
 class TestResolveDataPath:
@@ -164,3 +171,75 @@ class TestBuildS3Path:
         with patch("sbir_etl.utils.cloud_storage.get_s3_bucket_from_env", return_value=None):
             with pytest.raises(ValueError, match="S3 bucket not configured"):
                 build_s3_path("data/raw/file.csv")
+
+
+# ==================== Freshness Checking Tests ====================
+
+
+class TestCheckSbirDataFreshness:
+    """Tests for check_sbir_data_freshness function."""
+
+    def _recent_date(self, days_ago: int = 1) -> str:
+        return (datetime.now(UTC) - timedelta(days=days_ago)).strftime("%Y-%m-%d")
+
+    def test_fresh_data_no_warnings(self):
+        source = SbirAwardsSource(
+            path=Path("/tmp/test.csv"), origin="s3", s3_key_date=self._recent_date(2)
+        )
+        warnings = check_sbir_data_freshness(source, self._recent_date(2), days=7)
+        assert warnings == []
+
+    def test_stale_s3_key_date(self):
+        source = SbirAwardsSource(
+            path=Path("/tmp/test.csv"), origin="s3", s3_key_date=self._recent_date(30)
+        )
+        warnings = check_sbir_data_freshness(source, self._recent_date(1), days=7)
+        assert len(warnings) == 1
+        assert "S3 data is" in warnings[0]
+
+    def test_stale_max_award_date(self):
+        source = SbirAwardsSource(path=Path("/tmp/test.csv"), origin="download")
+        warnings = check_sbir_data_freshness(source, self._recent_date(30), days=7)
+        assert len(warnings) == 1
+        assert "Most recent award" in warnings[0]
+
+    def test_both_stale(self):
+        source = SbirAwardsSource(
+            path=Path("/tmp/test.csv"), origin="s3", s3_key_date=self._recent_date(30)
+        )
+        warnings = check_sbir_data_freshness(source, self._recent_date(30), days=7)
+        assert len(warnings) == 2
+
+    def test_no_s3_key_date_skips_check(self):
+        source = SbirAwardsSource(path=Path("/tmp/test.csv"), origin="download")
+        warnings = check_sbir_data_freshness(source, self._recent_date(1), days=7)
+        assert warnings == []
+
+    def test_no_max_award_date_skips_check(self):
+        source = SbirAwardsSource(
+            path=Path("/tmp/test.csv"), origin="s3", s3_key_date=self._recent_date(1)
+        )
+        warnings = check_sbir_data_freshness(source, None, days=7)
+        assert warnings == []
+
+    def test_custom_slack_days(self):
+        source = SbirAwardsSource(
+            path=Path("/tmp/test.csv"), origin="s3", s3_key_date=self._recent_date(12)
+        )
+        # Default slack is 3, so 12 days > 7+3=10 → stale
+        warnings_default = check_sbir_data_freshness(source, None, days=7)
+        assert len(warnings_default) == 1
+
+        # With slack=10, 12 days < 7+10=17 → fresh
+        warnings_custom = check_sbir_data_freshness(
+            source, None, days=7, s3_slack_days=10
+        )
+        assert warnings_custom == []
+
+    def test_edge_case_exactly_at_threshold(self):
+        # days=7, slack=3 → threshold=10; age=10 → NOT stale (> not >=)
+        source = SbirAwardsSource(
+            path=Path("/tmp/test.csv"), origin="s3", s3_key_date=self._recent_date(10)
+        )
+        warnings = check_sbir_data_freshness(source, None, days=7)
+        assert warnings == []


### PR DESCRIPTION
## Summary

Completes P1, P2, and the SolicitationExtractor enhancement from the DRY evaluation.

### Commit 1: Shared source/freshness (P1)
- `resolve_sbir_awards_csv()` and `check_sbir_data_freshness()` in `cloud_storage.py`
- Source resolution and freshness policy now in exactly one module

### Commit 2: Extract academic/LLM clients (P2)
- `sbir_etl/enrichers/semantic_scholar.py` — `SemanticScholarClient`
- `sbir_etl/enrichers/orcid_client.py` — `ORCIDClient`
- `sbir_etl/enrichers/openai_client.py` — `OpenAIClient` with semaphore concurrency

### Commit 3: Enhance SolicitationExtractor
- `query_by_keyword()` — search `/solicitations` by keyword with tenacity retry
- `query_awards_for_topic()` — `/awards` endpoint fallback for missing topics
- Weekly report now uses extractor for all three search strategies (year, keyword, awards) when installed

All clients support context manager, rate limiter injection, connection pooling. Inline httpx fallbacks preserved for standalone operation.

## Tests
- 9 freshness tests
- 18 client tests (S2 + ORCID + OpenAI)
- 11 solicitation extractor tests

https://claude.ai/code/session_01D8ws9MmBT6yXZzXSzMnWYw