### PR TITLE
refactor: drop backward-compat shims for cache and naics strategies

### DIFF
--- a/sbir_etl/enrichers/naics/fiscal/strategies/agency_defaults.py
+++ b/sbir_etl/enrichers/naics/fiscal/strategies/agency_defaults.py
@@ -1,4 +1,0 @@
-"""Backward-compat re-export. Canonical location: simple_strategies.py"""
-from .simple_strategies import AgencyDefaultsStrategy
-
-__all__ = ["AgencyDefaultsStrategy"]

--- a/sbir_etl/enrichers/naics/fiscal/strategies/original_data.py
+++ b/sbir_etl/enrichers/naics/fiscal/strategies/original_data.py
@@ -1,4 +1,0 @@
-"""Backward-compat re-export. Canonical location: simple_strategies.py"""
-from .simple_strategies import OriginalDataStrategy
-
-__all__ = ["OriginalDataStrategy"]

--- a/sbir_etl/enrichers/naics/fiscal/strategies/sector_fallback.py
+++ b/sbir_etl/enrichers/naics/fiscal/strategies/sector_fallback.py
@@ -1,4 +1,0 @@
-"""Backward-compat re-export. Canonical location: simple_strategies.py"""
-from .simple_strategies import SectorFallbackStrategy
-
-__all__ = ["SectorFallbackStrategy"]

--- a/sbir_etl/enrichers/naics/fiscal/strategies/topic_code.py
+++ b/sbir_etl/enrichers/naics/fiscal/strategies/topic_code.py
@@ -1,4 +1,0 @@
-"""Backward-compat re-export. Canonical location: simple_strategies.py"""
-from .simple_strategies import TopicCodeStrategy
-
-__all__ = ["TopicCodeStrategy"]

--- a/sbir_etl/utils/cache/api_cache.py
+++ b/sbir_etl/utils/cache/api_cache.py
@@ -314,7 +314,3 @@ class APICache:
             "ttl_hours": self.ttl_hours,
             "default_type": self.default_cache_type,
         }
-
-
-# Backward compatibility alias
-BaseDataFrameCache = APICache

--- a/sbir_etl/utils/cache/base_cache.py
+++ b/sbir_etl/utils/cache/base_cache.py
@@ -1,5 +1,0 @@
-"""Backward compatibility shim — BaseDataFrameCache now lives in api_cache.py."""
-
-from .api_cache import APICache as BaseDataFrameCache
-
-__all__ = ["BaseDataFrameCache"]

--- a/tests/unit/enrichers/naics/test_fiscal_strategies.py
+++ b/tests/unit/enrichers/naics/test_fiscal_strategies.py
@@ -11,7 +11,7 @@ class TestOriginalDataStrategy:
 
     def test_extracts_naics_from_standard_column(self):
         """Test extraction from NAICS column."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.original_data import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
 
         strategy = OriginalDataStrategy()
         row = pd.Series({"NAICS": "541715", "company_name": "Test Corp"})
@@ -26,7 +26,7 @@ class TestOriginalDataStrategy:
 
     def test_extracts_naics_from_alternative_columns(self):
         """Test extraction from alternative column names."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.original_data import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
 
         strategy = OriginalDataStrategy()
 
@@ -39,7 +39,7 @@ class TestOriginalDataStrategy:
 
     def test_returns_none_when_no_naics_column(self):
         """Test returns None when no NAICS column present."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.original_data import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
 
         strategy = OriginalDataStrategy()
         row = pd.Series({"company_name": "Test Corp", "award_amount": 100000})
@@ -50,7 +50,7 @@ class TestOriginalDataStrategy:
 
     def test_returns_none_for_null_naics(self):
         """Test returns None when NAICS value is null."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.original_data import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
 
         strategy = OriginalDataStrategy()
         row = pd.Series({"NAICS": None, "company_name": "Test Corp"})
@@ -61,7 +61,7 @@ class TestOriginalDataStrategy:
 
     def test_strategy_properties(self):
         """Test strategy name and confidence level."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.original_data import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
 
         strategy = OriginalDataStrategy()
 
@@ -74,7 +74,7 @@ class TestSectorFallbackStrategy:
 
     def test_returns_default_fallback_code(self):
         """Test returns default 5415 code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.sector_fallback import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
 
         strategy = SectorFallbackStrategy()
         row = pd.Series({"company_name": "Test Corp"})
@@ -89,7 +89,7 @@ class TestSectorFallbackStrategy:
 
     def test_custom_fallback_code(self):
         """Test with custom fallback code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.sector_fallback import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
 
         strategy = SectorFallbackStrategy(fallback_code="541712")
         row = pd.Series({"company_name": "Test Corp"})
@@ -101,7 +101,7 @@ class TestSectorFallbackStrategy:
 
     def test_always_succeeds(self):
         """Test fallback always returns a result."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.sector_fallback import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
 
         strategy = SectorFallbackStrategy()
 
@@ -114,7 +114,7 @@ class TestSectorFallbackStrategy:
 
     def test_strategy_properties(self):
         """Test strategy name and confidence level."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.sector_fallback import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
 
         strategy = SectorFallbackStrategy()
 
@@ -127,7 +127,7 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_dod_default(self):
         """Test DOD agency returns aerospace manufacturing code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.agency_defaults import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"agency": "DOD", "company_name": "Test Corp"})
