### PR TITLE
docs(specs): add data-imputation spec for SBIR.gov bulk data gaps

### DIFF
--- a/specs/data-imputation/design.md
+++ b/specs/data-imputation/design.md
@@ -203,17 +203,49 @@ For each `(normalize(company_name), company_state)` key:
 Name normalization reuses `sbir_etl/enrichers/company_fuzzy_matcher.py` so the join key
 matches what enrichment already uses.
 
-#### 4.3 `award_amount.agency_phase_median`
+#### 4.3 `award_amount.solicitation_max` (preferred when solicitation linkage available)
+
+Joins the award to its parent solicitation via `(solicitation_number, topic_code)` —
+both fields already exist on the Award model (`sbir_etl/models/award.py:129,133`) and
+the `Solicitation` model exists at `sbir_etl/models/solicitation.py`. Solicitations
+publish per-phase maximum award amounts (e.g., FY24 SBIR Phase I ≈ $314k, Phase II
+≈ $2.1M) and a period of performance, both of which are far tighter signals than the
+$5M global cap or the corpus median.
+
+Behavior:
+
+- If the linked solicitation publishes a per-phase max, use it as a **hard upper bound**
+  on any imputed amount and as the imputed value when the award is recorded as a
+  full-funded award (most common pattern: agencies fund to the announced ceiling).
+- `confidence: high` when the solicitation max equals a known modal cluster for that
+  agency/phase (≥80% of awards in the cluster equal the max).
+- `confidence: medium` otherwise — solicitation max becomes a ceiling, and we fall back
+  to `award_amount.agency_phase_median` for the point estimate, then clamp to the
+  ceiling.
+
+Prerequisite (Phase 4 task): extend `Solicitation` model and `SolicitationExtractor`
+to capture `phase_i_max_amount`, `phase_ii_max_amount`, and `period_of_performance_months`
+(per phase). These fields are present on agency solicitation pages but not yet
+extracted.
+
+#### 4.4 `award_amount.agency_phase_median` (fallback when no solicitation linkage)
 
 Group by `(agency, program, phase, fiscal_year)`. Impute the group median where
-`award_amount` is null. Guards:
+`award_amount` is null **and** no solicitation-derived value is available. Guards:
 
 - Minimum group size: 10 non-null members (else skip).
 - Imputed value must fall within $1k–$5M (existing cap).
 - `confidence: medium` across the board; `low` if group falls back to
   `(agency, program, phase)` without fiscal year.
 
-#### 4.4 `geography.congressional_district`
+#### 4.5 `contract_dates.solicitation_period_of_performance`
+
+When solicitation linkage exists and the solicitation publishes a phase period of
+performance, prefer it over the static phase-typical durations in §4.6. Used both for
+imputing missing `contract_end_date` and for repairing inverted pairs.
+`confidence: high` when populated.
+
+#### 4.6 `geography.congressional_district`
 
 Thin wrapper over existing `congressional_district_resolver.py`. Populates the existing
 `congressional_district` + `congressional_district_confidence` fields.
@@ -230,9 +262,10 @@ and is populated by the resolver; the imputation layer maps it to a provenance t
 | 0.70–0.89 (zip5) | medium |
 | < 0.70 (centroid) | low |
 
-#### 4.5 `contract_dates.end_date_repair`
+#### 4.7 `contract_dates.end_date_repair` (fallback when no solicitation period)
 
-When `contract_end_date` is null or `< contract_start_date`, impute
+When `contract_end_date` is null or `< contract_start_date` **and**
+`contract_dates.solicitation_period_of_performance` (§4.5) did not fill it, impute
 `contract_start_date + phase_typical_duration`:
 
 | Phase | Typical duration |
@@ -244,15 +277,19 @@ When `contract_end_date` is null or `< contract_start_date`, impute
 Durations are medians computed from the known-good corpus per agency, cached as a
 lookup.
 
-#### 4.6 `naics.hierarchical`
+#### 4.8 `naics.hierarchical` and topic-derived
 
-Two sub-methods sharing the `naics.*` namespace:
+Three sub-methods sharing the `naics.*` namespace:
 
 - **`naics.hierarchical_fallback`** — If 6-digit invalid but 4/3/2-digit prefix is
   valid, emit the shortest valid prefix. Reuses `sbir_etl/enrichers/naics/`.
-- **`naics.abstract_nn`** — When entirely missing, TF-IDF nearest-neighbor lookup on
-  `award_abstract` against awards with known NAICS. Only runs if abstract length > 100
-  chars. `confidence: low`.
+- **`naics.solicitation_topic`** — When solicitation linkage exists, derive NAICS from
+  the topic's research-domain mapping (agencies publish topic-to-NAICS or topic-to-CET
+  crosswalks; e.g., DoD topic prefixes map to defense NAICS clusters).
+  `confidence: medium`.
+- **`naics.abstract_nn`** — When entirely missing and no solicitation linkage exists,
+  TF-IDF nearest-neighbor lookup on `award_abstract` against awards with known NAICS.
+  Only runs if abstract length > 100 chars. `confidence: low`.
 
 ### 5. Configuration
 
@@ -272,6 +309,10 @@ imputation:
       enabled: true
       normalization: fuzzy_matcher_v1
 
+    award_amount.solicitation_max:
+      enabled: true
+      modal_cluster_threshold: 0.80   # high-confidence if ≥80% of cluster equals max
+
     award_amount.agency_phase_median:
       enabled: true
       min_group_size: 10
@@ -280,7 +321,13 @@ imputation:
     geography.congressional_district:
       enabled: true
 
+    contract_dates.solicitation_period_of_performance:
+      enabled: true
+
     contract_dates.end_date_repair:
+      enabled: true
+
+    naics.solicitation_topic:
       enabled: true
 
     naics.hierarchical_fallback:
@@ -415,16 +462,37 @@ would close.
    trivially on the non-null subset. Cross-row propagation (UEI backfill) needs
    careful holdout design to avoid leakage, and k-NN/MICE make leakage far worse.
 
+### The solicitation linkage shortcut
+
+**Solicitations are the highest-value imputation source we have access to**, because the
+linkage already exists on awards (`solicitation_number`, `topic_code`) and solicitations
+publish three of our hardest-to-impute fields directly:
+
+- **Per-phase maximum award amount** — converts `award_amount` from a statistical
+  estimation problem to a bounded lookup. For agencies that fund to the announced
+  ceiling (the modal pattern), the max *is* the imputed value with `confidence: high`.
+- **Period of performance** — replaces the static phase-typical durations in
+  `contract_dates.end_date_repair` with solicitation-specific durations.
+- **Topic research domain** — maps to NAICS far more reliably than abstract-NN.
+
+The cost is small and one-sided: extend `Solicitation` model and
+`SolicitationExtractor` (`sbir_etl/extractors/solicitation.py`) to capture
+`phase_i_max_amount`, `phase_ii_max_amount`, and `period_of_performance_months` per
+phase. This is a prerequisite tracked as a Phase 4 task.
+
+Once available, the solicitation-linked methods (§4.3, §4.5, §4.8 `naics.solicitation_topic`)
+take precedence over their statistical fallbacks for any award where the join succeeds.
+
 ### Expected value ranking
 
 | Rank | Field | Method | Rationale |
 |---|---|---|---|
 | 1 | `award_date` | Deterministic cascade | ~50% missing; unblocks all time-series/cohort analysis |
 | 2 | `company_uei` / `company_duns` | Cross-award backfill + external lookup | Unlocks entity resolution, M&A detection, transition scoring |
