### PR TITLE
Remove dead ImportError fallback code from weekly awards report

### DIFF
--- a/sbir_etl/enrichers/award_history.py
+++ b/sbir_etl/enrichers/award_history.py
@@ -1,0 +1,251 @@
+"""Historical award context building for SBIR companies and PIs.
+
+Extracts and aggregates historical SBIR/STTR award data from the full
+awards dataset, providing per-company and per-PI context useful for
+diligence and trend analysis.
+"""
+
+from __future__ import annotations
+
+import csv
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from sbir_etl.utils.date_utils import parse_date
+from sbir_etl.utils.text_normalization import pluralize_col_key
+
+if TYPE_CHECKING:
+    from sbir_etl.utils.cloud_storage import SbirAwardsSource
+
+
+def _parse_date_safe(value) -> str | None:
+    """Parse a date value and return ISO format string, or None."""
+    parsed = parse_date(value)
+    return parsed.isoformat() if parsed else None
+
+
+def _build_history_from_df(
+    df,
+    group_col: str,
+    extra_set_cols: list[str] | None = None,
+) -> dict[str, dict]:
+    """Build history dicts from a DataFrame grouped by a column.
+
+    Used by both company and PI history to avoid duplicating aggregation logic.
+    """
+    df = df.fillna("")
+    history: dict[str, dict] = {}
+
+    for group_key, group_df in df.groupby(group_col, sort=False):
+        name = str(group_key).strip()
+        if not name:
+            continue
+
+        phases = {v for v in group_df["Phase"].astype(str).str.strip() if v}
+        agencies = {v for v in group_df["Agency"].astype(str).str.strip() if v}
+        programs = {v for v in group_df["Program"].astype(str).str.strip() if v}
+
+        total_funding = 0.0
+        for val in group_df["Award Amount"].astype(str):
+            try:
+                total_funding += float(val.replace(",", "").replace("$", ""))
+            except (ValueError, TypeError):
+                pass
+
+        parsed_dates = []
+        for val in group_df["Proposal Award Date"].astype(str).str.strip():
+            if val:
+                iso = _parse_date_safe(val)
+                if iso:
+                    parsed_dates.append(iso)
+
+        titles: list[str] = []
+        for t in group_df["Award Title"].astype(str).str.strip():
+            if t and t not in titles:
+                titles.append(t)
+
+        entry: dict = {
+            "total_awards": len(group_df),
+            "phases": sorted(phases),
+            "agencies": sorted(agencies),
+            "programs": sorted(programs),
+            "total_funding": total_funding,
+            "earliest_date": min(parsed_dates) if parsed_dates else None,
+            "latest_date": max(parsed_dates) if parsed_dates else None,
+            "sample_titles": titles[:5],
+        }
+
+        # Extra set columns (e.g. "Company" for PI history)
+        if extra_set_cols:
+            for col in extra_set_cols:
+                col_key = pluralize_col_key(col)
+                entry[col_key] = sorted(
+                    {v for v in group_df[col].astype(str).str.strip() if v}
+                )
+
+        history[name] = entry
+
+    return history
+
+
+def _build_history_from_csv(
+    source: SbirAwardsSource,
+    target_names: set[str],
+    key_field: str,
+    extra_set_fields: list[str] | None = None,
+) -> dict[str, dict]:
+    """Build history dicts by streaming the CSV file.
+
+    Streams the file line-by-line to avoid loading the entire CSV into memory.
+    """
+    history: dict[str, dict] = {}
+    with source.path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            name = str(row.get(key_field, "")).strip().upper()
+            if name not in target_names:
+                continue
+            if name not in history:
+                entry: dict = {
+                    "total_awards": 0,
+                    "phases": set(),
+                    "agencies": set(),
+                    "programs": set(),
+                    "total_funding": 0.0,
+                    "dates": [],
+                    "sample_titles": [],
+                }
+                if extra_set_fields:
+                    for ef in extra_set_fields:
+                        entry[pluralize_col_key(ef)] = set()
+                history[name] = entry
+
+            h = history[name]
+            h["total_awards"] += 1
+            for field, set_key in [("Phase", "phases"), ("Agency", "agencies"), ("Program", "programs")]:
+                val = str(row.get(field, "")).strip()
+                if val:
+                    h[set_key].add(val)
+            if extra_set_fields:
+                for ef in extra_set_fields:
+                    val = str(row.get(ef, "")).strip()
+                    if val:
+                        h[pluralize_col_key(ef)].add(val)
+            try:
+                h["total_funding"] += float(
+                    str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
+                )
+            except (ValueError, TypeError):
+                pass
+            d = str(row.get("Proposal Award Date", "")).strip()
+            if d:
+                h["dates"].append(d)
+            t = str(row.get("Award Title", "")).strip()
+            if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
+                h["sample_titles"].append(t)
+
+    # Normalize sets to sorted lists and parse dates
+    for _name, h in history.items():
+        raw_dates = h.pop("dates", [])
+        parsed_dates = [_parse_date_safe(d) for d in raw_dates]
+        parsed_dates = [d for d in parsed_dates if d]
+        h["earliest_date"] = min(parsed_dates) if parsed_dates else None
+        h["latest_date"] = max(parsed_dates) if parsed_dates else None
+        for key in ["phases", "agencies", "programs"]:
+            if isinstance(h[key], set):
+                h[key] = sorted(h[key])
+        if extra_set_fields:
+            for ef in extra_set_fields:
+                set_key = ef.lower().replace(" ", "_") + "s"
+                if isinstance(h.get(set_key), set):
+                    h[set_key] = sorted(h[set_key])
+
+    return history
+
+
+def get_company_history(
+    awards: list[dict],
+    source: SbirAwardsSource | None = None,
+    extractor: object | None = None,
+    table: str | None = None,
+) -> dict[str, dict]:
+    """Extract historical SBIR award context per company from the full dataset.
+
+    Accepts optional shared source/extractor/table to avoid redundant CSV
+    downloads and DuckDB imports when called alongside get_pi_history().
+
+    Returns a dict keyed by upper-cased company name.
+    """
+    company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
+    company_names.discard("")
+    if not company_names:
+        return {}
+
+    if extractor is not None and table is not None:
+        # Build IN clause with escaped names
+        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(company_names)]
+        in_clause = ", ".join(escaped)
+        query = (
+            f'SELECT UPPER("Company") AS _group_key, "Phase", "Agency", '
+            f'"Award Amount", "Proposal Award Date", "Award Title", "Program" '
+            f"FROM {table} "
+            f'WHERE UPPER("Company") IN ({in_clause}) '
+            f'ORDER BY "Proposal Award Date" DESC'
+        )
+        df = extractor.duckdb_client.execute_query_df(query)
+        if df.empty:
+            return {}
+        return _build_history_from_df(df, "_group_key")
+
+    if source is None:
+        logger.debug("get_company_history: no source or extractor provided")
+        return {}
+
+    # Fallback: stream the CSV
+    return _build_history_from_csv(source, company_names, "Company")
+
+
+def get_pi_history(
+    awards: list[dict],
+    source: SbirAwardsSource | None = None,
+    extractor: object | None = None,
+    table: str | None = None,
+) -> dict[str, dict]:
+    """Extract historical SBIR context per Principal Investigator.
+
+    Accepts optional shared source/extractor/table to avoid redundant CSV
+    downloads and DuckDB imports.
+
+    Returns a dict keyed by upper-cased PI name.
+    """
+    pi_names = set()
+    for a in awards:
+        pi = str(a.get("PI Name", "")).strip().upper()
+        if pi:
+            pi_names.add(pi)
+
+    if not pi_names:
+        return {}
+
+    if extractor is not None and table is not None:
+        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(pi_names)]
+        in_clause = ", ".join(escaped)
+        query = (
+            f'SELECT UPPER("PI Name") AS _group_key, "Company", "Phase", "Agency", '
+            f'"Award Amount", "Proposal Award Date", "Award Title", "Program" '
+            f"FROM {table} "
+            f'WHERE UPPER("PI Name") IN ({in_clause}) '
+            f'ORDER BY "Proposal Award Date" DESC'
+        )
+        df = extractor.duckdb_client.execute_query_df(query)
+        if df.empty:
+            return {}
+        return _build_history_from_df(df, "_group_key", extra_set_cols=["Company"])
+
+    if source is None:
+        logger.debug("get_pi_history: no source or extractor provided")
+        return {}
+
+    # Fallback: stream the CSV
+    return _build_history_from_csv(source, pi_names, "PI Name", extra_set_fields=["Company"])

