### PR TITLE
Fix test structure issues flagged by Copilot review

### DIFF
--- a/tests/e2e/test_pipeline_validator.py
+++ b/tests/e2e/test_pipeline_validator.py
@@ -7,6 +7,10 @@ comprehensive validation of ETL pipeline stages.
 from unittest.mock import Mock
 
 import pandas as pd
+import pytest
+
+
+pytestmark = pytest.mark.e2e
 
 from sbir_etl.models.quality import QualitySeverity
 from tests.e2e.pipeline_validator import (
@@ -456,15 +460,3 @@ class TestIntegration:
         # Should have success recommendation
         success_rec = next((r for r in report.recommendations if r.category == "success"), None)
         assert success_rec is not None
-
-
-"""Tests for the E2E pipeline validator.
-
-This module tests the pipeline validator functionality to ensure
-comprehensive validation of ETL pipeline stages.
-"""
-
-import pytest
-
-
-pytestmark = pytest.mark.e2e

--- a/tests/unit/utils/test_date_utils.py
+++ b/tests/unit/utils/test_date_utils.py
@@ -109,7 +109,8 @@ class TestParseDate:
         """Test parsing pandas NaT."""
         pd = pandas_available
         result = parse_date(pd.NaT)
-        # Function returns NaT unchanged, not None
+        # NaT is isinstance(datetime), so it takes the datetime branch
+        # and returns NaT.date() which is NaT — not None
         assert pd.isna(result)
 
 


### PR DESCRIPTION
- Move pytest import and pytestmark to top of test_pipeline_validator.py,
  removing duplicate docstring/import block at bottom of file
- Clarify misleading comment in test_date_utils.py: NaT takes the datetime
  isinstance branch, returning NaT (not None)

https://claude.ai/code/session_0143sz5NdvR9nocL8Tnc82ui