-| 3 | `naics_code` | Hierarchical fallback + abstract-NN opt-in | Feeds CET classification and sector analysis |
-| 4 | `congressional_district` | Tiered zip crosswalk (reuse existing resolver) | High policy value; deterministic; confidence tiering is natural |
-| 5 | `award_amount` | Agency-phase-program-FY median | Tight modal distributions; bounded by $5M cap |
-| 6 | `contract_end_date` | Rule: start + phase-typical duration | Low standalone value; cheap repair of inverted pairs |
+| 3 | `award_amount` | **Solicitation max** → group median fallback | Solicitation linkage converts statistical problem into bounded lookup; high confidence where join exists |
+| 4 | `naics_code` | Solicitation topic → hierarchical fallback → abstract-NN opt-in | Topic-derived NAICS dominates abstract-NN where linkage exists |
+| 5 | `congressional_district` | Tiered zip crosswalk (reuse existing resolver) | High policy value; deterministic; confidence tiering is natural |
+| 6 | `contract_end_date` | **Solicitation period of performance** → start + phase-typical duration fallback | Solicitation period is far tighter than corpus medians |
 
 ### Explicitly not pursued in v1
 

--- a/specs/data-imputation/design.md
+++ b/specs/data-imputation/design.md
@@ -115,7 +115,6 @@ class ImputationMethod(Protocol):
     name: str                          # e.g., "award_date.cascade"
     target_field: str                  # "award_date"
     source_fields: list[str]           # ["proposal_award_date", ...]
