### PR TITLE
feat(ci): publish enriched SBIR awards to canonical S3 key

### DIFF
--- a/.github/workflows/etl-pipeline.yml
+++ b/.github/workflows/etl-pipeline.yml
@@ -140,8 +140,9 @@ jobs:
         # The enriched_sbir_awards asset uploads to s3://<bucket>/enriched/sbir_awards.parquet
         # but downstream consumers (phase_transition_latency_job) look for it at
         # s3://<bucket>/processed/sbir/enriched_sbir_awards.parquet. Mirror the object to the
-        # canonical key so downstream workflows can pick it up. Skip silently if the source
-        # isn't there (e.g. enrichment short-circuited without new data).
+        # canonical key so downstream workflows can pick it up. If the source isn't there,
+        # skip without failing and record a warning in the step summary
+        # (e.g. enrichment short-circuited without new data).
         env:
           S3_BUCKET: ${{ env.S3_BUCKET }}
         shell: bash
@@ -152,8 +153,10 @@ jobs:
 
           if aws s3api head-object --bucket "${S3_BUCKET}" --key "${SRC_KEY}" >/dev/null 2>&1; then
             aws s3 cp "s3://${S3_BUCKET}/${SRC_KEY}" "s3://${S3_BUCKET}/${DEST_KEY}"
+            echo "✅ Mirrored enriched awards to s3://${S3_BUCKET}/${DEST_KEY}"
             echo "✅ Mirrored enriched awards to s3://${S3_BUCKET}/${DEST_KEY}" >> "$GITHUB_STEP_SUMMARY"
           else
+            echo "⚠️ No enriched awards at s3://${S3_BUCKET}/${SRC_KEY}; skipping mirror"
             echo "⚠️ No enriched awards at s3://${S3_BUCKET}/${SRC_KEY}; skipping mirror" >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/.github/workflows/etl-pipeline.yml
+++ b/.github/workflows/etl-pipeline.yml
@@ -136,6 +136,27 @@ jobs:
             exit $EXIT_CODE
           fi
 
+      - name: Publish enriched SBIR awards to canonical S3 key
+        # The enriched_sbir_awards asset uploads to s3://<bucket>/enriched/sbir_awards.parquet
+        # but downstream consumers (phase_transition_latency_job) look for it at
+        # s3://<bucket>/processed/sbir/enriched_sbir_awards.parquet. Mirror the object to the
+        # canonical key so downstream workflows can pick it up. Skip silently if the source
+        # isn't there (e.g. enrichment short-circuited without new data).
+        env:
+          S3_BUCKET: ${{ env.S3_BUCKET }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          SRC_KEY="enriched/sbir_awards.parquet"
+          DEST_KEY="processed/sbir/enriched_sbir_awards.parquet"
+
+          if aws s3api head-object --bucket "${S3_BUCKET}" --key "${SRC_KEY}" >/dev/null 2>&1; then
+            aws s3 cp "s3://${S3_BUCKET}/${SRC_KEY}" "s3://${S3_BUCKET}/${DEST_KEY}"
+            echo "✅ Mirrored enriched awards to s3://${S3_BUCKET}/${DEST_KEY}" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "⚠️ No enriched awards at s3://${S3_BUCKET}/${SRC_KEY}; skipping mirror" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   usaspending-pipeline:
     name: USAspending Pipeline
     if: github.event.inputs.job == 'usaspending_ingestion' || github.event.inputs.job == 'all'


### PR DESCRIPTION
## Summary
Close the S3 key mismatch between the SBIR enrichment producer and the Phase Transition Latency consumer.

- The `sbir_usaspending_enrichment.enriched_sbir_awards` asset already uploads its output, but to `s3://<bucket>/enriched/sbir_awards.parquet` (see `sbir_usaspending_enrichment.py:475`).
- The Phase Transition Latency workflow looks for it at `s3://<bucket>/processed/sbir/enriched_sbir_awards.parquet` (see `.github/workflows/phase-transition-latency.yml:78`).
- Result: the last dispatched run reported *"No SBIR awards parquet in S3 at s3://sbir-etl-production-data/processed/sbir/enriched_sbir_awards.parquet — reconciliation layer will be empty"* even though enrichment had actually run.

This PR adds a post-SBIR-pipeline step that mirrors the object to the canonical key via `aws s3 cp` (in-bucket copy). It skips quietly if the source isn't there (e.g., enrichment was a no-op). The iterative-enrichment reader in `usaspending_iterative_enrichment.py:83` still reads from the original key, so no consumer is broken.

### Known remaining gap (not fixed here)

`s3://<bucket>/processed/transition/contracts_ingestion.parquet` — no workflow currently produces this. Its `raw_contracts` asset needs local FPDS dump data that's too large for CI runners. Options for a follow-up:
- Add a self-hosted/large-runner workflow that runs `raw_contracts` and uploads the output
- Seed S3 offline from a one-time local run
- Run `raw_contracts` on AWS Batch alongside fiscal

## Test plan
- [ ] Dispatch **ETL Pipeline** workflow with `job=sbir_weekly_refresh`
- [ ] Confirm the new "Publish enriched SBIR awards to canonical S3 key" step logs either `✅ Mirrored ...` or `⚠️ No enriched awards ...`
- [ ] Run `aws s3 ls s3://sbir-etl-production-data/processed/sbir/enriched_sbir_awards.parquet` and confirm the file appears (timestamp matches the run)
- [ ] Dispatch **Phase Transition Latency** workflow; the "Download upstream parquet files from S3" step should now log `Enriched SBIR awards parquet downloaded` instead of the missing-file warning

https://claude.ai/code/session_01FQpwda32kD2Dh9WPVqiiWw