@@ -140,7 +140,7 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_hhs_default(self):
         """Test HHS agency returns biotech R&D code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.agency_defaults import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"agency": "HHS", "company_name": "Test Corp"})
@@ -152,7 +152,7 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_none_for_unknown_agency(self):
         """Test returns None for unknown agency."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.agency_defaults import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"agency": "UNKNOWN_AGENCY", "company_name": "Test Corp"})
@@ -163,7 +163,7 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_none_when_no_agency(self):
         """Test returns None when agency column missing."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.agency_defaults import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"company_name": "Test Corp"})
@@ -174,7 +174,7 @@ class TestAgencyDefaultsStrategy:
 
     def test_strategy_properties(self):
         """Test strategy name and confidence level."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.agency_defaults import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
 
         strategy = AgencyDefaultsStrategy()
 

--- a/tests/unit/enrichers/test_naics_strategies.py
+++ b/tests/unit/enrichers/test_naics_strategies.py
@@ -16,12 +16,12 @@ from datetime import datetime
 import pandas as pd
 import pytest
 
-from sbir_etl.enrichers.naics.fiscal.strategies.agency_defaults import AgencyDefaultsStrategy
+from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
 from sbir_etl.enrichers.naics.fiscal.strategies.base import NAICSEnrichmentResult
-from sbir_etl.enrichers.naics.fiscal.strategies.original_data import OriginalDataStrategy
-from sbir_etl.enrichers.naics.fiscal.strategies.sector_fallback import SectorFallbackStrategy
+from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
+from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
 from sbir_etl.enrichers.naics.fiscal.strategies.text_inference import TextInferenceStrategy
-from sbir_etl.enrichers.naics.fiscal.strategies.topic_code import TopicCodeStrategy
+from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import TopicCodeStrategy
 from sbir_etl.enrichers.naics.fiscal.strategies.usaspending_dataframe import USAspendingDataFrameStrategy
 from sbir_etl.enrichers.naics.fiscal.utils import normalize_naics_code, validate_naics_code
 

--- a/tests/unit/utils/test_api_cache_core.py
+++ b/tests/unit/utils/test_api_cache_core.py
@@ -1,4 +1,4 @@
-"""Unit tests for cache utilities (backward compat for BaseDataFrameCache)."""
+"""Unit tests for APICache core functionality."""
 
 from datetime import datetime, timedelta
 from unittest.mock import patch
@@ -10,19 +10,10 @@ import pytest
 pytestmark = pytest.mark.fast
 
 from sbir_etl.utils.cache.api_cache import APICache
-from sbir_etl.utils.cache.base_cache import BaseDataFrameCache
-
-
-class TestBaseDataFrameCacheCompat:
-    """Tests that BaseDataFrameCache alias still works."""
-
-    def test_backward_compat_alias(self):
-        """BaseDataFrameCache should be an alias for APICache."""
-        assert BaseDataFrameCache is APICache
 
 
 class TestAPICacheCoreFunctionality:
-    """Tests for core cache functionality (formerly tested via BaseDataFrameCache)."""
+    """Tests for core APICache functionality."""
 
     @pytest.fixture
     def cache(self, tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #269. Two pure-deletion cleanups, **net -34 LOC**, public API unchanged.

- **Cache shim**: deleted `sbir_etl/utils/cache/base_cache.py` (re-exported `APICache` as `BaseDataFrameCache`) and the `BaseDataFrameCache = APICache` alias line in `api_cache.py`. Renamed `tests/unit/utils/test_base_cache.py` → `test_api_cache_core.py` and removed the now-tautological alias-test class.
- **NAICS strategy shims**: deleted four 4-line re-export files in `sbir_etl/enrichers/naics/fiscal/strategies/` (`agency_defaults.py`, `original_data.py`, `sector_fallback.py`, `topic_code.py`) — each just re-imported a class from `simple_strategies.py`. Updated test imports to use `simple_strategies` directly. The `strategies/__init__.py` public API still exports all four classes.

## Items considered but skipped

- **Phonetic-matching feature flags**: original suggestion was to remove them as dead code, but they're live feature-gated code (`company_fuzzy_matcher.py:458-480`). Skipped.
- **Orphan test fixtures**: spot-checking the agent's claimed orphans (`tests/conftest.py`, `tests/utils/fixtures.py`) showed they're used across multiple test files. Net-positive value isn't there for the risk of accidentally pruning a real fixture.

## Test plan

- [x] `tests/unit/enrichers/test_naics_strategies.py` + `tests/unit/enrichers/naics/test_fiscal_strategies.py` (39 tests) pass with new imports
- [x] `tests/unit/utils/test_api_cache.py` + `test_api_cache_core.py` (20 tests) pass after rename
- [x] Full unit suite: 3994 passed, 1 pre-existing HTML-report failure unrelated to this change (verified on HEAD)
- [ ] CI green

https://claude.ai/code/session_01CUP48DVPNevyh9BC7xRJ5G

---
_Generated by [Claude Code](https://claude.ai/code/session_01CUP48DVPNevyh9BC7xRJ5G)_