-    confidence: Literal["high", "medium", "low"]
     version: int
 
     def impute(
@@ -128,6 +127,12 @@ class ImputationMethod(Protocol):
 Uses `pandas.DataFrame` to match the existing pipeline
 (`packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py:325` and downstream
 assets all use pandas with `compute_kind="pandas"`). No Polars conversion is introduced.
+
+**Confidence is per-row, not per-method.** Several methods (notably
+`award_date.cascade`) produce different confidence tiers depending on which source
+field resolved the value. The protocol therefore carries **no class-level `confidence`
+attribute**; confidence is emitted per-row on each `ImputationEntry` inside the
+`ImputationResult` returned by `impute()`.
 
 `ImputationResult` carries the imputed Series plus a parallel Series of provenance
 entries, merged into the frame by the runner.
@@ -230,13 +235,23 @@ extracted.
 
 #### 4.4 `award_amount.agency_phase_median` (fallback when no solicitation linkage)
 
-Group by `(agency, program, phase, fiscal_year)`. Impute the group median where
-`award_amount` is null **and** no solicitation-derived value is available. Guards:
+Group by `(agency, program, phase, fiscal_year)`. Compute the group median as a
+candidate imputed value where `award_amount` is null **and** no solicitation-derived
+value is available. Guards (aligned with requirements §3):
 
-- Minimum group size: 10 non-null members (else skip).
-- Imputed value must fall within $1k–$5M (existing cap).
-- `confidence: medium` across the board; `low` if group falls back to
-  `(agency, program, phase)` without fiscal year.
+- **Minimum group size:** 10 non-null members (else skip).
+- **±2σ sanity bound:** only assign the median when it falls within the observed
+  `award_amount` distribution's `mean ± 2σ` at the grouping level used for the
+  estimate. If the `(agency, program, phase, fiscal_year)` group is too sparse and the
+  method falls back to `(agency, program, phase)`, apply the same `±2σ` check to that
+  fallback group.
+- **Hard cap:** imputed value must also fall within $1k–$5M (existing cap).
+- **Flag, don't assign:** if the candidate median falls outside the `±2σ` bound or
+  outside the hard cap, emit the record to `reports/imputation/amount_flags.json` and
+  leave `award_amount` null. Downstream consumers read the flag list; no imputed value
+  is written.
+- **Confidence:** `medium` when the `(agency, program, phase, fiscal_year)` group was
+  used; `low` when fallback to `(agency, program, phase)` was required.
 
 #### 4.5 `contract_dates.solicitation_period_of_performance`
 
@@ -382,12 +397,12 @@ migration and removed once all environments are updated.
 @asset(
     deps=[validated_sbir_awards],
     group_name="imputation",
-    compute_kind="duckdb",
+    compute_kind="pandas",
 )
 def imputed_sbir_awards(
     context: AssetExecutionContext,
-    validated_sbir_awards: pl.DataFrame,
-) -> pl.DataFrame: ...
+    validated_sbir_awards: pd.DataFrame,
+) -> pd.DataFrame: ...
 ```
 
 Existing downstream assets (enrichment, Neo4j load) rewire their dependency from

--- a/specs/data-imputation/design.md
+++ b/specs/data-imputation/design.md
@@ -1,0 +1,361 @@
+# Data Imputation — Design
+
+## Overview
+
+A dedicated imputation layer sits between raw validation and entity enrichment. It reads
+the validated-but-gap-riddled award frame, applies a registry of named imputation
+methods in a defined order, and emits a widened frame with effective values, preserved
+raw columns, and a per-record provenance struct. Downstream assets choose raw or
+effective columns via explicit contract.
+
+Key design tenets:
+
+1. **Never overwrite raw.** Raw columns are immutable after extraction.
+2. **One provenance struct per record.** Not a parallel file — it travels with the data.
+3. **Methods are cheap, composable, backtested.** Registry pattern; each method is a
+   pure function of the input frame plus optional lookups.
+4. **Imputation is enrichment's prerequisite, not its peer.** Enrichers that key on
+   `company_uei` benefit from UEI backfill; the order matters.
+
+## Architecture
+
+### Pipeline Position
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│                          SBIR ETL Pipeline                              │
+└─────────────────────────────────────────────────────────────────────────┘
+
+  Extractors           Validators            [NEW] Imputation          Enrichers
+  ──────────           ──────────             ──────────────           ─────────
+  sbir.gov bulk   ──►  sbir_awards.py   ──►  raw → effective    ──►   company_*
+  DuckDB load          (lenient)              + provenance             congressional
+                                                                       naics, patents
+                                                                              │
+                                                                              ▼
+                                                                       Neo4j loaders
+                                                                       Dagster assets
+                                                                              │
+                                                                              ▼
+                                                                       Quality checks
+                                                                       (raw + effective)
+```
+
+The imputation layer is a new Dagster op/asset group in `packages/sbir-analytics/`, with
+the library code living in `sbir_etl/imputation/` to keep it reusable outside Dagster.
+
+### Module Layout
+
+```text
+sbir_etl/imputation/
+├── __init__.py
+├── registry.py              # ImputationMethod registry, execution order
+├── provenance.py            # ImputationProvenance model + struct helpers
+├── config.py                # Pydantic config loaded from base.yaml[imputation]
+├── methods/
+│   ├── __init__.py
+│   ├── award_date.py        # Cascade + agency-lag
+│   ├── identifiers.py       # UEI/DUNS cross-award backfill
+│   ├── award_amount.py      # Agency-phase-program median
+│   ├── geography.py         # Wraps congressional_district_resolver
+│   ├── contract_dates.py    # End-date repair
+│   └── naics.py             # Hierarchical + abstract-NN fallback
+├── backtest.py              # Mask-and-compare harness
+└── runner.py                # Orchestrates method registry over a frame
+
+packages/sbir-analytics/sbir_analytics/assets/
+└── imputation.py            # Dagster asset wrapping runner
+
+config/base.yaml              # + imputation section
+sbir_etl/quality/checks.py    # + raw-vs-effective split
+sbir_etl/models/award.py      # + raw_* shadow fields + imputation struct
+reports/imputation/           # Per-run coverage + backtest results
+```
+
+### Data Flow
+
+```text
+validated_sbir_awards (raw)
+        │
+        ▼
+┌───────────────────────────┐
+│  ImputationRunner         │
+│  ─────────────────────    │
+│  for method in registry:  │
+│     if config.enabled:    │
+│       frame = method(     │
+│         frame,            │
+│         lookups,          │
+│         provenance)       │
+└───────────────────────────┘
+        │
+        ├──► raw_<field> columns (untouched copy)
+        ├──► <field> columns (effective: raw if present, else imputed)
+        ├──► <field>_is_imputed columns (bool)
+        └──► imputation struct column (method, confidence, sources, timestamp)
+        │
+        ▼
+imputed_sbir_awards
+        │
+        ├──► reports/imputation/coverage.json
+        ├──► reports/imputation/backtest.json (CI gate)
+        └──► downstream enrichers + Neo4j loaders
+```
+
+## Components
+
+### 1. ImputationMethod (registry protocol)
+
+**Purpose:** Uniform interface so methods are discoverable, orderable, and backtestable.
+
+**Protocol** (`sbir_etl/imputation/registry.py`):
+
+```python
+class ImputationMethod(Protocol):
+    name: str                          # e.g., "award_date.cascade"
+    target_field: str                  # "award_date"
+    source_fields: list[str]           # ["proposal_award_date", ...]
+    confidence: Literal["high", "medium", "low"]
+    version: int
+
+    def impute(
+        self,
+        frame: pl.DataFrame,
+        lookups: ImputationLookups,
+    ) -> ImputationResult: ...
+```
+
+`ImputationResult` carries the imputed Series plus a parallel Series of provenance
+entries, merged into the frame by the runner.
+
+### 2. ImputationRunner
+
+**Purpose:** Executes methods in dependency order, builds the provenance struct,
+emits coverage metrics.
+
+**Ordering rule:** Methods that fill inputs to other methods run first. E.g., UEI
+backfill runs before any method that groups by UEI. The registry validates no cycles
+at load time.
+
+**Key operations:**
+
+1. Clone raw columns into `raw_<field>` shadow columns.
+2. For each enabled method in topological order, invoke and merge results.
+3. Compose per-record `imputation` struct by folding method-level results.
+4. Emit `<field>_is_imputed` convenience booleans.
+5. Write coverage report to `reports/imputation/coverage.json`.
+
+### 3. Provenance Model
+
+**Schema** (`sbir_etl/models/award.py` additions):
+
+```python
+class ImputationEntry(BaseModel):
+    field: str
+    method: str
+    method_version: int
+    confidence: Literal["high", "medium", "low"]
+    source_fields: list[str]
+    imputed_at: datetime  # UTC
+
+# Added to Award model:
+raw_award_date: date | None = None
+raw_award_amount: float | None = None
+raw_company_uei: str | None = None
+# ... one per imputable field
+award_date_is_imputed: bool = False
+# ... one per imputable field
+imputation: list[ImputationEntry] = Field(default_factory=list)
+```
+
+For DuckDB/Parquet persistence the struct serializes as a nested list; for Neo4j the
+list flattens to `imputation_methods: list[str]` plus the per-field boolean flags.
+
+### 4. Method Implementations
+
+#### 4.1 `award_date.cascade`
+
+Walks this ordered cascade, taking the first non-null:
+
+| Source | Confidence | Notes |
+|---|---|---|
+| `proposal_award_date` | high | Tight semantic match |
+| `contract_start_date` | high | Usually within weeks of award |
+| `date_of_notification` | medium | Agency-dependent lag |
+| `solicitation_close_date + agency_lag` | medium | Uses agency-specific median lag from awards with both fields present |
+| `fiscal_year` midpoint (April 1) | low | Last resort; year-only resolution |
+
+Per-agency lag lookup is computed once from the non-null corpus and cached as an
+`ImputationLookups` asset.
+
+#### 4.2 `identifiers.cross_award_backfill`
+
+For each `(normalize(company_name), company_state)` key:
+1. Gather all UEI/DUNS values observed across the corpus.
+2. If exactly one non-null value exists, backfill to sibling rows missing it.
+3. If multiple values exist, skip — flag for review via
+   `reports/imputation/uei_conflicts.json`.
+
+Name normalization reuses `sbir_etl/enrichers/company_fuzzy_matcher.py` so the join key
+matches what enrichment already uses.
+
+#### 4.3 `award_amount.agency_phase_median`
+
+Group by `(agency, program, phase, fiscal_year)`. Impute the group median where
+`award_amount` is null. Guards:
+
+- Minimum group size: 10 non-null members (else skip).
+- Imputed value must fall within $1k–$5M (existing cap).
+- `confidence: medium` across the board; `low` if group falls back to
+  `(agency, program, phase)` without fiscal year.
+
+#### 4.4 `geography.congressional_district`
+
+Thin wrapper over existing `congressional_district_resolver.py`. Populates the existing
+`congressional_district` + `congressional_district_confidence` fields. Tiers:
+
+- zip+4 match → high
+- zip5 match → medium
+- city/state centroid → low
+
+#### 4.5 `contract_dates.end_date_repair`
+
+When `contract_end_date` is null or `< contract_start_date`, impute
+`contract_start_date + phase_typical_duration`:
+
+| Phase | Typical duration |
+|---|---|
+| Phase I | 6 months |
+| Phase II | 24 months |
+| Phase III | skip (highly variable) |
+
+Durations are medians computed from the known-good corpus per agency, cached as a
+lookup.
+
+#### 4.6 `naics.hierarchical`
+
+Two sub-methods sharing the `naics.*` namespace:
+
+- **`naics.hierarchical_fallback`** — If 6-digit invalid but 4/3/2-digit prefix is
+  valid, emit the shortest valid prefix. Reuses `sbir_etl/enrichers/naics/`.
+- **`naics.abstract_nn`** — When entirely missing, TF-IDF nearest-neighbor lookup on
+  `award_abstract` against awards with known NAICS. Only runs if abstract length > 100
+  chars. `confidence: low`.
+
+### 5. Configuration
+
+**`config/base.yaml` additions:**
+
+```yaml
+imputation:
+  enabled: true
+  dry_run: false
+
+  methods:
+    award_date.cascade:
+      enabled: true
+      agency_lag_min_group_size: 20
+
+    identifiers.cross_award_backfill:
+      enabled: true
+      normalization: fuzzy_matcher_v1
+
+    award_amount.agency_phase_median:
+      enabled: true
+      min_group_size: 10
+      fallback_grouping: [agency, program, phase]
+
+    geography.congressional_district:
+      enabled: true
+
+    contract_dates.end_date_repair:
+      enabled: true
+
+    naics.hierarchical_fallback:
+      enabled: true
+
+    naics.abstract_nn:
+      enabled: false      # opt-in, expensive
+      min_abstract_chars: 100
+      k_neighbors: 5
+
+  backtest:
+    holdout_fraction: 0.1
+    random_seed: 42
+    regression_threshold_pp: 5
+
+  quality:
+    effective_thresholds:
+      award_date: 0.95
+      award_amount: 0.92
+      company_uei: 0.80
+```
+
+Quality checks gain a `raw_` vs `effective_` split:
+
+```yaml
+quality:
+  raw_completeness:
+    award_date: 0.50        # realistic source coverage
+    # ...
+  effective_completeness:   # references imputation.quality.effective_thresholds
+    # ...
+```
+
+### 6. Dagster Integration
+
+**New asset** (`packages/sbir-analytics/sbir_analytics/assets/imputation.py`):
+
+```python
+@asset(
+    deps=[validated_sbir_awards],
+    group_name="imputation",
+    compute_kind="duckdb",
+)
+def imputed_sbir_awards(
+    context: AssetExecutionContext,
+    validated_sbir_awards: pl.DataFrame,
+) -> pl.DataFrame: ...
+```
+
+Existing downstream assets (enrichment, Neo4j load) rewire their dependency from
+`validated_sbir_awards` to `imputed_sbir_awards`. Quality checks run on both.
+
+### 7. Backtest Harness
+
+`sbir_etl/imputation/backtest.py` provides:
+
+- `mask_and_reimpute(frame, field, fraction=0.1)` — randomly nulls ground-truth values,
+  reruns imputation, returns accuracy/MAE per method.
+- `run_backtest_suite()` — invoked by CI, writes
+  `reports/imputation/backtest.json`, fails if any method regresses ≥5pp vs baseline
+  in `reports/imputation/backtest_baseline.json`.
+
+### 8. Consumer Contract
+
+| Consumer | Reads |
+|---|---|
+| `packages/sbir-ml/` (CET, transition detection) | `raw_*` by default; opt-in flag to include imputed |
+| `packages/sbir-analytics/` reporting | Effective columns + `_is_imputed` flags surfaced |
+| `packages/sbir-graph/` Neo4j loaders | Effective values; `is_imputed` flags as node properties |
+| `sbir_etl/quality/checks.py` | Both — raw for source thresholds, effective for effective thresholds |
+
+## Testing Strategy
+
+- **Unit:** Each method in isolation against fixture frames with hand-crafted nulls.
+- **Property tests:** Raw columns byte-identical pre/post imputation; idempotency
+  (running imputation twice yields identical output).
+- **Integration:** End-to-end pipeline run on a fixture bulk-download snapshot, asserting
+  Dagster assets materialize and Neo4j loaders persist `is_imputed` flags.
+- **Backtest gate in CI:** Fails the build if any method regresses.
+- **Precision benchmark:** `packages/sbir-ml/` evaluation tests re-run with imputation
+  enabled to confirm ≥85% transition-scoring precision holds when ML opts in.
+
+## Open Questions
+
+1. Should UEI/DUNS backfill go through the same `confidence` tiering, or is any
+   unambiguous cross-award match treated as `high`?
+2. Is `award_abstract` reliably present enough to make `naics.abstract_nn` worth the
+   dependency on TF-IDF infrastructure?
+3. Do we want a per-record `imputation_policy_version` so downstream ML can pin to a
+   specific imputation contract across retrains?

