### PR TITLE
ci: update composite action versions and add missing job timeouts

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -38,10 +38,9 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: ${{ inputs.filters }}

--- a/.github/actions/setup-aws-credentials/action.yml
+++ b/.github/actions/setup-aws-credentials/action.yml
@@ -14,7 +14,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.role-arn }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/actions/setup-docker-buildx/action.yml
+++ b/.github/actions/setup-docker-buildx/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Set up QEMU (optional)
       if: inputs.setup-qemu == 'true'
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4

--- a/.github/actions/taxonomy-checker/action.yml
+++ b/.github/actions/taxonomy-checker/action.yml
@@ -33,7 +33,7 @@ runs:
 
     - name: "Download checks artifact"
       id: download
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v8
       with:
         name: ${{ inputs.artifact-name }}
         path: ./taxonomy_checks_artifact
@@ -123,7 +123,7 @@ runs:
 
     - name: "Post PR comment when checks failed"
       if: ${{ steps.evaluate.outputs.failed == 'true' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         github-token: ${{ inputs.github-token }}
         script: |

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -33,6 +33,7 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       python-deps: ${{ steps.filter.outputs.python-deps }}
       etl-code: ${{ steps.filter.outputs.etl-code }}
@@ -60,6 +61,7 @@ jobs:
       github.event_name == 'schedule' ||
       (github.event_name == 'push' && needs.detect-changes.outputs.python-deps == 'true')
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -101,6 +103,7 @@ jobs:
        github.event_name == 'schedule' ||
        (github.event_name == 'push' && (needs.detect-changes.outputs.python-deps == 'true' || needs.detect-changes.outputs.etl-code == 'true')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -136,6 +139,7 @@ jobs:
     needs: [python-base]
     if: always() && (github.event.inputs.image == 'all' || github.event.inputs.image == 'full' || github.event.inputs.image == '' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/etl-pipeline.yml
+++ b/.github/workflows/etl-pipeline.yml
@@ -409,6 +409,7 @@ jobs:
     needs: [sbir-pipeline, usaspending-pipeline, uspto-pipeline, cet-pipeline, embeddings-pipeline, fiscal-pipeline]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Generate summary
         run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -165,6 +165,7 @@ jobs:
       (needs.attempt_repair.result == 'skipped' ||
        needs.attempt_repair.outputs.changed == 'false')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/github-script@v8
         with:


### PR DESCRIPTION
Align composite action versions with the versions used in workflows to
fix mismatches that could cause artifact incompatibilities. Add
timeout-minutes to all jobs in scheduled workflows to prevent runaway
jobs from consuming CI minutes.

Composite action updates:
- upload-artifacts: v4 → v7
- taxonomy-checker: download-artifact v3 → v8, github-script v7 → v8
- detect-changes: checkout v4 → v6, paths-filter v2 → v4
- setup-docker-buildx: qemu-action v3 → v4, buildx-action v3 → v4
- setup-aws-credentials: configure-aws-credentials v4 → v6

Timeout additions:
- build-images: detect-changes (5m), python-base (30m), etl (30m), full (45m)
- etl-pipeline: summary (5m)
- weekly: fallback_issue (5m)

https://claude.ai/code/session_016ecZFCAdaPtzoJZp62QoMH