### PR TITLE
Fix API endpoints, error handling, and event loop management

### DIFF
--- a/sbir_etl/enrichers/orcid_client.py
+++ b/sbir_etl/enrichers/orcid_client.py
@@ -147,7 +147,10 @@ class ORCIDClient:
         """
         query = f"family-name:{family_name}"
         if given_names:
-            query += f"+AND+given-names:{given_names}"
+            # Use literal " AND " — httpx encodes spaces in query params
+            # automatically.  The old "+AND+" was double-encoded (%2BAND%2B)
+            # which caused ORCID to return 500.
+            query += f" AND given-names:{given_names}"
 
         self._wait()
         try:

--- a/sbir_etl/enrichers/patentsview.py
+++ b/sbir_etl/enrichers/patentsview.py
@@ -381,7 +381,9 @@ class PatentsViewClient:
         escaped_name = self._escape_lucene_query(company_name)
 
         while len(all_patents) < max_patents:
-            # ODP uses Lucene-style query syntax with GET params
+            # ODP field-level Lucene queries go to the base endpoint (no
+            # /search suffix).  The /search endpoint only accepts a
+            # ``searchText`` free-text parameter and rejects ``q``.
             params = {
                 "q": f'assigneeName:"{escaped_name}"',
                 "offset": offset,
@@ -389,7 +391,7 @@ class PatentsViewClient:
             }
 
             try:
-                response = self._make_request("/search", method="GET", params=params)
+                response = self._make_request("", method="GET", params=params)
 
                 # ODP response format: patentFileWrapperDataBag array
                 records = response.get("patentFileWrapperDataBag", [])
@@ -468,7 +470,7 @@ class PatentsViewClient:
         }
 
         try:
-            response = self._make_request("/search", method="GET", params=params)
+            response = self._make_request("", method="GET", params=params)
             records = response.get("patentFileWrapperDataBag", [])
 
             # Deduplicate assignees from patent results

--- a/sbir_etl/utils/async_tools.py
+++ b/sbir_etl/utils/async_tools.py
@@ -3,23 +3,35 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from collections.abc import Coroutine
 from typing import Any, cast
+
+# Module-level persistent event loop.  Re-using one loop avoids the
+# "Event loop is closed" crash that occurs when an httpx.AsyncClient
+# created on loop A is later called from loop B (after A was closed by
+# ``asyncio.run``).
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_lock = threading.Lock()
+
+
+def _get_loop() -> asyncio.AbstractEventLoop:
+    """Return (and lazily create) the shared background event loop."""
+    global _loop  # noqa: PLW0603
+    if _loop is None or _loop.is_closed():
+        with _loop_lock:
+            # Double-check under lock
+            if _loop is None or _loop.is_closed():
+                _loop = asyncio.new_event_loop()
+    return _loop
 
 
 def run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
     """Run an async coroutine from synchronous code safely.
 