--- a/specs/data-imputation/design.md
+++ b/specs/data-imputation/design.md
@@ -120,10 +120,14 @@ class ImputationMethod(Protocol):
 
     def impute(
         self,
-        frame: pl.DataFrame,
+        frame: pd.DataFrame,
         lookups: ImputationLookups,
     ) -> ImputationResult: ...
 ```
+
+Uses `pandas.DataFrame` to match the existing pipeline
+(`packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py:325` and downstream
+assets all use pandas with `compute_kind="pandas"`). No Polars conversion is introduced.
 
 `ImputationResult` carries the imputed Series plus a parallel Series of provenance
 entries, merged into the frame by the runner.
@@ -212,11 +216,19 @@ Group by `(agency, program, phase, fiscal_year)`. Impute the group median where
 #### 4.4 `geography.congressional_district`
 
 Thin wrapper over existing `congressional_district_resolver.py`. Populates the existing
-`congressional_district` + `congressional_district_confidence` fields. Tiers:
+`congressional_district` + `congressional_district_confidence` fields.
 
-- zip+4 match → high
-- zip5 match → medium
-- city/state centroid → low
+Note: `congressional_district_confidence` is a float in `sbir_etl/models/award.py:82`,
+and the resolver already writes numeric scores directly. The high/medium/low tiers in
+this spec apply **only to the `ImputationEntry.confidence` provenance field**. The
+numeric `congressional_district_confidence` remains the source of truth for that field
+and is populated by the resolver; the imputation layer maps it to a provenance tier via:
+
+| Resolver score | `ImputationEntry.confidence` tier |
+|---|---|
+| ≥ 0.90 (zip+4) | high |
+| 0.70–0.89 (zip5) | medium |
+| < 0.70 (centroid) | low |
 
 #### 4.5 `contract_dates.end_date_repair`
 
@@ -291,16 +303,29 @@ imputation:
       company_uei: 0.80
 ```
 
-Quality checks gain a `raw_` vs `effective_` split:
+Quality checks gain a raw vs effective split **within the existing
+`data_quality.completeness` structure** (see `config/base.yaml:50` and
+`DataQualityConfig`). Rather than introducing a new top-level `quality:` section, the
+existing flat map is nested:
 
 ```yaml
-quality:
-  raw_completeness:
-    award_date: 0.50        # realistic source coverage
-    # ...
-  effective_completeness:   # references imputation.quality.effective_thresholds
-    # ...
+data_quality:
+  completeness:
+    raw:
+      award_id: 1.00
+      company_name: 0.95
+      award_amount: 0.90
+      award_date: 0.50          # realistic raw coverage
+      program: 0.98
+    effective:                  # applied to post-imputation columns
+      award_date: 0.95
+      award_amount: 0.92
+      company_uei: 0.80
 ```
+
+`DataQualityConfig` gains `raw: dict[str, float]` and `effective: dict[str, float]`
+members; the legacy flat form is read as `raw` for backward compatibility during
+migration and removed once all environments are updated.
 
 ### 6. Dagster Integration
 
@@ -350,6 +375,71 @@ Existing downstream assets (enrichment, Neo4j load) rewire their dependency from
 - **Backtest gate in CI:** Fails the build if any method regresses.
 - **Precision benchmark:** `packages/sbir-ml/` evaluation tests re-run with imputation
   enabled to confirm ≥85% transition-scoring precision holds when ML opts in.
