### PR TITLE
docs(spec): add NSF SBIR vs. private-capital comparison spec

### DIFF
--- a/specs/nsf-vc-comparison/design.md
+++ b/specs/nsf-vc-comparison/design.md
@@ -76,15 +76,23 @@ EDGAR full-text / bulk archives → Form D filings (XML)
 
 ### Components
 
-5. **`FormDIngestor`** — Wraps the existing disabled `sec_edgar` enrichment
-   source. Pulls Form D submissions from EDGAR (bulk archive or full-text
-   search), persists raw XML to `data/raw/sec_edgar/form_d/` and parsed
-   records to a DuckDB staging table. Idempotent + incremental.
+5. **`FormDIngestor`** — Adds a new `sec_edgar` enrichment source under
+   `sbir_etl/enrichers/sec_edgar/`, following the `BaseAsyncAPIClient`
+   pattern used by `sam_gov`, `usaspending_api`, `patentsview_api`. Pulls
+   Form D submissions from EDGAR (bulk archive preferred over full-text
+   search for completeness + rate-limit margin), persists raw XML to
+   `data/raw/sec_edgar/form_d/` and parsed records to a DuckDB staging
+   table. Idempotent + incremental (track last-processed accession number).
 6. **`FormDParser`** — XML → typed records. Captures all fields listed in
    requirement 8. Strict on schema violations; logs to AlertCollector.
