### PR TITLE
Refactor USAspending API award type groups for accuracy

### DIFF
--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -1322,11 +1322,15 @@ def _usaspending_search(
         "Description",
         "CFDA Number",
     ]
-    # USAspending requires award_type_codes from one group only:
-    # contracts (A-D) and assistance (02-11) must be separate requests.
+    # USAspending requires award_type_codes from one group only.
+    # The API enforces these groups: contracts (A-D), grants (02-05),
+    # direct_payments (06, 10), loans (07-09), other (11).
     type_groups = [
         ("contracts", ["A", "B", "C", "D"]),
-        ("assistance", ["02", "03", "04", "05", "06", "07", "08", "09", "10", "11"]),
+        ("grants", ["02", "03", "04", "05"]),
+        ("direct_payments", ["06", "10"]),
+        ("loans", ["07", "08", "09"]),
+        ("other", ["11"]),
     ]
 
     all_results: list[dict] = []


### PR DESCRIPTION
## Description

This change refactors the award type code grouping logic in the USAspending API search function to align with the actual API constraints. The previous implementation grouped all assistance-related codes (02-11) into a single request, which does not match the API's actual enforcement of separate groups.

The change splits the assistance category into four distinct groups as enforced by the USAspending API:
- **grants**: codes 02-05
- **direct_payments**: codes 06, 10
- **loans**: codes 07-09
- **other**: code 11

This ensures that API requests are properly segmented according to the actual API requirements, preventing potential request failures or incorrect data filtering.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

This change corrects the API request grouping logic to match actual API constraints. The fix ensures that award type codes are properly separated into valid groups for API requests. Existing integration tests that validate USAspending API responses will verify the correctness of this change.

- [x] Existing tests pass locally with these changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

https://claude.ai/code/session_01BApG2mQzCqqnkcUQmn3VvV