+
+## Methodology Evaluation
+
+Before selecting the methods in §4, we evaluated imputation methodology families
+against SBIR data characteristics. The conclusion: **deterministic + record-linkage +
+group-statistical methods dominate on every dimension that matters here.** Heavier
+model-based approaches are deferred unless the backtest harness surfaces a gap they
+would close.
+
+### Methodology families considered
+
+| Family | Examples | Notes on fit |
+|---|---|---|
+| Deterministic / rule-based | Cascade fallback, zip/NAICS crosswalks, hierarchical rollup | Strong fit — SBIR gaps are dominated by structural missingness with correlated proxy fields |
+| Record linkage / cross-row | Sibling-record backfill, external-source join (SAM.gov, USAspending) | Only viable approach for identifiers (UEI/DUNS); statistical methods cannot invent a correct ID |
+| Group statistical | Median/mode within `(agency, phase, program, fiscal_year)`, regression imputation, hot-deck | Good fit for `award_amount` — tight modal distributions per group; regression buys little above median |
+| Model-based (multivariate) | MICE, missForest, k-NN | Expensive, opaque, assumes MAR. Poor fit: most SBIR missingness is MNAR (older records) and has dedicated deterministic fixes |
+| ML / representation | Denoising autoencoders, GAIN, tabular transformers | Overkill for ~6 imputable fields; opaque provenance; not justified by current gaps |
+| Embedding nearest-neighbor | TF-IDF / sentence embeddings on `award_abstract` | Useful in one spot: `naics_code` when entirely missing and abstract length > 100 chars |
+| Multiple imputation | Generate N plausible values, propagate uncertainty | Only warranted for downstream statistical inference (regression coefficients) — not for point estimates, graph properties, or reporting |
+| Uncertainty-aware | Conformal prediction, bootstrap confidence | Implemented indirectly via the three-tier `ImputationEntry.confidence` field and backtest-derived tier assignments |
+
+### Why the chosen methods win
+
+1. **Missingness is predominantly MNAR, not MAR.** Older records systematically lack
+   `award_date` and `company_uei`. MICE and missForest assume MAR and would bias
+   temporal analyses. Deterministic cascades with explicit provenance are safer and
+   more auditable.
+2. **Strong proxy fields exist.** `proposal_award_date` and `contract_start_date` are
+   near-ground-truth substitutes for `award_date`; no model learns that relationship
+   better than a rule that reads it off.
+3. **Identifiers cannot be synthesized.** UEI/DUNS imputation has to come from
+   linkage — to sibling rows or external registries — full stop.
+4. **Provenance beats accuracy at the margin.** Downstream consumers
+   (`packages/sbir-ml/`) need to know which values are imputed more than they need a
+   marginally better imputation. Simpler methods produce cleaner provenance stories.
+5. **Backtest feasibility.** Deterministic and group-statistical methods backtest
+   trivially on the non-null subset. Cross-row propagation (UEI backfill) needs
+   careful holdout design to avoid leakage, and k-NN/MICE make leakage far worse.
+
+### Expected value ranking
+
+| Rank | Field | Method | Rationale |
+|---|---|---|---|
+| 1 | `award_date` | Deterministic cascade | ~50% missing; unblocks all time-series/cohort analysis |
+| 2 | `company_uei` / `company_duns` | Cross-award backfill + external lookup | Unlocks entity resolution, M&A detection, transition scoring |
+| 3 | `naics_code` | Hierarchical fallback + abstract-NN opt-in | Feeds CET classification and sector analysis |
+| 4 | `congressional_district` | Tiered zip crosswalk (reuse existing resolver) | High policy value; deterministic; confidence tiering is natural |
+| 5 | `award_amount` | Agency-phase-program-FY median | Tight modal distributions; bounded by $5M cap |
+| 6 | `contract_end_date` | Rule: start + phase-typical duration | Low standalone value; cheap repair of inverted pairs |
+
+### Explicitly not pursued in v1
+
+- **MICE / missForest across the schema.** Expensive, opaque, and worse on MNAR data
+  than the dedicated fixes above.
+- **Deep generative models (GAIN, autoencoders).** Wrong tool: SBIR fields have strong
+  structural/relational signal, not subtle multivariate patterns that justify learned
+  latent spaces.
+- **Imputing `principal_investigator`, contact fields, boolean classification flags.**
+  PII, unverifiable, or policy-sensitive. Normalize and dedupe existing values; do not
+  invent missing ones.
+
+These remain candidates for v2 **only if** the Phase 5 backtest surfaces a concrete gap
+that a model-based method would plausibly close. The decision gate is in
+`reports/imputation/backtest.json`, not in the spec.
 
 ## Open Questions
 

--- a/specs/data-imputation/requirements.md
+++ b/specs/data-imputation/requirements.md
@@ -6,7 +6,7 @@ The SBIR.gov bulk download is the canonical source of SBIR/STTR award records fo
 pipeline, but it is systematically incomplete and internally inconsistent:
 
 - `award_date` is missing on roughly **50% of records** while the configured completeness
-  threshold is **95%** (`sbir_etl/validators/sbir_awards.py:214`, `config/base.yaml:50-59`).
+  threshold is **95%** (`sbir_etl/validators/sbir_awards.py:561`, `config/base.yaml:50-59`).
 - Core fields (`award_amount`, `award_date`, `program`, `phase`) use **lenient validators**
   that silently coerce invalid values to `None` (`sbir_etl/models/award.py:189-332`) rather
   than rejecting records. This produces hidden nulls that look like missing-at-random data