-7. **`CIKCrosswalk`** — Implements the EIN-then-fuzzy-name cascade. Outputs
-   per-record match confidence and method tier. Reports per-vintage match
-   rate (Phase 2 gate: ≥30% before continuing).
+7. **`CIKCrosswalk`** — Extends the existing production `VendorCrosswalk`
+   class (`packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py`)
+   by adding a `cik` field to `CrosswalkRecord`, a `find_by_cik` accessor,
+   and an `_index_cik` lookup map alongside the existing UEI/CAGE/DUNS
+   indexes. Implements the EIN-then-fuzzy-name cascade on top of existing
+   `find_by_name` machinery. Outputs per-record match confidence and method
+   tier. Reports per-vintage match rate (Phase 2 gate: ≥30% before
+   continuing).
 8. **`PrivateCapitalCohortBuilder`** — Filters Form D issuers to those *not*
    matched to any SBIR awardee. Buckets by vintage / NAICS-2 / state.
 9. **`CohortMatcher`** — Coarsened-exact matching on (vintage-year, NAICS-2,

--- a/specs/nsf-vc-comparison/design.md
+++ b/specs/nsf-vc-comparison/design.md
@@ -1,0 +1,164 @@
+# NSF SBIR vs. Private-Capital Comparison — Design
+
+## Architecture
+
+Builds on existing NSF identification, transition detection, PATLINK, and
+entity-resolution pipelines. New code lives in `packages/sbir-analytics/sbir_analytics/assets/nsf_vc/`
+(an outcomes-comparison artifact, parallel to `leverage_ratio/`).
+
+## Phase 1 — Published-Baseline Comparison
+
+### Data Flow
+
+```
+SBIR.gov awards → filter ALN ∈ {47.041, 47.084} → NSF cohort
+                                                       ↓
+                                          stratify by vintage / phase / CET
+                                                       ↓
+                                          compute outcome metrics:
+                                              - I → II graduation
+                                              - II → federal-contract transition
+                                              - 5-yr survival proxy
+                                              - patent rate
+                                              - M&A exit rate (placeholder)
+                                                       ↓
+                                          present alongside cited VC baselines
+                                                       ↓
+                                          reconciliation narrative
+```
+
+### Components
+
+1. **`NSFCohortBuilder`** — Filters award universe to NSF SBIR (ALN-based),
+   stratifies by vintage / phase, attaches CET labels.
+2. **`OutcomeMetricsCalculator`** — Reuses existing transition detector, PATLINK,
+   and (when available) M&A detection. Emits per-cohort rates with confidence
+   intervals (Wilson) and sample sizes.
+3. **`PublishedBaselineRegistry`** — Hard-coded table of cited VC baselines with
+   source citation + as-of date. Examples:
+   - NVCA 2023 Yearbook: seed→A ~33% (5-yr cohort)
+   - BLS BED: ~50% 5-yr survival, all small firms
+   - Lerner [L10]: SBIR awardees grew 27% faster over 10 yrs (effect size, not rate)
+4. **`ReconciliationNarrative`** — For each (NSF metric, baseline) pair, emit
+   a structured comparison record: delta, plausible-cause attribution,
+   selection-bias caveat. Output as JSON + markdown, mirroring the leverage-
+   ratio reconciler.
+
+### Output
+
+- `nsf_cohort_outcomes.parquet` — long-format metrics table (vintage × phase ×
+  CET × metric)
+- `nsf_vs_published_baselines.md` — human-readable reconciliation narrative
+- `nsf_baseline_comparison.json` — structured comparison records for
+  programmatic consumption
+
+## Phase 2 — Form D Matched-Cohort Comparison
+
+### Data Flow
+
+```
+EDGAR full-text / bulk archives → Form D filings (XML)
+                                       ↓
+                              parse + normalize fields
+                                       ↓
+                              CIK ↔ UEI/EIN crosswalk
+                                  (EIN, name+state fuzzy, address)
+                                       ↓
+                          drop Form D issuers matched to any SBIR awardee
+                                       ↓
+                       match remaining Form D issuers to NSF cohort
+                          on (vintage, NAICS-2, state)
+                                       ↓
+                       compute same outcome metrics on matched cohort
+                                       ↓
+                       cohort-vs-cohort comparison + threats-to-validity
+```
+
+### Components
+
+5. **`FormDIngestor`** — Wraps the existing disabled `sec_edgar` enrichment
+   source. Pulls Form D submissions from EDGAR (bulk archive or full-text
+   search), persists raw XML to `data/raw/sec_edgar/form_d/` and parsed
+   records to a DuckDB staging table. Idempotent + incremental.
+6. **`FormDParser`** — XML → typed records. Captures all fields listed in
+   requirement 8. Strict on schema violations; logs to AlertCollector.
+7. **`CIKCrosswalk`** — Implements the EIN-then-fuzzy-name cascade. Outputs
+   per-record match confidence and method tier. Reports per-vintage match
+   rate (Phase 2 gate: ≥30% before continuing).
+8. **`PrivateCapitalCohortBuilder`** — Filters Form D issuers to those *not*
+   matched to any SBIR awardee. Buckets by vintage / NAICS-2 / state.
+9. **`CohortMatcher`** — Coarsened-exact matching on (vintage-year, NAICS-2,
+   state). Reports cohort balance and unmatched residuals. No propensity
+   scoring in v1 — intentionally simple, defensible, and reproducible.
+10. **`ThreatsToValidity`** — Emits a structured caveats record with the five
+    required entries (SAFE undercount, late-stage inclusion, NAICS noise,
+    crosswalk floor, selection bias). This component runs *first* in the
+    pipeline and gates the headline output — if any required caveat is
+    missing or stale, the headline is suppressed.
+
+### CIK ↔ UEI/EIN Crosswalk Strategy
+
+The crosswalk is the highest-risk component. Tiered approach:
+
+- **Tier A (high confidence, ~5–15% expected):** Form D EIN supplied + matches
+  EIN in vendor universe. Confidence 0.95.
+- **Tier B (medium, ~15–30%):** Issuer name (normalized) + state exact match
+  to vendor universe. Confidence 0.75.
+- **Tier C (low, ~10–20%):** Issuer name fuzzy match (rapidfuzz, ≥90 score) +
+  state + city match. Confidence 0.50.
+- **Unmatched:** the rest. Reported as residual.
+
+Backtest set: a hand-labeled sample of 200 issuer↔awardee pairs, drawn from
+known SBIR firms with public Form D filings (e.g., from PR #286 and existing
+SEC EDGAR research). Target: Tier A+B precision ≥0.95, recall (against
+backtest) ≥0.50.
+
+### Output
+
+- `form_d_filings.parquet` — parsed Form D records
+- `cik_uei_crosswalk.parquet` — match table with confidence + tier
+- `private_capital_cohort_outcomes.parquet` — long-format metrics, parallel
+  schema to NSF cohort
+- `nsf_vs_form_d_comparison.md` — headline reconciliation narrative
+- `threats_to_validity.json` — gating caveats record
+
+## Methodology Notes
+
+### Why Form D, not seed-VC-only
+
+Per user redirect: broader Form D coverage (debt, late-stage, multiple
+instrument types) is treated as feature. The framing is "private capital
+broadly" rather than "seed VC narrowly." This makes the comparison more
+robust to SAFE undercount (which is a seed-stage problem) at the cost of
+being a coarser instrument-mix. Phase 2 component 14 (security-type
+decomposition) preserves the option of zooming in on the seed slice if
+downstream readers want it.
+
+### Why no propensity scoring in v1
+
+Coarsened-exact matching is reproducible, debuggable, and matches the
+conservative tone of the leverage-ratio spec. Propensity scoring requires
+firm-level covariates that don't reliably exist on the Form D side
+(founding date, founder background, prior funding). Defer to a v2 if v1
+yields a publishable result.
+
+### Why no causal claim
+
+The user asked for a comparison; the scope-guard flagged that NSF-vs-private
+selection bias is severe and one-way. We deliberately frame the deliverable
+as "descriptive comparison with reconciliation narrative" — same posture
+as `leverage-ratio-analysis`. Causal claims (e.g., "NSF SBIR causes
+N% higher transition than private capital would have") require RDD or IV
+designs and are explicitly out of scope.
+
+## Risks
+
+- **CIK↔UEI match rate <30%**: Phase 2 gate triggers stop-and-discuss. Likely
+  outcome: drop CIK matching as primary key, fall back to name+state-only
+  cohort buckets without firm-level joining.
+- **Form D ingest scope creep**: this spec is the canonical implementation;
+  M&A spec consumes the artifact. Coordinate with whoever picks up the M&A
+  spec to avoid duplicate ingest pipelines.
+- **NSF cohort size**: NSF SBIR is smaller than DoD; vintage-stratified Wilson
+  intervals may be wide. Pre-register minimum cohort size (n=50 per stratum)
+  before reporting stratified rates.

--- a/specs/nsf-vc-comparison/requirements.md
+++ b/specs/nsf-vc-comparison/requirements.md
@@ -1,0 +1,136 @@
+# NSF SBIR vs. Private-Capital Comparison — Requirements
+
+Research-questions tags: **B2/B3** (commercialization), **A4** (private-capital signals),
+**[L21]** (ITIF "America's Seed Fund"), **[L10]** (Lerner), **[L11]** (Howell), **[L23]** (Form D).
+
+## Background
+
+ITIF [L21] frames NSF SBIR as the federal analogue of a seed-stage venture fund.
+Lerner [L10] and Howell [L11] establish empirically that SBIR awardees grow
+faster, attract more follow-on private capital, and produce more patents than
+matched non-awardees — but neither study uses a *private-capital cohort* as the
+control group. This spec builds that comparison for NSF specifically: how does
+the NSF SBIR portfolio perform on commercialization-outcome metrics relative to
+firms financed via private capital (Reg D / Form D filers)?
+
+The user-stated framing: "compare NSF SBIR portfolio rank against pre-seed/seed
+VCs." Per scope review, we drop the "rank" composite and frame the deliverable
+as a **comparison table with reconciliation narrative**, matching the pattern
+established by `specs/leverage-ratio-analysis/`. Form D is intentionally
+*not* filtered to seed-only — its broader coverage (debt, later-stage, multiple
+instrument types) is treated as feature, not bug, because the policy question
+is "what private-capital alternative would these firms otherwise rely on,"
+not "what would seed VCs alone do."
+
+## Phasing
+
+This spec ships in two sequential phases, each independently useful.
+
+- **Phase 1 — Published-baseline comparison.** Compute NSF SBIR cohort outcomes
+  on metrics with cited public VC baselines (Lerner, Howell, ITIF, NVCA/CB
+  Insights public summaries). No new data ingest.
+- **Phase 2 — Form D matched-cohort comparison.** Ingest SEC EDGAR Form D
+  filings, build a CIK ↔ UEI/EIN crosswalk, construct a matched cohort of
+  private-capital-financed firms, and compute the same outcome metrics on the
+  matched cohort.
+
+Phase 1 is the gating deliverable. Phase 2 is contingent on Phase 1 yielding a
+defensible NSF metric set and on Form D ingest landing for A4 / M&A.
+
+## Phase 1 Requirements
+
+1. **SHALL** isolate the NSF SBIR cohort using ALN `47.041` and `47.084`
+   (existing identification classifier).
+2. **SHALL** compute the following NSF-cohort outcomes, stratified by award
+   vintage (5-year buckets) and Phase (I, II):
+   - Phase I → Phase II graduation rate
+   - Phase II → first non-SBIR federal contract transition rate (reuse
+     existing transition detector, ≥85% precision benchmark)
+   - 5-year survival proxy (firm appears as recipient/vendor in any federal
+     dataset 5 years post-Phase-II)
+   - Patent rate (patents linked to award via PATLINK / award-recipient ÷
+     awards)
+   - M&A exit rate (placeholder — populated when M&A spec lands; emit
+     "not-yet-available" until then)
+3. **SHALL** present results alongside cited public VC baselines:
+   - Seed → Series A graduation (NVCA / CB Insights public summaries)
+   - 5-year startup survival (BLS BED, public)
+   - Exit rate at 5 / 10 years (NVCA, public)
+   - Lerner [L10] and Howell [L11] published effect sizes
+4. **SHALL** produce a reconciliation narrative explaining each delta between
+   the NSF metric and the cited VC baseline, including selection-bias caveats
+   ("NSF awardees pre-selected on technical merit and proposal quality; VC-
+   financed firms self-select on lawyer access and growth narrative").
+5. **SHOULD** stratify NSF outcomes by CET technology area (reuse CET
+   classifier) so the comparison is not blurred by sector mix.
+6. **SHALL** report match rates and entity-resolution coverage as sensitivity
+   metadata (mirrors `leverage-ratio-analysis` requirement 7).
+
+### Phase 1 Gate Condition
+
+Can produce a single artifact (notebook or markdown report) that states:
+"NVCA reports seed→A graduation at ~30%. NSF Phase I→II graduation is [X]%
+on cohort [vintage range, n=Y]. The difference is attributable to [Z]."
+Reproduces the exact reconciliation pattern of `leverage-ratio-analysis`.
+
+## Phase 2 Requirements
+
+7. **SHALL** ingest SEC EDGAR Form D filings (XML/JSON via EDGAR full-text or
+   bulk archives), persisted to the standard staging layout (DuckDB-backed).
+   Coordinates with existing `sec_edgar` enrichment-source config in
+   `config/base.yaml` (currently disabled-by-default stub).
+8. **SHALL** parse Form D fields needed for cohort comparison: filer CIK,
+   issuer name + address + state, issuer NAICS (self-reported), filing date,
+   amount sold, total offering, security type (equity / debt / option /
+   convertible), industry group, minimum-investment-accepted.
+9. **SHALL** construct a CIK ↔ UEI/EIN crosswalk using:
+   - EIN where Form D supplies it (often blank; record availability rate)
+   - Issuer-name + state fuzzy match against the existing entity-resolution
+     vendor universe (UEI → CAGE → DUNS cascade, name fallback)
+   - Address normalization for tie-breaking
+   - Crosswalk match rate must be reported per cohort year; under 30% match
+     triggers a Phase 2 stop-and-discuss gate.
+10. **SHALL** define the comparison cohort as Form D issuers that are *not*
+    matched to any SBIR awardee (so we compare NSF-funded firms vs.
+    privately-financed firms with no SBIR exposure).
+11. **SHALL** match NSF and Form D cohorts on covariates: vintage year, NAICS-2
+    sector, state. Document the resulting cohort sizes and balance.
+12. **SHALL** compute the same outcomes from Phase 1 on the Form D cohort,
+    using the same federal-contract / patent / M&A signals (where applicable
+    to private firms).
+13. **SHALL** publish a threats-to-validity section before any headline
+    finding. Required entries: SAFE/convertible undercount, late-stage
+    inclusion, NAICS self-report noise, CIK↔UEI match-rate floor, technical-
+    merit vs. lawyer-access selection bias.
+14. **SHOULD** decompose the Form D cohort by security-type and offering size
+    so that downstream readers can isolate the (noisy but estimable) seed-
+    stage subset if they want.
+
+### Phase 2 Gate Condition
+
+Can state: "On vintage [X], NAICS-2 [Y], state [Z]: NSF Phase II awardees
+transitioned to federal contract at [A]% within 5 years; matched Form D
+issuers transitioned at [B]%. Selection-bias and matching caveats below."
+The reconciliation matters more than the headline number.
+
+## Dependencies
+
+- NSF identification (ALN 47.041 / 47.084) — `sbir_etl/models/sbir_identification.py` (EXISTS)
+- Transition detection (≥85% precision) — `packages/sbir-ml/sbir_ml/transition/` (EXISTS)
+- Entity resolution cascade — UEI/DUNS/CAGE/fuzzy-name (EXISTS)
+- PATLINK patent linkage (EXISTS)
+- CET classifier (EXISTS, used for Phase 1 stratification)
+- M&A detection — `specs/merger_acquisition_detection/` (REQUIREMENTS-ONLY;
+  Phase 1 emits placeholder, Phase 2 consumes when available)
+- SEC EDGAR ingest stub — `config/base.yaml` `sec_edgar` source (DISABLED;
+  Phase 2 enables and implements)
+- Form D ingest is also implicitly claimed by the M&A spec; Phase 2 of this
+  spec is the canonical implementation, M&A spec consumes the same artifacts.
+
+## Out of Scope
+
+- Composite "portfolio rank" / scoring construct — explicitly rejected.
+- Crunchbase / PitchBook integration (deferred to a future licensed-data spec).
+- Causal-effect estimation. This spec is descriptive comparison only; any
+  causal claims require IV / regression-discontinuity machinery beyond scope.
+- Non-NSF SBIR programs. DoD / NIH / DOE comparisons are downstream extensions.

--- a/specs/nsf-vc-comparison/requirements.md
+++ b/specs/nsf-vc-comparison/requirements.md
@@ -77,16 +77,22 @@ Reproduces the exact reconciliation pattern of `leverage-ratio-analysis`.
 
 7. **SHALL** ingest SEC EDGAR Form D filings (XML/JSON via EDGAR full-text or
    bulk archives), persisted to the standard staging layout (DuckDB-backed).
-   Coordinates with existing `sec_edgar` enrichment-source config in
-   `config/base.yaml` (currently disabled-by-default stub).
+   Adds a new `sec_edgar` enrichment source under `sbir_etl/enrichers/sec_edgar/`
+   following the existing `BaseAsyncAPIClient` pattern (mirrors `sam_gov`,
+   `usaspending_api`, `patentsview_api`). No prior stub exists — earlier
+   `iterative_api_enrichment` task notes referenced a `sec_edgar` config entry
+   that was never landed.
 8. **SHALL** parse Form D fields needed for cohort comparison: filer CIK,
    issuer name + address + state, issuer NAICS (self-reported), filing date,
    amount sold, total offering, security type (equity / debt / option /
    convertible), industry group, minimum-investment-accepted.
-9. **SHALL** construct a CIK ↔ UEI/EIN crosswalk using:
+9. **SHALL** construct a CIK ↔ UEI/EIN crosswalk by extending the existing
+   production `VendorCrosswalk` class (`packages/sbir-ml/sbir_ml/transition/
+   features/vendor_crosswalk.py`, 580 lines, supports UEI/CAGE/DUNS + fuzzy
+   name + acquisition handling) with a CIK field on `CrosswalkRecord` and
+   a `find_by_cik` accessor. Match cascade:
    - EIN where Form D supplies it (often blank; record availability rate)
-   - Issuer-name + state fuzzy match against the existing entity-resolution
-     vendor universe (UEI → CAGE → DUNS cascade, name fallback)
+   - Issuer-name + state fuzzy match via existing `find_by_name` machinery
    - Address normalization for tie-breaking
    - Crosswalk match rate must be reported per cohort year; under 30% match
      triggers a Phase 2 stop-and-discuss gate.
@@ -120,12 +126,19 @@ The reconciliation matters more than the headline number.
 - Entity resolution cascade — UEI/DUNS/CAGE/fuzzy-name (EXISTS)
 - PATLINK patent linkage (EXISTS)
 - CET classifier (EXISTS, used for Phase 1 stratification)
-- M&A detection — `specs/merger_acquisition_detection/` (REQUIREMENTS-ONLY;
-  Phase 1 emits placeholder, Phase 2 consumes when available)
-- SEC EDGAR ingest stub — `config/base.yaml` `sec_edgar` source (DISABLED;
-  Phase 2 enables and implements)
-- Form D ingest is also implicitly claimed by the M&A spec; Phase 2 of this
-  spec is the canonical implementation, M&A spec consumes the same artifacts.
+- M&A detection — `specs/merger_acquisition_detection/` plus a 45-line stub
+  asset at `packages/sbir-analytics/sbir_analytics/assets/ma_detection.py`
+  (patent-assignor flag-flipping only; placeholder date and confidence; not
+  consumable as-is). Phase 1 emits placeholder; Phase 2 may rebuild M&A
+  signal on top of the SEC 8-K data we ingest, separately from this spec.
+- SEC EDGAR ingest — none. Add a new enrichment source under
+  `sbir_etl/enrichers/sec_edgar/` following the established
+  `BaseAsyncAPIClient` pattern (`sam_gov`, `usaspending_api`, etc.).
+- Form D ingest — none. This spec is the canonical implementation; the
+  un-started M&A spec can consume the artifacts when it picks up.
+- `VendorCrosswalk` — production-quality 580-line entity-resolution
+  utility; Phase 2 extends it with CIK rather than building a parallel
+  structure.
 
 ## Out of Scope
 

--- a/specs/nsf-vc-comparison/tasks.md
+++ b/specs/nsf-vc-comparison/tasks.md
@@ -40,18 +40,24 @@ Coordinate Form D ingest scope with whoever owns
 `specs/merger_acquisition_detection/` before starting; the ingest built here
 is the canonical one.
 
-- [ ] 2.1 Enable + implement the `sec_edgar` enrichment source already stubbed
-  in `config/base.yaml`. Pull Form D submissions via EDGAR bulk archives
-  (preferred) or full-text search API. Persist raw XML to
-  `data/raw/sec_edgar/form_d/`.
+- [ ] 2.1 Add a new `sec_edgar` enrichment source under
+  `sbir_etl/enrichers/sec_edgar/` following the `BaseAsyncAPIClient` pattern
+  (mirror `sam_gov`, `usaspending_api`, `patentsview_api`). Add the matching
+  config stanza in `config/base.yaml` (no prior stub exists despite earlier
+  task notes). Pull Form D submissions via EDGAR bulk archives (preferred
+  over full-text search). Persist raw XML to `data/raw/sec_edgar/form_d/`.
 - [ ] 2.2 Add `FormDParser` — XML → typed records (filer CIK, issuer name +
   address + state, NAICS, filing date, amount sold, total offering, security
   type, industry group, minimum-investment-accepted). Strict on schema
   violations; emit to AlertCollector.
 - [ ] 2.3 Persist parsed records to a DuckDB staging table; verify schema
   contract with `sbir_etl/models/quality.py` patterns.
-- [ ] 2.4 Build `CIKCrosswalk` — tiered EIN → name+state → fuzzy-name+state+
-  city cascade. Each match record carries tier label + confidence.
+- [ ] 2.4 Extend `VendorCrosswalk` (`packages/sbir-ml/sbir_ml/transition/
+  features/vendor_crosswalk.py`) with a `cik` field on `CrosswalkRecord`,
+  an `_index_cik` map, and a `find_by_cik` accessor. Add a `CIKCrosswalk`
+  helper that runs the tiered EIN → name+state → fuzzy-name+state+city
+  cascade on top of existing `find_by_name` and `add_alias` machinery.
+  Each match record carries tier label + confidence.
 - [ ] 2.5 Build a hand-labeled backtest set of 200 known SBIR-firm ↔ Form D
   issuer pairs (seed from PR #286 references and public NSF awardees with
   known financings). Compute Tier A+B precision and recall.

--- a/specs/nsf-vc-comparison/tasks.md
+++ b/specs/nsf-vc-comparison/tasks.md
@@ -1,0 +1,97 @@
+# NSF SBIR vs. Private-Capital Comparison — Tasks
+
+Tasks are grouped by phase. Phase 1 ships independently. Phase 2 is gated on
+Phase 1 + Form D ingest scope coordination with the M&A spec.
+
+## Phase 1 — Published-Baseline Comparison
+
+- [ ] 1.1 Add `NSFCohortBuilder` under `packages/sbir-analytics/sbir_analytics/assets/nsf_vc/`.
+  Filter award universe to ALN ∈ {47.041, 47.084}, stratify by vintage (5-yr
+  buckets) + phase. Verify: cohort sizes match SBA annual report [L18] NSF
+  totals within 5%.
+- [ ] 1.2 Add `OutcomeMetricsCalculator` that reuses existing transition
+  detector (`packages/sbir-ml/sbir_ml/transition/`) and PATLINK. Emits Wilson-
+  CI-bounded rates per stratum. Verify: re-running on the leverage-ratio
+  fixture set reproduces transition rates within tolerance.
+- [ ] 1.3 Add `PublishedBaselineRegistry` — hard-coded YAML at
+  `config/nsf_vc/published_baselines.yaml` with source citations + as-of
+  dates. Initial entries: NVCA seed→A, BLS BED 5-yr survival, Lerner [L10]
+  effect size, Howell [L11] follow-on-VC effect, ITIF [L21] framing claims.
+- [ ] 1.4 Add `ReconciliationNarrative` writer. For each (NSF metric,
+  baseline) pair, emit JSON record + markdown line. Mirror the structure
+  of `LeverageRatioReconciler`.
+- [ ] 1.5 Wire as a Dagster asset `nsf_vc_published_baseline_comparison`.
+  Output artifacts: `nsf_cohort_outcomes.parquet`,
+  `nsf_vs_published_baselines.md`, `nsf_baseline_comparison.json`.
+- [ ] 1.6 Add unit tests under `tests/unit/nsf_vc/` covering: ALN filter
+  correctness, Wilson CI math, baseline-registry loading, reconciliation
+  record shape.
+- [ ] 1.7 Add an integration test against a small NSF fixture (vintage 2015,
+  Phase II, n≈100) verifying the full Phase 1 pipeline produces a
+  reproducible report.
+- [ ] 1.8 Phase 1 gate: produce the report, hand to user for review.
+  Deliverable language: "NVCA reports seed→A graduation at ~33%. NSF Phase
+  I→II graduation is [X]% on vintage 2015–2020 (n=Y). Difference is
+  attributable to [Z]." Stop here for sign-off before Phase 2.
+
+## Phase 2 — Form D Matched-Cohort Comparison
+
+Coordinate Form D ingest scope with whoever owns
+`specs/merger_acquisition_detection/` before starting; the ingest built here
+is the canonical one.
+
+- [ ] 2.1 Enable + implement the `sec_edgar` enrichment source already stubbed
+  in `config/base.yaml`. Pull Form D submissions via EDGAR bulk archives
+  (preferred) or full-text search API. Persist raw XML to
+  `data/raw/sec_edgar/form_d/`.
+- [ ] 2.2 Add `FormDParser` — XML → typed records (filer CIK, issuer name +
+  address + state, NAICS, filing date, amount sold, total offering, security
+  type, industry group, minimum-investment-accepted). Strict on schema
+  violations; emit to AlertCollector.
+- [ ] 2.3 Persist parsed records to a DuckDB staging table; verify schema
+  contract with `sbir_etl/models/quality.py` patterns.
+- [ ] 2.4 Build `CIKCrosswalk` — tiered EIN → name+state → fuzzy-name+state+
+  city cascade. Each match record carries tier label + confidence.
+- [ ] 2.5 Build a hand-labeled backtest set of 200 known SBIR-firm ↔ Form D
+  issuer pairs (seed from PR #286 references and public NSF awardees with
+  known financings). Compute Tier A+B precision and recall.
+- [ ] 2.6 **Phase 2 gate-A:** crosswalk Tier A+B precision ≥0.95, recall
+  ≥0.50, and per-vintage match rate ≥30%. If not met, stop-and-discuss
+  with user before continuing.
+- [ ] 2.7 Build `PrivateCapitalCohortBuilder` — drop Form D issuers matched
+  to any SBIR awardee, bucket the remainder by (vintage-year, NAICS-2, state).
+- [ ] 2.8 Build `CohortMatcher` — coarsened-exact matching of NSF and
+  private-capital cohorts on (vintage, NAICS-2, state). Report balance and
+  unmatched residuals.
+- [ ] 2.9 Run `OutcomeMetricsCalculator` on the matched private-capital
+  cohort (federal-contract transition is computable for any firm in FPDS;
+  patents via PATLINK; M&A via M&A spec output if available, else placeholder).
+- [ ] 2.10 Build `ThreatsToValidity` gate — required entries: SAFE/convertible
+  undercount, late-stage inclusion, NAICS self-report noise, CIK↔UEI
+  crosswalk floor, technical-merit vs. lawyer-access selection bias. Headline
+  artifact is suppressed if any entry is missing or stale.
+- [ ] 2.11 Wire Phase 2 as a Dagster asset
+  `nsf_vc_form_d_matched_comparison`. Output artifacts:
+  `form_d_filings.parquet`, `cik_uei_crosswalk.parquet`,
+  `private_capital_cohort_outcomes.parquet`, `nsf_vs_form_d_comparison.md`,
+  `threats_to_validity.json`.
+- [ ] 2.12 Add security-type decomposition view (Form D cohort split by
+  equity / debt / convertible / option) so downstream readers can isolate
+  the noisy seed-stage subset.
+- [ ] 2.13 Add unit + integration tests under `tests/unit/nsf_vc/` and
+  `tests/integration/nsf_vc/`. Integration test on a small EDGAR fixture
+  set (≤50 filings) verifying parser + crosswalk + cohort builder.
+- [ ] 2.14 Phase 2 gate: produce the cohort-vs-cohort report. Deliverable
+  language: "On vintage [X], NAICS-2 [Y], state [Z]: NSF Phase II
+  awardees transitioned to federal contract at [A]% within 5 years; matched
+  Form D issuers transitioned at [B]%. Caveats below." Hand to user for
+  review.
+
+## Cross-Phase Tasks
+
+- [ ] X.1 Add `docs/nsf-vc-comparison/` with methodology, glossary, and
+  citation table (mirrors `docs/transition/`).
+- [ ] X.2 Update `docs/research-questions.md` to cite this spec under B2/B3
+  and A4 (do not invent a new question — annotate existing ones).
+- [ ] X.3 After Phase 2 ships, evaluate whether to extend to DoD / NIH / DOE
+  using the same machinery (separate spec, not in this scope).


### PR DESCRIPTION
Two-phase spec comparing NSF SBIR portfolio outcomes to private-capital-
financed firms.

Phase 1 ships independently: NSF cohort outcome metrics (I→II graduation,
II→federal contract transition, 5-yr survival, patent rate, M&A exit
placeholder) presented alongside cited public VC baselines (NVCA, BLS BED,
Lerner [L10], Howell [L11], ITIF [L21]). Reuses existing transition
detector, PATLINK, and CET classifier.

Phase 2 ingests SEC EDGAR Form D as a broad private-capital signal (not
filtered to seed-only — broader instrument coverage is intentional),
builds a CIK ↔ UEI/EIN crosswalk with a ≥30% match-rate gate, constructs
a matched cohort, and runs the same outcome metrics. Threats-to-validity
gating is a hard requirement before any headline output.

Coordinates with specs/merger_acquisition_detection/ on Form D ingest;
this spec is the canonical implementation. Composite "portfolio rank"
construct explicitly rejected — framed as comparison-table-with-
reconciliation, mirroring specs/leverage-ratio-analysis/.

https://claude.ai/code/session_01FUJuDdtaGnAMv3G47b7wx2