### PR TITLE
Update PatentsView API calls to use /search endpoint with Lucene queries

### DIFF
--- a/sbir_etl/enrichers/patentsview.py
+++ b/sbir_etl/enrichers/patentsview.py
@@ -382,7 +382,7 @@ class PatentsViewClient:
             # The ODP API uses the ``q`` parameter with Lucene query syntax
             # on the ``/search`` endpoint.
             params = {
-                "q": f"assignees.assigneeName:{escaped_name}",
+                "q": f'assignees.assigneeName:"{escaped_name}"',
                 "offset": offset,
                 "limit": limit,
             }
@@ -461,7 +461,7 @@ class PatentsViewClient:
 
         escaped_name = self._escape_lucene_query(company_name)
         params = {
-            "q": f"assignees.assigneeName:{escaped_name}",
+            "q": f'assignees.assigneeName:"{escaped_name}"',
             "offset": 0,
             "limit": 25,
         }

--- a/sbir_etl/enrichers/patentsview.py
+++ b/sbir_etl/enrichers/patentsview.py
@@ -376,18 +376,19 @@ class PatentsViewClient:
         all_patents: list[dict[str, Any]] = []
         offset = 0
         limit = 100  # ODP page size
+        escaped_name = self._escape_lucene_query(company_name)
 
         while len(all_patents) < max_patents:
-            # The ODP API uses ``searchText`` for free-text queries
-            # (replacing the old PatentsView Lucene ``q`` parameter).
+            # The ODP API uses the ``q`` parameter with Lucene query syntax
+            # on the ``/search`` endpoint.
             params = {
-                "searchText": company_name,
+                "q": f"assignees.assigneeName:{escaped_name}",
                 "offset": offset,
                 "limit": limit,
             }
 
             try:
-                response = self._make_request("", method="GET", params=params)
+                response = self._make_request("/search", method="GET", params=params)
 
                 # ODP response format: patentFileWrapperDataBag array
                 records = response.get("patentFileWrapperDataBag", [])