--- a/specs/data-imputation/requirements.md
+++ b/specs/data-imputation/requirements.md
@@ -1,0 +1,179 @@
+# Data Imputation — Requirements
+
+## Introduction
+
+The SBIR.gov bulk download is the canonical source of SBIR/STTR award records for this
+pipeline, but it is systematically incomplete and internally inconsistent:
+
+- `award_date` is missing on roughly **50% of records** while the configured completeness
+  threshold is **95%** (`sbir_etl/validators/sbir_awards.py:214`, `config/base.yaml:50-59`).
+- Core fields (`award_amount`, `award_date`, `program`, `phase`) use **lenient validators**
+  that silently coerce invalid values to `None` (`sbir_etl/models/award.py:189-332`) rather
+  than rejecting records. This produces hidden nulls that look like missing-at-random data
+  but are actually parse failures.
+- `company_uei` and `company_duns` are missing for many records, requiring fuzzy-name
+  fallback matching at enrichment time (`sbir_etl/enrichers/company_categorization.py`).
+- Date consistency violations (end-before-start, proposal-after-award) are emitted as
+  `WARNING` rather than `ERROR` and pass through unchanged.
+
+Downstream consumers — CET classification, phase-transition detection (≥85% precision
+benchmark), leverage-ratio analysis, and weekly reporting — treat these nulls as true
+absences. That biases cohort statistics (missing `award_date` disproportionately affects
+older awards), suppresses legitimate phase-transition matches (missing `company_uei`),
+and degrades any time-series analysis that keys on `award_year`.
+
+This spec defines a **transparent, auditable imputation layer** that fills recoverable
+gaps *without* overwriting source-of-truth data, so downstream code can deliberately
+choose whether to include imputed values.
+
+## Glossary
+
+- **Imputation** — Deriving a value for a missing/invalid field from other fields on the
+  same record, sibling records, or external enrichment sources. Distinct from
+  *enrichment* (adding net-new fields from external APIs).
+- **Raw field** — The value as it appeared in the SBIR.gov bulk download, after type
+  parsing but before imputation.
+- **Effective field** — The value downstream consumers should read: raw if present, else
+  imputed if available, else null.
+- **Imputation method** — The named strategy used to derive a value (e.g.,
+  `contract_start_date_fallback`, `agency_phase_median`, `zip5_crosswalk`).
+- **Provenance record** — Per-field metadata capturing whether a value was imputed, by
+  which method, from which source fields, with what confidence.
+- **Confidence tier** — `high` / `medium` / `low`, defined per imputation method based on
+  empirical accuracy measured against non-null ground-truth holdouts.
+
+## Requirements
+
+### Requirement 1 — Non-destructive imputation
+
+**User Story:** As a data consumer, I want imputed values to never overwrite raw source
+data, so that I can always recover the original and audit downstream claims.
+
+#### Acceptance Criteria
+
+1. THE System SHALL preserve the raw extracted value for every imputable field in a
+   `raw_<field>` column (or equivalent side table) alongside the imputed value.
+2. THE System SHALL write imputed values only to the effective column consumed by
+   downstream assets; the raw column SHALL remain byte-identical to extractor output.
+3. THE System SHALL NOT impute fields that are primary keys (`award_id`) or subjective
+   classification flags (`is_hubzone`, `is_woman_owned`, `is_socially_disadvantaged`).
+4. THE System SHALL produce identical raw columns across repeated runs of the same bulk
+   download (deterministic raw layer).
+
+### Requirement 2 — Provenance and auditability
+
+**User Story:** As an analyst, I want to filter imputed values in or out per-field, so
+that I can run analyses at different confidence levels without re-deriving imputations.
+
+#### Acceptance Criteria
+
+1. THE System SHALL emit a per-record `imputation` struct column containing, for each
+   imputed field: `method` (str), `confidence` (enum: high/medium/low),
+   `source_fields` (list[str]), and `imputed_at` (UTC timestamp).
+2. THE System SHALL expose boolean convenience columns `<field>_is_imputed` for every
+   imputable field to enable cheap downstream filtering.
+3. THE System SHALL version imputation methods (`method_version` int) so that historical
+   imputations remain attributable to a specific algorithm even after logic changes.
+4. THE System SHALL log a run-level imputation summary to `reports/imputation/` recording
+   per-field impute rates, method distribution, and confidence distribution.
+5. THE System SHALL ensure Neo4j nodes carry the `<field>_is_imputed` flags and
+   `imputation_methods` list as node properties for graph-time filtering.
+
+### Requirement 3 — Imputable fields and methods
+
+**User Story:** As a pipeline operator, I want a documented catalog of imputation
+methods per field, so that I know exactly what the pipeline will infer and what it
+won't.
+
+#### Acceptance Criteria
+
+1. THE System SHALL support imputation of `award_date` via cascade:
+   `proposal_award_date` → `contract_start_date` → `date_of_notification` →
+   `solicitation_close_date + agency_lag` → `fiscal_year midpoint`.
+2. THE System SHALL support imputation of `company_uei` and `company_duns` via
+   cross-award backfill: when the same normalized `(company_name, company_state)` key
+   has a known UEI/DUNS on any other award in the corpus, propagate it.
+3. THE System SHALL support imputation of `award_amount` via agency-phase-program-year
+   group median with a bounded `±2σ` sanity check; values that would fall outside the
+   existing `$5M` cap are flagged, not assigned.
+4. THE System SHALL support imputation of `congressional_district` via tiered zip
+   crosswalk (zip+4 → zip5 → city/state centroid), reusing
+   `sbir_etl/enrichers/congressional_district_resolver.py`, and populate the existing
+   `congressional_district_confidence` field.
+5. THE System SHALL support repair of `contract_end_date` when it is absent or precedes
+   `contract_start_date`, using agency-phase-typical durations.
+6. THE System SHALL support imputation of `naics_code` via hierarchical fallback
+   (6→4→3→2 digits) and, when entirely absent, nearest-neighbor inference from award
+   abstracts against awards with known NAICS.
+7. THE System SHALL NOT impute `principal_investigator`, contact fields, or classification
+   booleans; it SHALL only normalize/deduplicate existing values for these fields.
+
+### Requirement 4 — Configurable and toggleable
+
+**User Story:** As a developer, I want to enable, disable, and tune each imputation
+method from config, so that I can A/B test impact on downstream benchmarks.
+
+#### Acceptance Criteria
+
+1. THE System SHALL expose an `imputation` section in `config/base.yaml` with per-method
+   toggles (`enabled: true/false`) and method-specific parameters (cascade order,
+   grouping keys, confidence thresholds).
+2. THE System SHALL support dev/prod overrides via the existing config layering pattern.
+3. THE System SHALL allow a `dry_run` mode that computes imputations and emits the
+   provenance report *without* populating the effective columns, for validation.
+
+### Requirement 5 — Integration with existing quality and enrichment stages
+
+**User Story:** As a pipeline maintainer, I want imputation to run at a well-defined
+stage that does not corrupt quality metrics, so that source-completeness measurements
+remain truthful.
+
+#### Acceptance Criteria
+
+1. THE System SHALL run imputation **after** extraction and **after** raw validation
+   (`sbir_etl/validators/sbir_awards.py`), and **before** entity enrichment
+   (`sbir_etl/enrichers/company_enrichment.py`).
+2. THE System SHALL measure completeness thresholds in `sbir_etl/quality/checks.py`
+   against **raw** columns, not imputed columns, so that the ~50% `award_date` gap
+   remains visible as a source-data issue.
+3. THE System SHALL emit a separate quality report (`reports/imputation/coverage.json`)
+   that measures post-imputation effective completeness per field.
+4. THE System SHALL reconcile the `award_date` completeness threshold in
+   `config/base.yaml` to reflect realistic raw coverage (separate raw vs. effective
+   thresholds).
+
+### Requirement 6 — Validation and backtesting
+
+**User Story:** As a data scientist, I want each imputation method validated against
+records where ground truth exists, so that published confidence tiers are empirically
+defensible.
+
+#### Acceptance Criteria
+
+1. THE System SHALL provide a backtest harness that masks known-good values, re-imputes
+   them, and reports MAE/accuracy per method.
+2. THE System SHALL set `confidence: high` only for methods with ≥90% backtest accuracy
+   on holdout, `medium` for 75–90%, `low` below 75%.
+3. THE System SHALL verify the phase-transition precision benchmark (≥85%) does not
+   regress when imputed fields are included, via existing
+   `packages/sbir-ml/` evaluation tests.
+4. THE System SHALL fail CI if backtest accuracy for any method drops more than 5
+   percentage points below its recorded baseline.
+
+### Requirement 7 — Downstream consumer contract
+
+**User Story:** As a Neo4j loader author, I want a clear contract for consuming imputed
+fields, so that graph queries can opt in or out deterministically.
+
+#### Acceptance Criteria
+
+1. THE System SHALL document in `docs/steering/` which downstream assets read effective
+   vs. raw columns.
+2. THE System SHALL default `packages/sbir-ml/` (CET, transition detection) to reading
+   **raw** values with explicit opt-in to imputed values, to protect precision
+   benchmarks.
+3. THE System SHALL default `packages/sbir-analytics/` reporting assets to reading
+   **effective** values (imputed where available) with `_is_imputed` columns surfaced
+   in reports.
+4. THE System SHALL default `packages/sbir-graph/` loaders to writing effective values
+   with `is_imputed` flag properties on nodes.

