### PR TITLE
Replace requests library with httpx for HTTP calls

### DIFF
--- a/sbir_etl/enrichers/congressional_district_resolver.py
+++ b/sbir_etl/enrichers/congressional_district_resolver.py
@@ -161,7 +161,7 @@ class CongressionalDistrictResolver:
             District resolution result or None
         """
         try:
-            import requests
+            import httpx
 
             # Add delay to respect rate limits
             time.sleep(self.census_api_delay)
@@ -178,7 +178,7 @@ class CongressionalDistrictResolver:
                 "format": "json",
             }
 
-            response = requests.get(base_url, params=params, timeout=10)
+            response = httpx.get(base_url, params=params, timeout=10)
             response.raise_for_status()
             data = response.json()
 
@@ -235,7 +235,7 @@ class CongressionalDistrictResolver:
             District resolution result or None
         """
         try:
-            import requests
+            import httpx
 
             full_address = f"{address}, {city}, {state} {zip_code}"
 
@@ -247,7 +247,7 @@ class CongressionalDistrictResolver:
                 "roles": "legislatorLowerBody",
             }
 
-            response = requests.get(url, params=params, timeout=10)
+            response = httpx.get(url, params=params, timeout=10)
             response.raise_for_status()
             data = response.json()
 


### PR DESCRIPTION
## Description

Replace the `requests` library with `httpx` for making HTTP calls in the congressional district resolver module. This change affects two methods that query external APIs:
- `resolve_district_from_census_api()` - Census API calls
- `resolve_district_from_google_civic()` - Google Civic API calls

The `httpx` library provides a modern, async-capable HTTP client with a compatible API to `requests`, making this a straightforward drop-in replacement.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

The existing API call logic remains functionally identical - only the HTTP client library has changed. The `httpx.get()` method has the same signature and behavior as `requests.get()`, including support for `params`, `timeout`, and `raise_for_status()`.

- [x] Existing tests pass locally with my changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

https://claude.ai/code/session_012XxjYuFFJr3eXYn7boMw21