### PR TITLE
Fix USAspending API calls by adding required sort parameters

### DIFF
--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -2954,6 +2954,12 @@ def fetch_usaspending_contract_descriptions(
                 )
                 data = None
                 # Try spending_by_award, then spending_by_transaction
+                # USAspending requires a 'sort' field; use the appropriate
+                # default for each endpoint.
+                _sort_for_method = {
+                    "search_awards": "Award Amount",
+                    "search_transactions": "Transaction Amount",
+                }
                 for method in ("search_awards", "search_transactions"):
                     try:
                         _usaspending_limiter.wait_if_needed()
@@ -2961,8 +2967,8 @@ def fetch_usaspending_contract_descriptions(
                             filters=filters,
                             fields=desc_fields,
                             limit=len(ids),
-                            sort=None,
-                            order=None,
+                            sort=_sort_for_method.get(method, "Award Amount"),
+                            order="desc",
                         )
                         break
                     except Exception as e:
@@ -2982,25 +2988,29 @@ def fetch_usaspending_contract_descriptions(
             with httpx.Client(timeout=30) as client:
                 for ids, group_name, codes in requests_to_make:
                     quoted = [f'"{c}"' for c in ids]
-                    payload = {
-                        "filters": {
-                            "award_ids": quoted,
-                            "award_type_codes": codes,
-                        },
-                        "fields": desc_fields,
-                        "page": 1,
-                        "limit": len(ids),
-                    }
+                    # USAspending requires 'sort'; map each endpoint to its
+                    # default sort field.
+                    endpoints = [
+                        ("search/spending_by_award", "Award Amount"),
+                        ("search/spending_by_transaction", "Transaction Amount"),
+                    ]
                     _debug(
                         f"USAspending contract desc: {group_name} "
                         f"({len(ids)} IDs: {ids[:3]})"
                     )
-                    endpoints = [
-                        "search/spending_by_award",
-                        "search/spending_by_transaction",
-                    ]
                     data = None
-                    for endpoint in endpoints:
+                    for endpoint, sort_field in endpoints:
+                        payload = {
+                            "filters": {
+                                "award_ids": quoted,
+                                "award_type_codes": codes,
+                            },
+                            "fields": desc_fields,
+                            "page": 1,
+                            "limit": len(ids),
+                            "sort": sort_field,
+                            "order": "desc",
+                        }
                         for attempt in range(2):
                             _usaspending_limiter.wait_if_needed()
                             resp = client.post(


### PR DESCRIPTION
## Description

This change fixes API calls to USAspending endpoints by adding required `sort` and `order` parameters that were previously missing or set to `None`.

The USAspending API requires a `sort` field for both the Python SDK methods (`search_awards`, `search_transactions`) and the direct HTTP endpoints (`search/spending_by_award`, `search/spending_by_transaction`). The fix maps each endpoint to its appropriate default sort field:
- Award-related endpoints use "Award Amount"
- Transaction-related endpoints use "Transaction Amount"

Additionally, the `order` parameter is now explicitly set to "desc" for consistency.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

No new tests added. This is a straightforward parameter fix to comply with API requirements. The change ensures that existing calls to USAspending endpoints will now succeed instead of failing due to missing required parameters.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

https://claude.ai/code/session_01Ae7exSU69YuTJ38yyGXzsn