--- a/specs/data-imputation/tasks.md
+++ b/specs/data-imputation/tasks.md
@@ -1,0 +1,115 @@
+# Data Imputation — Implementation Plan
+
+Execution order is top-to-bottom within each phase. Phases 1–3 are required; Phase 4
+is the initial method rollout; Phase 5 hardens operability.
+
+## Phase 1 — Foundation
+
+- [ ] 1.1 Add `sbir_etl/imputation/` module skeleton with `registry.py`, `provenance.py`,
+  `config.py`, `runner.py`, and `methods/__init__.py`.
+- [ ] 1.2 Extend `sbir_etl/models/award.py` with `raw_<field>` shadow fields for
+  `award_date`, `award_amount`, `company_uei`, `company_duns`, `congressional_district`,
+  `contract_end_date`, `naics_code`; add `<field>_is_imputed` booleans; add
+  `imputation: list[ImputationEntry]` field.
+  → **verify**: Pydantic model round-trips a fixture record; raw fields serialize to
+  Parquet via existing DuckDB writer.
+- [ ] 1.3 Add `ImputationEntry` model in `sbir_etl/models/enrichment.py` (or new
+  `imputation.py`) with `field`, `method`, `method_version`, `confidence`,
+  `source_fields`, `imputed_at`.
+- [ ] 1.4 Implement `ImputationMethod` protocol + `ImputationRegistry` with topological
+  ordering and cycle detection.
+  → **verify**: Unit test registers two methods with a dependency, asserts correct
+  execution order; cycle raises at load time.
+- [ ] 1.5 Implement `ImputationRunner` that clones raw columns, applies methods in
+  order, builds the provenance struct, and emits `<field>_is_imputed` booleans.
+  → **verify**: Unit test on a 10-row fixture shows raw columns byte-identical and
+  effective columns populated.
+- [ ] 1.6 Add `imputation` section to `config/base.yaml` with per-method toggles and
+  `dry_run` flag; wire through `sbir_etl/config/` schemas.
+  → **verify**: `pytest tests/unit/test_config.py` passes with new section loaded.
+
+## Phase 2 — Provenance & quality integration
+
+- [ ] 2.1 Split `sbir_etl/quality/checks.py` completeness checks into `raw_*` and
+  `effective_*` variants; measure raw against source thresholds and effective against
+  post-imputation thresholds.
+  → **verify**: Existing quality report unchanged for raw; new
+  `reports/imputation/coverage.json` emitted.
+- [ ] 2.2 Update `config/base.yaml` thresholds to split raw vs effective completeness
+  for `award_date`, `award_amount`, `company_uei`, `congressional_district`.
+  → **verify**: Raw `award_date` threshold set near actual coverage (~50%); effective
+  threshold remains 95%.
+- [ ] 2.3 Emit run-level imputation summary log to `reports/imputation/summary.json`
+  with per-field impute rate, per-method counts, per-confidence distribution.
+- [ ] 2.4 Add `imputation_methods` list property and `<field>_is_imputed` booleans to
+  Neo4j loaders in `packages/sbir-graph/sbir_graph/loaders/`.
+  → **verify**: Cypher query `MATCH (a:Award) WHERE a.award_date_is_imputed = true
+  RETURN count(a)` returns expected count on fixture load.
+
+## Phase 3 — Dagster integration
+
+- [ ] 3.1 Create `imputed_sbir_awards` asset in
+  `packages/sbir-analytics/sbir_analytics/assets/imputation.py` depending on
+  `validated_sbir_awards`.
+- [ ] 3.2 Rewire downstream enrichment assets (`company_enrichment`,
+  `congressional_district_*`, etc.) to depend on `imputed_sbir_awards` instead of
+  `validated_sbir_awards`.
+  → **verify**: `dagster asset materialize --select imputed_sbir_awards+` succeeds end
+  to end on fixture data.
+- [ ] 3.3 Add quality-check asset that emits `reports/imputation/coverage.json` and
+  fails materialization if effective thresholds not met.
+
+## Phase 4 — Method implementations
+
+- [ ] 4.1 `award_date.cascade` — cascade through `proposal_award_date`,
+  `contract_start_date`, `date_of_notification`, `solicitation_close_date +
+  agency_lag`, `fiscal_year` midpoint. Build agency-lag lookup at runner init.
+  → **verify**: On a labeled fixture, cascade fills ≥95% of null `award_date`s;
+  agency-lag derivation is deterministic.
+- [ ] 4.2 `identifiers.cross_award_backfill` — build `(normalized_name, state)` →
+  UEI/DUNS lookup from non-null records, apply to null rows; log conflicts to
+  `reports/imputation/uei_conflicts.json`.
+  → **verify**: Fixture with 3 awards from same company (1 with UEI, 2 without) ends
+  with all 3 having the same UEI and `_is_imputed` correctly flagged.
+- [ ] 4.3 `award_amount.agency_phase_median` — group-median imputation with min group
+  size of 10, $5M cap check.
+  → **verify**: Fixture with known group medians produces expected imputed values;
+  small groups are skipped.
+- [ ] 4.4 `geography.congressional_district` — wrap existing
+  `congressional_district_resolver.py`; tier confidence by zip+4 / zip5 / centroid.
+  → **verify**: Uses existing resolver fixtures; confidence tier matches resolver
+  output.
+- [ ] 4.5 `contract_dates.end_date_repair` — derive `contract_end_date` when null or
+  inverted, using phase-typical durations.
+  → **verify**: Inverted end dates are replaced; original values preserved in
+  `raw_contract_end_date`.
+- [ ] 4.6 `naics.hierarchical_fallback` — validate 6-digit code; fall back to shortest
+  valid prefix via `sbir_etl/enrichers/naics/`.
+  → **verify**: Invalid 6-digit codes with valid 4-digit prefixes are repaired;
+  already-valid codes are unchanged.
+- [ ] 4.7 `naics.abstract_nn` — TF-IDF nearest-neighbor on abstracts ≥100 chars;
+  `enabled: false` by default.
+  → **verify**: Method runs under opt-in flag; `confidence: low` applied.
+
+## Phase 5 — Backtest, validation, docs
+
+- [ ] 5.1 Implement `sbir_etl/imputation/backtest.py` with `mask_and_reimpute(field,
+  fraction)` and `run_backtest_suite()`.
+  → **verify**: CLI `python -m sbir_etl.imputation.backtest` produces
+  `reports/imputation/backtest.json` with per-method accuracy/MAE.
+- [ ] 5.2 Record baseline backtest accuracy to
+  `reports/imputation/backtest_baseline.json`; add CI gate that fails on ≥5pp
+  regression.
+- [ ] 5.3 Re-run `packages/sbir-ml/` transition-detection evaluation with imputed-opt-in
+  mode; confirm ≥85% precision benchmark holds.
+  → **verify**: Evaluation report shows precision ≥0.85 both with and without imputed
+  values.
+- [ ] 5.4 Add integration test in `tests/integration/` that materializes
+  `imputed_sbir_awards` + downstream enrichment on a fixture snapshot and asserts
+  provenance fields round-trip through DuckDB and Neo4j.
+- [ ] 5.5 Document the imputation layer in `docs/steering/imputation.md`: method
+  catalog, confidence definitions, consumer contract, and operator runbook for
+  toggling methods.
+- [ ] 5.6 Update CLAUDE.md "Key Directories" table to reference
+  `sbir_etl/imputation/`; add a one-line note about `raw_*` shadow columns under
+  "Common Patterns".

--- a/specs/data-imputation/tasks.md
+++ b/specs/data-imputation/tasks.md
@@ -73,24 +73,47 @@ is the initial method rollout; Phase 5 hardens operability.
   `reports/imputation/uei_conflicts.json`.
   → **verify**: Fixture with 3 awards from same company (1 with UEI, 2 without) ends
   with all 3 having the same UEI and `_is_imputed` correctly flagged.