-    Handles the common case where another event loop is already running
-    (e.g., inside IPython) by creating a temporary loop.
+    Uses a persistent module-level event loop so that async clients
+    (e.g. httpx.AsyncClient) whose transports are bound to a loop
+    remain usable across multiple ``run_sync`` calls.
     """
-    try:
-        return asyncio.run(cast(Coroutine[Any, Any, Any], coro))
-    except RuntimeError as exc:
-        if "asyncio.run()" in str(exc):
-            loop = asyncio.new_event_loop()
-            try:
-                return loop.run_until_complete(coro)
-            finally:
-                loop.close()
-        raise
+    loop = _get_loop()
+    return loop.run_until_complete(cast(Coroutine[Any, Any, Any], coro))

--- a/sbir_etl/utils/async_tools.py
+++ b/sbir_etl/utils/async_tools.py
@@ -7,31 +7,53 @@ import threading
 from collections.abc import Coroutine
 from typing import Any, cast
 
-# Module-level persistent event loop.  Re-using one loop avoids the
-# "Event loop is closed" crash that occurs when an httpx.AsyncClient
-# created on loop A is later called from loop B (after A was closed by
-# ``asyncio.run``).
+# ---------------------------------------------------------------------------
+# Persistent background event loop
+# ---------------------------------------------------------------------------
+# A single event loop runs in a dedicated daemon thread.  Synchronous callers
+# submit coroutines via ``asyncio.run_coroutine_threadsafe`` which is safe to
+# call from *any* thread.  This avoids:
+#   1. "Event loop is closed" — the loop stays alive for the process lifetime
+#      so httpx.AsyncClient transports bound to it remain usable.
+#   2. Thread-safety issues — ``run_coroutine_threadsafe`` is designed for
+#      cross-thread scheduling, unlike ``loop.run_until_complete`` which must
+#      be called from the thread that owns the loop.
+# ---------------------------------------------------------------------------
+
 _loop: asyncio.AbstractEventLoop | None = None
 _loop_lock = threading.Lock()
 
 
 def _get_loop() -> asyncio.AbstractEventLoop:
-    """Return (and lazily create) the shared background event loop."""
+    """Return (and lazily start) the shared background event loop."""
     global _loop  # noqa: PLW0603
-    if _loop is None or _loop.is_closed():
-        with _loop_lock:
-            # Double-check under lock
-            if _loop is None or _loop.is_closed():
-                _loop = asyncio.new_event_loop()
+    if _loop is not None and not _loop.is_closed():
+        return _loop
+    with _loop_lock:
+        # Double-check under lock
+        if _loop is not None and not _loop.is_closed():
+            return _loop
+        new_loop = asyncio.new_event_loop()
+
+        def _run_loop() -> None:
+            asyncio.set_event_loop(new_loop)
+            new_loop.run_forever()
+
+        t = threading.Thread(target=_run_loop, daemon=True, name="async-loop")
+        t.start()
+        _loop = new_loop
     return _loop
 
 
 def run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
-    """Run an async coroutine from synchronous code safely.
+    """Run an async coroutine from synchronous code, from any thread.
 
-    Uses a persistent module-level event loop so that async clients
-    (e.g. httpx.AsyncClient) whose transports are bound to a loop
-    remain usable across multiple ``run_sync`` calls.
+    Submits the coroutine to a persistent background event loop and
+    blocks until the result is ready.  Safe to call concurrently from
+    multiple threads (e.g. ``ThreadPoolExecutor`` workers).
     """
     loop = _get_loop()
