### PR TITLE
fix(ci): evaluate docs-only with every-file semantics so mixed PRs aren't skipped

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -11,16 +11,19 @@ inputs:
   every-file-filters:
     description: |
       YAML string of path filters evaluated with "every file matches" semantics
-      (dorny/paths-filter `predicate-quantifier: 'every'`). Use for the
-      `docs-only` filter and similar all-files-must-match checks.
+      (dorny/paths-filter `predicate-quantifier: 'every'`). Currently only the
+      `docs-only` filter is wired through to a named output; add more outputs
+      below if you need to expose additional every-file filters.
     required: false
     default: ''
 
 outputs:
-  # Common outputs
+  # Common outputs. `docs-only` is sourced from the every_filter step (run
+  # only when `every-file-filters` is non-empty) and falls back to 'false'
+  # so callers can always compare against a stable boolean string.
   docs-only:
     description: Whether only documentation files changed (every-file semantics)
-    value: ${{ steps.every_filter.outputs.docs-only }}
+    value: ${{ steps.every_filter.outputs.docs-only || 'false' }}
   # CI-specific outputs (some-file semantics)
   performance:
     description: Whether performance-related files changed

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -3,15 +3,25 @@ description: Reusable change detection with configurable path filters
 
 inputs:
   filters:
-    description: YAML string of path filters (same format as dorny/paths-filter)
+    description: |
+      YAML string of path filters (same format as dorny/paths-filter).
+      Evaluated with default "some" semantics: a filter is true if at least
+      one changed file matches the filter.
     required: true
+  every-file-filters:
+    description: |
+      YAML string of path filters evaluated with "every file matches" semantics
+      (dorny/paths-filter `predicate-quantifier: 'every'`). Use for the
+      `docs-only` filter and similar all-files-must-match checks.
+    required: false
+    default: ''
 
 outputs:
   # Common outputs
   docs-only:
-    description: Whether only documentation files changed
-    value: ${{ steps.filter.outputs.docs-only }}
-  # CI-specific outputs
+    description: Whether only documentation files changed (every-file semantics)
+    value: ${{ steps.every_filter.outputs.docs-only }}
+  # CI-specific outputs (some-file semantics)
   performance:
     description: Whether performance-related files changed
     value: ${{ steps.filter.outputs.performance }}
@@ -44,3 +54,12 @@ runs:
       id: filter
       with:
         filters: ${{ inputs.filters }}
+
+    # Evaluate every-file-filters separately with predicate-quantifier='every'
+    # so e.g. `docs-only` is true only when EVERY changed file is a doc.
+    - if: inputs.every-file-filters != ''
+      uses: dorny/paths-filter@v4
+      id: every_filter
+      with:
+        filters: ${{ inputs.every-file-filters }}
+        predicate-quantifier: 'every'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,20 @@ jobs:
         id: detect
         uses: ./.github/actions/detect-changes
         with:
+          # docs-only uses every-file semantics — true only when EVERY changed
+          # file is a doc. Otherwise a mixed PR (code + docs) would skip CI.
+          every-file-filters: |
+            docs-only:
+              - '**/*.md'
+              - 'docs/**'
+              - '!**/*.py'
+              - '!**/*.yaml'
+              - '!**/*.yml'
+              - '!**/*.json'
+              - '!**/*.toml'
+              - '!**/*.lock'
+              - '!Makefile'
+              - '!.github/**'
           filters: |
             performance:
               - 'src/enrichers/**'
@@ -92,17 +106,6 @@ jobs:
               - '.github/actions/**'
             infrastructure:
               - 'infrastructure/cdk/**'
-            docs-only:
-              - '**/*.md'
-              - 'docs/**'
-              - '!**/*.py'
-              - '!**/*.yaml'
-              - '!**/*.yml'
-              - '!**/*.json'
-              - '!**/*.toml'
-              - '!**/*.lock'
-              - '!Makefile'
-              - '!.github/**'
 
   code-quality:
     name: Code Quality (Lint + Type Check)


### PR DESCRIPTION
## Summary

Pre-existing CI bug: mixed PRs (code + docs) are being treated as `docs-only`, causing every gated job to skip. Tests / lint / type-check don't run when a single `.md` file is touched alongside Python code.

## Root cause

`.github/actions/detect-changes/action.yml` invokes `dorny/paths-filter@v4` with default `predicate-quantifier: 'some'` semantics — a filter is true if **at least one** changed file matches. The `docs-only` filter:

```yaml
docs-only:
  - '**/*.md'
  - 'docs/**'
  - '!**/*.py'
  - ...
```

evaluates to `true` whenever any `.md` or `docs/**` file changed, regardless of whether the PR also changed code. Downstream jobs gated on `if: needs.detect-changes.outputs.docs-only != 'true'` then skip.

Observed on #295: 11 of 17 CI checks (Tests, Code Quality, E2E, Container Build, Performance, CET Smoke, Transition MVP, etc.) were skipped because the PR happened to also touch a few `.md` files.

## Fix

Add an `every-file-filters` input to `.github/actions/detect-changes` that's evaluated by a second `dorny/paths-filter@v4` step with `predicate-quantifier: 'every'`. Filters listed there match only when **every** changed file satisfies the patterns. Move `docs-only` from `filters` to `every-file-filters` so it matches the intent implied by its name.

The other filters (`performance`, `cet`, `transition`, `docker`, `workflows`, `infrastructure`) keep "some" semantics — they should fire when **any** relevant file changes, not only when all changes are in that area.

## Verification

This PR itself is the verification — it touches only `.github/...` files, so `docs-only` will correctly be `false` and the gated jobs will run.

## Test plan

- [ ] On this PR: tests, code quality, type checking run (they were skipping for `claude/simplify-codebase-tHS3g` before this fix)
- [ ] A docs-only PR (just `.md` / `docs/**` changes) correctly skips gated jobs

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur

---
_Generated by [Claude Code](https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur)_