### PR TITLE
fix(ci): Phase Transition workflow import + Dagster context annotation

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/pairs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/pairs.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 from datetime import date
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 
@@ -265,7 +264,7 @@ def _latency_summary(pairs: pd.DataFrame) -> dict[str, float | int | None]:
     ),
 )
 def transformed_phase_ii_iii_pairs(
-    context: Any | None = None,
+    context=None,
     validated_phase_ii_awards: pd.DataFrame | None = None,
     validated_phase_iii_contracts: pd.DataFrame | None = None,
 ) -> Output[pd.DataFrame]:
@@ -334,7 +333,7 @@ def transformed_phase_ii_iii_pairs(
     ),
 )
 def transformed_phase_transition_survival(
-    context: Any | None = None,
+    context=None,
     validated_phase_ii_awards: pd.DataFrame | None = None,
     transformed_phase_ii_iii_pairs: pd.DataFrame | None = None,
 ) -> Output[pd.DataFrame]:

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_ii.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_ii.py
@@ -257,7 +257,7 @@ def _agency_coverage(df: pd.DataFrame) -> dict[str, int]:
         "`sbir_etl.models.phase_transition.PhaseIIAward`."
     ),
 )
-def validated_phase_ii_awards(context: Any | None = None) -> Output[pd.DataFrame]:
+def validated_phase_ii_awards(context=None) -> Output[pd.DataFrame]:
     """Materialize the unified Phase II frame."""
 
     contracts_path = Path(env_str("SBIR_ETL__PHASE_TRANSITION__CONTRACTS_PATH", DEFAULT_CONTRACTS_PATH) or DEFAULT_CONTRACTS_PATH)

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_iii.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_iii.py
@@ -9,8 +9,6 @@ logged by agency so downstream analysis can qualify the transition rate.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
-
 import pandas as pd
 
 from .phase_ii import DEFAULT_CONTRACTS_PATH, _classify_contract_phase, _is_assistance_row
@@ -134,7 +132,7 @@ def _agency_coverage_table(all_contracts: pd.DataFrame, phase_iii: pd.DataFrame)
         "Row-level contract: `sbir_etl.models.phase_transition.PhaseIIIContract`."
     ),
 )
-def validated_phase_iii_contracts(context: Any | None = None) -> Output[pd.DataFrame]:
+def validated_phase_iii_contracts(context=None) -> Output[pd.DataFrame]:
     contracts_path = Path(
         env_str("SBIR_ETL__PHASE_TRANSITION__CONTRACTS_PATH", DEFAULT_CONTRACTS_PATH)
         or DEFAULT_CONTRACTS_PATH


### PR DESCRIPTION
## Summary
- Fix `ModuleNotFoundError: No module named 'sbir_analytics'` in the Phase Transition Latency workflow by exporting `PYTHONPATH` from `$GITHUB_WORKSPACE` (container mount path) inside the shell, instead of via workflow-level `env:` that expands `${{ github.workspace }}` to the host path.
- Apply the same PYTHONPATH fix to the 5 containerized dagster steps in `etl-pipeline.yml` (sbir, usaspending, uspto, cet, embeddings) — same latent bug.
- Fix `DagsterInvalidDefinitionError` by dropping the `Any | None` type annotation on `context` parameters in the 4 phase_transition asset functions (`validated_phase_ii_awards`, `validated_phase_iii_contracts`, `transformed_phase_ii_iii_pairs`, `transformed_phase_transition_survival`). Dagster requires `context` to be annotated with an execution-context type or left blank; `context=None` satisfies the rule and preserves the test shim path.

## Test plan
- [ ] Trigger the Phase Transition Latency workflow via `workflow_dispatch` with `skip_upstream_download=true` after merge
- [ ] Confirm the "Materialize phase_transition assets" step loads `sbir_analytics.definitions` without `ModuleNotFoundError`
- [ ] Confirm no `DagsterInvalidDefinitionError` is raised while building the asset graph

https://claude.ai/code/session_01FQpwda32kD2Dh9WPVqiiWw