-    return loop.run_until_complete(cast(Coroutine[Any, Any, Any], coro))
+    future = asyncio.run_coroutine_threadsafe(
+        cast(Coroutine[Any, Any, Any], coro), loop
+    )
+    return future.result()

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1765,8 +1765,9 @@ def lookup_usaspending_recipients(
                 key, profile = future.result(timeout=10)
                 if profile:
                     results[key] = profile
-            except Exception:
-                pass
+            except Exception as e:
+                item = futures[future]
+                _debug(f"USAspending recipient lookup failed for {item[0]}: {e}")
 
     print(f"Found {len(results)}/{total} recipient profiles on USAspending", file=sys.stderr)
     return results
@@ -2003,8 +2004,9 @@ def lookup_sam_entities(
                 key, record = future.result(timeout=10)
                 if record:
                     results[key] = record
-            except Exception:
-                pass
+            except Exception as e:
+                item = futures[future]
+                _debug(f"SAM.gov entity lookup failed for {item[0]}: {e}")
 
     print(f"Found {len(results)}/{total} companies on SAM.gov", file=sys.stderr)
     return results
@@ -4271,19 +4273,22 @@ def main():
                 fetch_futures["sol_topics"] = fetch_pool.submit(
                     fetch_solicitation_topics, awards
                 )
-            elif args.skip_sbir_api:
+            else:
                 print("Skipping SBIR.gov API calls (--skip-sbir-api)", file=sys.stderr)
 
-            if api_key and not args.no_ai:
-                fetch_futures["usa_descs"] = fetch_pool.submit(
-                    fetch_usaspending_contract_descriptions, awards
-                )
-                fetch_futures["usa_recipients"] = fetch_pool.submit(
-                    lookup_usaspending_recipients, awards
-                )
-                fetch_futures["sam_data"] = fetch_pool.submit(
-                    lookup_sam_entities, awards
-                )
+            # Government data APIs (USAspending, SAM.gov) are independent of AI —
+            # always fetch when awards exist so enrichment data (BEA sectors,
+            # congressional districts, recipient profiles) is available regardless
+            # of whether AI descriptions are generated.
+            fetch_futures["usa_descs"] = fetch_pool.submit(
+                fetch_usaspending_contract_descriptions, awards
+            )
+            fetch_futures["usa_recipients"] = fetch_pool.submit(
+                lookup_usaspending_recipients, awards
+            )
+            fetch_futures["sam_data"] = fetch_pool.submit(
+                lookup_sam_entities, awards
+            )
 
             # Collect results
             for name, future in fetch_futures.items():

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -249,7 +249,9 @@ OPENAI_RETRY_BACKOFF_BASE = 2  # seconds
 
 # External API endpoints for PI diligence and solicitation lookup
 # PatentsView migrated to USPTO Open Data Portal (data.uspto.gov) March 2026
-USPTO_ODP_PATENT_SEARCH_URL = "https://data.uspto.gov/api/v1/patent/applications/search"
+# ODP field-level Lucene queries (q=inventorNameText:"...") go to the base
+# endpoint.  The /search sub-path only accepts free-text ``searchText``.
+USPTO_ODP_PATENT_QUERY_URL = "https://data.uspto.gov/api/v1/patent/applications"
 SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
 USASPENDING_API_URL = "https://api.usaspending.gov/api/v2"
 SBIR_GOV_API_URL = "https://api.www.sbir.gov/public/api"
@@ -977,11 +979,11 @@ def lookup_pi_patents(pi_name: str, company_name: str | None = None) -> PIPatent
         "limit": 100,
     }
 
-    _debug(f"USPTO ODP query for '{pi_name}': GET {USPTO_ODP_PATENT_SEARCH_URL} params={params}")
+    _debug(f"USPTO ODP query for '{pi_name}': GET {USPTO_ODP_PATENT_QUERY_URL} params={params}")
     try:
         _uspto_limiter.wait_if_needed()
         with httpx.Client(timeout=30) as client:
-            resp = client.get(USPTO_ODP_PATENT_SEARCH_URL, headers=headers, params=params)
+            resp = client.get(USPTO_ODP_PATENT_QUERY_URL, headers=headers, params=params)
             _debug_response(f"USPTO ODP [{pi_name}]", resp)
             if resp.status_code != 200:
                 print(
@@ -2070,7 +2072,7 @@ def lookup_pi_orcid(pi_name: str) -> ORCIDRecord | None:
     try:
         query = f"family-name:{last}"
         if first:
-            query += f"+AND+given-names:{first}"
+            query += f" AND given-names:{first}"
 
         _orcid_limiter.wait_if_needed()
         with httpx.Client(timeout=30) as client:

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1769,7 +1769,10 @@ def lookup_usaspending_recipients(
                     results[key] = profile
             except Exception as e:
                 item = futures[future]
-                _debug(f"USAspending recipient lookup failed for {item[0]}: {e}")
+                print(
+                    f"Warning: USAspending recipient lookup failed for {item[0]}: {e}",
+                    file=sys.stderr,
+                )
 
     print(f"Found {len(results)}/{total} recipient profiles on USAspending", file=sys.stderr)
     return results
@@ -2008,7 +2011,10 @@ def lookup_sam_entities(
                     results[key] = record
             except Exception as e:
                 item = futures[future]
-                _debug(f"SAM.gov entity lookup failed for {item[0]}: {e}")
+                print(
+                    f"Warning: SAM.gov entity lookup failed for {item[0]}: {e}",
+                    file=sys.stderr,
+                )
 
     print(f"Found {len(results)}/{total} companies on SAM.gov", file=sys.stderr)
     return results

--- a/tests/unit/utils/test_async_tools.py
+++ b/tests/unit/utils/test_async_tools.py
@@ -1,7 +1,7 @@
 """Unit tests for async tools utilities."""
 
 import asyncio
-from unittest.mock import patch
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
@@ -37,28 +37,31 @@ class TestRunSync:
             run_sync(failing_coro())
 
     def test_run_sync_with_existing_loop(self):
-        """Test run_sync handles case where event loop already exists."""
-        # Create an event loop
+        """Test run_sync works even when the calling thread has its own loop."""
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
 
         try:
-            # This should work even with an existing loop
             result = run_sync(simple_coro(7))
             assert result == 14
         finally:
             loop.close()
             asyncio.set_event_loop(None)
 
-    def test_run_sync_with_runtime_error(self):
-        """Test run_sync handles RuntimeError from asyncio.run()."""
-        with patch("asyncio.run", side_effect=RuntimeError("asyncio.run() cannot be called")):
-            # Should fall back to new_event_loop approach
-            result = run_sync(simple_coro(3))
-            assert result == 6
+    def test_run_sync_multiple_calls_reuse_loop(self):
+        """Test that multiple run_sync calls reuse the same background loop."""
+        r1 = run_sync(simple_coro(3))
+        r2 = run_sync(simple_coro(4))
+        assert r1 == 6
+        assert r2 == 8
 
-    def test_run_sync_with_other_runtime_error(self):
-        """Test run_sync re-raises non-asyncio RuntimeErrors."""
-        with patch("asyncio.run", side_effect=RuntimeError("Different error")):
-            with pytest.raises(RuntimeError, match="Different error"):
-                run_sync(simple_coro(1))
+    def test_run_sync_thread_safety(self):
+        """Test that run_sync can be called safely from multiple threads."""
+        def call_from_thread(val: int) -> int:
+            return run_sync(simple_coro(val))
+
+        with ThreadPoolExecutor(max_workers=4) as pool:
+            futures = [pool.submit(call_from_thread, i) for i in range(8)]
+            results = [f.result(timeout=10) for f in futures]
+
+        assert results == [i * 2 for i in range(8)]


### PR DESCRIPTION
## Description

This PR addresses several bugs and improvements across the codebase:

1. **USPTO ODP API endpoint correction**: Changed from `/search` endpoint to base endpoint for field-level Lucene queries. The `/search` sub-path only accepts free-text `searchText` parameters and rejects field-level `q` parameters. Updated variable name from `USPTO_ODP_PATENT_SEARCH_URL` to `USPTO_ODP_PATENT_QUERY_URL` for clarity.

2. **ORCID query encoding fix**: Fixed double-encoding issue in ORCID search queries. Changed from `+AND+` (which gets URL-encoded to `%2BAND%2B`) to literal ` AND ` (which httpx encodes correctly as `%20AND%20`). This was causing ORCID API to return 500 errors.

3. **Improved error logging**: Enhanced exception handling in `lookup_usaspending_recipients()` and `lookup_sam_entities()` to log the actual error message and item identifier instead of silently swallowing exceptions. This improves debuggability of API failures.

4. **Event loop lifecycle fix**: Refactored `run_sync()` in `async_tools.py` to use a persistent module-level event loop instead of creating/closing loops with `asyncio.run()`. This prevents "Event loop is closed" crashes when httpx.AsyncClient transports bound to a loop are reused across multiple `run_sync()` calls.

5. **API fetch logic correction**: Changed conditional from `elif args.skip_sbir_api:` to `else:` to properly handle the skip case, and moved USAspending/SAM.gov API calls outside the `if api_key and not args.no_ai:` block. These government data APIs should always be fetched when awards exist, independent of AI configuration, to ensure enrichment data (BEA sectors, congressional districts, recipient profiles) is available regardless of AI settings.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Existing integration tests cover USPTO ODP, ORCID, and USAspending/SAM.gov API calls
- Event loop changes are covered by existing async client usage patterns
- Changes are backward compatible with no API contract changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

https://claude.ai/code/session_0151ETBsZfv2i3boP41Gp3Ew