### PR TITLE
fix(ci): install stack-dev extras so dagster/sbir_graph are available

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -7,7 +7,11 @@ inputs:
     required: false
     default: "3.11"
   install-dev-deps:
-    description: Whether to install dev dependencies
+    description: |
+      Whether to install dev dependencies. When "true", installs the
+      `stack-dev` meta-extra (covers sbir-etl[dev] plus the workspace
+      packages: sbir-ml, sbir-graph, sbir-rag, sbir-analytics — the
+      latter pulling in dagster). When "false", runs `uv sync --no-dev`.
     required: false
     default: "true"
   cache-venv:
@@ -96,10 +100,12 @@ runs:
 
     - name: Install dependencies
       run: |
-        # Fiscal analysis uses BEA REST API (no R/rpy2 required)
-        # Use install-r-deps input to include them when R is installed
+        # `stack-dev` is the meta-extra that includes sbir-etl[dev] plus the
+        # four workspace packages (sbir-ml, sbir-graph, sbir-rag,
+        # sbir-analytics). Without it, tests that import dagster, neo4j
+        # loaders, or ML pieces fail with ModuleNotFoundError.
         if [ "${{ inputs.install-dev-deps }}" = "true" ]; then
-          uv sync --extra dev
+          uv sync --extra stack-dev
         else
           uv sync --no-dev
         fi


### PR DESCRIPTION
## Summary

Switch CI's shared `setup-python-uv` action from `uv sync --extra dev` to `uv sync --extra stack-dev` so the workspace packages (sbir-ml, sbir-graph, sbir-rag, sbir-analytics) and their transitive deps (dagster, neo4j, etc.) are actually installed.

## Why

CI's test jobs were failing with `ModuleNotFoundError: No module named 'dagster'` / `'sbir_graph'` once the docs-only gating bug (#296) stopped silently skipping them. The shared setup action ran `uv sync --extra dev`, which only resolves the core `sbir-etl` package's dev dependencies — none of the four workspace packages.

`stack-dev` is the existing meta-extra in `pyproject.toml`:

```toml
stack-dev = [
    "sbir-etl[dev]",
    "sbir-ml",
    "sbir-graph",
    "sbir-rag",
    "sbir-analytics",
]
```

with workspace path sources resolved via `[tool.uv.sources]`.

## Verified locally

```
uv run python -c "import dagster, sbir_graph, sbir_ml, sbir_analytics; print('all imports succeed')"
# → all imports succeed
```

## Test plan

- [ ] On this PR's CI: `Tests (unit-fast)`, `Tests (integration)` jobs no longer fail with `ModuleNotFoundError`
- [ ] Pre-existing fixture/lint failures (covered in separate follow-ups) remain visible

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur

---
_Generated by [Claude Code](https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur)_