-- [ ] 4.3 `award_amount.agency_phase_median` — group-median imputation with min group
-  size of 10, $5M cap check.
+- [ ] 4.3 **Prerequisite — extend solicitation extraction.** Add
+  `phase_i_max_amount`, `phase_ii_max_amount`, and
+  `period_of_performance_months` (per phase) to `sbir_etl/models/solicitation.py` and
+  populate them in `sbir_etl/extractors/solicitation.py`. Backfill historical
+  solicitations from SBIR.gov bulk download.
+  → **verify**: Solicitation fixtures parse the new fields; coverage of solicitations
+  with at least `phase_i_max_amount` is ≥80% on a recent fiscal-year sample.
+- [ ] 4.4 `award_amount.solicitation_max` — join awards to solicitations on
+  `(solicitation_number, topic_code)`; use phase max as imputed value when the
+  agency-phase modal cluster equals the max (≥80%), otherwise as a hard upper bound on
+  §4.5 fallback.
+  → **verify**: Backtest accuracy on labeled awards with known solicitation linkage
+  ≥90% MAPE for high-confidence tier; ceiling is never exceeded.
+- [ ] 4.5 `award_amount.agency_phase_median` — group-median imputation (only runs when
+  §4.4 did not produce a value) with min group size of 10, $5M cap check.
   → **verify**: Fixture with known group medians produces expected imputed values;
   small groups are skipped.
-- [ ] 4.4 `geography.congressional_district` — wrap existing
-  `congressional_district_resolver.py`; tier confidence by zip+4 / zip5 / centroid.
-  → **verify**: Uses existing resolver fixtures; confidence tier matches resolver
-  output.
-- [ ] 4.5 `contract_dates.end_date_repair` — derive `contract_end_date` when null or
-  inverted, using phase-typical durations.
+- [ ] 4.6 `geography.congressional_district` — wrap existing
+  `congressional_district_resolver.py`; map resolver score to provenance tier
+  (≥0.90 → high, 0.70–0.89 → medium, <0.70 → low).
+  → **verify**: Uses existing resolver fixtures; provenance tier matches the mapping
+  table in design §4.6.
+- [ ] 4.7 `contract_dates.solicitation_period_of_performance` — derive
+  `contract_end_date` from `contract_start_date + solicitation period_of_performance`
+  when solicitation linkage exists.
+  → **verify**: When solicitation period is present, end date matches start +
+  period_of_performance_months; raw value preserved.
+- [ ] 4.8 `contract_dates.end_date_repair` — fallback when §4.7 did not fill it;
+  uses phase-typical durations.
   → **verify**: Inverted end dates are replaced; original values preserved in
   `raw_contract_end_date`.
-- [ ] 4.6 `naics.hierarchical_fallback` — validate 6-digit code; fall back to shortest
-  valid prefix via `sbir_etl/enrichers/naics/`.
+- [ ] 4.9 `naics.solicitation_topic` — derive NAICS from solicitation topic
+  research-domain crosswalk (reuses agency topic-prefix mappings where available).
+  → **verify**: For a fixture set of awards with known solicitation linkage and known
+  NAICS, top-1 accuracy ≥75% on the agency-topic crosswalk.
+- [ ] 4.10 `naics.hierarchical_fallback` — validate 6-digit code; fall back to
+  shortest valid prefix via `sbir_etl/enrichers/naics/`.
   → **verify**: Invalid 6-digit codes with valid 4-digit prefixes are repaired;
   already-valid codes are unchanged.
-- [ ] 4.7 `naics.abstract_nn` — TF-IDF nearest-neighbor on abstracts ≥100 chars;
-  `enabled: false` by default.
+- [ ] 4.11 `naics.abstract_nn` — TF-IDF nearest-neighbor on abstracts ≥100 chars;
+  `enabled: false` by default. Runs only when §4.9 produced nothing.
   → **verify**: Method runs under opt-in flag; `confidence: low` applied.
 
 ## Phase 5 — Backtest, validation, docs

--- a/specs/data-imputation/tasks.md
+++ b/specs/data-imputation/tasks.md
@@ -12,7 +12,9 @@ is the initial method rollout; Phase 5 hardens operability.
   `contract_end_date`, `naics_code`; add `<field>_is_imputed` booleans; add
   `imputation: list[ImputationEntry]` field.
   → **verify**: Pydantic model round-trips a fixture record; raw fields serialize to
-  Parquet via existing DuckDB writer.
+  Parquet via the existing `validated_sbir_awards` persistence path
+  (`pandas.DataFrame.to_parquet`, see
+  `packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py:158`).
 - [ ] 1.3 Add `ImputationEntry` model in `sbir_etl/models/enrichment.py` (or new
   `imputation.py`) with `field`, `method`, `method_version`, `confidence`,
   `source_fields`, `imputed_at`.

--- a/specs/data-imputation/tasks.md
+++ b/specs/data-imputation/tasks.md
@@ -7,10 +7,13 @@ is the initial method rollout; Phase 5 hardens operability.
 
 - [ ] 1.1 Add `sbir_etl/imputation/` module skeleton with `registry.py`, `provenance.py`,
   `config.py`, `runner.py`, and `methods/__init__.py`.
-- [ ] 1.2 Extend `sbir_etl/models/award.py` with `raw_<field>` shadow fields for
-  `award_date`, `award_amount`, `company_uei`, `company_duns`, `congressional_district`,
-  `contract_end_date`, `naics_code`; add `<field>_is_imputed` booleans; add
-  `imputation: list[ImputationEntry]` field.
+- [ ] 1.2 Extend `sbir_etl/models/award.py`:
+  - **Add the base `naics_code: str | None` field** to the `Award` model — it does not
+    currently exist (verified: no `naics` occurrences in `sbir_etl/models/award.py`).
+  - Add `raw_<field>` shadow fields for `award_date`, `award_amount`, `company_uei`,
+    `company_duns`, `congressional_district`, `contract_end_date`, `naics_code`.
+  - Add `<field>_is_imputed` booleans for each of the above.
+  - Add `imputation: list[ImputationEntry]` field.
   → **verify**: Pydantic model round-trips a fixture record; raw fields serialize to
   Parquet via the existing `validated_sbir_awards` persistence path
   (`pandas.DataFrame.to_parquet`, see
@@ -84,8 +87,9 @@ is the initial method rollout; Phase 5 hardens operability.
   `(solicitation_number, topic_code)`; use phase max as imputed value when the
   agency-phase modal cluster equals the max (≥80%), otherwise as a hard upper bound on
   §4.5 fallback.
-  → **verify**: Backtest accuracy on labeled awards with known solicitation linkage
-  ≥90% MAPE for high-confidence tier; ceiling is never exceeded.
+  → **verify**: Backtest on labeled awards with known solicitation linkage achieves
+  **≤10% MAPE** (lower is better) for the high-confidence tier; ceiling is never
+  exceeded.
 - [ ] 4.5 `award_amount.agency_phase_median` — group-median imputation (only runs when
   §4.4 did not produce a value) with min group size of 10, $5M cap check.
   → **verify**: Fixture with known group medians produces expected imputed values;


### PR DESCRIPTION
Defines a non-destructive imputation layer between raw validation and
enrichment. Preserves raw columns, emits per-field provenance, and
splits quality thresholds into raw vs effective.