@@ -458,14 +459,15 @@ class PatentsViewClient:
         """
         logger.debug(f"Querying assignees for company name: {company_name}")
 
+        escaped_name = self._escape_lucene_query(company_name)
         params = {
-            "searchText": company_name,
+            "q": f"assignees.assigneeName:{escaped_name}",
             "offset": 0,
             "limit": 25,
         }
 
         try:
-            response = self._make_request("", method="GET", params=params)
+            response = self._make_request("/search", method="GET", params=params)
             records = response.get("patentFileWrapperDataBag", [])
 
             # Deduplicate assignees from patent results

--- a/tests/unit/enrichers/test_patentsview.py
+++ b/tests/unit/enrichers/test_patentsview.py
@@ -1,0 +1,106 @@
+"""Unit tests for PatentsView/ODP client query construction."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sbir_etl.enrichers.patentsview import PatentsViewClient
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.fixture
+def client():
+    """Create a PatentsViewClient with mocked config and API key."""
+    mock_config = MagicMock()
+    mock_config.enrichment.patentsview_api = {
+        "base_url": "https://data.uspto.gov/api/v1/patent/applications",
+        "api_key_env_var": "USPTO_ODP_API_KEY",
+        "rate_limit_per_minute": 60,
+        "timeout_seconds": 30,
+        "cache": {"enabled": False, "cache_dir": "/tmp/test_cache", "ttl_hours": 1},
+    }
+    with patch("sbir_etl.enrichers.patentsview.get_config", return_value=mock_config):
+        return PatentsViewClient(api_key="test-key")
+
+
+class TestQueryPatentsByAssignee:
+    """Test that query_patents_by_assignee builds correct API requests."""
+
+    def test_uses_search_endpoint_with_q_param(self, client):
+        """Verify /search endpoint and q parameter with quoted phrase."""
+        client._make_request = MagicMock(return_value={"patentFileWrapperDataBag": []})
+
+        client.query_patents_by_assignee("Acme Corp")
+
+        client._make_request.assert_called_once()
+        args, kwargs = client._make_request.call_args
+        assert args[0] == "/search"
+        assert kwargs["method"] == "GET"
+        params = kwargs["params"]
+        assert params["q"] == 'assignees.assigneeName:"Acme Corp"'
+
+    def test_quotes_company_name_with_special_characters(self, client):
+        """Company names with commas/periods are quoted for phrase matching."""
+        client._make_request = MagicMock(return_value={"patentFileWrapperDataBag": []})
+
+        client.query_patents_by_assignee("Verinomics, Inc.")
+
+        params = client._make_request.call_args[1]["params"]
+        assert params["q"] == 'assignees.assigneeName:"Verinomics, Inc."'
+
+    def test_pagination_params(self, client):
+        """Verify offset and limit are passed through."""
+        client._make_request = MagicMock(return_value={"patentFileWrapperDataBag": []})
+
+        client.query_patents_by_assignee("Test Co")
+
+        params = client._make_request.call_args[1]["params"]
+        assert params["offset"] == 0
+        assert params["limit"] == 100
+
+
+class TestQueryAssigneeByName:
+    """Test that query_assignee_by_name builds correct API requests."""
+
+    def test_uses_search_endpoint_with_q_param(self, client):
+        """Verify /search endpoint and q parameter with quoted phrase."""
+        client._make_request = MagicMock(return_value={"patentFileWrapperDataBag": []})
+
+        client.query_assignee_by_name("Acme Corp")
+
+        client._make_request.assert_called_once()
+        args, kwargs = client._make_request.call_args
+        assert args[0] == "/search"
+        assert kwargs["method"] == "GET"
+        params = kwargs["params"]
+        assert params["q"] == 'assignees.assigneeName:"Acme Corp"'
+
+    def test_quotes_company_name_with_special_characters(self, client):
+        """Company names with commas/periods are quoted for phrase matching."""
+        client._make_request = MagicMock(return_value={"patentFileWrapperDataBag": []})
+
+        client.query_assignee_by_name("AERODYNE RESEARCH, INC.")
+
+        params = client._make_request.call_args[1]["params"]
+        assert params["q"] == 'assignees.assigneeName:"AERODYNE RESEARCH, INC."'
+
+
+class TestEscapeLuceneQuery:
+    """Test Lucene special character escaping."""
+
+    def test_escapes_common_special_chars(self):
+        assert PatentsViewClient._escape_lucene_query("a+b") == r"a\+b"
+        assert PatentsViewClient._escape_lucene_query("a:b") == r"a\:b"
+        assert PatentsViewClient._escape_lucene_query('a"b') == r'a\"b'
+
+    def test_leaves_plain_text_unchanged(self):
+        assert PatentsViewClient._escape_lucene_query("Acme Corp") == "Acme Corp"
+
+    def test_does_not_escape_non_special_chars(self):
+        # Commas and periods are not Lucene special characters
+        result = PatentsViewClient._escape_lucene_query("Verinomics, Inc.")
+        assert result == "Verinomics, Inc."


### PR DESCRIPTION
## Description

Updates the PatentsView enricher to use the correct ODP API endpoint and query format. The changes migrate from the deprecated `searchText` parameter on the root endpoint to the `/search` endpoint with proper Lucene query syntax using the `q` parameter and `assignees.assigneeName` field.

Additionally, company names are now properly escaped using the existing `_escape_lucene_query` method to prevent query injection and handle special characters correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Updated `query_patents_by_assignee()` to use `/search` endpoint with Lucene query syntax
- Updated `query_assignee_by_name()` to use `/search` endpoint with Lucene query syntax
- Added proper escaping of company names in both methods using `_escape_lucene_query()`
- Changed query parameter from `searchText` to `q` with field-specific syntax: `assignees.assigneeName:{escaped_name}`
- Updated endpoint path from `""` to `"/search"`

## Testing

These changes align the implementation with the ODP API specification. The existing test suite should validate that:
- Patent queries return results in the expected format
- Assignee queries return deduplicated results
- Special characters in company names are handled correctly

- [x] Existing unit tests pass locally with these changes

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

https://claude.ai/code/session_013HC45TWDq9jwyj2qX8MKrr