--- a/sbir_etl/enrichers/company_enrichment.py
+++ b/sbir_etl/enrichers/company_enrichment.py
@@ -1,0 +1,716 @@
+"""Company-level enrichment functions.
+
+Provides USAspending federal award lookups, SAM.gov entity registration
+checks, and FPDS contract description retrieval. Each lookup function
+returns a typed dataclass on success or ``None`` on failure.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+
+from loguru import logger
+
+from sbir_etl.enrichers.fpds_atom import FPDSAtomClient
+from sbir_etl.enrichers.patentsview import RateLimiter
+from sbir_etl.enrichers.pi_enrichment import _is_sbir_award_type
+from sbir_etl.enrichers.sync_wrappers import SyncSAMGovClient, SyncUSAspendingClient
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FederalAwardSummary:
+    """Summary of a company's federal awards from USAspending.
+
+    Separates SBIR/STTR awards from non-SBIR federal work. Non-SBIR
+    awards to a company with SBIR history are potential follow-on /
+    Phase III commercialization signals.
+    """
+
+    total_awards: int
+    total_funding: float
+    agencies: list[str]
+    award_types: list[str]  # e.g. contracts, grants, IDVs
+    date_range: tuple[str | None, str | None]
+    # Follow-on analysis
+    sbir_award_count: int = 0
+    sbir_funding: float = 0.0
+    non_sbir_award_count: int = 0
+    non_sbir_funding: float = 0.0
+    non_sbir_agencies: list[str] = field(default_factory=list)
+    non_sbir_sample_descriptions: list[str] = field(default_factory=list)
+
+
+@dataclass
+class USARecipientProfile:
+    """Key data from a USAspending recipient profile."""
+
+    recipient_id: str
+    name: str
+    uei: str | None
+    parent_name: str | None
+    parent_uei: str | None
+    location_state: str | None
+    location_congressional_district: str | None
+    business_types: list[str]
+    total_transaction_amount: float
+    total_transactions: int
+
+
+@dataclass
+class SAMEntityRecord:
+    """Key SAM.gov entity registration data for diligence."""
+
+    uei: str
+    legal_business_name: str
+    dba_name: str | None
+    registration_status: str | None
+    expiration_date: str | None
+    business_type: str | None
+    entity_structure: str | None
+    naics_codes: list[str]
+    cage_code: str | None
+    exclusion_status: str | None
+    state: str | None
+    congressional_district: str | None
+
+
+# ---------------------------------------------------------------------------
+# USAspending helpers
+# ---------------------------------------------------------------------------
+
+# Abbreviation patterns for fuzzy name matching
+_ABBREVIATIONS = {
+    r"\bIntl\.?\b": "International",
+    r"\bInt'l\.?\b": "International",
+    r"\bInc\.?\b": "Incorporated",
+    r"\bCorp\.?\b": "Corporation",
+    r"\bLtd\.?\b": "Limited",
+    r"\bLLC\.?\b": "Limited Liability Company",
+    r"\bTech\.?\b": "Technology",
+    r"\bMfg\.?\b": "Manufacturing",
+    r"\bSvcs\.?\b": "Services",
+    r"\bDev\.?\b": "Development",
+}
+
+
+def usaspending_autocomplete(
+    company_name: str,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> dict[str, str] | None:
+    """Use USAspending recipient autocomplete for fuzzy company name matching.
+
+    Generates name variations (abbreviation expansion, punctuation normalization,
+    suffix removal) and tries each against the autocomplete endpoint until a match
+    with a UEI or resolved name is found.
+    """
+    if not company_name or not company_name.strip():
+        return None
+
+    # Generate name variations, ordered most-to-least specific
+    variations: list[str] = [company_name.strip()]
+
+    # Expand abbreviations
+    expanded = company_name
+    for pattern, replacement in _ABBREVIATIONS.items():
+        expanded = re.sub(pattern, replacement, expanded, flags=re.IGNORECASE)
+    if expanded != company_name:
+        variations.append(expanded.strip())
+
+    # Normalize punctuation
+    normalized = expanded.replace("/", " AND ").replace("&", " AND ")
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    if normalized not in variations:
+        variations.append(normalized)
+
+    # Remove legal suffixes for broadest match
+    base = re.sub(
+        r",?\s*(Inc\.?|Incorporated|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?)$",
+        "", normalized, flags=re.IGNORECASE,
+    ).strip().rstrip(",").strip()
+    if base and base not in variations and len(base) >= 10:
+        variations.append(base)
+
+    # Add uppercase versions (USAspending often stores uppercase)
+    upper_vars = [v.upper() for v in variations[:2] if v.upper() != v]
+    variations = variations[:2] + upper_vars + variations[2:]
+
+    # Deduplicate preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for v in variations:
+        key = v.lower()
+        if key not in seen and len(v) >= 5:
+            seen.add(key)
+            unique.append(v)
+
+    logger.debug(
+        "USAspending autocomplete: {} name variations for '{}'",
+        len(unique), company_name,
+    )
+
+    best_candidate = None
+
+    usa = SyncUSAspendingClient()
+    try:
+        for idx, name in enumerate(unique, 1):
+            try:
+                if rate_limiter:
+                    rate_limiter.wait_if_needed()
+                data = usa.autocomplete_recipient(name, limit=5)
+                results = data.get("results", [])
+                if not results:
+                    continue
+                match = results[0]
+                matched_name = match.get("legal_business_name", "")
+                matched_uei = match.get("uei")
+                if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
+                    logger.debug(
+                        "USAspending autocomplete matched '{}' "
+                        "(variation {}: '{}') → '{}' UEI={}",
+                        company_name, idx, name, matched_name, matched_uei,
+                    )
+                    return {"uei": matched_uei, "name": matched_name}
+                if matched_name and best_candidate is None:
+                    best_candidate = {"uei": matched_uei, "name": matched_name}
+            except Exception:
+                continue
+    finally:
+        usa.close()
+
+    if best_candidate:
+        logger.debug(
+            "USAspending autocomplete: best candidate for '{}' → '{}' (no UEI)",
+            company_name, best_candidate["name"],
+        )
+        return best_candidate
+
+    logger.debug(
+        "USAspending autocomplete: no match for '{}' after {} variations",
+        company_name, len(unique),
+    )
+    return None
+
+
+def usaspending_search(
+    company_name: str,
+    search_text: str,
+    label: str,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> list[dict] | None:
+    """Execute USAspending spending_by_award searches for a company.
+
+    Makes separate requests for contracts and grants/other (USAspending
+    requires award_type_codes from a single group per request), then
+    merges the results.
+
+    Returns the combined results list on success, or None on error.
+    """
+    fields = [
+        "Award ID",
+        "Recipient Name",
+        "Award Amount",
+        "Awarding Agency",
+        "Award Type",
+        "Start Date",
+        "Description",
+        "CFDA Number",
+    ]
+    # USAspending requires award_type_codes from one group only.
+    type_groups = [
+        ("contracts", ["A", "B", "C", "D"]),
+        ("grants", ["02", "03", "04", "05"]),
+        ("direct_payments", ["06", "10"]),
+        ("loans", ["07", "08", "09"]),
+        ("other", ["11"]),
+    ]
+
+    all_results: list[dict] = []
+    logger.debug(
+        "USAspending query for '{}' ({}='{}'): POST /search/spending_by_award/",
+        company_name, label, search_text,
+    )
+
+    usa = SyncUSAspendingClient()
+    try:
+        for group_name, codes in type_groups:
+            try:
+                if rate_limiter:
+                    rate_limiter.wait_if_needed()
+                data = usa.search_awards(
+                    filters={
+                        "award_type_codes": codes,
+                        "recipient_search_text": [search_text],
+                    },
+                    fields=fields,
+                    limit=50,
+                )
+                group_results = data.get("results", [])
+                logger.debug(
+                    "USAspending [{} via {}/{}]: {} results",
+                    company_name, label, group_name, len(group_results),
+                )
+                all_results.extend(group_results)
+            except Exception as e:
+                logger.debug(
+                    "USAspending [{}] {}/{} error: {}",
+                    company_name, label, group_name, e,
+                )
+                continue
+    finally:
+        usa.close()
+
+    logger.debug(
+        "USAspending [{} via {}]: {} total results",
+        company_name, label, len(all_results),
+    )
+    return all_results if all_results else None
+
+
+def lookup_company_federal_awards(
+    company_name: str,
+    uei: str | None = None,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> FederalAwardSummary | None:
+    """Query USAspending for all federal awards to a company.
+
+    Tries UEI first (most reliable), then falls back to company name search,
+    then fuzzy autocomplete match.
+
+    Separates SBIR/STTR awards from non-SBIR federal work. Non-SBIR
+    contracts and grants to a company with SBIR history are the strongest
+    signal of successful commercialization / Phase III transition.
+    """
+    if not company_name:
+        return None
+
+    # Cascading lookup: UEI → exact name → fuzzy autocomplete match
+    results = None
+    if uei:
+        results = usaspending_search(company_name, uei, "UEI", rate_limiter=rate_limiter)
+    if not results:
+        results = usaspending_search(company_name, company_name, "name", rate_limiter=rate_limiter)
+    if not results:
+        match = usaspending_autocomplete(company_name, rate_limiter=rate_limiter)
+        if match:
+            search_key = match["uei"] if match.get("uei") else match["name"]
+            label = "autocomplete-UEI" if match.get("uei") else "autocomplete-name"
+            results = usaspending_search(company_name, search_key, label, rate_limiter=rate_limiter)
+    if not results:
+        return None
+
+    agencies: set[str] = set()
+    award_types: set[str] = set()
+    total_funding = 0.0
+    dates: list[str] = []
+
+    sbir_count = 0
+    sbir_funding = 0.0
+    non_sbir_count = 0
+    non_sbir_funding = 0.0
+    non_sbir_agencies: set[str] = set()
+    non_sbir_descriptions: list[str] = []
+
+    for r in results:
+        ag = r.get("Awarding Agency", "")
+        if ag:
+            agencies.add(ag)
+        at = r.get("Award Type", "")
+        if at:
+            award_types.add(at)
+        try:
+            amount = float(r.get("Award Amount", 0) or 0)
+        except (ValueError, TypeError):
+            amount = 0.0
+        total_funding += amount
+        d = r.get("Start Date", "")
+        if d:
+            dates.append(d)
+
+        desc = str(r.get("Description", "") or "")
+        cfda = str(r.get("CFDA Number", "") or "")
+
+        if _is_sbir_award_type(desc, cfda):
+            sbir_count += 1
+            sbir_funding += amount
+        else:
+            non_sbir_count += 1
+            non_sbir_funding += amount
+            if ag:
+                non_sbir_agencies.add(ag)
+            if desc and len(non_sbir_descriptions) < 5:
+                if len(desc) > 200:
+                    desc = desc[:200] + "..."
+                non_sbir_descriptions.append(
+                    f"{desc} ({ag}, {at}, ${amount:,.0f})"
+                )
+
+    return FederalAwardSummary(
+        total_awards=len(results),
+        total_funding=total_funding,
+        agencies=sorted(agencies),
+        award_types=sorted(award_types),
+        date_range=(min(dates) if dates else None, max(dates) if dates else None),
+        sbir_award_count=sbir_count,
+        sbir_funding=sbir_funding,
+        non_sbir_award_count=non_sbir_count,
+        non_sbir_funding=non_sbir_funding,
+        non_sbir_agencies=sorted(non_sbir_agencies),
+        non_sbir_sample_descriptions=non_sbir_descriptions,
+    )
+
+
+# ---------------------------------------------------------------------------
+# USAspending recipient profile
+# ---------------------------------------------------------------------------
+
+
+def lookup_usaspending_recipient(
+    company_name: str,
+    uei: str | None = None,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> USARecipientProfile | None:
+    """Look up a company's USAspending recipient profile.
+
+    Two-step: POST /recipient/ to find the hash ID, then GET /recipient/{id}/
+    for the full profile. Tries UEI first, then company name.
+    """
+    if not company_name:
+        return None
+
+    search_terms = []
+    if uei:
+        search_terms.append(uei)
+    search_terms.append(company_name)
+
+    recipient_id = None
+
+    usa = SyncUSAspendingClient()
+    try:
+        for term in search_terms:
+            logger.debug("USAspending recipient search: keyword='{}'", term)
+            try:
+                if rate_limiter:
+                    rate_limiter.wait_if_needed()
+                results = usa.search_recipients(term, limit=5)
+                if results:
+                    recipient_id = results[0].get("id")
+                    logger.debug(
+                        "USAspending recipient matched '{}' → '{}' id={}",
+                        term, results[0].get("name"), recipient_id,
+                    )
+                    break
+            except Exception as e:
+                logger.debug("USAspending recipient search error for '{}': {}", term, e)
+                continue
+
+        if not recipient_id:
+            logger.debug("USAspending recipient: no match for '{}'", company_name)
+            return None
+
+        # Fetch the full profile
+        logger.debug("USAspending recipient profile: GET /recipient/{}/?year=all", recipient_id)
+        try:
+            if rate_limiter:
+                rate_limiter.wait_if_needed()
+            profile = usa.get_recipient_profile(recipient_id)
+        except Exception as e:
+            logger.debug("USAspending recipient profile error: {}", e)
+            return None
+        if not profile:
+            return None
+    finally:
+        usa.close()
+
+    location = profile.get("location") or {}
+
+    return USARecipientProfile(
+        recipient_id=recipient_id,
+        name=profile.get("name") or company_name,
+        uei=profile.get("uei"),
+        parent_name=profile.get("parent_name"),
+        parent_uei=profile.get("parent_uei"),
+        location_state=location.get("state_code"),
+        location_congressional_district=location.get("congressional_code"),
+        business_types=profile.get("business_types") or [],
+        total_transaction_amount=float(profile.get("total_transaction_amount") or 0),
+        total_transactions=int(profile.get("total_transactions") or 0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SAM.gov entity lookup
+# ---------------------------------------------------------------------------
+
+
+def lookup_sam_entity(
+    company_name: str,
+    uei: str | None = None,
+    cage: str | None = None,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> SAMEntityRecord | None:
+    """Query SAM.gov Entity Information API for company registration data.
+
+    Tries UEI first (exact match), then CAGE, then name search.
+    Requires SAM_GOV_API_KEY environment variable.
+    """
+    api_key = os.environ.get("SAM_GOV_API_KEY", "")
+    if not api_key:
+        return None
+
+    entity = None
+
+    sam = SyncSAMGovClient()
+    try:
+        if uei:
+            logger.debug("SAM.gov [{}]: lookup by UEI={}", company_name, uei)
+            try:
+                if rate_limiter:
+                    rate_limiter.wait_if_needed()
+                entity = sam.get_entity_by_uei(uei)
+            except Exception as e:
+                logger.debug("SAM.gov [{}]: UEI lookup error: {}", company_name, e)
+
+        if not entity and cage:
+            logger.debug("SAM.gov [{}]: lookup by CAGE={}", company_name, cage)
+            try:
+                if rate_limiter:
+                    rate_limiter.wait_if_needed()
+                entity = sam.get_entity_by_cage(cage)
+            except Exception as e:
+                logger.debug("SAM.gov [{}]: CAGE lookup error: {}", company_name, e)
+
+        if not entity and company_name:
+            logger.debug("SAM.gov [{}]: name search", company_name)
+            try:
+                if rate_limiter:
+                    rate_limiter.wait_if_needed()
+                results = sam.search_entities(
+                    legal_business_name=company_name,
+                    registration_status="A",
+                    limit=1,
+                )
+                entity = results[0] if results else None
+            except Exception as e:
+                logger.debug("SAM.gov [{}]: name search error: {}", company_name, e)
+    finally:
+        sam.close()
+
+    if not entity:
+        methods_tried = []
+        if uei:
+            methods_tried.append(f"UEI={uei}")
+        if cage:
+            methods_tried.append(f"CAGE={cage}")
+        methods_tried.append(f"name='{company_name}'")
+        logger.info(
+            "SAM.gov: no entity found for {} (tried: {})",
+            company_name, ", ".join(methods_tried),
+        )
+        return None
+
+    # Extract fields — SAM.gov API nests data under various keys
+    core = entity.get("entityRegistration", entity)
+    address = entity.get("coreData", {}).get("physicalAddress", {})
+    business_types = entity.get("coreData", {}).get("businessTypes", {})
+
+    naics_list = entity.get("coreData", {}).get("naicsCodeList", [])
+    if isinstance(naics_list, list):
+        naics_codes = [
+            str(n.get("naicsCode", "")) for n in naics_list if n.get("naicsCode")
+        ]
+    else:
+        naics_codes = []
+
+    return SAMEntityRecord(
+        uei=core.get("ueiSAM", ""),
+        legal_business_name=core.get("legalBusinessName", ""),
+        dba_name=core.get("dbaName"),
+        registration_status=core.get("registrationStatus"),
+        expiration_date=core.get("registrationExpirationDate"),
+        business_type=(
+            business_types.get("businessTypeList", [{}])[0].get("businessType")
+            if isinstance(business_types.get("businessTypeList"), list)
+            and business_types.get("businessTypeList")
+            else None
+        ),
+        entity_structure=core.get("entityStructureDesc"),
+        naics_codes=naics_codes,
+        cage_code=core.get("cageCode"),
+        exclusion_status=core.get("exclusionStatusFlag"),
+        state=address.get("stateOrProvinceCode"),
+        congressional_district=address.get("congressionalDistrict"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# FPDS contract descriptions
+# ---------------------------------------------------------------------------
+
+
+def fetch_fpds_descriptions(
+    contract_ids: list[str],
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> dict[str, str]:
+    """Fetch contract descriptions from FPDS Atom Feed (public, no API key).
+
+    Only accepts contract PIIDs — assistance FAINs (e.g. DE-*) are not
+    indexed in FPDS and should be filtered out before calling this function.
+    """
+    if not contract_ids:
+        return {}
+
+    logger.debug("FPDS: querying {} contract IDs", len(contract_ids))
+
+    with FPDSAtomClient(rate_limiter=rate_limiter) as fpds:
+        try:
+            results = fpds.get_descriptions(contract_ids)
+        except Exception as e:
+            logger.debug("FPDS error: {}", e)
+            results = {}
+    logger.debug("FPDS: {}/{} descriptions found", len(results), len(contract_ids))
+    return results
+
+
+def fetch_usaspending_contract_descriptions(
+    awards: list[dict],
+    *,
+    rate_limiter: RateLimiter | None = None,
+    fpds_rate_limiter: RateLimiter | None = None,
+) -> dict[str, str]:
+    """Fetch contract descriptions from USAspending for awards with contract numbers.
+
+    Returns a dict keyed by contract number with the award description text.
+    Used as supplementary LLM context when solicitation topic data is unavailable.
+
+    Falls back to FPDS Atom Feed for contract PIIDs that fail at USAspending.
+    """
+    # Use shared award-ID classification when available, inline fallback otherwise.
+    try:
+        from sbir_etl.enrichers.usaspending.client import build_award_type_groups
+    except ImportError:
+        def build_award_type_groups(ids):  # type: ignore[misc]
+            piids, fains, unknown = [], [], []
+            seen: set[str] = set()
+            for raw in ids:
+                s = raw.strip()
+                if not s or s in seen:
+                    continue
+                seen.add(s)
+                if re.match(r"^DE-", s, re.IGNORECASE):
+                    fains.append(s)
+                elif re.match(r"^[A-Z]{2}\d", s):
+                    piids.append(s)
+                else:
+                    unknown.append(s)
+            groups = []
+            if piids:
+                groups.append((piids, "contracts", ["A", "B", "C", "D"]))
+            if fains:
+                groups.append((fains, "assistance", ["02", "03", "04", "05"]))
+            for uid in unknown:
+                groups.append(([uid], "contracts", ["A", "B", "C", "D"]))
+                groups.append(([uid], "assistance", ["02", "03", "04", "05"]))
+            return groups
+
+    raw_ids = [str(a.get("Contract", "")).strip() for a in awards]
+    raw_ids = [c for c in raw_ids if c]
+    if not raw_ids:
+        return {}
+
+    requests_to_make = build_award_type_groups(raw_ids)
+    all_ids = list({aid for ids, _, _ in requests_to_make for aid in ids})
+
+    logger.debug(
+        "USAspending contract desc: {} IDs in {} groups",
+        len(all_ids), len(requests_to_make),
+    )
+    results: dict[str, str] = {}
+    failed_ids: set[str] = set()
+
+    desc_fields = ["Award ID", "Description", "Awarding Agency", "Award Type"]
+
+    def _extract_descriptions(data: dict) -> None:
+        for r in data.get("results", []):
+            aid = str(r.get("Award ID", "")).strip()
+            desc = str(r.get("Description", "")).strip()
+            if aid and desc and aid not in results:
+                if len(desc) > 500:
+                    desc = desc[:500] + "..."
+                results[aid] = desc
+
+    usa = SyncUSAspendingClient()
+    try:
+        for ids, group_name, codes in requests_to_make:
+            quoted = [f'"{c}"' for c in ids]
+            filters = {"award_ids": quoted, "award_type_codes": codes}
+            logger.debug(
+                "USAspending contract desc: {} ({} IDs: {})",
+                group_name, len(ids), ids[:3],
+            )
+            data = None
+            _sort_for_method = {
+                "search_awards": "Award Amount",
+                "search_transactions": "Transaction Amount",
+            }
+            for method in ("search_awards", "search_transactions"):
+                try:
+                    if rate_limiter:
+                        rate_limiter.wait_if_needed()
+                    data = getattr(usa, method)(
+                        filters=filters,
+                        fields=desc_fields,
+                        limit=len(ids),
+                        sort=_sort_for_method.get(method, "Award Amount"),
+                        order="desc",
+                    )
+                    break
+                except Exception as e:
+                    logger.debug("USAspending {}/{} failed: {}", method, group_name, e)
+                    continue
+            if data is None:
+                failed_ids.update(ids)
+                continue
+            _extract_descriptions(data)
+    except Exception as e:
+        failed_ids.update(cid for cid in all_ids if cid not in results)
+        logger.warning("USAspending contract desc error: {}", e)
+    finally:
+        usa.close()
+
+    # FPDS Atom Feed fallback for contract PIIDs that failed at USAspending.
+    fpds_eligible = [
+        cid for cid in failed_ids
+        if cid not in results and not re.match(r"^DE-", cid, re.IGNORECASE)
+    ]
+    if fpds_eligible:
+        logger.debug(
+            "USAspending failed for {} IDs, {} eligible for FPDS fallback",
+            len(failed_ids), len(fpds_eligible),
+        )
+        fpds_results = fetch_fpds_descriptions(
+            fpds_eligible, rate_limiter=fpds_rate_limiter or rate_limiter,
+        )
+        if fpds_results:
+            results.update(fpds_results)
+            logger.info(
+                "FPDS fallback recovered {}/{} descriptions",
+                len(fpds_results), len(fpds_eligible),
+            )
+
+    logger.debug(
+        "Contract descriptions: {}/{} found (USAspending + FPDS)",
+        len(results), len(all_ids),
+    )
+    return results

--- a/sbir_etl/enrichers/pi_enrichment.py
+++ b/sbir_etl/enrichers/pi_enrichment.py
@@ -1,0 +1,214 @@
+"""PI (Principal Investigator) enrichment functions.
+
+Extracts patent, publication, and ORCID profile data for principal
+investigators using external API clients. Each lookup function returns
+a typed dataclass on success or ``None`` on failure, making them safe
+to call unconditionally in enrichment pipelines.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from loguru import logger
+
+from sbir_etl.enrichers.orcid_client import ORCIDClient
+from sbir_etl.enrichers.patentsview import PatentsViewClient, RateLimiter
+from sbir_etl.enrichers.semantic_scholar import SemanticScholarClient
+from sbir_etl.models.sbir_identification import classify_sbir_award
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PIPatentRecord:
+    """Summary of a PI's patent portfolio from PatentsView."""
+
+    total_patents: int
+    sample_titles: list[str]
+    assignees: list[str]
+    date_range: tuple[str | None, str | None]
+
+
+@dataclass
+class PIPublicationRecord:
+    """Summary of a PI's publication history from Semantic Scholar."""
+
+    total_papers: int
+    h_index: int | None
+    citation_count: int
+    sample_titles: list[str]
+    affiliations: list[str]
+
+
+@dataclass
+class ORCIDRecord:
+    """Key data from an ORCID researcher profile."""
+
+    orcid_id: str
+    given_name: str | None
+    family_name: str | None
+    affiliations: list[str]
+    works_count: int
+    sample_work_titles: list[str]
+    funding_count: int
+    keywords: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _split_pi_name(full_name: str) -> tuple[str, str]:
+    """Split a PI name into (first, last) for API queries.
+
+    SBIR data typically stores names as 'First Last' or 'Last, First'.
+    """
+    full_name = full_name.strip()
+    if "," in full_name:
+        parts = [p.strip() for p in full_name.split(",", 1)]
+        return (parts[1], parts[0]) if len(parts) == 2 else (parts[0], "")
+    parts = full_name.split()
+    if len(parts) >= 2:
+        return (parts[0], parts[-1])
+    return (full_name, "")
+
+
+def _is_sbir_award_type(description: str, cfda: str) -> bool:
+    """Identify SBIR/STTR awards using ALN numbers and description keywords.
+
+    Delegates to :func:`sbir_etl.models.sbir_identification.classify_sbir_award`.
+    """
+    result = classify_sbir_award(cfda_number=cfda, description=description)
+    return result is not None
+
+
+# ---------------------------------------------------------------------------
+# External API lookups
+# ---------------------------------------------------------------------------
+
+
+def lookup_pi_patents(
+    pi_name: str,
+    company_name: str | None = None,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> PIPatentRecord | None:
+    """Query USPTO ODP for patents where the PI is a named inventor.
+
+    Uses PatentsViewClient when available (rate limiting, caching, retry).
+    Falls back to bare httpx calls otherwise.
+    """
+    first, last = _split_pi_name(pi_name)
+    if not last:
+        return None
+
+    logger.debug("Using PatentsViewClient for '{}'", pi_name)
+    try:
+        client = PatentsViewClient()
+        try:
+            # Query by company name to get patents, then we'll have all
+            # inventor/assignee data in the results
+            patents = client.query_patents_by_assignee(
+                company_name=company_name or last,
+                max_patents=100,
+            )
+        finally:
+            if hasattr(client, "close"):
+                client.close()
+        if not patents:
+            return None
+
+        titles = []
+        assignees: set[str] = set()
+        dates: list[str] = []
+        for p in patents:
+            t = p.get("patent_title", "")
+            if t and t not in titles and len(titles) < 5:
+                titles.append(t)
+            org = p.get("assignee_organization", "")
+            if org:
+                assignees.add(org)
+            d = p.get("grant_date") or p.get("patent_date", "")
+            if d:
+                dates.append(d)
+
+        return PIPatentRecord(
+            total_patents=len(patents),
+            sample_titles=titles,
+            assignees=sorted(assignees),
+            date_range=(min(dates) if dates else None, max(dates) if dates else None),
+        )
+    except Exception as e:
+        logger.debug("PatentsViewClient error for '{}': {}", pi_name, e)
+        return None
+
+
+def lookup_pi_publications(
+    pi_name: str,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> PIPublicationRecord | None:
+    """Query Semantic Scholar for the PI's publication history.
+
+    Uses :class:`SemanticScholarClient` when the library is available;
+    falls back to inline httpx calls for standalone operation.
+    """
+    first, last = _split_pi_name(pi_name)
+    if not last:
+        return None
+
+    search_query = f"{first} {last}".strip()
+
+    with SemanticScholarClient(rate_limiter=rate_limiter) as s2:
+        try:
+            rec = s2.lookup_author(search_query)
+        except Exception as e:
+            logger.debug("Semantic Scholar API error for {}: {}", pi_name, e)
+            return None
+    if rec is None:
+        return None
+    return PIPublicationRecord(
+        total_papers=rec.total_papers,
+        h_index=rec.h_index,
+        citation_count=rec.citation_count,
+        sample_titles=rec.sample_titles,
+        affiliations=rec.affiliations,
+    )
+
+
+def lookup_pi_orcid(
+    pi_name: str,
+    *,
+    rate_limiter: RateLimiter | None = None,
+) -> ORCIDRecord | None:
+    """Search the ORCID public API for a PI's researcher profile.
+
+    Uses :class:`ORCIDClient` when the library is available;
+    falls back to inline httpx calls for standalone operation.
+    """
+    first, last = _split_pi_name(pi_name)
+    if not last:
+        return None
+
+    with ORCIDClient(rate_limiter=rate_limiter) as orcid:
+        try:
+            rec = orcid.lookup(pi_name)
+        except Exception as e:
+            logger.debug("ORCID API error for {}: {}", pi_name, e)
+            return None
+    if rec is None:
+        return None
+    return ORCIDRecord(
+        orcid_id=rec.orcid_id,
+        given_name=rec.given_name,
+        family_name=rec.family_name,
+        affiliations=rec.affiliations,
+        works_count=rec.works_count,
+        sample_work_titles=rec.sample_work_titles,
+        funding_count=rec.funding_count,
+        keywords=rec.keywords,
+    )

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -927,9 +927,9 @@ def build_usaspending_url(award: dict) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-# Lazy-initialized OpenAI client — created on first use when the library is
-# available.  Shares the concurrency semaphore with the fallback path.
-_openai_client_instance: object | None = None
+# Lazy-initialized OpenAI client — created on first use.  Concurrency
+# control lives inside OpenAIClient (via its internal semaphore).
+_openai_client_instance: OpenAIClient | None = None
 
 
 def _get_openai_client(api_key: str) -> OpenAIClient:
@@ -1824,7 +1824,7 @@ def enrich_with_inflation(awards: list[dict], base_year: int | None = None) -> d
     - 'adjusted_total': the sum of inflation-adjusted award amounts
     - 'base_year': the dollar year used for the adjustment
 
-    Returns an empty dict if inflation support is unavailable or fails.
+    Returns an empty dict if inflation adjustment fails or raises an exception.
     """
     import pandas as pd
 

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -27,150 +27,33 @@ import argparse
 import json
 import os
 import sys
-import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, UTC
-from pathlib import Path
 from urllib.parse import quote
 
 import httpx
 
-# Lazy imports from the sbir_etl package.  These are optional — the script
-# falls back to a standalone CSV download + Python-based filtering when the
-# full package isn't installed (e.g. lightweight CI runners).
-try:
-    from sbir_etl.extractors.sbir import SbirDuckDBExtractor
-    from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
-    from sbir_etl.utils.cloud_storage import find_latest_sbir_awards, get_s3_bucket_from_env
-    from sbir_etl.utils.date_utils import parse_date as _parse_date
-    from sbir_etl.utils.text_normalization import normalize_name as _normalize_name
-    from sbir_etl.utils.text_normalization import pluralize_col_key as _pluralize_col_key
-    from sbir_etl.validators.sbir_awards import validate_sbir_award_record as _validate_record
+# sbir_etl is the root package — always available via `uv sync`.
+from sbir_etl.extractors.sbir import SbirDuckDBExtractor
+from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
+from sbir_etl.utils.date_utils import parse_date as _parse_date
+from sbir_etl.utils.text_normalization import normalize_name as _normalize_name
+from sbir_etl.utils.text_normalization import pluralize_col_key as _pluralize_col_key
+from sbir_etl.validators.sbir_awards import validate_sbir_award_record as _validate_record
 
-    _HAS_SBIR_ETL = True
-except ImportError:
-    SBIR_AWARDS_URL = "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
-    _HAS_SBIR_ETL = False
-    SbirDuckDBExtractor = None  # type: ignore[assignment, misc]
-
-    def _parse_date(value, **_kwargs):  # type: ignore[misc]
-        """Minimal fallback date parser when sbir_etl is unavailable."""
-        from datetime import date as _date
-
-        if not value or not str(value).strip():
-            return None
-        s = str(value).strip()
-        for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%Y-%m-%d %H:%M:%S", "%m/%d/%y"):
-            try:
-                return datetime.strptime(s, fmt).date()
-            except ValueError:
-                continue
-        return None
-
-    _validate_record = None  # type: ignore[assignment]
-
-    def _pluralize_col_key(col: str) -> str:  # type: ignore[misc]
-        """Fallback pluralizer when sbir_etl is unavailable."""
-        key = col.lower().replace(" ", "_")
-        if key.endswith("y"):
-            return key[:-1] + "ies"
-        return key + "s"
-
-    def _normalize_name(name, *, remove_suffixes=False, **_kwargs):  # type: ignore[misc]
-        """Minimal fallback company name normalizer."""
-        import re as _re
-
-        if not name:
-            return ""
-        s = str(name).strip().lower()
-        s = _re.sub(r"[^\w\s]", " ", s)
-        if remove_suffixes:
-            s = _re.sub(
-                r"\b(incorporated|incorporation|inc|corp|corporation|llc|ltd|limited|co|company)\b",
-                "",
-                s,
-            )
-        else:
-            s = _re.sub(r"\b(incorporated|incorporation)\b", "inc", s)
-            s = _re.sub(r"\b(company|co)\b", "company", s)
-            s = _re.sub(r"\b(limited|ltd)\b", "ltd", s)
-        return _re.sub(r"\s+", " ", s).strip()
-
-# Optional enricher imports — each degrades gracefully if unavailable.
-try:
-    from sbir_etl.extractors.solicitation import SolicitationExtractor
-
-    _HAS_SOLICITATION_EXTRACTOR = True
-except ImportError:
-    _HAS_SOLICITATION_EXTRACTOR = False
-
-try:
-    from sbir_etl.enrichers.patentsview import PatentsViewClient, RateLimiter, parse_patent_record
-
-    _HAS_PATENTS_CLIENT = True
-except ImportError:
-    _HAS_PATENTS_CLIENT = False
-    parse_patent_record = None  # type: ignore[assignment]
-    RateLimiter = None  # type: ignore[assignment, misc]
-
-try:
-    from sbir_etl.enrichers.inflation_adjuster import InflationAdjuster
-
-    _HAS_INFLATION = True
-except ImportError:
-    _HAS_INFLATION = False
-
-try:
-    from sbir_etl.enrichers.congressional_district_resolver import CongressionalDistrictResolver
-
-    _HAS_CONGRESS_RESOLVER = True
-except ImportError:
-    _HAS_CONGRESS_RESOLVER = False
-
-try:
-    from sbir_etl.enrichers.fiscal_bea_mapper import NAICSToBEAMapper
-
-    _HAS_BEA_MAPPER = True
-except ImportError:
-    _HAS_BEA_MAPPER = False
-
-try:
-    from sbir_etl.enrichers.sync_wrappers import SyncSAMGovClient, SyncUSAspendingClient
-
-    _HAS_SYNC_CLIENTS = True
-except ImportError:
-    _HAS_SYNC_CLIENTS = False
-
-try:
-    from sbir_etl.enrichers.fpds_atom import FPDSAtomClient
-
-    _HAS_FPDS_CLIENT = True
-except ImportError:
-    _HAS_FPDS_CLIENT = False
-
-try:
-    from sbir_etl.enrichers.semantic_scholar import (
-        PublicationRecord as _LibPublicationRecord,
-        SemanticScholarClient,
-    )
-
-    _HAS_S2_CLIENT = True
-except ImportError:
-    _HAS_S2_CLIENT = False
-
-try:
-    from sbir_etl.enrichers.orcid_client import ORCIDClient, ORCIDRecord as _LibORCIDRecord
-
-    _HAS_ORCID_CLIENT = True
-except ImportError:
-    _HAS_ORCID_CLIENT = False
-
-try:
-    from sbir_etl.enrichers.openai_client import OpenAIClient, WebSearchResult
-
-    _HAS_OPENAI_CLIENT = True
-except ImportError:
-    _HAS_OPENAI_CLIENT = False
+from sbir_etl.extractors.solicitation import SolicitationExtractor
+from sbir_etl.enrichers.patentsview import PatentsViewClient, RateLimiter
+from sbir_etl.enrichers.inflation_adjuster import InflationAdjuster
+from sbir_etl.enrichers.congressional_district_resolver import CongressionalDistrictResolver
+from sbir_etl.enrichers.fiscal_bea_mapper import NAICSToBEAMapper
+from sbir_etl.enrichers.sync_wrappers import SyncSAMGovClient, SyncUSAspendingClient
+from sbir_etl.enrichers.fpds_atom import FPDSAtomClient
+from sbir_etl.enrichers.semantic_scholar import (
+    SemanticScholarClient,
+)
+from sbir_etl.enrichers.orcid_client import ORCIDClient
+from sbir_etl.enrichers.openai_client import OpenAIClient
+from sbir_etl.models.sbir_identification import classify_sbir_award
 
 
 # ---------------------------------------------------------------------------
@@ -231,8 +114,6 @@ SBIR_AWARD_SEARCH_URL = "https://www.sbir.gov/awards"
 SBIR_SOLICITATION_URL = "https://www.sbir.gov/awards"
 USASPENDING_SEARCH_URL = "https://www.usaspending.gov/search"
 
-OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions"
-OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses"
 OPENAI_MODEL = "gpt-4.1-mini"
 OPENAI_DILIGENCE_MODEL = "gpt-4.1"
 
@@ -243,62 +124,15 @@ DESCRIPTION_BATCH_SIZE = 10
 MAX_COMPANIES_TO_RESEARCH = int(os.environ.get("MAX_COMPANIES_TO_RESEARCH", "50"))
 MAX_AWARDS_TO_DESCRIBE = int(os.environ.get("MAX_AWARDS_TO_DESCRIBE", "100"))
 
-# Retry configuration for OpenAI API calls
-OPENAI_MAX_RETRIES = 3
-OPENAI_RETRY_BACKOFF_BASE = 2  # seconds
-
-# External API endpoints for PI diligence and solicitation lookup
-# PatentsView migrated to USPTO Open Data Portal (data.uspto.gov) March 2026
-# ODP field-level Lucene queries (q=inventorNameText:"...") go to the base
-# endpoint.  The /search sub-path only accepts free-text ``searchText``.
-USPTO_ODP_PATENT_QUERY_URL = "https://data.uspto.gov/api/v1/patent/applications"
-SEMANTIC_SCHOLAR_API_URL = "https://api.semanticscholar.org/graph/v1"
-USASPENDING_API_URL = "https://api.usaspending.gov/api/v2"
-SBIR_GOV_API_URL = "https://api.www.sbir.gov/public/api"
-SAM_GOV_API_URL = "https://api.sam.gov/entity-information/v3/entities"
-FPDS_ATOM_SEARCH_URL = "https://www.fpds.gov/ezsearch/LATEST"
-ORCID_API_URL = "https://pub.orcid.org/v3.0"
-
 
 # ---------------------------------------------------------------------------
 # Rate limiters — shared across threads to prevent API throttling.
-# Uses the library's thread-safe RateLimiter when available, with a minimal
-# fallback that tracks nothing (effectively unlimited) when sbir_etl isn't
-# installed.
 # ---------------------------------------------------------------------------
 
-def _make_rate_limiter(rpm: int) -> object:
-    """Create a thread-safe rate limiter (library or no-op fallback)."""
-    if RateLimiter is not None:
-        return RateLimiter(rate_limit_per_minute=rpm)
-
-    class _NoOpLimiter:
-        def wait_if_needed(self) -> None:
-            pass
-
-    return _NoOpLimiter()
-
-
-# USAspending: 120 req/min (matches library default)
-_usaspending_limiter = _make_rate_limiter(120)
-# Semantic Scholar: 100 req/min (default for unauthenticated)
-_semantic_scholar_limiter = _make_rate_limiter(100)
-# USPTO ODP: 60 req/min (conservative)
-_uspto_limiter = _make_rate_limiter(60)
-# SAM.gov: 60 req/min (matches library default)
-_sam_gov_limiter = _make_rate_limiter(60)
-# ORCID: 60 req/min (conservative)
-_orcid_limiter = _make_rate_limiter(60)
-# SBIR.gov API: 30 req/min (aggressive rate limiting observed)
-_sbir_gov_limiter = _make_rate_limiter(30)
-
-
-# Shared semaphore limiting total concurrent OpenAI API calls across all
-# thread pools (company diligence + PI diligence run concurrently, each with
-# up to 4 workers — without a cap that's 8 parallel LLM requests).
-import threading as _threading
-
-_openai_semaphore = _threading.Semaphore(int(os.environ.get("OPENAI_MAX_CONCURRENT", "4")))
+_usaspending_limiter = RateLimiter(rate_limit_per_minute=120)
+_semantic_scholar_limiter = RateLimiter(rate_limit_per_minute=100)
+_sam_gov_limiter = RateLimiter(rate_limit_per_minute=60)
+_orcid_limiter = RateLimiter(rate_limit_per_minute=60)
 
 
 # ---------------------------------------------------------------------------
@@ -319,154 +153,65 @@ class CompanyResearch:
 # ---------------------------------------------------------------------------
 
 
-# Source resolution and freshness checking — prefer shared library functions,
-# fall back to inline implementations when sbir_etl is not installed.
-try:
-    from sbir_etl.utils.cloud_storage import (
-        SbirAwardsSource as DataSource,
-        check_sbir_data_freshness as _check_data_freshness_lib,
-        resolve_sbir_awards_csv as _resolve_csv_path_lib,
-    )
+# Source resolution and freshness checking — delegates to library functions.
+from sbir_etl.utils.cloud_storage import (
+    SbirAwardsSource as DataSource,
+    check_sbir_data_freshness as _check_data_freshness_lib,
+    resolve_sbir_awards_csv as _resolve_csv_path_lib,
+)
 
-    def _resolve_csv_path() -> DataSource:
-        source = _resolve_csv_path_lib(download_url=SBIR_AWARDS_URL)
-        print(f"Resolved CSV: {source.path} (origin={source.origin})", file=sys.stderr)
-        return source
 
-    def _check_data_freshness(
-        source: DataSource, max_award_date: str | None, days: int
-    ) -> list[str]:
-        return _check_data_freshness_lib(source, max_award_date, days)
+def _resolve_csv_path() -> DataSource:
+    source = _resolve_csv_path_lib(download_url=SBIR_AWARDS_URL)
+    print(f"Resolved CSV: {source.path} (origin={source.origin})", file=sys.stderr)
+    return source
 
-except ImportError:
-    from dataclasses import dataclass as _dataclass
 
-    @_dataclass
-    class DataSource:  # type: ignore[no-redef]
-        """Metadata about the resolved CSV data source (fallback)."""
-        path: Path
-        origin: str
-        s3_key_date: str | None = None
-
-    def _resolve_csv_path() -> DataSource:  # type: ignore[misc]
-        """Fallback source resolver for standalone operation."""
-        print(f"S3 not available; downloading from {SBIR_AWARDS_URL}...", file=sys.stderr)
-        with httpx.Client(timeout=600, follow_redirects=True) as client:
-            response = client.get(SBIR_AWARDS_URL)
-            response.raise_for_status()
-        tmp = Path(tempfile.gettempdir()) / "sbir_weekly_award_data.csv"
-        tmp.write_bytes(response.content)
-        print(f"Downloaded {tmp.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
-        return DataSource(path=tmp, origin="download")
-
-    def _check_data_freshness(  # type: ignore[misc]
-        source: DataSource, max_award_date: str | None, days: int
-    ) -> list[str]:
-        """Fallback freshness checker for standalone operation."""
-        warnings: list[str] = []
-        now = datetime.now(UTC).replace(tzinfo=None)
-        if source.s3_key_date:
-            key_dt = _parse_date(source.s3_key_date)
-            if key_dt:
-                age = (now - datetime(key_dt.year, key_dt.month, key_dt.day)).days
-                if age > days + 3:
-                    warnings.append(
-                        f"S3 data is {age} days old (key date: {source.s3_key_date}). "
-                        f"The data-refresh workflow may have failed."
-                    )
-        if max_award_date:
-            max_dt = _parse_date(max_award_date)
-            if max_dt:
-                data_age = (now - datetime(max_dt.year, max_dt.month, max_dt.day)).days
-                if data_age > days + 14:
-                    warnings.append(
-                        f"Most recent award in data is from {max_award_date} "
-                        f"({data_age} days ago). SBIR.gov bulk data may not have "
-                        f"been updated recently."
-                    )
-        return warnings
+def _check_data_freshness(
+    source: DataSource, max_award_date: str | None, days: int
+) -> list[str]:
+    return _check_data_freshness_lib(source, max_award_date, days)
 
 
 def fetch_weekly_awards(
     days: int = 7,
-) -> tuple[list[dict], list[str], DataSource, object | None, str | None]:
+) -> tuple[list[dict], list[str], DataSource, SbirDuckDBExtractor, str]:
     """Load SBIR CSV and filter for awards in the past N days.
 
-    When sbir_etl is installed, uses SbirDuckDBExtractor for fast
-    columnar import and SQL-based date filtering.  Otherwise falls back
-    to csv.DictReader with Python-level filtering.
+    Uses SbirDuckDBExtractor for fast columnar import and SQL-based
+    date filtering.
 
-    Returns (awards, freshness_warnings, source, extractor_or_None, table_or_None).
+    Returns (awards, freshness_warnings, source, extractor, table).
     The source/extractor/table can be reused for historical queries to avoid
     re-downloading and re-importing the ~376 MB CSV.
     """
     source = _resolve_csv_path()
     cutoff_str = (datetime.now(UTC) - timedelta(days=days)).strftime("%Y-%m-%d")
 
-    extractor = None
-    table = None
+    extractor = SbirDuckDBExtractor(
+        csv_path=source.path,
+        duckdb_path=":memory:",
+        use_s3_first=False,  # we already resolved the path
+    )
+    extractor.import_csv()
 
-    if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
-        # Fast path: DuckDB columnar import + SQL filtering
-        extractor = SbirDuckDBExtractor(
-            csv_path=source.path,
-            duckdb_path=":memory:",
-            use_s3_first=False,  # we already resolved the path
-        )
-        extractor.import_csv()
+    table = extractor._table_identifier
+    query = (
+        f"SELECT * FROM {table} "
+        f"WHERE \"Proposal Award Date\" >= '{cutoff_str}' "
+        f"ORDER BY \"Proposal Award Date\" DESC, "
+        f"TRY_CAST(\"Award Amount\" AS DOUBLE) DESC"
+    )
 
-        table = extractor._table_identifier
-        query = (
-            f"SELECT * FROM {table} "
-            f"WHERE \"Proposal Award Date\" >= '{cutoff_str}' "
-            f"ORDER BY \"Proposal Award Date\" DESC, "
-            f"TRY_CAST(\"Award Amount\" AS DOUBLE) DESC"
-        )
+    df = extractor.duckdb_client.execute_query_df(query)
+    print(f"Found {len(df)} awards since {cutoff_str} (DuckDB)", file=sys.stderr)
+    awards = df.fillna("").to_dict("records")
 
-        df = extractor.duckdb_client.execute_query_df(query)
-        print(f"Found {len(df)} awards since {cutoff_str} (DuckDB)", file=sys.stderr)
-        awards = df.fillna("").to_dict("records")
-
-        # Get max date across the full dataset for freshness check
-        max_date_df = extractor.duckdb_client.execute_query_df(
-            f'SELECT MAX("Proposal Award Date") AS max_date FROM {table}'
-        )
-        max_award_date = str(max_date_df.iloc[0]["max_date"]) if len(max_date_df) else None
-
-    else:
-        # Fallback: csv.DictReader + Python filtering
-        import csv
-        import io
-
-        print("Using csv.DictReader fallback for filtering", file=sys.stderr)
-        cutoff_dt = datetime.now(UTC).replace(tzinfo=None) - timedelta(days=days)
-
-        text = source.path.read_text(encoding="utf-8")
-        reader = csv.DictReader(io.StringIO(text))
-        awards = []
-        all_dates: list[str] = []
-        for row in reader:
-            date_val = row.get("Proposal Award Date", "")
-            if date_val:
-                all_dates.append(date_val)
-            parsed = _parse_date(date_val)
-            if parsed:
-                row_dt = datetime(parsed.year, parsed.month, parsed.day)
-                if row_dt >= cutoff_dt:
-                    awards.append(row)
-
-        def sort_key(a):
-            dt = _parse_date(a.get("Proposal Award Date", ""))
-            ts = datetime(dt.year, dt.month, dt.day).timestamp() if dt else 0
-            try:
-                amount = float(str(a.get("Award Amount", "0")).replace(",", "").replace("$", ""))
-            except (ValueError, AttributeError):
-                amount = 0
-            return (-ts, -amount)
-
-        awards.sort(key=sort_key)
-        max_award_date = max(all_dates) if all_dates else None
-        print(f"Found {len(awards)} awards since {cutoff_str} (csv fallback)", file=sys.stderr)
+    # Get max date across the full dataset for freshness check
+    max_date_df = extractor.duckdb_client.execute_query_df(
+        f'SELECT MAX("Proposal Award Date") AS max_date FROM {table}'
+    )
+    max_award_date = str(max_date_df.iloc[0]["max_date"]) if len(max_date_df) else None
 
     # Verify data freshness
     freshness_warnings = _check_data_freshness(source, max_award_date, days)
@@ -479,8 +224,6 @@ def fetch_weekly_awards(
 # ---------------------------------------------------------------------------
 # Data cleaning & deduplication
 # ---------------------------------------------------------------------------
-
-_FALLBACK_VALID_PHASES = {"Phase I", "Phase II", "Phase III"}
 
 
 def _company_key(award: dict) -> str:
@@ -532,21 +275,6 @@ def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
                 str(a.get("Company", "")), remove_suffixes=True
             )
             cleaned.append(a)
-    else:
-        # Minimal fallback when sbir_etl is not installed
-        for a in awards:
-            company = str(a.get("Company", "")).strip()
-            if not company:
-                stats["validation_errors"] += 1
-                continue
-            phase = str(a.get("Phase", "")).strip()
-            if phase and phase not in _FALLBACK_VALID_PHASES:
-                stats["validation_errors"] += 1
-                continue
-            a["_normalized_company"] = _normalize_name(
-                company, remove_suffixes=True
-            )
-            cleaned.append(a)
 
     stats["output"] = len(cleaned)
     stats["total_removed"] = stats["input"] - stats["output"]
@@ -579,30 +307,23 @@ def _parse_date_safe(value) -> str | None:
 
 def _resolve_shared_extractor(
     source: DataSource | None = None,
-) -> tuple[DataSource, object | None, str | None]:
-    """Resolve a CSV path and optionally create a shared DuckDB extractor.
+) -> tuple[DataSource, SbirDuckDBExtractor, str]:
+    """Resolve a CSV path and create a shared DuckDB extractor.
 
-    Returns (source, extractor_or_None, table_name_or_None).
+    Returns (source, extractor, table_name).
     """
     if source is None:
         source = _resolve_csv_path()
 
-    extractor = None
-    table = None
-    if _HAS_SBIR_ETL and SbirDuckDBExtractor is not None:
-        extractor = SbirDuckDBExtractor(
-            csv_path=source.path,
-            duckdb_path=":memory:",
-            use_s3_first=False,
-        )
-        extractor.import_csv()
-        table = extractor._table_identifier
+    extractor = SbirDuckDBExtractor(
+        csv_path=source.path,
+        duckdb_path=":memory:",
+        use_s3_first=False,
+    )
+    extractor.import_csv()
+    table = extractor._table_identifier
 
     return source, extractor, table
-
-
-# _pluralize_col_key is imported from sbir_etl.utils.text_normalization
-# (with a fallback defined in the ImportError block above).
 
 
 def _build_history_from_df(
@@ -728,7 +449,7 @@ def _build_history_from_csv(
                 h["sample_titles"].append(t)
 
     # Normalize sets to sorted lists and parse dates
-    for name, h in history.items():
+    for _name, h in history.items():
         raw_dates = h.pop("dates", [])
         parsed_dates = [_parse_date_safe(d) for d in raw_dates]
         parsed_dates = [d for d in parsed_dates if d]
@@ -918,251 +639,77 @@ def lookup_pi_patents(pi_name: str, company_name: str | None = None) -> PIPatent
     if not last:
         return None
 
-    # Prefer PatentsViewClient — handles rate limiting and retry via tenacity
-    if _HAS_PATENTS_CLIENT:
-        _debug(f"Using PatentsViewClient for '{pi_name}'")
-        try:
-            client = PatentsViewClient()
-            try:
-                # Query by company name to get patents, then we'll have all
-                # inventor/assignee data in the results
-                patents = client.query_patents_by_assignee(
-                    company_name=company_name or last,
-                    max_patents=100,
-                )
-            finally:
-                if hasattr(client, "close"):
-                    client.close()
-            if not patents:
-                return None
-
-            titles = []
-            assignees: set[str] = set()
-            dates: list[str] = []
-            for p in patents:
-                t = p.get("patent_title", "")
-                if t and t not in titles and len(titles) < 5:
-                    titles.append(t)
-                org = p.get("assignee_organization", "")
-                if org:
-                    assignees.add(org)
-                d = p.get("grant_date") or p.get("patent_date", "")
-                if d:
-                    dates.append(d)
-
-            return PIPatentRecord(
-                total_patents=len(patents),
-                sample_titles=titles,
-                assignees=sorted(assignees),
-                date_range=(min(dates) if dates else None, max(dates) if dates else None),
-            )
-        except Exception as e:
-            _debug(f"PatentsViewClient error for '{pi_name}': {e}, falling back")
-
-    # Fallback: bare httpx call to USPTO ODP
-    api_key = os.environ.get("USPTO_ODP_API_KEY", "")
-    headers: dict[str, str] = {}
-    if api_key:
-        headers["X-API-KEY"] = api_key
-
-    # ODP uses ``searchText`` for free-text queries (not Lucene ``q``).
-    # Combine inventor name and company into a single search string.
-    search_terms = f"{first} {last}".strip() if first else last
-    if company_name:
-        search_terms += f" {company_name}"
-
-    params = {
-        "searchText": search_terms,
-        "offset": 0,
-        "limit": 100,
-    }
-
-    _debug(f"USPTO ODP query for '{pi_name}': GET {USPTO_ODP_PATENT_QUERY_URL} params={params}")
+    _debug(f"Using PatentsViewClient for '{pi_name}'")
     try:
-        _uspto_limiter.wait_if_needed()
-        with httpx.Client(timeout=30) as client:
-            resp = client.get(USPTO_ODP_PATENT_QUERY_URL, headers=headers, params=params)
-            _debug_response(f"USPTO ODP [{pi_name}]", resp)
-            if resp.status_code != 200:
-                print(
-                    f"USPTO ODP API returned {resp.status_code} for {pi_name}",
-                    file=sys.stderr,
-                )
-                return None
-            data = resp.json()
+        client = PatentsViewClient()
+        try:
+            patents = client.query_patents_by_assignee(
+                company_name=company_name or last,
+                max_patents=100,
+            )
+        finally:
+            if hasattr(client, "close"):
+                client.close()
+        if not patents:
+            return None
+
+        titles = []
+        assignees: set[str] = set()
+        dates: list[str] = []
+        for p in patents:
+            t = p.get("patent_title", "")
+            if t and t not in titles and len(titles) < 5:
+                titles.append(t)
+            org = p.get("assignee_organization", "")
+            if org:
+                assignees.add(org)
+            d = p.get("grant_date") or p.get("patent_date", "")
+            if d:
+                dates.append(d)
+
+        return PIPatentRecord(
+            total_patents=len(patents),
+            sample_titles=titles,
+            assignees=sorted(assignees),
+            date_range=(min(dates) if dates else None, max(dates) if dates else None),
+        )
     except Exception as e:
-        print(f"USPTO ODP API error for {pi_name}: {e}", file=sys.stderr)
+        _debug(f"PatentsViewClient error for '{pi_name}': {e}")
         return None
-
-    records = data.get("patentFileWrapperDataBag", [])
-    _debug(f"USPTO ODP [{pi_name}]: {len(records)} patent records returned")
-    if not records:
-        return None
-
-    titles = []
-    assignees: set[str] = set()
-    dates: list[str] = []
-
-    for raw_record in records:
-        # Use shared parser when available, inline fallback otherwise
-        if parse_patent_record is not None:
-            parsed = parse_patent_record(raw_record)
-            title = parsed.get("patent_title", "")
-            org = parsed.get("assignee_organization", "")
-            grant_date = parsed.get("grant_date", "")
-        else:
-            metadata = raw_record.get("applicationMetaData", {}) or {}
-            title = raw_record.get("inventionTitle") or metadata.get("inventionTitle") or ""
-            org = ""
-            for a in (raw_record.get("assignees", []) or []):
-                if isinstance(a, dict):
-                    org = a.get("assigneeName") or a.get("orgName") or ""
-                    break
-            if not org:
-                org = raw_record.get("assigneeName") or metadata.get("assigneeName") or ""
-            grant_date = metadata.get("grantDate") or raw_record.get("grantDate") or ""
-
-        if title and title not in titles and len(titles) < 5:
-            titles.append(title)
-        if org:
-            assignees.add(org)
-        if grant_date:
-            dates.append(grant_date)
-
-    return PIPatentRecord(
-        total_patents=len(records),
-        sample_titles=titles,
-        assignees=sorted(assignees),
-        date_range=(min(dates) if dates else None, max(dates) if dates else None),
-    )
 
 
 def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
-    """Query Semantic Scholar for the PI's publication history.
-
-    Uses :class:`SemanticScholarClient` when the library is available;
-    falls back to inline httpx calls for standalone operation.
-    """
+    """Query Semantic Scholar for the PI's publication history."""
     first, last = _split_pi_name(pi_name)
     if not last:
         return None
 
     search_query = f"{first} {last}".strip()
 
-    if _HAS_S2_CLIENT:
-        with SemanticScholarClient(rate_limiter=_semantic_scholar_limiter) as s2:
-            try:
-                rec = s2.lookup_author(search_query)
-            except Exception as e:
-                print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
-                return None
-        if rec is None:
+    with SemanticScholarClient(rate_limiter=_semantic_scholar_limiter) as s2:
+        try:
+            rec = s2.lookup_author(search_query)
+        except Exception as e:
+            print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
             return None
-        return PIPublicationRecord(
-            total_papers=rec.total_papers,
-            h_index=rec.h_index,
-            citation_count=rec.citation_count,
-            sample_titles=rec.sample_titles,
-            affiliations=rec.affiliations,
-        )
-
-    # Inline fallback for standalone operation
-    s2_api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY", "")
-    headers: dict[str, str] = {}
-    if s2_api_key:
-        headers["x-api-key"] = s2_api_key
-
-    import time
-
-    try:
-        search_data = None
-        with httpx.Client(timeout=30, headers=headers) as client:
-            for attempt in range(3):
-                _semantic_scholar_limiter.wait_if_needed()
-                resp = client.get(
-                    f"{SEMANTIC_SCHOLAR_API_URL}/author/search",
-                    params={"query": search_query, "limit": 5},
-                )
-                if resp.status_code == 429:
-                    time.sleep(2 ** (attempt + 1))
-                    continue
-                if resp.status_code != 200:
-                    return None
-                search_data = resp.json()
-                break
-        if search_data is None:
-            return None
-        authors = search_data.get("data", [])
-        if not authors:
-            return None
-        author_id = authors[0].get("authorId")
-        if not author_id:
-            return None
-
-        author_data = None
-        with httpx.Client(timeout=30, headers=headers) as client:
-            for attempt in range(3):
-                _semantic_scholar_limiter.wait_if_needed()
-                resp = client.get(
-                    f"{SEMANTIC_SCHOLAR_API_URL}/author/{author_id}",
-                    params={"fields": "name,hIndex,citationCount,affiliations,papers.title,papers.year"},
-                )
-                if resp.status_code == 429:
-                    time.sleep(2 ** (attempt + 1))
-                    continue
-                if resp.status_code != 200:
-                    return None
-                author_data = resp.json()
-                break
-        if author_data is None:
-            return None
-    except Exception as e:
-        print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
+    if rec is None:
         return None
-
-    papers = author_data.get("papers", [])
     return PIPublicationRecord(
-        total_papers=len(papers),
-        h_index=author_data.get("hIndex"),
-        citation_count=author_data.get("citationCount", 0),
-        sample_titles=[p["title"] for p in papers[:5] if p.get("title")],
-        affiliations=author_data.get("affiliations", []) or [],
+        total_papers=rec.total_papers,
+        h_index=rec.h_index,
+        citation_count=rec.citation_count,
+        sample_titles=rec.sample_titles,
+        affiliations=rec.affiliations,
     )
 
 
 def _is_sbir_award_type(description: str, cfda: str) -> bool:
     """Identify SBIR/STTR awards using ALN numbers and description keywords.
 
-    Delegates to :func:`sbir_etl.models.sbir_identification.classify_sbir_award`
-    when the library is available; falls back to a minimal inline heuristic.
+    Delegates to :func:`sbir_etl.models.sbir_identification.classify_sbir_award`.
     """
-    try:
-        from sbir_etl.models.sbir_identification import classify_sbir_award
-
-        result = classify_sbir_award(cfda_number=cfda, description=description)
-        return result is not None
-    except ImportError:
-        pass
-
-    # Fallback for standalone operation
-    _sbir_alns = {
-        "10.212", "12.910", "12.911", "81.049", "43.002", "43.003",
-        "47.041", "47.084", "66.511", "66.512", "97.077", "20.701",
-        "84.133",
-        "93.855", "93.856", "93.859", "93.837", "93.847", "93.853",
-        "93.865", "93.866", "93.867", "93.879", "93.242", "93.273",
-        "93.279", "93.395", "93.393", "93.394", "93.396", "93.399",
-    }
-    if cfda and cfda.strip() in _sbir_alns:
-        return True
-    desc_upper = description.upper()
-    if "SBIR" in desc_upper or "STTR" in desc_upper:
-        return True
-    if "SMALL BUSINESS INNOVATION RESEARCH" in desc_upper:
-        return True
-    if "SMALL BUSINESS TECHNOLOGY TRANSFER" in desc_upper:
-        return True
-    return False
+    result = classify_sbir_award(cfda_number=cfda, description=description)
+    return result is not None
 
 
 def _usaspending_autocomplete(company_name: str) -> dict[str, str] | None:
@@ -1234,60 +781,30 @@ def _usaspending_autocomplete(company_name: str) -> dict[str, str] | None:
 
     best_candidate = None
 
-    # Use shared sync client when available (gets rate limiting + retry from
-    # the library); fall back to raw httpx for standalone operation.
-    if _HAS_SYNC_CLIENTS:
-        usa = SyncUSAspendingClient()
-        try:
-            for idx, name in enumerate(unique, 1):
-                try:
-                    _usaspending_limiter.wait_if_needed()
-                    data = usa.autocomplete_recipient(name, limit=5)
-                    results = data.get("results", [])
-                    if not results:
-                        continue
-                    match = results[0]
-                    matched_name = match.get("legal_business_name", "")
-                    matched_uei = match.get("uei")
-                    if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
-                        _debug(
-                            f"USAspending autocomplete matched '{company_name}' "
-                            f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
-                        )
-                        return {"uei": matched_uei, "name": matched_name}
-                    if matched_name and best_candidate is None:
-                        best_candidate = {"uei": matched_uei, "name": matched_name}
-                except Exception:
+    usa = SyncUSAspendingClient()
+    try:
+        for idx, name in enumerate(unique, 1):
+            try:
+                _usaspending_limiter.wait_if_needed()
+                data = usa.autocomplete_recipient(name, limit=5)
+                results = data.get("results", [])
+                if not results:
                     continue
-        finally:
-            usa.close()
-    else:
-        with httpx.Client(timeout=15) as client:
-            for idx, name in enumerate(unique, 1):
-                try:
-                    _usaspending_limiter.wait_if_needed()
-                    resp = client.post(
-                        f"{USASPENDING_API_URL}/autocomplete/recipient/",
-                        json={"search_text": name, "limit": 5},
+                match = results[0]
+                matched_name = match.get("legal_business_name", "")
+                matched_uei = match.get("uei")
+                if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
+                    _debug(
+                        f"USAspending autocomplete matched '{company_name}' "
+                        f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
                     )
-                    if resp.status_code != 200:
-                        continue
-                    results = resp.json().get("results", [])
-                    if not results:
-                        continue
-                    match = results[0]
-                    matched_name = match.get("legal_business_name", "")
-                    matched_uei = match.get("uei")
-                    if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
-                        _debug(
-                            f"USAspending autocomplete matched '{company_name}' "
-                            f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
-                        )
-                        return {"uei": matched_uei, "name": matched_name}
-                    if matched_name and best_candidate is None:
-                        best_candidate = {"uei": matched_uei, "name": matched_name}
-                except Exception:
-                    continue
+                    return {"uei": matched_uei, "name": matched_name}
+                if matched_name and best_candidate is None:
+                    best_candidate = {"uei": matched_uei, "name": matched_name}
+            except Exception:
+                continue
+    finally:
+        usa.close()
 
     if best_candidate:
         _debug(f"USAspending autocomplete: best candidate for '{company_name}' → '{best_candidate['name']}' (no UEI)")
@@ -1337,58 +854,27 @@ def _usaspending_search(
         f"POST /search/spending_by_award/"
     )
 
-    if _HAS_SYNC_CLIENTS:
-        usa = SyncUSAspendingClient()
-        try:
-            for group_name, codes in type_groups:
-                try:
-                    _usaspending_limiter.wait_if_needed()
-                    data = usa.search_awards(
-                        filters={
-                            "award_type_codes": codes,
-                            "recipient_search_text": [search_text],
-                        },
-                        fields=fields,
-                        limit=50,
-                    )
-                    group_results = data.get("results", [])
-                    _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
-                    all_results.extend(group_results)
-                except Exception as e:
-                    _debug(f"USAspending [{company_name}] {label}/{group_name} error: {e}")
-                    continue
-        finally:
-            usa.close()
-    else:
-        try:
-            with httpx.Client(timeout=30) as client:
-                for group_name, codes in type_groups:
-                    _usaspending_limiter.wait_if_needed()
-                    payload = {
-                        "filters": {
-                            "award_type_codes": codes,
-                            "recipient_search_text": [search_text],
-                        },
-                        "fields": fields,
-                        "page": 1,
-                        "limit": 50,
-                        "sort": "Award Amount",
-                        "order": "desc",
-                    }
-                    resp = client.post(
-                        f"{USASPENDING_API_URL}/search/spending_by_award/",
-                        json=payload,
-                    )
-                    if resp.status_code != 200:
-                        _debug(f"USAspending [{company_name}] {label}/{group_name} returned {resp.status_code}")
-                        continue
-                    data = resp.json()
-                    group_results = data.get("results", [])
-                    _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
-                    all_results.extend(group_results)
-        except Exception as e:
-            _debug(f"USAspending [{company_name}] {label} error: {e}")
-            return None
+    usa = SyncUSAspendingClient()
+    try:
+        for group_name, codes in type_groups:
+            try:
+                _usaspending_limiter.wait_if_needed()
+                data = usa.search_awards(
+                    filters={
+                        "award_type_codes": codes,
+                        "recipient_search_text": [search_text],
+                    },
+                    fields=fields,
+                    limit=50,
+                )
+                group_results = data.get("results", [])
+                _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
+                all_results.extend(group_results)
+            except Exception as e:
+                _debug(f"USAspending [{company_name}] {label}/{group_name} error: {e}")
+                continue
+    finally:
+        usa.close()
 
     _debug(f"USAspending [{company_name} via {label}]: {len(all_results)} total results")
     return all_results if all_results else None
@@ -1627,63 +1113,20 @@ def lookup_usaspending_recipient(
 
     recipient_id = None
 
-    if _HAS_SYNC_CLIENTS:
-        usa = SyncUSAspendingClient()
-        try:
-            for term in search_terms:
-                _debug(f"USAspending recipient search: keyword='{term}'")
-                try:
-                    _usaspending_limiter.wait_if_needed()
-                    results = usa.search_recipients(term, limit=5)
-                    if results:
-                        recipient_id = results[0].get("id")
-                        _debug(
-                            f"USAspending recipient matched '{term}' → "
-                            f"'{results[0].get('name')}' id={recipient_id}"
-                        )
-                        break
-                except Exception as e:
-                    _debug(f"USAspending recipient search error for '{term}': {e}")
-                    continue
-
-            if not recipient_id:
-                _debug(f"USAspending recipient: no match for '{company_name}'")
-                return None
-
-            # Step 2: Fetch the full profile
-            _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
-            try:
-                _usaspending_limiter.wait_if_needed()
-                profile = usa.get_recipient_profile(recipient_id)
-            except Exception as e:
-                _debug(f"USAspending recipient profile error: {e}")
-                return None
-            if not profile:
-                return None
-        finally:
-            usa.close()
-    else:
+    usa = SyncUSAspendingClient()
+    try:
         for term in search_terms:
             _debug(f"USAspending recipient search: keyword='{term}'")
             try:
                 _usaspending_limiter.wait_if_needed()
-                with httpx.Client(timeout=15) as client:
-                    resp = client.post(
-                        f"{USASPENDING_API_URL}/recipient/",
-                        json={"keyword": term, "limit": 5},
+                results = usa.search_recipients(term, limit=5)
+                if results:
+                    recipient_id = results[0].get("id")
+                    _debug(
+                        f"USAspending recipient matched '{term}' → "
+                        f"'{results[0].get('name')}' id={recipient_id}"
                     )
-                    if resp.status_code != 200:
-                        _debug(f"USAspending recipient search returned {resp.status_code}")
-                        continue
-                    data = resp.json()
-                    results = data.get("results", [])
-                    if results:
-                        recipient_id = results[0].get("id")
-                        _debug(
-                            f"USAspending recipient matched '{term}' → "
-                            f"'{results[0].get('name')}' id={recipient_id}"
-                        )
-                        break
+                    break
             except Exception as e:
                 _debug(f"USAspending recipient search error for '{term}': {e}")
                 continue
@@ -1692,21 +1135,18 @@ def lookup_usaspending_recipient(
             _debug(f"USAspending recipient: no match for '{company_name}'")
             return None
 
+        # Step 2: Fetch the full profile
         _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
         try:
             _usaspending_limiter.wait_if_needed()
-            with httpx.Client(timeout=15) as client:
-                resp = client.get(
-                    f"{USASPENDING_API_URL}/recipient/{recipient_id}/",
-                    params={"year": "all"},
-                )
-                if resp.status_code != 200:
-                    _debug(f"USAspending recipient profile returned {resp.status_code}")
-                    return None
-                profile = resp.json()
+            profile = usa.get_recipient_profile(recipient_id)
         except Exception as e:
             _debug(f"USAspending recipient profile error: {e}")
             return None
+        if not profile:
+            return None
+    finally:
+        usa.close()
 
     location = profile.get("location") or {}
 
@@ -1819,92 +1259,41 @@ def lookup_sam_entity(
 
     entity = None
 
-    if _HAS_SYNC_CLIENTS:
-        sam = SyncSAMGovClient()
-        try:
-            # Try UEI first (most reliable)
-            if uei:
-                _debug(f"SAM.gov [{company_name}]: lookup by UEI={uei}")
-                try:
-                    _sam_gov_limiter.wait_if_needed()
-                    entity = sam.get_entity_by_uei(uei)
-                except Exception as e:
-                    _debug(f"SAM.gov [{company_name}]: UEI lookup error: {e}")
-
-            # Try CAGE code
-            if not entity and cage:
-                _debug(f"SAM.gov [{company_name}]: lookup by CAGE={cage}")
-                try:
-                    _sam_gov_limiter.wait_if_needed()
-                    entity = sam.get_entity_by_cage(cage)
-                except Exception as e:
-                    _debug(f"SAM.gov [{company_name}]: CAGE lookup error: {e}")
-
-            # Fall back to name search
-            if not entity and company_name:
-                _debug(f"SAM.gov [{company_name}]: name search")
-                try:
-                    _sam_gov_limiter.wait_if_needed()
-                    results = sam.search_entities(
-                        legal_business_name=company_name,
-                        registration_status="A",
-                        limit=1,
-                    )
-                    entity = results[0] if results else None
-                except Exception as e:
-                    _debug(f"SAM.gov [{company_name}]: name search error: {e}")
-        finally:
-            sam.close()
-    else:
-        headers = {"X-Api-Key": api_key, "Accept": "application/json"}
-
-        def _try_query(params: dict) -> dict | None:
-            _debug(f"SAM.gov query for '{company_name}': GET {SAM_GOV_API_URL} params={params}")
-            import time
-
-            for attempt in range(3):
-                try:
-                    _sam_gov_limiter.wait_if_needed()
-                    with httpx.Client(timeout=30) as client:
-                        resp = client.get(SAM_GOV_API_URL, headers=headers, params=params)
-                        _debug_response(f"SAM.gov [{company_name}]", resp)
-                        if resp.status_code == 429:
-                            wait = 2 ** (attempt + 1)
-                            _debug(f"SAM.gov [{company_name}]: rate limited, retrying in {wait}s")
-                            time.sleep(wait)
-                            continue
-                        if resp.status_code != 200:
-                            return None
-                        data = resp.json()
-                        results = data.get("entityData", data.get("results", []))
-                        result_count = len(results) if isinstance(results, list) else (1 if results else 0)
-                        _debug(f"SAM.gov [{company_name}]: {result_count} entities in response")
-                        if isinstance(results, list) and results:
-                            return results[0]
-                        if isinstance(results, dict):
-                            return results
-                        return None
-                except Exception as e:
-                    if attempt < 2:
-                        wait = 2 ** (attempt + 1)
-                        _debug(f"SAM.gov [{company_name}]: request error ({e}), retrying in {wait}s")
-                        time.sleep(wait)
-                        continue
-                    print(f"SAM.gov API error: {e}", file=sys.stderr)
-                    return None
-            return None
-
+    sam = SyncSAMGovClient()
+    try:
         # Try UEI first (most reliable)
         if uei:
-            entity = _try_query({"ueiSAM": uei})
+            _debug(f"SAM.gov [{company_name}]: lookup by UEI={uei}")
+            try:
+                _sam_gov_limiter.wait_if_needed()
+                entity = sam.get_entity_by_uei(uei)
+            except Exception as e:
+                _debug(f"SAM.gov [{company_name}]: UEI lookup error: {e}")
 
         # Try CAGE code
         if not entity and cage:
-            entity = _try_query({"cageCode": cage})
+            _debug(f"SAM.gov [{company_name}]: lookup by CAGE={cage}")
+            try:
+                _sam_gov_limiter.wait_if_needed()
+                entity = sam.get_entity_by_cage(cage)
+            except Exception as e:
+                _debug(f"SAM.gov [{company_name}]: CAGE lookup error: {e}")
 
         # Fall back to name search
         if not entity and company_name:
-            entity = _try_query({"legalBusinessName": company_name, "registrationStatus": "A"})
+            _debug(f"SAM.gov [{company_name}]: name search")
+            try:
+                _sam_gov_limiter.wait_if_needed()
+                results = sam.search_entities(
+                    legal_business_name=company_name,
+                    registration_status="A",
+                    limit=1,
+                )
+                entity = results[0] if results else None
+            except Exception as e:
+                _debug(f"SAM.gov [{company_name}]: name search error: {e}")
+    finally:
+        sam.close()
 
     if not entity:
         # Always log — helps diagnose silent failures in CI
@@ -2051,95 +1440,23 @@ def lookup_pi_orcid(pi_name: str) -> ORCIDRecord | None:
     if not last:
         return None
 
-    if _HAS_ORCID_CLIENT:
-        with ORCIDClient(rate_limiter=_orcid_limiter) as orcid:
-            try:
-                rec = orcid.lookup(pi_name)
-            except Exception as e:
-                print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
-                return None
-        if rec is None:
+    with ORCIDClient(rate_limiter=_orcid_limiter) as orcid:
+        try:
+            rec = orcid.lookup(pi_name)
+        except Exception as e:
+            print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
             return None
-        return ORCIDRecord(
-            orcid_id=rec.orcid_id,
-            given_name=rec.given_name,
-            family_name=rec.family_name,
-            affiliations=rec.affiliations,
-            works_count=rec.works_count,
-            sample_work_titles=rec.sample_work_titles,
-            funding_count=rec.funding_count,
-            keywords=rec.keywords,
-        )
-
-    # Inline fallback for standalone operation
-    headers = {"Accept": "application/json"}
-    orcid_token = os.environ.get("ORCID_ACCESS_TOKEN", "")
-    if orcid_token:
-        headers["Authorization"] = f"Bearer {orcid_token}"
-
-    try:
-        query = f"family-name:{last}"
-        if first:
-            query += f" AND given-names:{first}"
-
-        _orcid_limiter.wait_if_needed()
-        with httpx.Client(timeout=30) as client:
-            resp = client.get(
-                f"{ORCID_API_URL}/expanded-search/",
-                headers=headers,
-                params={"q": query, "rows": 5},
-            )
-            if resp.status_code != 200:
-                return None
-            search_data = resp.json()
-
-        results = search_data.get("expanded-result", [])
-        if not results:
-            return None
-        best = results[0]
-        orcid_id = best.get("orcid-id", "")
-        if not orcid_id:
-            return None
-
-        _orcid_limiter.wait_if_needed()
-        with httpx.Client(timeout=30) as client:
-            resp = client.get(f"{ORCID_API_URL}/{orcid_id}/record", headers=headers)
-            if resp.status_code != 200:
-                return None
-            profile = resp.json()
-    except Exception as e:
-        print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
+    if rec is None:
         return None
-
-    affiliations: list[str] = []
-    for group in (profile.get("activities-summary", {}).get("employments", {}).get("affiliation-group", []))[:10]:
-        for s in group.get("summaries", []):
-            org_name = s.get("employment-summary", {}).get("organization", {}).get("name", "")
-            if org_name and org_name not in affiliations:
-                affiliations.append(org_name)
-
-    works_group = profile.get("activities-summary", {}).get("works", {}).get("group", [])
-    sample_titles = []
-    for wg in works_group[:5]:
-        summaries = wg.get("work-summary", [])
-        if summaries:
-            title_val = summaries[0].get("title", {}).get("title", {}).get("value", "")
-            if title_val:
-                sample_titles.append(title_val)
-
-    funding_group = profile.get("activities-summary", {}).get("fundings", {}).get("group", [])
-    keyword_list = profile.get("person", {}).get("keywords", {}).get("keyword", [])
-    keywords = [kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")]
-
     return ORCIDRecord(
-        orcid_id=orcid_id,
-        given_name=best.get("given-names"),
-        family_name=best.get("family-names"),
-        affiliations=affiliations,
-        works_count=len(works_group),
-        sample_work_titles=sample_titles,
-        funding_count=len(funding_group),
-        keywords=keywords,
+        orcid_id=rec.orcid_id,
+        given_name=rec.given_name,
+        family_name=rec.family_name,
+        affiliations=rec.affiliations,
+        works_count=rec.works_count,
+        sample_work_titles=rec.sample_work_titles,
+        funding_count=rec.funding_count,
+        keywords=rec.keywords,
     )
 
 
@@ -2205,177 +1522,71 @@ def fetch_solicitation_topics(awards: list[dict]) -> dict[str, SolicitationTopic
             program=topic.get("program"),
         )
 
-    # --- Path A: SolicitationExtractor (tenacity retry + all query modes) ---
-    if _HAS_SOLICITATION_EXTRACTOR:
-        _debug("Using SolicitationExtractor")
-        try:
-            extractor = SolicitationExtractor()
-            try:
-                # Group topic codes by year
-                sol_years: dict[int, list[str]] = {}
-                no_year_codes: list[tuple[str, str]] = []
-                for tc, sol in topic_codes.items():
-                    year = _parse_year(sol)
-                    if year:
-                        sol_years.setdefault(year, []).append(tc)
-                    else:
-                        no_year_codes.append((tc, sol))
+    _debug("Using SolicitationExtractor")
+    extractor = SolicitationExtractor()
+    try:
+        # Group topic codes by year
+        sol_years: dict[int, list[str]] = {}
+        no_year_codes: list[tuple[str, str]] = []
+        for tc, sol in topic_codes.items():
+            year = _parse_year(sol)
+            if year:
+                sol_years.setdefault(year, []).append(tc)
+            else:
+                no_year_codes.append((tc, sol))
 
-                # Step 1: Year-based batch queries
-                import pandas as pd
+        # Step 1: Year-based batch queries
+        import pandas as pd
 
-                all_topics = pd.DataFrame()
-                for year in sol_years:
-                    df = extractor.extract_topics(year=year, max_results=1000)
-                    if not df.empty:
-                        all_topics = pd.concat([all_topics, df], ignore_index=True)
+        all_topics = pd.DataFrame()
+        for year in sol_years:
+            df = extractor.extract_topics(year=year, max_results=1000)
+            if not df.empty:
+                all_topics = pd.concat([all_topics, df], ignore_index=True)
 
-                if not all_topics.empty:
-                    all_topics = extractor.deduplicate_topics(all_topics)
-                    codes_set = set(topic_codes.keys())
-                    for _, row in all_topics.iterrows():
-                        tc = str(row.get("topic_code", "")).strip()
-                        if tc in codes_set and tc not in results:
-                            results[tc] = _make_topic(tc, topic_codes.get(tc, ""), row.to_dict())
+        if not all_topics.empty:
+            all_topics = extractor.deduplicate_topics(all_topics)
+            codes_set = set(topic_codes.keys())
+            for _, row in all_topics.iterrows():
+                tc = str(row.get("topic_code", "")).strip()
+                if tc in codes_set and tc not in results:
+                    results[tc] = _make_topic(tc, topic_codes.get(tc, ""), row.to_dict())
 
-                # Step 2: Keyword search for no-year codes
-                for tc, sol in no_year_codes:
-                    if tc in results:
-                        continue
-                    keyword = sol if sol else tc
-                    topics = extractor.query_by_keyword(keyword)
-                    for topic in topics:
-                        found_tc = topic.get("topicCode") or topic.get("topic_code") or ""
-                        if found_tc == tc:
-                            results[tc] = _make_topic(tc, sol, topic)
-                            break
-
-                # Step 3: Awards fallback for anything still missing
-                missing = [tc for tc in topic_codes if tc not in results]
-                if missing:
-                    _debug(f"Awards fallback for {len(missing)} missing topic codes")
-                    for tc in missing:
-                        fallback = extractor.query_awards_for_topic(tc)
-                        if fallback:
-                            results[tc] = SolicitationTopic(
-                                topic_code=tc,
-                                solicitation_number=topic_codes.get(tc, ""),
-                                title=fallback.get("title", ""),
-                                description=(
-                                    str(fallback["description"])[:3000] + "..."
-                                    if fallback.get("description") and len(str(fallback["description"])) > 3000
-                                    else fallback.get("description")
-                                ),
-                                agency=fallback.get("agency"),
-                                program=fallback.get("program"),
-                            )
-
-                print(f"SolicitationExtractor found {len(results)}/{total} topics", file=sys.stderr)
-            finally:
-                extractor.close()
-            return results
-        except Exception as e:
-            print(f"SolicitationExtractor error: {e}, falling back to manual queries", file=sys.stderr)
-
-    # --- Path B: Inline httpx fallback (standalone mode) ---
-    sol_years_fb: dict[int, list[str]] = {}
-    no_year_codes_fb: list[tuple[str, str]] = []
-    for tc, sol in topic_codes.items():
-        year = _parse_year(sol)
-        if year:
-            sol_years_fb.setdefault(year, []).append(tc)
-        else:
-            no_year_codes_fb.append((tc, sol))
-
-    import time
-
-    for tc, sol in no_year_codes_fb:
-        keyword = sol if sol else tc
-        try:
-            _sbir_gov_limiter.wait_if_needed()
-            with httpx.Client(timeout=30) as client:
-                resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params={"rows": 25, "start": 0, "keyword": keyword})
-                if resp.status_code == 429:
-                    time.sleep(3)
-                    _sbir_gov_limiter.wait_if_needed()
-                    resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params={"rows": 25, "start": 0, "keyword": keyword})
-                if resp.status_code != 200:
-                    continue
-                data = resp.json()
-        except Exception:
-            continue
-        topics = data if isinstance(data, list) else (data.get("results") or data.get("data") or [])
-        for topic in topics:
-            found_tc = topic.get("topicCode") or topic.get("topic_code") or ""
-            if found_tc == tc and tc not in results:
-                results[tc] = _make_topic(tc, sol, topic)
-                break
-
-    for year, codes in sol_years_fb.items():
-        data = None
-        for attempt in range(3):
-            try:
-                _sbir_gov_limiter.wait_if_needed()
-                with httpx.Client(timeout=30) as client:
-                    resp = client.get(f"{SBIR_GOV_API_URL}/solicitations", params={"rows": 500, "start": 0, "year": year})
-                    if resp.status_code == 429:
-                        time.sleep(2 ** (attempt + 1))
-                        continue
-                    if resp.status_code != 200:
-                        break
-                    data = resp.json()
-                    break
-            except Exception:
-                break
-        if data is None:
-            continue
-        topics = data if isinstance(data, list) else (data.get("results") or data.get("data") or [])
-        codes_set = set(codes)
-        for topic in topics:
-            tc = topic.get("topicCode") or topic.get("topic_code") or ""
-            if tc in codes_set and tc not in results:
-                results[tc] = _make_topic(tc, topic_codes.get(tc, ""), topic)
-
-    found = len(results)
-    print(f"Fetched {found}/{total} solicitation topics from SBIR.gov", file=sys.stderr)
-
-    # Awards fallback for missing codes
-    missing_codes = [tc for tc in topic_codes if tc not in results]
-    if missing_codes:
-        print(f"Falling back to SBIR.gov awards API for {len(missing_codes)} missing topic codes...", file=sys.stderr)
-        time.sleep(2)
-        for tc in missing_codes:
-            try:
-                _sbir_gov_limiter.wait_if_needed()
-                with httpx.Client(timeout=30) as client:
-                    resp = client.get(f"{SBIR_GOV_API_URL}/awards", params={"keyword": tc, "rows": 5, "start": 0})
-                    if resp.status_code == 429:
-                        time.sleep(3)
-                        resp = client.get(f"{SBIR_GOV_API_URL}/awards", params={"keyword": tc, "rows": 5, "start": 0})
-                        if resp.status_code != 200:
-                            continue
-                    elif resp.status_code != 200:
-                        continue
-                    data = resp.json()
-            except Exception:
+        # Step 2: Keyword search for no-year codes
+        for tc, sol in no_year_codes:
+            if tc in results:
                 continue
-            award_list = data if isinstance(data, list) else (data.get("results") or data.get("data") or [])
-            for award in award_list:
-                award_tc = award.get("topicCode") or award.get("topic_code") or ""
-                if award_tc != tc:
-                    continue
-                title = award.get("topicTitle") or award.get("topic_title") or award.get("awardTitle") or award.get("award_title") or ""
-                desc = award.get("topicDescription") or award.get("topic_description") or award.get("abstract") or award.get("Abstract") or None
-                if desc and len(desc) > 3000:
-                    desc = desc[:3000] + "..."
-                if title or desc:
-                    results[tc] = SolicitationTopic(
-                        topic_code=tc, solicitation_number=topic_codes.get(tc, ""),
-                        title=title, description=desc, agency=award.get("agency"), program=award.get("program"),
-                    )
+            keyword = sol if sol else tc
+            topics = extractor.query_by_keyword(keyword)
+            for topic in topics:
+                found_tc = topic.get("topicCode") or topic.get("topic_code") or ""
+                if found_tc == tc:
+                    results[tc] = _make_topic(tc, sol, topic)
                     break
-        fallback_found = len(results) - found
-        print(f"Fallback recovered {fallback_found}/{len(missing_codes)} topic descriptions from awards API", file=sys.stderr)
+
+        # Step 3: Awards fallback for anything still missing
+        missing = [tc for tc in topic_codes if tc not in results]
+        if missing:
+            _debug(f"Awards fallback for {len(missing)} missing topic codes")
+            for tc in missing:
+                fallback = extractor.query_awards_for_topic(tc)
+                if fallback:
+                    results[tc] = SolicitationTopic(
+                        topic_code=tc,
+                        solicitation_number=topic_codes.get(tc, ""),
+                        title=fallback.get("title", ""),
+                        description=(
+                            str(fallback["description"])[:3000] + "..."
+                            if fallback.get("description") and len(str(fallback["description"])) > 3000
+                            else fallback.get("description")
+                        ),
+                        agency=fallback.get("agency"),
+                        program=fallback.get("program"),
+                    )
+
+        print(f"SolicitationExtractor found {len(results)}/{total} topics", file=sys.stderr)
+    finally:
+        extractor.close()
 
     return results
 
@@ -2575,11 +1786,9 @@ def build_usaspending_url(award: dict) -> str | None:
 _openai_client_instance: object | None = None
 
 
-def _get_openai_client(api_key: str) -> object | None:
-    """Return (and cache) an OpenAIClient if the library is installed."""
+def _get_openai_client(api_key: str) -> OpenAIClient:
+    """Return (and cache) the shared OpenAIClient instance."""
     global _openai_client_instance  # noqa: PLW0603
-    if not _HAS_OPENAI_CLIENT:
-        return None
     if _openai_client_instance is None:
         _openai_client_instance = OpenAIClient(
             api_key=api_key,
@@ -2587,40 +1796,6 @@ def _get_openai_client(api_key: str) -> object | None:
             model=OPENAI_MODEL,
         )
     return _openai_client_instance
-
-
-def _openai_request_with_retry(
-    method: str,
-    url: str,
-    headers: dict,
-    payload: dict,
-    timeout: int = 120,
-) -> httpx.Response | None:
-    """Fallback: make an OpenAI API request with retry/backoff."""
-    import time
-
-    for attempt in range(OPENAI_MAX_RETRIES + 1):
-        try:
-            _openai_semaphore.acquire()
-            try:
-                with httpx.Client(timeout=timeout) as client:
-                    resp = client.request(method, url, headers=headers, json=payload)
-            finally:
-                _openai_semaphore.release()
-            if resp.status_code == 429 or resp.status_code >= 500:
-                if attempt < OPENAI_MAX_RETRIES:
-                    wait = OPENAI_RETRY_BACKOFF_BASE ** (attempt + 1)
-                    time.sleep(wait)
-                    continue
-            resp.raise_for_status()
-            return resp
-        except httpx.HTTPStatusError:
-            if attempt < OPENAI_MAX_RETRIES:
-                continue
-            return None
-        except Exception:
-            return None
-    return None
 
 
 def _openai_chat(
@@ -2636,89 +1811,22 @@ def _openai_chat(
         f"system_len={len(system)} user_len={len(user)}"
     )
 
-    # Prefer library client (has its own retry + semaphore)
     oai = _get_openai_client(api_key)
-    if oai is not None:
-        result = oai.chat(system, user, model=model, temperature=temperature)
-        if result:
-            _debug(f"OpenAI chat response: {len(result)} chars")
-        return result
-
-    # Inline fallback
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-    payload = {
-        "model": model,
-        "temperature": temperature,
-        "messages": [
-            {"role": "system", "content": system},
-            {"role": "user", "content": user},
-        ],
-    }
-    resp = _openai_request_with_retry("POST", OPENAI_CHAT_URL, headers, payload)
-    if resp is None:
-        return None
-    try:
-        data = resp.json()
-        content = data["choices"][0]["message"]["content"].strip()
-        usage = data.get("usage", {})
-        _debug(
-            f"OpenAI chat response: {len(content)} chars | "
-            f"tokens: prompt={usage.get('prompt_tokens', '?')} "
-            f"completion={usage.get('completion_tokens', '?')} "
-            f"total={usage.get('total_tokens', '?')}"
-        )
-        return content
-    except (KeyError, IndexError) as e:
-        print(f"OpenAI Chat API unexpected response: {e}", file=sys.stderr)
-        return None
+    result = oai.chat(system, user, model=model, temperature=temperature)
+    if result:
+        _debug(f"OpenAI chat response: {len(result)} chars")
+    return result
 
 
 def _openai_web_search(api_key: str, query: str) -> CompanyResearch | None:
     """Use the OpenAI Responses API with web_search_preview to research a company."""
     _debug(f"OpenAI web search: query='{query[:200]}'")
 
-    # Prefer library client
     oai = _get_openai_client(api_key)
-    if oai is not None:
-        result = oai.web_search(query)
-        if result is None:
-            return None
-        return CompanyResearch(summary=result.summary, source_urls=result.source_urls)
-
-    # Inline fallback
-    headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
-    payload = {
-        "model": OPENAI_MODEL,
-        "tools": [{"type": "web_search_preview"}],
-        "instructions": (
-            "You are a research assistant gathering public information about "
-            "companies that receive SBIR/STTR federal awards. Provide a concise "
-            "2-3 sentence summary covering: what the company does, its size/stage, "
-            "notable products or contracts, and any previous SBIR/STTR history. "
-            "Cite your sources."
-        ),
-        "input": query,
-    }
-    resp = _openai_request_with_retry("POST", OPENAI_RESPONSES_URL, headers, payload, timeout=60)
-    if resp is None:
+    result = oai.web_search(query)
+    if result is None:
         return None
-    data = resp.json()
-
-    summary_text = ""
-    source_urls: list[str] = []
-    for output_item in data.get("output", []):
-        if output_item.get("type") == "message":
-            for content_block in output_item.get("content", []):
-                if content_block.get("type") == "output_text":
-                    summary_text = content_block.get("text", "")
-                    for annotation in content_block.get("annotations", []):
-                        url = annotation.get("url", "")
-                        if url and url not in source_urls:
-                            source_urls.append(url)
-
-    if not summary_text:
-        return None
-    return CompanyResearch(summary=summary_text, source_urls=source_urls)
+    return CompanyResearch(summary=result.summary, source_urls=result.source_urls)
 
 
 def research_companies(
@@ -2803,73 +1911,12 @@ def _fetch_fpds_descriptions(
 
     _debug(f"FPDS: querying {len(contract_ids)} contract IDs")
 
-    if _HAS_FPDS_CLIENT:
-        with FPDSAtomClient(rate_limiter=_usaspending_limiter) as fpds:
-            try:
-                results = fpds.get_descriptions(contract_ids)
-            except Exception as e:
-                print(f"FPDS error: {e}", file=sys.stderr)
-                results = {}
-        _debug(f"FPDS: {len(results)}/{len(contract_ids)} descriptions found")
-        return results
-
-    # Inline fallback for standalone operation (no sbir_etl)
-    import time as _t
-    import xml.etree.ElementTree as ET
-
-    results: dict[str, str] = {}
-    try:
-        with httpx.Client(timeout=30) as client:
-            for cid in contract_ids:
-                if cid in results:
-                    continue
-                query = f'PIID:"{cid}" OR REF_IDV_PIID:"{cid}"'
-                for attempt in range(3):
-                    try:
-                        _usaspending_limiter.wait_if_needed()
-                        resp = client.get(
-                            FPDS_ATOM_SEARCH_URL,
-                            params={"q": query, "s": 0, "num": 1},
-                        )
-                        if resp.status_code in (429, 500, 502, 503, 504):
-                            wait = 2 ** (attempt + 1)
-                            _debug(f"FPDS [{cid}] returned {resp.status_code}, retrying in {wait}s")
-                            _t.sleep(wait)
-                            continue
-                        if resp.status_code != 200:
-                            break
-
-                        root = ET.fromstring(resp.text)
-                        ns = {"atom": "http://www.w3.org/2005/Atom"}
-                        entry = root.find("atom:entry", ns)
-                        if entry is None:
-                            break
-
-                        content_el = entry.find("atom:content", ns)
-                        desc = None
-                        if content_el is not None:
-                            for local_name in ("descriptionOfContractRequirement", "description"):
-                                for el in content_el.iter():
-                                    tag = el.tag.split("}", 1)[-1] if "}" in el.tag else el.tag
-                                    if tag == local_name and el.text:
-                                        desc = el.text.strip()
-                                        break
-                                if desc:
-                                    break
-                        if not desc:
-                            title_el = entry.find("atom:title", ns)
-                            if title_el is not None and title_el.text:
-                                desc = title_el.text.strip()
-                        if desc:
-                            if len(desc) > 500:
-                                desc = desc[:500] + "..."
-                            results[cid] = desc
-                        break
-                    except (httpx.HTTPError, ET.ParseError, UnicodeDecodeError) as e:
-                        _t.sleep(2 ** (attempt + 1))
-    except Exception as e:
-        print(f"FPDS fallback error: {e}", file=sys.stderr)
-
+    with FPDSAtomClient(rate_limiter=_usaspending_limiter) as fpds:
+        try:
+            results = fpds.get_descriptions(contract_ids)
+        except Exception as e:
+            print(f"FPDS error: {e}", file=sys.stderr)
+            results = {}
     _debug(f"FPDS: {len(results)}/{len(contract_ids)} descriptions found")
     return results
 
@@ -2882,7 +1929,6 @@ def fetch_usaspending_contract_descriptions(
     Returns a dict keyed by contract number with the award description text.
     Used as supplementary LLM context when solicitation topic data is unavailable.
     """
-    import time as _t
 
     # Use shared award-ID classification when available, inline fallback otherwise.
     try:
@@ -2944,110 +1990,46 @@ def fetch_usaspending_contract_descriptions(
                     desc = desc[:500] + "..."
                 results[aid] = desc
 
-    if _HAS_SYNC_CLIENTS:
-        usa = SyncUSAspendingClient()
-        try:
-            for ids, group_name, codes in requests_to_make:
-                quoted = [f'"{c}"' for c in ids]
-                filters = {"award_ids": quoted, "award_type_codes": codes}
-                _debug(
-                    f"USAspending contract desc: {group_name} "
-                    f"({len(ids)} IDs: {ids[:3]})"
-                )
-                data = None
-                # Try spending_by_award, then spending_by_transaction
-                # USAspending requires a 'sort' field; use the appropriate
-                # default for each endpoint.
-                _sort_for_method = {
-                    "search_awards": "Award Amount",
-                    "search_transactions": "Transaction Amount",
-                }
-                for method in ("search_awards", "search_transactions"):
-                    try:
-                        _usaspending_limiter.wait_if_needed()
-                        data = getattr(usa, method)(
-                            filters=filters,
-                            fields=desc_fields,
-                            limit=len(ids),
-                            sort=_sort_for_method.get(method, "Award Amount"),
-                            order="desc",
-                        )
-                        break
-                    except Exception as e:
-                        _debug(f"USAspending {method}/{group_name} failed: {e}")
-                        continue
-                if data is None:
-                    failed_ids.update(ids)
-                    continue
-                _extract_descriptions(data)
-        except Exception as e:
-            failed_ids.update(cid for cid in all_ids if cid not in results)
-            print(f"USAspending contract desc error: {e}", file=sys.stderr)
-        finally:
-            usa.close()
-    else:
-        try:
-            with httpx.Client(timeout=30) as client:
-                for ids, group_name, codes in requests_to_make:
-                    quoted = [f'"{c}"' for c in ids]
-                    # USAspending requires 'sort'; map each endpoint to its
-                    # default sort field.
-                    endpoints = [
-                        ("search/spending_by_award", "Award Amount"),
-                        ("search/spending_by_transaction", "Transaction Amount"),
-                    ]
-                    _debug(
-                        f"USAspending contract desc: {group_name} "
-                        f"({len(ids)} IDs: {ids[:3]})"
+    usa = SyncUSAspendingClient()
+    try:
+        for ids, group_name, codes in requests_to_make:
+            quoted = [f'"{c}"' for c in ids]
+            filters = {"award_ids": quoted, "award_type_codes": codes}
+            _debug(
+                f"USAspending contract desc: {group_name} "
+                f"({len(ids)} IDs: {ids[:3]})"
+            )
+            data = None
+            # Try spending_by_award, then spending_by_transaction
+            # USAspending requires a 'sort' field; use the appropriate
+            # default for each endpoint.
+            _sort_for_method = {
+                "search_awards": "Award Amount",
+                "search_transactions": "Transaction Amount",
+            }
+            for method in ("search_awards", "search_transactions"):
+                try:
+                    _usaspending_limiter.wait_if_needed()
+                    data = getattr(usa, method)(
+                        filters=filters,
+                        fields=desc_fields,
+                        limit=len(ids),
+                        sort=_sort_for_method.get(method, "Award Amount"),
+                        order="desc",
                     )
-                    data = None
-                    for endpoint, sort_field in endpoints:
-                        payload = {
-                            "filters": {
-                                "award_ids": quoted,
-                                "award_type_codes": codes,
-                            },
-                            "fields": desc_fields,
-                            "page": 1,
-                            "limit": len(ids),
-                            "sort": sort_field,
-                            "order": "desc",
-                        }
-                        for attempt in range(2):
-                            _usaspending_limiter.wait_if_needed()
-                            resp = client.post(
-                                f"{USASPENDING_API_URL}/{endpoint}/",
-                                json=payload,
-                            )
-                            if resp.status_code in (429, 500, 502, 503, 504):
-                                wait = 2 ** (attempt + 1)
-                                _debug(
-                                    f"USAspending {endpoint}/{group_name} "
-                                    f"returned {resp.status_code}, retrying in {wait}s"
-                                )
-                                _t.sleep(wait)
-                                continue
-                            if resp.status_code != 200:
-                                _debug(
-                                    f"USAspending {endpoint}/{group_name} "
-                                    f"returned {resp.status_code}"
-                                )
-                                break
-                            data = resp.json()
-                            break
-                        if data is not None:
-                            break
-                        _debug(
-                            f"USAspending {endpoint} failed for {group_name}, "
-                            f"trying next endpoint"
-                        )
-                    if data is None:
-                        failed_ids.update(ids)
-                        continue
-                    _extract_descriptions(data)
-        except Exception as e:
-            failed_ids.update(cid for cid in all_ids if cid not in results)
-            print(f"USAspending contract desc error: {e}", file=sys.stderr)
+                    break
+                except Exception as e:
+                    _debug(f"USAspending {method}/{group_name} failed: {e}")
+                    continue
+            if data is None:
+                failed_ids.update(ids)
+                continue
+            _extract_descriptions(data)
+    except Exception as e:
+        failed_ids.update(cid for cid in all_ids if cid not in results)
+        print(f"USAspending contract desc error: {e}", file=sys.stderr)
+    finally:
+        usa.close()
 
     # FPDS Atom Feed fallback for contract PIIDs that failed at USAspending.
     # FPDS only indexes procurement contracts (PIIDs), not assistance FAINs
@@ -3590,7 +2572,7 @@ def generate_company_diligence(
             if sam.exclusion_status:
                 sam_parts.append(f"Exclusion Status: {sam.exclusion_status}")
             context_parts.append(
-                f"SAM.gov registration data:\n" + "\n".join(sam_parts)
+                "SAM.gov registration data:\n" + "\n".join(sam_parts)
             )
         else:
             context_parts.append(
@@ -3862,9 +2844,6 @@ def enrich_with_inflation(awards: list[dict], base_year: int | None = None) -> d
 
     Returns an empty dict if inflation support is unavailable or fails.
     """
-    if not _HAS_INFLATION:
-        return {}
-
     import pandas as pd
 
     try:
@@ -3905,9 +2884,6 @@ def resolve_congressional_districts(awards: list[dict]) -> dict[str, str]:
 
     Returns a dict keyed by upper-cased company name → "ST-DD" district string.
     """
-    if not _HAS_CONGRESS_RESOLVER:
-        return {}
-
     results: dict[str, str] = {}
     resolver = CongressionalDistrictResolver(method="auto")
 
@@ -3950,9 +2926,6 @@ def map_naics_to_bea_sectors(naics_codes: list[str]) -> dict[str, str]:
 
     Returns a dict keyed by NAICS code → BEA sector name.
     """
-    if not _HAS_BEA_MAPPER:
-        return {}
-
     try:
         mapper = NAICSToBEAMapper(
             crosswalk_path=None,  # Will use fallback YAML

--- a/scripts/data/weekly_awards_report.py
+++ b/scripts/data/weekly_awards_report.py
@@ -38,22 +38,35 @@ from sbir_etl.extractors.sbir import SbirDuckDBExtractor
 from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL as SBIR_AWARDS_URL
 from sbir_etl.utils.date_utils import parse_date as _parse_date
 from sbir_etl.utils.text_normalization import normalize_name as _normalize_name
-from sbir_etl.utils.text_normalization import pluralize_col_key as _pluralize_col_key
 from sbir_etl.validators.sbir_awards import validate_sbir_award_record as _validate_record
 
 from sbir_etl.extractors.solicitation import SolicitationExtractor
-from sbir_etl.enrichers.patentsview import PatentsViewClient, RateLimiter
+from sbir_etl.enrichers.patentsview import RateLimiter
 from sbir_etl.enrichers.inflation_adjuster import InflationAdjuster
 from sbir_etl.enrichers.congressional_district_resolver import CongressionalDistrictResolver
 from sbir_etl.enrichers.fiscal_bea_mapper import NAICSToBEAMapper
-from sbir_etl.enrichers.sync_wrappers import SyncSAMGovClient, SyncUSAspendingClient
-from sbir_etl.enrichers.fpds_atom import FPDSAtomClient
-from sbir_etl.enrichers.semantic_scholar import (
-    SemanticScholarClient,
-)
-from sbir_etl.enrichers.orcid_client import ORCIDClient
 from sbir_etl.enrichers.openai_client import OpenAIClient
-from sbir_etl.models.sbir_identification import classify_sbir_award
+from sbir_etl.enrichers.award_history import (
+    get_company_history as _lib_get_company_history,
+    get_pi_history as _lib_get_pi_history,
+)
+from sbir_etl.enrichers.pi_enrichment import (
+    PIPatentRecord,
+    PIPublicationRecord,
+    ORCIDRecord,
+    lookup_pi_patents as _lib_lookup_pi_patents,
+    lookup_pi_publications as _lib_lookup_pi_publications,
+    lookup_pi_orcid as _lib_lookup_pi_orcid,
+)
+from sbir_etl.enrichers.company_enrichment import (
+    FederalAwardSummary as PIFederalAwardRecord,
+    USARecipientProfile,
+    SAMEntityRecord,
+    lookup_company_federal_awards as _lib_lookup_company_federal_awards,
+    lookup_usaspending_recipient as _lib_lookup_usaspending_recipient,
+    lookup_sam_entity as _lib_lookup_sam_entity,
+    fetch_usaspending_contract_descriptions as _lib_fetch_usaspending_contract_descriptions,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -299,12 +312,6 @@ def clean_and_dedup_awards(awards: list[dict]) -> tuple[list[dict], dict]:
 # ---------------------------------------------------------------------------
 
 
-def _parse_date_safe(value) -> str | None:
-    """Parse a date value and return ISO format string, or None."""
-    parsed = _parse_date(value)
-    return parsed.isoformat() if parsed else None
-
-
 def _resolve_shared_extractor(
     source: DataSource | None = None,
 ) -> tuple[DataSource, SbirDuckDBExtractor, str]:
@@ -326,186 +333,16 @@ def _resolve_shared_extractor(
     return source, extractor, table
 
 
-def _build_history_from_df(
-    df,
-    group_col: str,
-    extra_set_cols: list[str] | None = None,
-) -> dict[str, dict]:
-    """Build history dicts from a DataFrame grouped by a column.
-
-    Used by both company and PI history to avoid duplicating aggregation logic.
-    """
-    df = df.fillna("")
-    history: dict[str, dict] = {}
-
-    for group_key, group_df in df.groupby(group_col, sort=False):
-        name = str(group_key).strip()
-        if not name:
-            continue
-
-        phases = {v for v in group_df["Phase"].astype(str).str.strip() if v}
-        agencies = {v for v in group_df["Agency"].astype(str).str.strip() if v}
-        programs = {v for v in group_df["Program"].astype(str).str.strip() if v}
-
-        total_funding = 0.0
-        for val in group_df["Award Amount"].astype(str):
-            try:
-                total_funding += float(val.replace(",", "").replace("$", ""))
-            except (ValueError, TypeError):
-                pass
-
-        parsed_dates = []
-        for val in group_df["Proposal Award Date"].astype(str).str.strip():
-            if val:
-                iso = _parse_date_safe(val)
-                if iso:
-                    parsed_dates.append(iso)
-
-        titles: list[str] = []
-        for t in group_df["Award Title"].astype(str).str.strip():
-            if t and t not in titles:
-                titles.append(t)
-
-        entry: dict = {
-            "total_awards": len(group_df),
-            "phases": sorted(phases),
-            "agencies": sorted(agencies),
-            "programs": sorted(programs),
-            "total_funding": total_funding,
-            "earliest_date": min(parsed_dates) if parsed_dates else None,
-            "latest_date": max(parsed_dates) if parsed_dates else None,
-            "sample_titles": titles[:5],
-        }
-
-        # Extra set columns (e.g. "Company" for PI history)
-        if extra_set_cols:
-            for col in extra_set_cols:
-                col_key = _pluralize_col_key(col)
-                entry[col_key] = sorted(
-                    {v for v in group_df[col].astype(str).str.strip() if v}
-                )
-
-        history[name] = entry
-
-    return history
-
-
-def _build_history_from_csv(
-    source: DataSource,
-    target_names: set[str],
-    key_field: str,
-    extra_set_fields: list[str] | None = None,
-) -> dict[str, dict]:
-    """Build history dicts by streaming the CSV file.
-
-    Streams the file line-by-line to avoid loading the entire CSV into memory.
-    """
-    import csv
-
-    history: dict[str, dict] = {}
-    with source.path.open(newline="", encoding="utf-8") as f:
-        reader = csv.DictReader(f)
-        for row in reader:
-            name = str(row.get(key_field, "")).strip().upper()
-            if name not in target_names:
-                continue
-            if name not in history:
-                entry: dict = {
-                    "total_awards": 0,
-                    "phases": set(),
-                    "agencies": set(),
-                    "programs": set(),
-                    "total_funding": 0.0,
-                    "dates": [],
-                    "sample_titles": [],
-                }
-                if extra_set_fields:
-                    for ef in extra_set_fields:
-                        entry[_pluralize_col_key(ef)] = set()
-                history[name] = entry
-
-            h = history[name]
-            h["total_awards"] += 1
-            for field, set_key in [("Phase", "phases"), ("Agency", "agencies"), ("Program", "programs")]:
-                val = str(row.get(field, "")).strip()
-                if val:
-                    h[set_key].add(val)
-            if extra_set_fields:
-                for ef in extra_set_fields:
-                    val = str(row.get(ef, "")).strip()
-                    if val:
-                        h[_pluralize_col_key(ef)].add(val)
-            try:
-                h["total_funding"] += float(
-                    str(row.get("Award Amount", "0")).replace(",", "").replace("$", "")
-                )
-            except (ValueError, TypeError):
-                pass
-            d = str(row.get("Proposal Award Date", "")).strip()
-            if d:
-                h["dates"].append(d)
-            t = str(row.get("Award Title", "")).strip()
-            if t and len(h["sample_titles"]) < 5 and t not in h["sample_titles"]:
-                h["sample_titles"].append(t)
-
-    # Normalize sets to sorted lists and parse dates
-    for _name, h in history.items():
-        raw_dates = h.pop("dates", [])
-        parsed_dates = [_parse_date_safe(d) for d in raw_dates]
-        parsed_dates = [d for d in parsed_dates if d]
-        h["earliest_date"] = min(parsed_dates) if parsed_dates else None
-        h["latest_date"] = max(parsed_dates) if parsed_dates else None
-        for key in ["phases", "agencies", "programs"]:
-            if isinstance(h[key], set):
-                h[key] = sorted(h[key])
-        if extra_set_fields:
-            for ef in extra_set_fields:
-                set_key = ef.lower().replace(" ", "_") + "s"
-                if isinstance(h.get(set_key), set):
-                    h[set_key] = sorted(h[set_key])
-
-    return history
-
-
 def get_company_history(
     awards: list[dict],
     source: DataSource | None = None,
     extractor: object | None = None,
     table: str | None = None,
 ) -> dict[str, dict]:
-    """Extract historical SBIR award context per company from the full dataset.
-
-    Accepts optional shared source/extractor/table to avoid redundant CSV
-    downloads and DuckDB imports when called alongside get_pi_history().
-
-    Returns a dict keyed by upper-cased company name.
-    """
-    company_names = {str(a.get("Company", "")).strip().upper() for a in awards}
-    company_names.discard("")
-    if not company_names:
-        return {}
-
+    """Extract historical SBIR award context per company from the full dataset."""
     if source is None:
         source, extractor, table = _resolve_shared_extractor()
-
-    if extractor is not None and table is not None:
-        # Build IN clause with escaped names
-        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(company_names)]
-        in_clause = ", ".join(escaped)
-        query = (
-            f'SELECT UPPER("Company") AS _group_key, "Phase", "Agency", '
-            f'"Award Amount", "Proposal Award Date", "Award Title", "Program" '
-            f"FROM {table} "
-            f'WHERE UPPER("Company") IN ({in_clause}) '
-            f'ORDER BY "Proposal Award Date" DESC'
-        )
-        df = extractor.duckdb_client.execute_query_df(query)
-        if df.empty:
-            return {}
-        return _build_history_from_df(df, "_group_key")
-
-    # Fallback: stream the CSV
-    return _build_history_from_csv(source, company_names, "Company")
+    return _lib_get_company_history(awards, source=source, extractor=extractor, table=table)
 
 
 def get_pi_history(
@@ -514,68 +351,10 @@ def get_pi_history(
     extractor: object | None = None,
     table: str | None = None,
 ) -> dict[str, dict]:
-    """Extract historical SBIR context per Principal Investigator.
-
-    Accepts optional shared source/extractor/table to avoid redundant CSV
-    downloads and DuckDB imports.
-
-    Returns a dict keyed by upper-cased PI name.
-    """
-    pi_names = set()
-    for a in awards:
-        pi = str(a.get("PI Name", "")).strip().upper()
-        if pi:
-            pi_names.add(pi)
-
-    if not pi_names:
-        return {}
-
+    """Extract historical SBIR context per Principal Investigator."""
     if source is None:
         source, extractor, table = _resolve_shared_extractor()
-
-    if extractor is not None and table is not None:
-        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(pi_names)]
-        in_clause = ", ".join(escaped)
-        query = (
-            f'SELECT UPPER("PI Name") AS _group_key, "Company", "Phase", "Agency", '
-            f'"Award Amount", "Proposal Award Date", "Award Title", "Program" '
-            f"FROM {table} "
-            f'WHERE UPPER("PI Name") IN ({in_clause}) '
-            f'ORDER BY "Proposal Award Date" DESC'
-        )
-        df = extractor.duckdb_client.execute_query_df(query)
-        if df.empty:
-            return {}
-        return _build_history_from_df(df, "_group_key", extra_set_cols=["Company"])
-
-    # Fallback: stream the CSV
-    return _build_history_from_csv(source, pi_names, "PI Name", extra_set_fields=["Company"])
-
-
-# ---------------------------------------------------------------------------
-# PI external data lookups (patents, publications, federal awards)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class PIPatentRecord:
-    """Summary of a PI's patent portfolio from PatentsView."""
-
-    total_patents: int
-    sample_titles: list[str]
-    assignees: list[str]
-    date_range: tuple[str | None, str | None]
-
-
-@dataclass
-class PIPublicationRecord:
-    """Summary of a PI's publication history from Semantic Scholar."""
-
-    total_papers: int
-    h_index: int | None
-    citation_count: int
-    sample_titles: list[str]
-    affiliations: list[str]
+    return _lib_get_pi_history(awards, source=source, extractor=extractor, table=table)
 
 
 @dataclass
@@ -591,386 +370,9 @@ class FederalAwardSummary:
     cfda_number: str  # Assistance Listing Number
 
 
-@dataclass
-class PIFederalAwardRecord:
-    """Summary of a PI's company's federal awards from USAspending.
-
-    Separates SBIR/STTR awards from non-SBIR federal work. Non-SBIR
-    awards to a company with SBIR history are potential follow-on /
-    Phase III commercialization signals.
-    """
-
-    total_awards: int
-    total_funding: float
-    agencies: list[str]
-    award_types: list[str]  # e.g. contracts, grants, IDVs
-    date_range: tuple[str | None, str | None]
-    # Follow-on analysis
-    sbir_award_count: int = 0
-    sbir_funding: float = 0.0
-    non_sbir_award_count: int = 0
-    non_sbir_funding: float = 0.0
-    non_sbir_agencies: list[str] = field(default_factory=list)
-    non_sbir_sample_descriptions: list[str] = field(default_factory=list)
-
-
-def _split_pi_name(full_name: str) -> tuple[str, str]:
-    """Split a PI name into (first, last) for API queries.
-
-    SBIR data typically stores names as 'First Last' or 'Last, First'.
-    """
-    full_name = full_name.strip()
-    if "," in full_name:
-        parts = [p.strip() for p in full_name.split(",", 1)]
-        return (parts[1], parts[0]) if len(parts) == 2 else (parts[0], "")
-    parts = full_name.split()
-    if len(parts) >= 2:
-        return (parts[0], parts[-1])
-    return (full_name, "")
-
-
-def lookup_pi_patents(pi_name: str, company_name: str | None = None) -> PIPatentRecord | None:
-    """Query USPTO ODP for patents where the PI is a named inventor.
-
-    Uses PatentsViewClient when available (rate limiting, caching, retry).
-    Falls back to bare httpx calls otherwise.
-    """
-    first, last = _split_pi_name(pi_name)
-    if not last:
-        return None
-
-    _debug(f"Using PatentsViewClient for '{pi_name}'")
-    try:
-        client = PatentsViewClient()
-        try:
-            patents = client.query_patents_by_assignee(
-                company_name=company_name or last,
-                max_patents=100,
-            )
-        finally:
-            if hasattr(client, "close"):
-                client.close()
-        if not patents:
-            return None
-
-        titles = []
-        assignees: set[str] = set()
-        dates: list[str] = []
-        for p in patents:
-            t = p.get("patent_title", "")
-            if t and t not in titles and len(titles) < 5:
-                titles.append(t)
-            org = p.get("assignee_organization", "")
-            if org:
-                assignees.add(org)
-            d = p.get("grant_date") or p.get("patent_date", "")
-            if d:
-                dates.append(d)
-
-        return PIPatentRecord(
-            total_patents=len(patents),
-            sample_titles=titles,
-            assignees=sorted(assignees),
-            date_range=(min(dates) if dates else None, max(dates) if dates else None),
-        )
-    except Exception as e:
-        _debug(f"PatentsViewClient error for '{pi_name}': {e}")
-        return None
-
-
-def lookup_pi_publications(pi_name: str) -> PIPublicationRecord | None:
-    """Query Semantic Scholar for the PI's publication history."""
-    first, last = _split_pi_name(pi_name)
-    if not last:
-        return None
-
-    search_query = f"{first} {last}".strip()
-
-    with SemanticScholarClient(rate_limiter=_semantic_scholar_limiter) as s2:
-        try:
-            rec = s2.lookup_author(search_query)
-        except Exception as e:
-            print(f"Semantic Scholar API error for {pi_name}: {e}", file=sys.stderr)
-            return None
-    if rec is None:
-        return None
-    return PIPublicationRecord(
-        total_papers=rec.total_papers,
-        h_index=rec.h_index,
-        citation_count=rec.citation_count,
-        sample_titles=rec.sample_titles,
-        affiliations=rec.affiliations,
-    )
-
-
-def _is_sbir_award_type(description: str, cfda: str) -> bool:
-    """Identify SBIR/STTR awards using ALN numbers and description keywords.
-
-    Delegates to :func:`sbir_etl.models.sbir_identification.classify_sbir_award`.
-    """
-    result = classify_sbir_award(cfda_number=cfda, description=description)
-    return result is not None
-
-
-def _usaspending_autocomplete(company_name: str) -> dict[str, str] | None:
-    """Use USAspending recipient autocomplete for fuzzy company name matching.
-
-    Generates name variations (abbreviation expansion, punctuation normalization,
-    suffix removal) and tries each against the autocomplete endpoint until a match
-    with a UEI or resolved name is found.
-
-    Based on sbir_etl.enrichers.company_categorization._fuzzy_match_recipient
-    but uses synchronous httpx to avoid async dependencies.
-    """
-    import re as _re
-
-    if not company_name or not company_name.strip():
-        return None
-
-    # Generate name variations, ordered most-to-least specific
-    abbreviations = {
-        r"\bIntl\.?\b": "International",
-        r"\bInt'l\.?\b": "International",
-        r"\bInc\.?\b": "Incorporated",
-        r"\bCorp\.?\b": "Corporation",
-        r"\bLtd\.?\b": "Limited",
-        r"\bLLC\.?\b": "Limited Liability Company",
-        r"\bTech\.?\b": "Technology",
-        r"\bMfg\.?\b": "Manufacturing",
-        r"\bSvcs\.?\b": "Services",
-        r"\bDev\.?\b": "Development",
-    }
-
-    variations: list[str] = [company_name.strip()]
-
-    # Expand abbreviations
-    expanded = company_name
-    for pattern, replacement in abbreviations.items():
-        expanded = _re.sub(pattern, replacement, expanded, flags=_re.IGNORECASE)
-    if expanded != company_name:
-        variations.append(expanded.strip())
-
-    # Normalize punctuation
-    normalized = expanded.replace("/", " AND ").replace("&", " AND ")
-    normalized = _re.sub(r"\s+", " ", normalized).strip()
-    if normalized not in variations:
-        variations.append(normalized)
-
-    # Remove legal suffixes for broadest match
-    base = _re.sub(
-        r",?\s*(Inc\.?|Incorporated|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?)$",
-        "", normalized, flags=_re.IGNORECASE,
-    ).strip().rstrip(",").strip()
-    if base and base not in variations and len(base) >= 10:
-        variations.append(base)
-
-    # Add uppercase versions (USAspending often stores uppercase)
-    upper_vars = [v.upper() for v in variations[:2] if v.upper() != v]
-    variations = variations[:2] + upper_vars + variations[2:]
-
-    # Deduplicate preserving order
-    seen: set[str] = set()
-    unique: list[str] = []
-    for v in variations:
-        key = v.lower()
-        if key not in seen and len(v) >= 5:
-            seen.add(key)
-            unique.append(v)
-
-    _debug(f"USAspending autocomplete: {len(unique)} name variations for '{company_name}'")
-
-    best_candidate = None
-
-    usa = SyncUSAspendingClient()
-    try:
-        for idx, name in enumerate(unique, 1):
-            try:
-                _usaspending_limiter.wait_if_needed()
-                data = usa.autocomplete_recipient(name, limit=5)
-                results = data.get("results", [])
-                if not results:
-                    continue
-                match = results[0]
-                matched_name = match.get("legal_business_name", "")
-                matched_uei = match.get("uei")
-                if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
-                    _debug(
-                        f"USAspending autocomplete matched '{company_name}' "
-                        f"(variation {idx}: '{name}') → '{matched_name}' UEI={matched_uei}"
-                    )
-                    return {"uei": matched_uei, "name": matched_name}
-                if matched_name and best_candidate is None:
-                    best_candidate = {"uei": matched_uei, "name": matched_name}
-            except Exception:
-                continue
-    finally:
-        usa.close()
-
-    if best_candidate:
-        _debug(f"USAspending autocomplete: best candidate for '{company_name}' → '{best_candidate['name']}' (no UEI)")
-        return best_candidate
-
-    _debug(f"USAspending autocomplete: no match for '{company_name}' after {len(unique)} variations")
-    return None
-
-
-def _usaspending_search(
-    company_name: str,
-    search_text: str,
-    label: str,
-) -> list[dict] | None:
-    """Execute USAspending spending_by_award searches for a company.
-
-    Makes separate requests for contracts and grants/other (USAspending
-    requires award_type_codes from a single group per request), then
-    merges the results.
-
-    Returns the combined results list on success, or None on error.
-    """
-    fields = [
-        "Award ID",
-        "Recipient Name",
-        "Award Amount",
-        "Awarding Agency",
-        "Award Type",
-        "Start Date",
-        "Description",
-        "CFDA Number",
-    ]
-    # USAspending requires award_type_codes from one group only.
-    # The API enforces these groups: contracts (A-D), grants (02-05),
-    # direct_payments (06, 10), loans (07-09), other (11).
-    type_groups = [
-        ("contracts", ["A", "B", "C", "D"]),
-        ("grants", ["02", "03", "04", "05"]),
-        ("direct_payments", ["06", "10"]),
-        ("loans", ["07", "08", "09"]),
-        ("other", ["11"]),
-    ]
-
-    all_results: list[dict] = []
-    _debug(
-        f"USAspending query for '{company_name}' ({label}='{search_text}'): "
-        f"POST /search/spending_by_award/"
-    )
-
-    usa = SyncUSAspendingClient()
-    try:
-        for group_name, codes in type_groups:
-            try:
-                _usaspending_limiter.wait_if_needed()
-                data = usa.search_awards(
-                    filters={
-                        "award_type_codes": codes,
-                        "recipient_search_text": [search_text],
-                    },
-                    fields=fields,
-                    limit=50,
-                )
-                group_results = data.get("results", [])
-                _debug(f"USAspending [{company_name} via {label}/{group_name}]: {len(group_results)} results")
-                all_results.extend(group_results)
-            except Exception as e:
-                _debug(f"USAspending [{company_name}] {label}/{group_name} error: {e}")
-                continue
-    finally:
-        usa.close()
-
-    _debug(f"USAspending [{company_name} via {label}]: {len(all_results)} total results")
-    return all_results if all_results else None
-
-
-def lookup_company_federal_awards(
-    company_name: str,
-    uei: str | None = None,
-) -> PIFederalAwardRecord | None:
-    """Query USAspending for all federal awards to the PI's company.
-
-    Tries UEI first (most reliable), then falls back to company name search.
-    Separates SBIR/STTR awards from non-SBIR federal work. Non-SBIR
-    contracts and grants to a company with SBIR history are the strongest
-    signal of successful commercialization / Phase III transition.
-    """
-    if not company_name:
-        return None
-
-    # Cascading lookup: UEI → exact name → fuzzy autocomplete match
-    results = None
-    if uei:
-        results = _usaspending_search(company_name, uei, "UEI")
-    if not results:
-        results = _usaspending_search(company_name, company_name, "name")
-    if not results:
-        # Fuzzy match: try USAspending autocomplete with name variations
-        match = _usaspending_autocomplete(company_name)
-        if match:
-            search_key = match["uei"] if match.get("uei") else match["name"]
-            label = "autocomplete-UEI" if match.get("uei") else "autocomplete-name"
-            results = _usaspending_search(company_name, search_key, label)
-    if not results:
-        return None
-
-    agencies: set[str] = set()
-    award_types: set[str] = set()
-    total_funding = 0.0
-    dates: list[str] = []
-
-    sbir_count = 0
-    sbir_funding = 0.0
-    non_sbir_count = 0
-    non_sbir_funding = 0.0
-    non_sbir_agencies: set[str] = set()
-    non_sbir_descriptions: list[str] = []
-
-    for r in results:
-        ag = r.get("Awarding Agency", "")
-        if ag:
-            agencies.add(ag)
-        at = r.get("Award Type", "")
-        if at:
-            award_types.add(at)
-        try:
-            amount = float(r.get("Award Amount", 0) or 0)
-        except (ValueError, TypeError):
-            amount = 0.0
-        total_funding += amount
-        d = r.get("Start Date", "")
-        if d:
-            dates.append(d)
-
-        desc = str(r.get("Description", "") or "")
-        cfda = str(r.get("CFDA Number", "") or "")
-
-        if _is_sbir_award_type(desc, cfda):
-            sbir_count += 1
-            sbir_funding += amount
-        else:
-            non_sbir_count += 1
-            non_sbir_funding += amount
-            if ag:
-                non_sbir_agencies.add(ag)
-            # Keep sample descriptions of non-SBIR awards (the follow-on signals)
-            if desc and len(non_sbir_descriptions) < 5:
-                # Truncate long descriptions
-                if len(desc) > 200:
-                    desc = desc[:200] + "..."
-                non_sbir_descriptions.append(
-                    f"{desc} ({ag}, {at}, ${amount:,.0f})"
-                )
-
-    return PIFederalAwardRecord(
-        total_awards=len(results),
-        total_funding=total_funding,
-        agencies=sorted(agencies),
-        award_types=sorted(award_types),
-        date_range=(min(dates) if dates else None, max(dates) if dates else None),
-        sbir_award_count=sbir_count,
-        sbir_funding=sbir_funding,
-        non_sbir_award_count=non_sbir_count,
-        non_sbir_funding=non_sbir_funding,
-        non_sbir_agencies=sorted(non_sbir_agencies),
-        non_sbir_sample_descriptions=non_sbir_descriptions,
-    )
+# ---------------------------------------------------------------------------
+# PI external data lookups (patents, publications, federal awards)
+# ---------------------------------------------------------------------------
 
 
 def lookup_pi_external_data(
@@ -1015,9 +417,9 @@ def lookup_pi_external_data(
 
         # Run the 3 independent API calls concurrently per PI
         with ThreadPoolExecutor(max_workers=3) as inner:
-            patent_future = inner.submit(lookup_pi_patents, name, company)
-            pub_future = inner.submit(lookup_pi_publications, name)
-            orcid_future = inner.submit(lookup_pi_orcid, name)
+            patent_future = inner.submit(_lib_lookup_pi_patents, name, company)
+            pub_future = inner.submit(_lib_lookup_pi_publications, name, rate_limiter=_semantic_scholar_limiter)
+            orcid_future = inner.submit(_lib_lookup_pi_orcid, name, rate_limiter=_orcid_limiter)
 
             patents = patent_future.result()
             publications = pub_future.result()
@@ -1028,7 +430,7 @@ def lookup_pi_external_data(
         if company_federal_awards is not None:
             fed = company_federal_awards.get(info["company_key"])
         if fed is None and company_federal_awards is None:
-            fed = lookup_company_federal_awards(company, uei)
+            fed = _lib_lookup_company_federal_awards(company, uei, rate_limiter=_usaspending_limiter)
 
         return key, {
             "patents": patents,
@@ -1077,93 +479,6 @@ def lookup_pi_external_data(
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class USARecipientProfile:
-    """Key data from a USAspending recipient profile."""
-
-    recipient_id: str
-    name: str
-    uei: str | None
-    parent_name: str | None
-    parent_uei: str | None
-    location_state: str | None
-    location_congressional_district: str | None
-    business_types: list[str]
-    total_transaction_amount: float
-    total_transactions: int
-
-
-def lookup_usaspending_recipient(
-    company_name: str,
-    uei: str | None = None,
-) -> USARecipientProfile | None:
-    """Look up a company's USAspending recipient profile.
-
-    Two-step: POST /recipient/ to find the hash ID, then GET /recipient/{id}/
-    for the full profile. Tries UEI first, then company name.
-    """
-    if not company_name:
-        return None
-
-    # Step 1: Find the recipient hash ID
-    search_terms = []
-    if uei:
-        search_terms.append(uei)
-    search_terms.append(company_name)
-
-    recipient_id = None
-
-    usa = SyncUSAspendingClient()
-    try:
-        for term in search_terms:
-            _debug(f"USAspending recipient search: keyword='{term}'")
-            try:
-                _usaspending_limiter.wait_if_needed()
-                results = usa.search_recipients(term, limit=5)
-                if results:
-                    recipient_id = results[0].get("id")
-                    _debug(
-                        f"USAspending recipient matched '{term}' → "
-                        f"'{results[0].get('name')}' id={recipient_id}"
-                    )
-                    break
-            except Exception as e:
-                _debug(f"USAspending recipient search error for '{term}': {e}")
-                continue
-
-        if not recipient_id:
-            _debug(f"USAspending recipient: no match for '{company_name}'")
-            return None
-
-        # Step 2: Fetch the full profile
-        _debug(f"USAspending recipient profile: GET /recipient/{recipient_id}/?year=all")
-        try:
-            _usaspending_limiter.wait_if_needed()
-            profile = usa.get_recipient_profile(recipient_id)
-        except Exception as e:
-            _debug(f"USAspending recipient profile error: {e}")
-            return None
-        if not profile:
-            return None
-    finally:
-        usa.close()
-
-    location = profile.get("location") or {}
-
-    return USARecipientProfile(
-        recipient_id=recipient_id,
-        name=profile.get("name") or company_name,
-        uei=profile.get("uei"),
-        parent_name=profile.get("parent_name"),
-        parent_uei=profile.get("parent_uei"),
-        location_state=location.get("state_code"),
-        location_congressional_district=location.get("congressional_code"),
-        business_types=profile.get("business_types") or [],
-        total_transaction_amount=float(profile.get("total_transaction_amount") or 0),
-        total_transactions=int(profile.get("total_transactions") or 0),
-    )
-
-
 def lookup_usaspending_recipients(
     awards: list[dict],
 ) -> dict[str, USARecipientProfile]:
@@ -1192,7 +507,7 @@ def lookup_usaspending_recipients(
 
     def _lookup_one(item: tuple[str, dict]) -> tuple[str, USARecipientProfile | None]:
         key, info = item
-        return key, lookup_usaspending_recipient(info["name"], info["uei"])
+        return key, _lib_lookup_usaspending_recipient(info["name"], info["uei"], rate_limiter=_usaspending_limiter)
 
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = {executor.submit(_lookup_one, item): item for item in companies.items()}
@@ -1223,126 +538,6 @@ def lookup_usaspending_recipients(
 # ---------------------------------------------------------------------------
 # SAM.gov entity lookup (company diligence)
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class SAMEntityRecord:
-    """Key SAM.gov entity registration data for diligence."""
-
-    uei: str
-    legal_business_name: str
-    dba_name: str | None
-    registration_status: str | None
-    expiration_date: str | None
-    business_type: str | None
-    entity_structure: str | None
-    naics_codes: list[str]
-    cage_code: str | None
-    exclusion_status: str | None
-    state: str | None
-    congressional_district: str | None
-
-
-def lookup_sam_entity(
-    company_name: str,
-    uei: str | None = None,
-    cage: str | None = None,
-) -> SAMEntityRecord | None:
-    """Query SAM.gov Entity Information API for company registration data.
-
-    Tries UEI first (exact match), then CAGE, then name search.
-    Requires SAM_GOV_API_KEY environment variable.
-    """
-    api_key = os.environ.get("SAM_GOV_API_KEY", "")
-    if not api_key:
-        return None
-
-    entity = None
-
-    sam = SyncSAMGovClient()
-    try:
-        # Try UEI first (most reliable)
-        if uei:
-            _debug(f"SAM.gov [{company_name}]: lookup by UEI={uei}")
-            try:
-                _sam_gov_limiter.wait_if_needed()
-                entity = sam.get_entity_by_uei(uei)
-            except Exception as e:
-                _debug(f"SAM.gov [{company_name}]: UEI lookup error: {e}")
-
-        # Try CAGE code
-        if not entity and cage:
-            _debug(f"SAM.gov [{company_name}]: lookup by CAGE={cage}")
-            try:
-                _sam_gov_limiter.wait_if_needed()
-                entity = sam.get_entity_by_cage(cage)
-            except Exception as e:
-                _debug(f"SAM.gov [{company_name}]: CAGE lookup error: {e}")
-
-        # Fall back to name search
-        if not entity and company_name:
-            _debug(f"SAM.gov [{company_name}]: name search")
-            try:
-                _sam_gov_limiter.wait_if_needed()
-                results = sam.search_entities(
-                    legal_business_name=company_name,
-                    registration_status="A",
-                    limit=1,
-                )
-                entity = results[0] if results else None
-            except Exception as e:
-                _debug(f"SAM.gov [{company_name}]: name search error: {e}")
-    finally:
-        sam.close()
-
-    if not entity:
-        # Always log — helps diagnose silent failures in CI
-        methods_tried = []
-        if uei:
-            methods_tried.append(f"UEI={uei}")
-        if cage:
-            methods_tried.append(f"CAGE={cage}")
-        methods_tried.append(f"name='{company_name}'")
-        print(
-            f"SAM.gov: no entity found for {company_name} "
-            f"(tried: {', '.join(methods_tried)})",
-            file=sys.stderr,
-        )
-        return None
-
-    # Extract fields — SAM.gov API nests data under various keys
-    core = entity.get("entityRegistration", entity)
-    address = entity.get("coreData", {}).get("physicalAddress", {})
-    business_types = entity.get("coreData", {}).get("businessTypes", {})
-
-    # Extract NAICS codes
-    naics_list = entity.get("coreData", {}).get("naicsCodeList", [])
-    if isinstance(naics_list, list):
-        naics_codes = [
-            str(n.get("naicsCode", "")) for n in naics_list if n.get("naicsCode")
-        ]
-    else:
-        naics_codes = []
-
-    return SAMEntityRecord(
-        uei=core.get("ueiSAM", ""),
-        legal_business_name=core.get("legalBusinessName", ""),
-        dba_name=core.get("dbaName"),
-        registration_status=core.get("registrationStatus"),
-        expiration_date=core.get("registrationExpirationDate"),
-        business_type=(
-            business_types.get("businessTypeList", [{}])[0].get("businessType")
-            if isinstance(business_types.get("businessTypeList"), list)
-            and business_types.get("businessTypeList")
-            else None
-        ),
-        entity_structure=core.get("entityStructureDesc"),
-        naics_codes=naics_codes,
-        cage_code=core.get("cageCode"),
-        exclusion_status=core.get("exclusionStatusFlag"),
-        state=address.get("stateOrProvinceCode"),
-        congressional_district=address.get("congressionalDistrict"),
-    )
 
 
 def lookup_sam_entities(
@@ -1382,7 +577,7 @@ def lookup_sam_entities(
 
     def _lookup_one(item: tuple[str, dict]) -> tuple[str, SAMEntityRecord | None]:
         key, info = item
-        return key, lookup_sam_entity(info["name"], info["uei"], info["cage"])
+        return key, _lib_lookup_sam_entity(info["name"], info["uei"], info["cage"], rate_limiter=_sam_gov_limiter)
 
     # Cap at 3 workers to respect SAM.gov 60 req/min rate limit
     with ThreadPoolExecutor(max_workers=3) as executor:
@@ -1409,55 +604,6 @@ def lookup_sam_entities(
 
     print(f"Found {len(results)}/{total} companies on SAM.gov", file=sys.stderr)
     return results
-
-
-# ---------------------------------------------------------------------------
-# ORCID API lookup (PI diligence)
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class ORCIDRecord:
-    """Key data from an ORCID researcher profile."""
-
-    orcid_id: str
-    given_name: str | None
-    family_name: str | None
-    affiliations: list[str]
-    works_count: int
-    sample_work_titles: list[str]
-    funding_count: int
-    keywords: list[str]
-
-
-def lookup_pi_orcid(pi_name: str) -> ORCIDRecord | None:
-    """Search the ORCID public API for a PI's researcher profile.
-
-    Uses :class:`ORCIDClient` when the library is available;
-    falls back to inline httpx calls for standalone operation.
-    """
-    first, last = _split_pi_name(pi_name)
-    if not last:
-        return None
-
-    with ORCIDClient(rate_limiter=_orcid_limiter) as orcid:
-        try:
-            rec = orcid.lookup(pi_name)
-        except Exception as e:
-            print(f"ORCID API error for {pi_name}: {e}", file=sys.stderr)
-            return None
-    if rec is None:
-        return None
-    return ORCIDRecord(
-        orcid_id=rec.orcid_id,
-        given_name=rec.given_name,
-        family_name=rec.family_name,
-        affiliations=rec.affiliations,
-        works_count=rec.works_count,
-        sample_work_titles=rec.sample_work_titles,
-        funding_count=rec.funding_count,
-        keywords=rec.keywords,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -1895,180 +1041,16 @@ def research_companies(
     return results
 
 
-def _fetch_fpds_descriptions(
-    contract_ids: list[str],
-) -> dict[str, str]:
-    """Fetch contract descriptions from FPDS Atom Feed (public, no API key).
-
-    Uses :class:`FPDSAtomClient` when the library is available; falls back
-    to inline httpx + XML parsing for standalone operation.
-
-    Only accepts contract PIIDs — assistance FAINs (e.g. DE-*) are not
-    indexed in FPDS and should be filtered out before calling this function.
-    """
-    if not contract_ids:
-        return {}
-
-    _debug(f"FPDS: querying {len(contract_ids)} contract IDs")
-
-    with FPDSAtomClient(rate_limiter=_usaspending_limiter) as fpds:
-        try:
-            results = fpds.get_descriptions(contract_ids)
-        except Exception as e:
-            print(f"FPDS error: {e}", file=sys.stderr)
-            results = {}
-    _debug(f"FPDS: {len(results)}/{len(contract_ids)} descriptions found")
-    return results
-
-
 def fetch_usaspending_contract_descriptions(
     awards: list[dict],
 ) -> dict[str, str]:
-    """Fetch contract descriptions from USAspending for awards with contract numbers.
+    """Fetch contract descriptions from USAspending + FPDS fallback.
 
-    Returns a dict keyed by contract number with the award description text.
-    Used as supplementary LLM context when solicitation topic data is unavailable.
+    Delegates to :func:`sbir_etl.enrichers.company_enrichment.fetch_usaspending_contract_descriptions`.
     """
-
-    # Use shared award-ID classification when available, inline fallback otherwise.
-    try:
-        from sbir_etl.enrichers.usaspending.client import build_award_type_groups
-    except ImportError:
-        import re as _re
-
-        def build_award_type_groups(ids):  # type: ignore[misc]
-            piids, fains, unknown = [], [], []
-            seen: set[str] = set()
-            for raw in ids:
-                s = raw.strip()
-                if not s or s in seen:
-                    continue
-                seen.add(s)
-                if _re.match(r"^DE-", s, _re.IGNORECASE):
-                    fains.append(s)
-                elif _re.match(r"^[A-Z]{2}\d", s):
-                    piids.append(s)
-                else:
-                    unknown.append(s)
-            groups = []
-            if piids:
-                groups.append((piids, "contracts", ["A", "B", "C", "D"]))
-            if fains:
-                groups.append((fains, "assistance", ["02", "03", "04", "05"]))
-            for uid in unknown:
-                groups.append(([uid], "contracts", ["A", "B", "C", "D"]))
-                groups.append(([uid], "assistance", ["02", "03", "04", "05"]))
-            return groups
-
-    raw_ids = [str(a.get("Contract", "")).strip() for a in awards]
-    raw_ids = [c for c in raw_ids if c]
-    if not raw_ids:
-        return {}
-
-    requests_to_make = build_award_type_groups(raw_ids)
-    all_ids = list({aid for ids, _, _ in requests_to_make for aid in ids})
-
-    _debug(f"USAspending contract desc: {len(all_ids)} IDs in {len(requests_to_make)} groups")
-    print(
-        f"Fetching {len(all_ids)} contract descriptions from USAspending...",
-        file=sys.stderr,
+    return _lib_fetch_usaspending_contract_descriptions(
+        awards, rate_limiter=_usaspending_limiter,
     )
-    results: dict[str, str] = {}
-    # Track IDs from groups that failed at the API level (503, 422, etc.)
-    # so the FPDS fallback only fires for actual USAspending outages.
-    failed_ids: set[str] = set()
-
-    desc_fields = ["Award ID", "Description", "Awarding Agency", "Award Type"]
-
-    def _extract_descriptions(data: dict) -> None:
-        """Extract descriptions from a USAspending response into results."""
-        for r in data.get("results", []):
-            aid = str(r.get("Award ID", "")).strip()
-            desc = str(r.get("Description", "")).strip()
-            if aid and desc and aid not in results:
-                if len(desc) > 500:
-                    desc = desc[:500] + "..."
-                results[aid] = desc
-
-    usa = SyncUSAspendingClient()
-    try:
-        for ids, group_name, codes in requests_to_make:
-            quoted = [f'"{c}"' for c in ids]
-            filters = {"award_ids": quoted, "award_type_codes": codes}
-            _debug(
-                f"USAspending contract desc: {group_name} "
-                f"({len(ids)} IDs: {ids[:3]})"
-            )
-            data = None
-            # Try spending_by_award, then spending_by_transaction
-            # USAspending requires a 'sort' field; use the appropriate
-            # default for each endpoint.
-            _sort_for_method = {
-                "search_awards": "Award Amount",
-                "search_transactions": "Transaction Amount",
-            }
-            for method in ("search_awards", "search_transactions"):
-                try:
-                    _usaspending_limiter.wait_if_needed()
-                    data = getattr(usa, method)(
-                        filters=filters,
-                        fields=desc_fields,
-                        limit=len(ids),
-                        sort=_sort_for_method.get(method, "Award Amount"),
-                        order="desc",
-                    )
-                    break
-                except Exception as e:
-                    _debug(f"USAspending {method}/{group_name} failed: {e}")
-                    continue
-            if data is None:
-                failed_ids.update(ids)
-                continue
-            _extract_descriptions(data)
-    except Exception as e:
-        failed_ids.update(cid for cid in all_ids if cid not in results)
-        print(f"USAspending contract desc error: {e}", file=sys.stderr)
-    finally:
-        usa.close()
-
-    # FPDS Atom Feed fallback for contract PIIDs that failed at USAspending.
-    # FPDS only indexes procurement contracts (PIIDs), not assistance FAINs
-    # (e.g. DE-* DOE awards), so we filter to contract-type IDs only.
-    import re as _re_fallback
-    fpds_eligible = [
-        cid for cid in failed_ids
-        if cid not in results and not _re_fallback.match(r"^DE-", cid, _re_fallback.IGNORECASE)
-    ]
-    if fpds_eligible:
-        _debug(
-            f"USAspending failed for {len(failed_ids)} IDs, "
-            f"{len(fpds_eligible)} eligible for FPDS fallback"
-        )
-        print(
-            f"Falling back to FPDS for {len(fpds_eligible)} missing contract descriptions...",
-            file=sys.stderr,
-        )
-        fpds_results = _fetch_fpds_descriptions(fpds_eligible)
-        if fpds_results:
-            results.update(fpds_results)
-            print(
-                f"FPDS fallback recovered {len(fpds_results)}/{len(fpds_eligible)} descriptions",
-                file=sys.stderr,
-            )
-
-    if not results and all_ids:
-        print(
-            f"Contract descriptions: 0 results for {len(all_ids)} award IDs "
-            f"from USAspending + FPDS (sample: {all_ids[:3]})",
-            file=sys.stderr,
-        )
-
-    _debug(f"Contract descriptions: {len(results)}/{len(all_ids)} found (USAspending + FPDS)")
-    print(
-        f"Fetched {len(results)}/{len(all_ids)} contract descriptions (USAspending + FPDS fallback)",
-        file=sys.stderr,
-    )
-    return results
 
 
 def _award_digest(
@@ -3380,7 +2362,7 @@ def main():
 
             def _lookup_co_fed(item: tuple[str, dict]) -> tuple[str, PIFederalAwardRecord | None]:
                 k, info = item
-                return k, lookup_company_federal_awards(info["name"], info["uei"])
+                return k, _lib_lookup_company_federal_awards(info["name"], info["uei"], rate_limiter=_usaspending_limiter)
 
             co_fed_deadline = _stage_deadline()
             with ThreadPoolExecutor(max_workers=4) as executor:

--- a/tests/unit/enrichers/test_award_history.py
+++ b/tests/unit/enrichers/test_award_history.py
@@ -1,0 +1,245 @@
+"""Unit tests for award history extraction logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.award_history import (
+    _build_history_from_df,
+    get_company_history,
+    get_pi_history,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# Helper to build a test DataFrame
+# ---------------------------------------------------------------------------
+
+
+def _make_awards_df(rows: list[dict]) -> pd.DataFrame:
+    """Create a DataFrame with the columns expected by _build_history_from_df."""
+    cols = [
+        "_group_key", "Phase", "Agency", "Award Amount",
+        "Proposal Award Date", "Award Title", "Program",
+    ]
+    for col in cols:
+        for row in rows:
+            row.setdefault(col, "")
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# _build_history_from_df
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHistoryFromDF:
+    def test_basic_aggregation(self):
+        df = _make_awards_df([
+            {
+                "_group_key": "ACME CORP",
+                "Phase": "Phase I",
+                "Agency": "DOD",
+                "Award Amount": "150000",
+                "Proposal Award Date": "2021-06-01",
+                "Award Title": "Widget Research",
+                "Program": "SBIR",
+            },
+            {
+                "_group_key": "ACME CORP",
+                "Phase": "Phase II",
+                "Agency": "DOD",
+                "Award Amount": "1000000",
+                "Proposal Award Date": "2023-01-15",
+                "Award Title": "Widget Prototype",
+                "Program": "SBIR",
+            },
+        ])
+
+        result = _build_history_from_df(df, "_group_key")
+
+        assert "ACME CORP" in result
+        entry = result["ACME CORP"]
+        assert entry["total_awards"] == 2
+        assert entry["total_funding"] == 1150000.0
+        assert "Phase I" in entry["phases"]
+        assert "Phase II" in entry["phases"]
+        assert entry["agencies"] == ["DOD"]
+        assert entry["earliest_date"] is not None
+        assert entry["latest_date"] is not None
+        assert len(entry["sample_titles"]) == 2
+
+    def test_multiple_groups(self):
+        df = _make_awards_df([
+            {
+                "_group_key": "ACME CORP",
+                "Phase": "Phase I",
+                "Agency": "DOD",
+                "Award Amount": "100000",
+                "Proposal Award Date": "2021-01-01",
+                "Award Title": "Title A",
+                "Program": "SBIR",
+            },
+            {
+                "_group_key": "BETA INC",
+                "Phase": "Phase I",
+                "Agency": "NASA",
+                "Award Amount": "200000",
+                "Proposal Award Date": "2022-06-01",
+                "Award Title": "Title B",
+                "Program": "STTR",
+            },
+        ])
+
+        result = _build_history_from_df(df, "_group_key")
+
+        assert len(result) == 2
+        assert result["ACME CORP"]["total_funding"] == 100000.0
+        assert result["BETA INC"]["agencies"] == ["NASA"]
+
+    def test_extra_set_cols(self):
+        df = _make_awards_df([
+            {
+                "_group_key": "JANE DOE",
+                "Phase": "Phase I",
+                "Agency": "DOD",
+                "Award Amount": "100000",
+                "Proposal Award Date": "2021-01-01",
+                "Award Title": "Research A",
+                "Program": "SBIR",
+                "Company": "Acme Corp",
+            },
+        ])
+
+        result = _build_history_from_df(df, "_group_key", extra_set_cols=["Company"])
+
+        assert "companies" in result["JANE DOE"]
+        assert result["JANE DOE"]["companies"] == ["Acme Corp"]
+
+    def test_empty_group_key_skipped(self):
+        df = _make_awards_df([
+            {
+                "_group_key": "",
+                "Phase": "Phase I",
+                "Agency": "DOD",
+                "Award Amount": "50000",
+                "Award Title": "Phantom",
+                "Program": "SBIR",
+            },
+        ])
+
+        result = _build_history_from_df(df, "_group_key")
+        assert len(result) == 0
+
+
+# ---------------------------------------------------------------------------
+# get_company_history (DuckDB path)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCompanyHistory:
+    def test_duckdb_path(self):
+        awards = [{"Company": "Acme Corp"}, {"Company": "Beta Inc"}]
+
+        mock_extractor = MagicMock()
+        df = _make_awards_df([
+            {
+                "_group_key": "ACME CORP",
+                "Phase": "Phase I",
+                "Agency": "DOD",
+                "Award Amount": "150000",
+                "Proposal Award Date": "2021-06-01",
+                "Award Title": "Widget Research",
+                "Program": "SBIR",
+            },
+        ])
+        mock_extractor.duckdb_client.execute_query_df.return_value = df
+
+        result = get_company_history(
+            awards, source=None, extractor=mock_extractor, table="sbir_awards"
+        )
+
+        assert "ACME CORP" in result
+        assert result["ACME CORP"]["total_awards"] == 1
+        mock_extractor.duckdb_client.execute_query_df.assert_called_once()
+
+    def test_empty_awards_returns_empty(self):
+        result = get_company_history([])
+        assert result == {}
+
+    def test_empty_df_returns_empty(self):
+        awards = [{"Company": "Acme Corp"}]
+        mock_extractor = MagicMock()
+        mock_extractor.duckdb_client.execute_query_df.return_value = pd.DataFrame()
+
+        result = get_company_history(
+            awards, source=None, extractor=mock_extractor, table="sbir_awards"
+        )
+        assert result == {}
+
+    def test_no_source_or_extractor_returns_empty(self):
+        awards = [{"Company": "Acme Corp"}]
+        result = get_company_history(awards)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# get_pi_history (DuckDB path)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPIHistory:
+    def test_duckdb_path(self):
+        awards = [{"PI Name": "Jane Doe"}]
+
+        mock_extractor = MagicMock()
+        rows = [
+            {
+                "_group_key": "JANE DOE",
+                "Company": "Acme Corp",
+                "Phase": "Phase I",
+                "Agency": "NASA",
+                "Award Amount": "200000",
+                "Proposal Award Date": "2022-03-01",
+                "Award Title": "Space Widget",
+                "Program": "SBIR",
+            },
+            {
+                "_group_key": "JANE DOE",
+                "Company": "Beta Inc",
+                "Phase": "Phase II",
+                "Agency": "NASA",
+                "Award Amount": "750000",
+                "Proposal Award Date": "2024-01-15",
+                "Award Title": "Space Widget v2",
+                "Program": "SBIR",
+            },
+        ]
+        df = _make_awards_df(rows)
+        mock_extractor.duckdb_client.execute_query_df.return_value = df
+
+        result = get_pi_history(
+            awards, source=None, extractor=mock_extractor, table="sbir_awards"
+        )
+
+        assert "JANE DOE" in result
+        entry = result["JANE DOE"]
+        assert entry["total_awards"] == 2
+        assert entry["total_funding"] == 950000.0
+        assert "companies" in entry
+        assert sorted(entry["companies"]) == ["Acme Corp", "Beta Inc"]
+
+    def test_empty_pi_names_returns_empty(self):
+        result = get_pi_history([{"PI Name": ""}])
+        assert result == {}
+
+    def test_no_source_or_extractor_returns_empty(self):
+        awards = [{"PI Name": "Jane Doe"}]
+        result = get_pi_history(awards)
+        assert result == {}

--- a/tests/unit/enrichers/test_company_enrichment.py
+++ b/tests/unit/enrichers/test_company_enrichment.py
@@ -1,0 +1,392 @@
+"""Unit tests for company enrichment orchestration logic."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sbir_etl.enrichers.company_enrichment import (
+    FederalAwardSummary,
+    SAMEntityRecord,
+    USARecipientProfile,
+    fetch_fpds_descriptions,
+    fetch_usaspending_contract_descriptions,
+    lookup_company_federal_awards,
+    lookup_sam_entity,
+    lookup_usaspending_recipient,
+    usaspending_autocomplete,
+    usaspending_search,
+)
+
+
+pytestmark = pytest.mark.fast
+
+MODULE = "sbir_etl.enrichers.company_enrichment"
+
+
+# ---------------------------------------------------------------------------
+# usaspending_autocomplete
+# ---------------------------------------------------------------------------
+
+
+class TestUSAspendingAutocomplete:
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_match_with_uei(self, MockClient):
+        client = MockClient.return_value
+        client.autocomplete_recipient.return_value = {
+            "results": [
+                {"legal_business_name": "Acme Inc", "uei": "ABC123DEF456"}
+            ]
+        }
+
+        result = usaspending_autocomplete("Acme Inc")
+
+        assert result == {"uei": "ABC123DEF456", "name": "Acme Inc"}
+        client.close.assert_called_once()
+
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_match_without_uei_returns_best_candidate(self, MockClient):
+        client = MockClient.return_value
+        client.autocomplete_recipient.return_value = {
+            "results": [
+                {"legal_business_name": "Acme Incorporated", "uei": None}
+            ]
+        }
+
+        result = usaspending_autocomplete("Acme Inc")
+
+        assert result is not None
+        assert result["name"] == "Acme Incorporated"
+        assert result["uei"] is None
+
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_no_match_returns_none(self, MockClient):
+        client = MockClient.return_value
+        client.autocomplete_recipient.return_value = {"results": []}
+
+        result = usaspending_autocomplete("Totally Unknown Corp")
+        assert result is None
+
+    def test_empty_name_returns_none(self):
+        assert usaspending_autocomplete("") is None
+        assert usaspending_autocomplete("   ") is None
+
+
+# ---------------------------------------------------------------------------
+# usaspending_search
+# ---------------------------------------------------------------------------
+
+
+class TestUSAspendingSearch:
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_success_with_results(self, MockClient):
+        client = MockClient.return_value
+        client.search_awards.return_value = {
+            "results": [{"Award ID": "W911NF-20-1-0001", "Award Amount": 100000}]
+        }
+
+        result = usaspending_search("Acme", "ABC123", "UEI")
+
+        assert result is not None
+        # 5 type groups, each returning 1 result
+        assert len(result) == 5
+        client.close.assert_called_once()
+
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_empty_results_returns_none(self, MockClient):
+        client = MockClient.return_value
+        client.search_awards.return_value = {"results": []}
+
+        result = usaspending_search("Acme", "ABC123", "UEI")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_company_federal_awards
+# ---------------------------------------------------------------------------
+
+
+class TestLookupCompanyFederalAwards:
+    @patch(f"{MODULE}.usaspending_autocomplete")
+    @patch(f"{MODULE}.usaspending_search")
+    @patch(f"{MODULE}._is_sbir_award_type")
+    def test_uei_path(self, mock_is_sbir, mock_search, mock_auto):
+        mock_is_sbir.return_value = False
+        mock_search.return_value = [
+            {
+                "Awarding Agency": "DOD",
+                "Award Type": "Contract",
+                "Award Amount": 500000,
+                "Start Date": "2022-01-01",
+                "Description": "R&D services",
+                "CFDA Number": "",
+            }
+        ]
+
+        result = lookup_company_federal_awards("Acme Corp", uei="ABC123")
+
+        assert isinstance(result, FederalAwardSummary)
+        assert result.total_awards == 1
+        assert result.total_funding == 500000.0
+        assert "DOD" in result.agencies
+        # UEI path was used first
+        mock_search.assert_called_once_with("Acme Corp", "ABC123", "UEI", rate_limiter=None)
+        mock_auto.assert_not_called()
+
+    @patch(f"{MODULE}.usaspending_autocomplete")
+    @patch(f"{MODULE}.usaspending_search")
+    @patch(f"{MODULE}._is_sbir_award_type")
+    def test_name_fallback(self, mock_is_sbir, mock_search, mock_auto):
+        mock_is_sbir.return_value = False
+        # First call (UEI) returns None, second call (name) returns results
+        mock_search.side_effect = [None, [
+            {
+                "Awarding Agency": "NASA",
+                "Award Type": "Grant",
+                "Award Amount": 100000,
+                "Start Date": "2023-03-15",
+                "Description": "Space stuff",
+                "CFDA Number": "",
+            }
+        ]]
+
+        result = lookup_company_federal_awards("Acme Corp", uei="ABC123")
+
+        assert isinstance(result, FederalAwardSummary)
+        assert result.total_awards == 1
+        assert "NASA" in result.agencies
+
+    @patch(f"{MODULE}.usaspending_autocomplete")
+    @patch(f"{MODULE}.usaspending_search")
+    @patch(f"{MODULE}._is_sbir_award_type")
+    def test_sbir_non_sbir_separation(self, mock_is_sbir, mock_search, mock_auto):
+        # First award is SBIR, second is not
+        mock_is_sbir.side_effect = [True, False]
+        mock_search.return_value = [
+            {
+                "Awarding Agency": "DOD",
+                "Award Type": "Grant",
+                "Award Amount": 150000,
+                "Start Date": "2021-06-01",
+                "Description": "SBIR Phase I",
+                "CFDA Number": "12.900",
+            },
+            {
+                "Awarding Agency": "DOD",
+                "Award Type": "Contract",
+                "Award Amount": 2000000,
+                "Start Date": "2023-01-01",
+                "Description": "Production contract",
+                "CFDA Number": "",
+            },
+        ]
+
+        result = lookup_company_federal_awards("Acme Corp", uei="ABC123")
+
+        assert result.sbir_award_count == 1
+        assert result.sbir_funding == 150000.0
+        assert result.non_sbir_award_count == 1
+        assert result.non_sbir_funding == 2000000.0
+
+    def test_empty_company_returns_none(self):
+        assert lookup_company_federal_awards("") is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_usaspending_recipient
+# ---------------------------------------------------------------------------
+
+
+class TestLookupUSAspendingRecipient:
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_two_step_lookup(self, MockClient):
+        client = MockClient.return_value
+        client.search_recipients.return_value = [
+            {"id": "hash-abc-123", "name": "Acme Corp"}
+        ]
+        client.get_recipient_profile.return_value = {
+            "name": "Acme Corp",
+            "uei": "ABC123DEF456",
+            "parent_name": None,
+            "parent_uei": None,
+            "location": {"state_code": "VA", "congressional_code": "11"},
+            "business_types": ["Small Business"],
+            "total_transaction_amount": 5000000,
+            "total_transactions": 12,
+        }
+
+        result = lookup_usaspending_recipient("Acme Corp", uei="ABC123DEF456")
+
+        assert isinstance(result, USARecipientProfile)
+        assert result.recipient_id == "hash-abc-123"
+        assert result.name == "Acme Corp"
+        assert result.location_state == "VA"
+        assert result.total_transactions == 12
+        client.close.assert_called_once()
+
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_no_recipient_match_returns_none(self, MockClient):
+        client = MockClient.return_value
+        client.search_recipients.return_value = []
+
+        result = lookup_usaspending_recipient("Unknown Corp")
+        assert result is None
+
+    def test_empty_name_returns_none(self):
+        assert lookup_usaspending_recipient("") is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_sam_entity
+# ---------------------------------------------------------------------------
+
+
+class TestLookupSAMEntity:
+    @patch.dict("os.environ", {"SAM_GOV_API_KEY": "test-key"})
+    @patch(f"{MODULE}.SyncSAMGovClient")
+    def test_uei_path(self, MockClient):
+        client = MockClient.return_value
+        client.get_entity_by_uei.return_value = {
+            "entityRegistration": {
+                "ueiSAM": "ABC123",
+                "legalBusinessName": "Acme Corp",
+                "cageCode": "1ABC2",
+            },
+            "coreData": {
+                "physicalAddress": {"stateOrProvinceCode": "VA"},
+                "businessTypes": {},
+                "naicsCodeList": [{"naicsCode": "541511"}],
+            },
+        }
+
+        result = lookup_sam_entity("Acme Corp", uei="ABC123")
+
+        assert isinstance(result, SAMEntityRecord)
+        assert result.uei == "ABC123"
+        assert result.legal_business_name == "Acme Corp"
+        assert "541511" in result.naics_codes
+        client.close.assert_called_once()
+
+    @patch.dict("os.environ", {"SAM_GOV_API_KEY": "test-key"})
+    @patch(f"{MODULE}.SyncSAMGovClient")
+    def test_cage_fallback(self, MockClient):
+        client = MockClient.return_value
+        client.get_entity_by_uei.return_value = None
+        client.get_entity_by_cage.return_value = {
+            "entityRegistration": {
+                "ueiSAM": "XYZ789",
+                "legalBusinessName": "Acme Corp",
+                "cageCode": "1ABC2",
+            },
+            "coreData": {
+                "physicalAddress": {},
+                "businessTypes": {},
+                "naicsCodeList": [],
+            },
+        }
+
+        result = lookup_sam_entity("Acme Corp", cage="1ABC2")
+
+        assert isinstance(result, SAMEntityRecord)
+        assert result.uei == "XYZ789"
+        client.get_entity_by_cage.assert_called_once_with("1ABC2")
+
+    @patch.dict("os.environ", {"SAM_GOV_API_KEY": "test-key"})
+    @patch(f"{MODULE}.SyncSAMGovClient")
+    def test_name_search_fallback(self, MockClient):
+        client = MockClient.return_value
+        client.search_entities.return_value = [
+            {
+                "entityRegistration": {
+                    "ueiSAM": "DEF456",
+                    "legalBusinessName": "Acme Corp",
+                },
+                "coreData": {
+                    "physicalAddress": {},
+                    "businessTypes": {},
+                    "naicsCodeList": [],
+                },
+            }
+        ]
+
+        result = lookup_sam_entity("Acme Corp")
+
+        assert isinstance(result, SAMEntityRecord)
+        assert result.uei == "DEF456"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_api_key_returns_none(self):
+        result = lookup_sam_entity("Acme Corp", uei="ABC123")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_fpds_descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFPDSDescriptions:
+    @patch(f"{MODULE}.FPDSAtomClient")
+    def test_success(self, MockClient):
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.get_descriptions.return_value = {
+            "W911NF-20-1-0001": "Research on advanced materials"
+        }
+
+        result = fetch_fpds_descriptions(["W911NF-20-1-0001"])
+        assert result == {"W911NF-20-1-0001": "Research on advanced materials"}
+
+    def test_empty_list_returns_empty_dict(self):
+        assert fetch_fpds_descriptions([]) == {}
+
+
+# ---------------------------------------------------------------------------
+# fetch_usaspending_contract_descriptions
+# ---------------------------------------------------------------------------
+
+
+class TestFetchUSAspendingContractDescriptions:
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_success(self, MockClient):
+        client = MockClient.return_value
+        client.search_awards.return_value = {
+            "results": [
+                {
+                    "Award ID": "W911NF-20-1-0001",
+                    "Description": "Advanced R&D",
+                    "Awarding Agency": "DOD",
+                    "Award Type": "Contract",
+                }
+            ]
+        }
+
+        awards = [{"Contract": "W911NF-20-1-0001"}]
+        result = fetch_usaspending_contract_descriptions(awards)
+
+        assert "W911NF-20-1-0001" in result
+        assert result["W911NF-20-1-0001"] == "Advanced R&D"
+
+    @patch(f"{MODULE}.fetch_fpds_descriptions")
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_fpds_fallback_on_failure(self, MockClient, mock_fpds):
+        client = MockClient.return_value
+        # Both USAspending methods fail
+        client.search_awards.side_effect = RuntimeError("API error")
+        client.search_transactions.side_effect = RuntimeError("API error")
+
+        mock_fpds.return_value = {
+            "W911NF-20-1-0001": "Fallback description from FPDS"
+        }
+
+        awards = [{"Contract": "W911NF-20-1-0001"}]
+        result = fetch_usaspending_contract_descriptions(awards)
+
+        assert "W911NF-20-1-0001" in result
+        assert "Fallback" in result["W911NF-20-1-0001"]
+        mock_fpds.assert_called_once()
+
+    @patch(f"{MODULE}.SyncUSAspendingClient")
+    def test_empty_awards_returns_empty_dict(self, MockClient):
+        result = fetch_usaspending_contract_descriptions([])
+        assert result == {}

--- a/tests/unit/enrichers/test_pi_enrichment.py
+++ b/tests/unit/enrichers/test_pi_enrichment.py
@@ -1,0 +1,210 @@
+"""Unit tests for PI enrichment orchestration logic."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sbir_etl.enrichers.pi_enrichment import (
+    ORCIDRecord,
+    PIPatentRecord,
+    PIPublicationRecord,
+    _is_sbir_award_type,
+    _split_pi_name,
+    lookup_pi_orcid,
+    lookup_pi_patents,
+    lookup_pi_publications,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# _split_pi_name
+# ---------------------------------------------------------------------------
+
+
+class TestSplitPIName:
+    def test_first_last(self):
+        assert _split_pi_name("Jane Doe") == ("Jane", "Doe")
+
+    def test_last_comma_first(self):
+        assert _split_pi_name("Doe, Jane") == ("Jane", "Doe")
+
+    def test_single_name(self):
+        assert _split_pi_name("Madonna") == ("Madonna", "")
+
+    def test_whitespace_stripped(self):
+        assert _split_pi_name("  Jane   Doe  ") == ("Jane", "Doe")
+
+    def test_multi_part_name_takes_first_and_last(self):
+        assert _split_pi_name("Mary Jane Watson") == ("Mary", "Watson")
+
+
+# ---------------------------------------------------------------------------
+# _is_sbir_award_type
+# ---------------------------------------------------------------------------
+
+
+class TestIsSbirAwardType:
+    @patch("sbir_etl.enrichers.pi_enrichment.classify_sbir_award")
+    def test_returns_true_when_classified(self, mock_classify):
+        mock_classify.return_value = {"program": "SBIR"}
+        assert _is_sbir_award_type("SBIR Phase I", "12.900") is True
+        mock_classify.assert_called_once_with(cfda_number="12.900", description="SBIR Phase I")
+
+    @patch("sbir_etl.enrichers.pi_enrichment.classify_sbir_award")
+    def test_returns_false_when_not_classified(self, mock_classify):
+        mock_classify.return_value = None
+        assert _is_sbir_award_type("General contract", "10.001") is False
+
+
+# ---------------------------------------------------------------------------
+# lookup_pi_patents
+# ---------------------------------------------------------------------------
+
+
+class TestLookupPIPatents:
+    @patch("sbir_etl.enrichers.pi_enrichment.PatentsViewClient")
+    def test_success_returns_record(self, MockClient):
+        client = MockClient.return_value
+        client.query_patents_by_assignee.return_value = [
+            {
+                "patent_title": "Novel Widget",
+                "assignee_organization": "Acme Corp",
+                "grant_date": "2020-01-15",
+            },
+            {
+                "patent_title": "Better Widget",
+                "assignee_organization": "Acme Corp",
+                "grant_date": "2022-06-01",
+            },
+        ]
+
+        result = lookup_pi_patents("Jane Doe", "Acme Corp")
+
+        assert isinstance(result, PIPatentRecord)
+        assert result.total_patents == 2
+        assert "Novel Widget" in result.sample_titles
+        assert "Acme Corp" in result.assignees
+        assert result.date_range == ("2020-01-15", "2022-06-01")
+
+    @patch("sbir_etl.enrichers.pi_enrichment.PatentsViewClient")
+    def test_empty_results_returns_none(self, MockClient):
+        client = MockClient.return_value
+        client.query_patents_by_assignee.return_value = []
+
+        result = lookup_pi_patents("Jane Doe", "Acme Corp")
+        assert result is None
+
+    @patch("sbir_etl.enrichers.pi_enrichment.PatentsViewClient")
+    def test_api_error_returns_none(self, MockClient):
+        client = MockClient.return_value
+        client.query_patents_by_assignee.side_effect = RuntimeError("API down")
+
+        result = lookup_pi_patents("Jane Doe", "Acme Corp")
+        assert result is None
+
+    def test_single_name_returns_none(self):
+        """Single name has no last name, should return None early."""
+        result = lookup_pi_patents("Madonna")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_pi_publications
+# ---------------------------------------------------------------------------
+
+
+class TestLookupPIPublications:
+    @patch("sbir_etl.enrichers.pi_enrichment.SemanticScholarClient")
+    def test_success_returns_record(self, MockClient):
+        mock_rec = MagicMock()
+        mock_rec.total_papers = 42
+        mock_rec.h_index = 10
+        mock_rec.citation_count = 500
+        mock_rec.sample_titles = ["Paper A", "Paper B"]
+        mock_rec.affiliations = ["MIT"]
+
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.lookup_author.return_value = mock_rec
+
+        result = lookup_pi_publications("Jane Doe")
+
+        assert isinstance(result, PIPublicationRecord)
+        assert result.total_papers == 42
+        assert result.h_index == 10
+        assert result.citation_count == 500
+        assert result.affiliations == ["MIT"]
+
+    @patch("sbir_etl.enrichers.pi_enrichment.SemanticScholarClient")
+    def test_none_result_returns_none(self, MockClient):
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.lookup_author.return_value = None
+
+        result = lookup_pi_publications("Jane Doe")
+        assert result is None
+
+    @patch("sbir_etl.enrichers.pi_enrichment.SemanticScholarClient")
+    def test_api_error_returns_none(self, MockClient):
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.lookup_author.side_effect = RuntimeError("timeout")
+
+        result = lookup_pi_publications("Jane Doe")
+        assert result is None
+
+    def test_single_name_returns_none(self):
+        result = lookup_pi_publications("Prince")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# lookup_pi_orcid
+# ---------------------------------------------------------------------------
+
+
+class TestLookupPIOrcid:
+    @patch("sbir_etl.enrichers.pi_enrichment.ORCIDClient")
+    def test_success_returns_record(self, MockClient):
+        mock_rec = MagicMock()
+        mock_rec.orcid_id = "0000-0001-2345-6789"
+        mock_rec.given_name = "Jane"
+        mock_rec.family_name = "Doe"
+        mock_rec.affiliations = ["Stanford"]
+        mock_rec.works_count = 20
+        mock_rec.sample_work_titles = ["Study X"]
+        mock_rec.funding_count = 3
+        mock_rec.keywords = ["AI", "ML"]
+
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.lookup.return_value = mock_rec
+
+        result = lookup_pi_orcid("Jane Doe")
+
+        assert isinstance(result, ORCIDRecord)
+        assert result.orcid_id == "0000-0001-2345-6789"
+        assert result.given_name == "Jane"
+        assert result.affiliations == ["Stanford"]
+        assert result.works_count == 20
+
+    @patch("sbir_etl.enrichers.pi_enrichment.ORCIDClient")
+    def test_none_result_returns_none(self, MockClient):
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.lookup.return_value = None
+
+        result = lookup_pi_orcid("Jane Doe")
+        assert result is None
+
+    @patch("sbir_etl.enrichers.pi_enrichment.ORCIDClient")
+    def test_api_error_returns_none(self, MockClient):
+        ctx = MockClient.return_value.__enter__.return_value
+        ctx.lookup.side_effect = RuntimeError("connection refused")
+
+        result = lookup_pi_orcid("Jane Doe")
+        assert result is None
+
+    def test_single_name_returns_none(self):
+        result = lookup_pi_orcid("Cher")
+        assert result is None


### PR DESCRIPTION
The weekly_awards_report.py script contained 13 try/except ImportError
blocks with inline fallback re-implementations of sbir_etl functions
(date parsing, name normalization, CSV downloading, API clients for
USPTO, Semantic Scholar, USAspending, SAM.gov, ORCID, FPDS, and
OpenAI). These fallbacks were never triggered because sbir_etl is the
root package and always available via `uv sync`.

Changes:
- Replace all conditional imports with direct imports from sbir_etl
- Remove all _HAS_* guard flags and their else: branches
- Remove orphaned URL constants, rate limiters, and retry helpers
- Simplify rate limiter creation to use RateLimiter directly
- Fix unused imports flagged by ruff

Reduces the script from 4,538 to 3,521 lines (-1,017 lines / -22%).

https://claude.ai/code/session_01Jxt46rA1BHDM2xYrixJ6Vu