### PR TITLE
fix(dagster): unblock phase-transition definitions load

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/sam_gov_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sam_gov_ingestion.py
@@ -6,8 +6,6 @@ Data Source Priority:
 3. FAIL: If both sources fail
 """
 
-from __future__ import annotations
-
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
@@ -1,7 +1,5 @@
 """Neo4j loading assets for SBIR awards."""
 
-from __future__ import annotations
-
 import json
 import re
 import time

--- a/sbir_etl/utils/enrichment/freshness.py
+++ b/sbir_etl/utils/enrichment/freshness.py
@@ -13,7 +13,7 @@ from typing import Any
 import pandas as pd
 from loguru import logger
 
-from ..models.enrichment import (
+from ...models.enrichment import (
     EnrichmentFreshnessRecord,
     EnrichmentFreshnessRecordModel,
     EnrichmentStatus,

--- a/sbir_etl/utils/enrichment/metrics.py
+++ b/sbir_etl/utils/enrichment/metrics.py
@@ -13,8 +13,8 @@ from typing import Any
 
 from loguru import logger
 
-from ..config.loader import get_config
-from ..utils.enrichment_freshness import FreshnessStore
+from ...config.loader import get_config
+from .freshness import FreshnessStore
 
 
 class EnrichmentFreshnessMetrics:


### PR DESCRIPTION
## Summary
Follow-up to PR #274. With the phase-transition workflow's PYTHONPATH fixed, loading `sbir_analytics.definitions` now surfaced three pre-existing bugs in sibling asset modules that kept the whole asset graph from validating:

1. **`sam_gov_ingestion.py` + `sbir_neo4j_loading.py`** — Dagster rejects `context: AssetExecutionContext` when the module uses `from __future__ import annotations`: annotations become strings and the validator's class-identity check can't resolve them. Dropped the future-import in both files. Python 3.11 (the project's minimum) already supports PEP 604 union syntax natively.
2. **`sbir_etl/utils/enrichment/freshness.py`** — `from ..models.enrichment` resolved to the non-existent `sbir_etl.utils.models`. Fixed to `from ...models.enrichment` → `sbir_etl.models.enrichment`.
3. **`sbir_etl/utils/enrichment/metrics.py`** — `from ..config.loader` (→ `sbir_etl.utils.config.loader`) and `from ..utils.enrichment_freshness` (→ `sbir_etl.utils.utils.enrichment_freshness`) both pointed at non-existent modules. Fixed to `...config.loader` and `.freshness` respectively.

Without (2) and (3), `usaspending_iterative_enrichment.py` failed to import. Without (1), the `raw_sam_gov_entities` asset was missing from the graph, leaving `enriched_sbir_awards` with a dangling input, causing the `Definitions(...)` constructor to raise `DagsterInvalidDefinitionError: Input asset '["raw_sam_gov_entities"]' ... is not produced by any of the provided asset ops`.

## Test plan
- [ ] Trigger Phase Transition Latency workflow via `workflow_dispatch` with `skip_upstream_download=true`
- [ ] Confirm the "Materialize phase_transition assets" step loads `sbir_analytics.definitions` and builds the asset graph without `DagsterInvalidDefinitionError`
- [ ] Confirm no "Failed to import sbir_analytics.assets.*" warnings in the output

https://claude.ai/code/session_01FQpwda32kD2Dh9WPVqiiWw