### PR TITLE
Refactor award description extraction and fix SAM.gov API parameter

### DIFF
--- a/sbir_etl/enrichers/company_enrichment.py
+++ b/sbir_etl/enrichers/company_enrichment.py
@@ -639,12 +639,23 @@ def fetch_usaspending_contract_descriptions(
     results: dict[str, str] = {}
     failed_ids: set[str] = set()
 
-    desc_fields = ["Award ID", "Description", "Awarding Agency", "Award Type"]
+    _method_config = {
+        "search_awards": {
+            "fields": ["Award ID", "Description", "Awarding Agency", "Award Type"],
+            "sort": "Award ID",
+            "desc_key": "Description",
+        },
+        "search_transactions": {
+            "fields": ["Award ID", "Transaction Description", "Awarding Agency", "Award Type"],
+            "sort": "Award ID",
+            "desc_key": "Transaction Description",
+        },
+    }
 
-    def _extract_descriptions(data: dict) -> None:
+    def _extract_descriptions(data: dict, desc_key: str = "Description") -> None:
         for r in data.get("results", []):
             aid = str(r.get("Award ID", "")).strip()
-            desc = str(r.get("Description", "")).strip()
+            desc = str(r.get(desc_key, "")).strip()
             if aid and desc and aid not in results:
                 if len(desc) > 500:
                     desc = desc[:500] + "..."
@@ -660,21 +671,20 @@ def fetch_usaspending_contract_descriptions(
                 group_name, len(ids), ids[:3],
             )
             data = None
-            _sort_for_method = {
-                "search_awards": "Award Amount",
-                "search_transactions": "Transaction Amount",
-            }
+            used_method = "search_awards"
             for method in ("search_awards", "search_transactions"):
+                cfg = _method_config[method]
                 try:
                     if rate_limiter:
                         rate_limiter.wait_if_needed()
                     data = getattr(usa, method)(
                         filters=filters,
-                        fields=desc_fields,
+                        fields=cfg["fields"],
                         limit=len(ids),
-                        sort=_sort_for_method.get(method, "Award Amount"),
+                        sort=cfg["sort"],
                         order="desc",
                     )
+                    used_method = method
                     break
                 except Exception as e:
                     logger.debug("USAspending {}/{} failed: {}", method, group_name, e)
@@ -682,7 +692,7 @@ def fetch_usaspending_contract_descriptions(
             if data is None:
                 failed_ids.update(ids)
                 continue
-            _extract_descriptions(data)
+            _extract_descriptions(data, _method_config[used_method]["desc_key"])
     except Exception as e:
         failed_ids.update(cid for cid in all_ids if cid not in results)
         logger.warning("USAspending contract desc error: {}", e)

--- a/sbir_etl/enrichers/sam_gov/client.py
+++ b/sbir_etl/enrichers/sam_gov/client.py
@@ -139,7 +139,7 @@ class SAMGovAPIClient(BaseAsyncAPIClient):
         Returns:
             List of entity data dicts
         """
-        params: dict[str, Any] = {"limit": limit}
+        params: dict[str, Any] = {"pageSize": limit}
         if legal_business_name:
             params["legalBusinessName"] = legal_business_name
         if duns:


### PR DESCRIPTION
## Description

This PR makes two key improvements to the ETL pipeline:

1. **Refactors award description extraction logic** in `company_enrichment.py` to support multiple data sources with different field names. Previously, the code was hardcoded to use the "Description" field from the `search_awards` API. The refactored version introduces a `_method_config` dictionary that maps each API method to its configuration (fields, sort order, and description field key). This allows the `_extract_descriptions` function to work with both `search_awards` (which uses "Description") and `search_transactions` (which uses "Transaction Description").

2. **Fixes SAM.gov API parameter** in `sam_gov/client.py` by changing the `limit` parameter to `pageSize`, which is the correct parameter name expected by the SAM.gov entity search API.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

- Existing unit tests should pass with these changes
- The refactored code maintains backward compatibility with the `search_awards` method while adding support for `search_transactions`
- The SAM.gov API parameter fix aligns the client with the actual API specification

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

https://claude.ai/code/session_01CTvGXJhBxFsjdpYrGo7yZH