### PR TITLE
Fix USPTO ODP queries: use searchText instead of Lucene q parameter

### DIFF
--- a/sbir_etl/enrichers/patentsview.py
+++ b/sbir_etl/enrichers/patentsview.py
@@ -377,15 +377,11 @@ class PatentsViewClient:
         offset = 0
         limit = 100  # ODP page size
 
-        # Escape special Lucene characters in company name for query
-        escaped_name = self._escape_lucene_query(company_name)
-
         while len(all_patents) < max_patents:
-            # ODP field-level Lucene queries go to the base endpoint (no
-            # /search suffix).  The /search endpoint only accepts a
-            # ``searchText`` free-text parameter and rejects ``q``.
+            # The ODP API uses ``searchText`` for free-text queries
+            # (replacing the old PatentsView Lucene ``q`` parameter).
             params = {
-                "q": f'assigneeName:"{escaped_name}"',
+                "searchText": company_name,
                 "offset": offset,
                 "limit": limit,
             }
@@ -462,9 +458,8 @@ class PatentsViewClient:
         """
         logger.debug(f"Querying assignees for company name: {company_name}")
 
-        escaped_name = self._escape_lucene_query(company_name)
         params = {
-            "q": f'assigneeName:"{escaped_name}"',
+            "searchText": company_name,
             "offset": 0,
             "limit": 25,
         }

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -965,16 +965,14 @@ def lookup_pi_patents(pi_name: str, company_name: str | None = None) -> PIPatent
     if api_key:
         headers["X-API-KEY"] = api_key
 
-    # Build Lucene-style query for inventor name
-    query_parts = [f'inventorNameText:"{last}"']
-    if first:
-        query_parts.append(f'inventorNameText:"{first}"')
+    # ODP uses ``searchText`` for free-text queries (not Lucene ``q``).
+    # Combine inventor name and company into a single search string.
+    search_terms = f"{first} {last}".strip() if first else last
     if company_name:
-        safe_company = company_name.replace('"', '\\"')
-        query_parts.append(f'assigneeName:"{safe_company}"')
+        search_terms += f" {company_name}"
 
     params = {
-        "q": " AND ".join(query_parts),
+        "searchText": search_terms,
         "offset": 0,
         "limit": 100,
     }


### PR DESCRIPTION
The ODP API at data.uspto.gov/api/v1/patent/applications uses ``searchText`` for free-text queries. The old PatentsView Lucene ``q=assigneeName:"..."`` syntax is not supported and returns 400.

Updated PatentsViewClient.query_patents_by_assignee, query_assignee_by_name, and the weekly report fallback to use ``searchText`` parameter.

https://claude.ai/code/session_0151ETBsZfv2i3boP41Gp3Ew

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
