### PR TITLE
style: ruff check --fix + ruff format on tests/

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,7 +92,6 @@ def cached_sbir_sample_df(sbir_sample_csv_path: Path):
     return pd.read_csv(sbir_sample_csv_path)
 
 
-
 # SBIR Data Fixtures
 # ===================
 

--- a/tests/conftest_shared.py
+++ b/tests/conftest_shared.py
@@ -71,7 +71,6 @@ def neo4j_client(neo4j_config):
     client.close()
 
 
-
 class Neo4jTestHelper:
     """Helper class for Neo4j integration tests."""
 

--- a/tests/e2e/transition/test_quality_metrics.py
+++ b/tests/e2e/transition/test_quality_metrics.py
@@ -6,7 +6,10 @@ import pandas as pd
 import pytest
 
 from sbir_ml.transition.evaluation.evaluator import TransitionEvaluator
-from sbir_ml.transition.performance.monitoring import PerformanceTracker, profile_detection_performance
+from sbir_ml.transition.performance.monitoring import (
+    PerformanceTracker,
+    profile_detection_performance,
+)
 
 
 pytestmark = [pytest.mark.e2e, pytest.mark.slow]

--- a/tests/integration/test_company_categorization_client_injection.py
+++ b/tests/integration/test_company_categorization_client_injection.py
@@ -48,12 +48,8 @@ def mock_client():
             {"results": [], "page_metadata": {"hasNext": False, "total": 0}}
         )
     )
-    client.autocomplete_recipient = MagicMock(
-        side_effect=lambda *_a, **_k: _coro({"results": []})
-    )
-    client.fetch_award_details = MagicMock(
-        side_effect=lambda *_a, **_k: _coro({})
-    )
+    client.autocomplete_recipient = MagicMock(side_effect=lambda *_a, **_k: _coro({"results": []}))
+    client.fetch_award_details = MagicMock(side_effect=lambda *_a, **_k: _coro({}))
     return client
 
 
@@ -78,9 +74,7 @@ def test_retrieve_sbir_awards_api_uses_injected_client(mock_client):
 
 def test_fuzzy_match_branch_uses_injected_client(mock_client):
     """When UEI/DUNS are missing, fuzzy-match autocomplete also uses injected client."""
-    df = retrieve_company_contracts_api(
-        company_name="Advanced Technologies", client=mock_client
-    )
+    df = retrieve_company_contracts_api(company_name="Advanced Technologies", client=mock_client)
 
     assert isinstance(df, pd.DataFrame)
     assert mock_client.autocomplete_recipient.called

--- a/tests/integration/test_exception_handling.py
+++ b/tests/integration/test_exception_handling.py
@@ -7,14 +7,12 @@ useful information in real pipeline scenarios.
 import tempfile
 from pathlib import Path
 
-import pandas as pd
 import pytest
 
 from sbir_etl.exceptions import (
     APIError,
     ConfigurationError,
     DependencyError,
-    ValidationError,
 )
 from tests.utils.exception_helpers import (
     assert_exception_structure,
@@ -67,7 +65,6 @@ class TestConfigurationErrorHandling:
                 expected_operation="load_config_from_files",
             )
             assert exc.cause is not None  # Should preserve original YAML error
-
 
 
 class TestExceptionRetryability:

--- a/tests/integration/test_fiscal_pipeline_integration.py
+++ b/tests/integration/test_fiscal_pipeline_integration.py
@@ -168,7 +168,9 @@ class TestFiscalPipelineIntegration:
     @patch("sbir_etl.enrichers.geographic_resolver.resolve_award_geography")
     @patch("sbir_etl.enrichers.inflation_adjuster.adjust_awards_for_inflation")
     @patch("sbir_etl.enrichers.fiscal_bea_mapper.enrich_awards_with_bea_sectors")
-    @patch("sbir_etl.transformers.fiscal.shocks.FiscalShockAggregator.aggregate_shocks_to_dataframe")
+    @patch(
+        "sbir_etl.transformers.fiscal.shocks.FiscalShockAggregator.aggregate_shocks_to_dataframe"
+    )
     @patch("sbir_etl.transformers.bea_io_adapter.BEAIOAdapter._compute_impacts_bea")
     @patch("sbir_etl.transformers.bea_io_adapter.BEAIOAdapter.is_available")
     def test_end_to_end_pipeline(

--- a/tests/integration/test_sam_gov_integration.py
+++ b/tests/integration/test_sam_gov_integration.py
@@ -147,7 +147,9 @@ class TestSAMGovAssetIntegration:
                 mock_path.return_value.exists.return_value = True
 
                 # Mock SAMGovExtractor to return our test data
-                with patch("sbir_analytics.assets.sam_gov_ingestion.SAMGovExtractor") as mock_extractor_class:
+                with patch(
+                    "sbir_analytics.assets.sam_gov_ingestion.SAMGovExtractor"
+                ) as mock_extractor_class:
                     mock_extractor = MagicMock()
                     test_df = pd.read_parquet(sample_sam_gov_parquet)
                     mock_extractor.load_parquet.return_value = test_df

--- a/tests/integration/test_transition_integration.py
+++ b/tests/integration/test_transition_integration.py
@@ -188,9 +188,7 @@ class TestScoringCorrectness:
         }
 
         _, score_no_pat, _ = scorer.score_and_classify(award, contract)
-        _, score_with_pat, _ = scorer.score_and_classify(
-            award, contract, patent_data=patent_data
-        )
+        _, score_with_pat, _ = scorer.score_and_classify(award, contract, patent_data=patent_data)
 
         assert score_with_pat > score_no_pat
 
@@ -232,8 +230,7 @@ class TestScoringCorrectness:
         # Composite should be well above base_score
         base = detector_config.get("base_score", 0.15)
         assert score > base + 0.15, (
-            f"All-positive score ({score:.3f}) should be significantly above "
-            f"base_score ({base})"
+            f"All-positive score ({score:.3f}) should be significantly above base_score ({base})"
         )
 
     def test_minimal_signals_produces_possible_confidence(self, detector_config):

--- a/tests/mocks/bea_mocks.py
+++ b/tests/mocks/bea_mocks.py
@@ -1,7 +1,5 @@
 """Mock factories for BEA I-O adapter testing."""
 
-from unittest.mock import MagicMock
-
 import pandas as pd
 
 
@@ -11,31 +9,69 @@ class BEAMocks:
     @staticmethod
     def mock_bea_use_table() -> pd.DataFrame:
         """Create a mock BEA Use table API response."""
-        return pd.DataFrame([
-            {"RowCode": "11", "ColCode": "11", "DataValue": "10", "RowDescription": "Ag", "ColDescription": "Ag"},
-            {"RowCode": "11", "ColCode": "21", "DataValue": "20", "RowDescription": "Ag", "ColDescription": "Mining"},
-            {"RowCode": "21", "ColCode": "11", "DataValue": "5", "RowDescription": "Mining", "ColDescription": "Ag"},
-            {"RowCode": "21", "ColCode": "21", "DataValue": "10", "RowDescription": "Mining", "ColDescription": "Mining"},
-        ])
+        return pd.DataFrame(
+            [
+                {
+                    "RowCode": "11",
+                    "ColCode": "11",
+                    "DataValue": "10",
+                    "RowDescription": "Ag",
+                    "ColDescription": "Ag",
+                },
+                {
+                    "RowCode": "11",
+                    "ColCode": "21",
+                    "DataValue": "20",
+                    "RowDescription": "Ag",
+                    "ColDescription": "Mining",
+                },
+                {
+                    "RowCode": "21",
+                    "ColCode": "11",
+                    "DataValue": "5",
+                    "RowDescription": "Mining",
+                    "ColDescription": "Ag",
+                },
+                {
+                    "RowCode": "21",
+                    "ColCode": "21",
+                    "DataValue": "10",
+                    "RowDescription": "Mining",
+                    "ColDescription": "Mining",
+                },
+            ]
+        )
 
     @staticmethod
     def mock_bea_va_table() -> pd.DataFrame:
         """Create a mock BEA Value Added API response."""
-        return pd.DataFrame([
-            {"ColCode": "11", "RowDescription": "Compensation of employees", "DataValue": "400"},
-            {"ColCode": "11", "RowDescription": "Gross operating surplus", "DataValue": "300"},
-            {"ColCode": "11", "RowDescription": "Taxes on production", "DataValue": "150"},
-            {"ColCode": "11", "RowDescription": "Total value added", "DataValue": "850"},
-            {"ColCode": "21", "RowDescription": "Compensation of employees", "DataValue": "200"},
-            {"ColCode": "21", "RowDescription": "Gross operating surplus", "DataValue": "150"},
-            {"ColCode": "21", "RowDescription": "Taxes on production", "DataValue": "75"},
-            {"ColCode": "21", "RowDescription": "Total value added", "DataValue": "425"},
-        ])
+        return pd.DataFrame(
+            [
+                {
+                    "ColCode": "11",
+                    "RowDescription": "Compensation of employees",
+                    "DataValue": "400",
+                },
+                {"ColCode": "11", "RowDescription": "Gross operating surplus", "DataValue": "300"},
+                {"ColCode": "11", "RowDescription": "Taxes on production", "DataValue": "150"},
+                {"ColCode": "11", "RowDescription": "Total value added", "DataValue": "850"},
+                {
+                    "ColCode": "21",
+                    "RowDescription": "Compensation of employees",
+                    "DataValue": "200",
+                },
+                {"ColCode": "21", "RowDescription": "Gross operating surplus", "DataValue": "150"},
+                {"ColCode": "21", "RowDescription": "Taxes on production", "DataValue": "75"},
+                {"ColCode": "21", "RowDescription": "Total value added", "DataValue": "425"},
+            ]
+        )
 
     @staticmethod
     def mock_bea_employment_table() -> pd.DataFrame:
         """Create a mock BEA Employment API response."""
-        return pd.DataFrame([
-            {"ColCode": "11", "DataValue": "2000", "RowDescription": "Employment"},
-            {"ColCode": "21", "DataValue": "1000", "RowDescription": "Employment"},
-        ])
+        return pd.DataFrame(
+            [
+                {"ColCode": "11", "DataValue": "2000", "RowDescription": "Employment"},
+                {"ColCode": "21", "DataValue": "1000", "RowDescription": "Employment"},
+            ]
+        )

--- a/tests/unit/assets/cet/test_classifications.py
+++ b/tests/unit/assets/cet/test_classifications.py
@@ -141,7 +141,9 @@ class TestCETAwardClassificationsQualityCheck:
             mock_path_class.return_value = mock_path
 
             # Call the check function directly (it's decorated but still callable)
-            from sbir_analytics.assets.cet.classifications import cet_award_classifications_quality_check
+            from sbir_analytics.assets.cet.classifications import (
+                cet_award_classifications_quality_check,
+            )
 
             result = cet_award_classifications_quality_check(mock_context)
 

--- a/tests/unit/clients/test_clients.py
+++ b/tests/unit/clients/test_clients.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import json
-import tempfile
 from datetime import datetime, timedelta
-from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -180,7 +178,7 @@ class TestMetricsCollector:
 
 class TestReExports:
     def test_neo4j_classes_importable(self):
-        from sbir_analytics.clients import Neo4jClient, Neo4jConfig, Neo4jHealthStatus, Neo4jStatistics
+        from sbir_analytics.clients import Neo4jClient
 
         # Verify they're the actual sbir-graph classes
         from sbir_graph.loaders.neo4j.client import Neo4jClient as GraphClient
@@ -191,8 +189,14 @@ class TestReExports:
         from sbir_analytics import clients
 
         expected = {
-            "AssetStatus", "DagsterClient", "MetricsCollector",
-            "Neo4jClient", "Neo4jConfig", "Neo4jHealthStatus",
-            "Neo4jStatistics", "PipelineMetrics", "RunResult",
+            "AssetStatus",
+            "DagsterClient",
+            "MetricsCollector",
+            "Neo4jClient",
+            "Neo4jConfig",
+            "Neo4jHealthStatus",
+            "Neo4jStatistics",
+            "PipelineMetrics",
+            "RunResult",
         }
         assert expected.issubset(set(clients.__all__))

--- a/tests/unit/enrichers/naics/test_core.py
+++ b/tests/unit/enrichers/naics/test_core.py
@@ -9,7 +9,12 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
-from sbir_etl.enrichers.naics.core import NAICS_RE, RECIPIENT_UEI_RE, NAICSEnricher, NAICSEnricherConfig
+from sbir_etl.enrichers.naics.core import (
+    NAICS_RE,
+    RECIPIENT_UEI_RE,
+    NAICSEnricher,
+    NAICSEnricherConfig,
+)
 
 
 # ==================== Fixtures ====================

--- a/tests/unit/enrichers/naics/test_fiscal_strategies.py
+++ b/tests/unit/enrichers/naics/test_fiscal_strategies.py
@@ -11,7 +11,9 @@ class TestOriginalDataStrategy:
 
     def test_extracts_naics_from_standard_column(self):
         """Test extraction from NAICS column."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            OriginalDataStrategy,
+        )
 
         strategy = OriginalDataStrategy()
         row = pd.Series({"NAICS": "541715", "company_name": "Test Corp"})
@@ -26,7 +28,9 @@ class TestOriginalDataStrategy:
 
     def test_extracts_naics_from_alternative_columns(self):
         """Test extraction from alternative column names."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            OriginalDataStrategy,
+        )
 
         strategy = OriginalDataStrategy()
 
@@ -39,7 +43,9 @@ class TestOriginalDataStrategy:
 
     def test_returns_none_when_no_naics_column(self):
         """Test returns None when no NAICS column present."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            OriginalDataStrategy,
+        )
 
         strategy = OriginalDataStrategy()
         row = pd.Series({"company_name": "Test Corp", "award_amount": 100000})
@@ -50,7 +56,9 @@ class TestOriginalDataStrategy:
 
     def test_returns_none_for_null_naics(self):
         """Test returns None when NAICS value is null."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            OriginalDataStrategy,
+        )
 
         strategy = OriginalDataStrategy()
         row = pd.Series({"NAICS": None, "company_name": "Test Corp"})
@@ -61,7 +69,9 @@ class TestOriginalDataStrategy:
 
     def test_strategy_properties(self):
         """Test strategy name and confidence level."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import OriginalDataStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            OriginalDataStrategy,
+        )
 
         strategy = OriginalDataStrategy()
 
@@ -74,7 +84,9 @@ class TestSectorFallbackStrategy:
 
     def test_returns_default_fallback_code(self):
         """Test returns default 5415 code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            SectorFallbackStrategy,
+        )
 
         strategy = SectorFallbackStrategy()
         row = pd.Series({"company_name": "Test Corp"})
@@ -89,7 +101,9 @@ class TestSectorFallbackStrategy:
 
     def test_custom_fallback_code(self):
         """Test with custom fallback code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            SectorFallbackStrategy,
+        )
 
         strategy = SectorFallbackStrategy(fallback_code="541712")
         row = pd.Series({"company_name": "Test Corp"})
@@ -101,7 +115,9 @@ class TestSectorFallbackStrategy:
 
     def test_always_succeeds(self):
         """Test fallback always returns a result."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            SectorFallbackStrategy,
+        )
 
         strategy = SectorFallbackStrategy()
 
@@ -114,7 +130,9 @@ class TestSectorFallbackStrategy:
 
     def test_strategy_properties(self):
         """Test strategy name and confidence level."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            SectorFallbackStrategy,
+        )
 
         strategy = SectorFallbackStrategy()
 
@@ -127,7 +145,9 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_dod_default(self):
         """Test DOD agency returns aerospace manufacturing code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            AgencyDefaultsStrategy,
+        )
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"agency": "DOD", "company_name": "Test Corp"})
@@ -140,7 +160,9 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_hhs_default(self):
         """Test HHS agency returns biotech R&D code."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            AgencyDefaultsStrategy,
+        )
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"agency": "HHS", "company_name": "Test Corp"})
@@ -152,7 +174,9 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_none_for_unknown_agency(self):
         """Test returns None for unknown agency."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            AgencyDefaultsStrategy,
+        )
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"agency": "UNKNOWN_AGENCY", "company_name": "Test Corp"})
@@ -163,7 +187,9 @@ class TestAgencyDefaultsStrategy:
 
     def test_returns_none_when_no_agency(self):
         """Test returns None when agency column missing."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            AgencyDefaultsStrategy,
+        )
 
         strategy = AgencyDefaultsStrategy()
         row = pd.Series({"company_name": "Test Corp"})
@@ -174,7 +200,9 @@ class TestAgencyDefaultsStrategy:
 
     def test_strategy_properties(self):
         """Test strategy name and confidence level."""
-        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import AgencyDefaultsStrategy
+        from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import (
+            AgencyDefaultsStrategy,
+        )
 
         strategy = AgencyDefaultsStrategy()
 

--- a/tests/unit/enrichers/test_award_history.py
+++ b/tests/unit/enrichers/test_award_history.py
@@ -25,8 +25,13 @@ pytestmark = pytest.mark.fast
 def _make_awards_df(rows: list[dict]) -> pd.DataFrame:
     """Create a DataFrame with the columns expected by _build_history_from_df."""
     cols = [
-        "_group_key", "Phase", "Agency", "Award Amount",
-        "Proposal Award Date", "Award Title", "Program",
+        "_group_key",
+        "Phase",
+        "Agency",
+        "Award Amount",
+        "Proposal Award Date",
+        "Award Title",
+        "Program",
     ]
     for col in cols:
         for row in rows:
@@ -41,26 +46,28 @@ def _make_awards_df(rows: list[dict]) -> pd.DataFrame:
 
 class TestBuildHistoryFromDF:
     def test_basic_aggregation(self):
-        df = _make_awards_df([
-            {
-                "_group_key": "ACME CORP",
-                "Phase": "Phase I",
-                "Agency": "DOD",
-                "Award Amount": "150000",
-                "Proposal Award Date": "2021-06-01",
-                "Award Title": "Widget Research",
-                "Program": "SBIR",
-            },
-            {
-                "_group_key": "ACME CORP",
-                "Phase": "Phase II",
-                "Agency": "DOD",
-                "Award Amount": "1000000",
-                "Proposal Award Date": "2023-01-15",
-                "Award Title": "Widget Prototype",
-                "Program": "SBIR",
-            },
-        ])
+        df = _make_awards_df(
+            [
+                {
+                    "_group_key": "ACME CORP",
+                    "Phase": "Phase I",
+                    "Agency": "DOD",
+                    "Award Amount": "150000",
+                    "Proposal Award Date": "2021-06-01",
+                    "Award Title": "Widget Research",
+                    "Program": "SBIR",
+                },
+                {
+                    "_group_key": "ACME CORP",
+                    "Phase": "Phase II",
+                    "Agency": "DOD",
+                    "Award Amount": "1000000",
+                    "Proposal Award Date": "2023-01-15",
+                    "Award Title": "Widget Prototype",
+                    "Program": "SBIR",
+                },
+            ]
+        )
 
         result = _build_history_from_df(df, "_group_key")
 
@@ -76,26 +83,28 @@ class TestBuildHistoryFromDF:
         assert len(entry["sample_titles"]) == 2
 
     def test_multiple_groups(self):
-        df = _make_awards_df([
-            {
-                "_group_key": "ACME CORP",
-                "Phase": "Phase I",
-                "Agency": "DOD",
-                "Award Amount": "100000",
-                "Proposal Award Date": "2021-01-01",
-                "Award Title": "Title A",
-                "Program": "SBIR",
-            },
-            {
-                "_group_key": "BETA INC",
-                "Phase": "Phase I",
-                "Agency": "NASA",
-                "Award Amount": "200000",
-                "Proposal Award Date": "2022-06-01",
-                "Award Title": "Title B",
-                "Program": "STTR",
-            },
-        ])
+        df = _make_awards_df(
+            [
+                {
+                    "_group_key": "ACME CORP",
+                    "Phase": "Phase I",
+                    "Agency": "DOD",
+                    "Award Amount": "100000",
+                    "Proposal Award Date": "2021-01-01",
+                    "Award Title": "Title A",
+                    "Program": "SBIR",
+                },
+                {
+                    "_group_key": "BETA INC",
+                    "Phase": "Phase I",
+                    "Agency": "NASA",
+                    "Award Amount": "200000",
+                    "Proposal Award Date": "2022-06-01",
+                    "Award Title": "Title B",
+                    "Program": "STTR",
+                },
+            ]
+        )
 
         result = _build_history_from_df(df, "_group_key")
 
@@ -104,18 +113,20 @@ class TestBuildHistoryFromDF:
         assert result["BETA INC"]["agencies"] == ["NASA"]
 
     def test_extra_set_cols(self):
-        df = _make_awards_df([
-            {
-                "_group_key": "JANE DOE",
-                "Phase": "Phase I",
-                "Agency": "DOD",
-                "Award Amount": "100000",
-                "Proposal Award Date": "2021-01-01",
-                "Award Title": "Research A",
-                "Program": "SBIR",
-                "Company": "Acme Corp",
-            },
-        ])
+        df = _make_awards_df(
+            [
+                {
+                    "_group_key": "JANE DOE",
+                    "Phase": "Phase I",
+                    "Agency": "DOD",
+                    "Award Amount": "100000",
+                    "Proposal Award Date": "2021-01-01",
+                    "Award Title": "Research A",
+                    "Program": "SBIR",
+                    "Company": "Acme Corp",
+                },
+            ]
+        )
 
         result = _build_history_from_df(df, "_group_key", extra_set_cols=["Company"])
 
@@ -123,16 +134,18 @@ class TestBuildHistoryFromDF:
         assert result["JANE DOE"]["companies"] == ["Acme Corp"]
 
     def test_empty_group_key_skipped(self):
-        df = _make_awards_df([
-            {
-                "_group_key": "",
-                "Phase": "Phase I",
-                "Agency": "DOD",
-                "Award Amount": "50000",
-                "Award Title": "Phantom",
-                "Program": "SBIR",
-            },
-        ])
+        df = _make_awards_df(
+            [
+                {
+                    "_group_key": "",
+                    "Phase": "Phase I",
+                    "Agency": "DOD",
+                    "Award Amount": "50000",
+                    "Award Title": "Phantom",
+                    "Program": "SBIR",
+                },
+            ]
+        )
 
         result = _build_history_from_df(df, "_group_key")
         assert len(result) == 0
@@ -148,17 +161,19 @@ class TestGetCompanyHistory:
         awards = [{"Company": "Acme Corp"}, {"Company": "Beta Inc"}]
 
         mock_extractor = MagicMock()
-        df = _make_awards_df([
-            {
-                "_group_key": "ACME CORP",
-                "Phase": "Phase I",
-                "Agency": "DOD",
-                "Award Amount": "150000",
-                "Proposal Award Date": "2021-06-01",
-                "Award Title": "Widget Research",
-                "Program": "SBIR",
-            },
-        ])
+        df = _make_awards_df(
+            [
+                {
+                    "_group_key": "ACME CORP",
+                    "Phase": "Phase I",
+                    "Agency": "DOD",
+                    "Award Amount": "150000",
+                    "Proposal Award Date": "2021-06-01",
+                    "Award Title": "Widget Research",
+                    "Program": "SBIR",
+                },
+            ]
+        )
         mock_extractor.duckdb_client.execute_query_df.return_value = df
 
         result = get_company_history(
@@ -224,9 +239,7 @@ class TestGetPIHistory:
         df = _make_awards_df(rows)
         mock_extractor.duckdb_client.execute_query_df.return_value = df
 
-        result = get_pi_history(
-            awards, source=None, extractor=mock_extractor, table="sbir_awards"
-        )
+        result = get_pi_history(awards, source=None, extractor=mock_extractor, table="sbir_awards")
 
         assert "JANE DOE" in result
         entry = result["JANE DOE"]

--- a/tests/unit/enrichers/test_base_client.py
+++ b/tests/unit/enrichers/test_base_client.py
@@ -111,18 +111,14 @@ class TestRateLimiting:
 
         assert len(client.request_times) == 11
 
-    async def test_records_timestamp_on_every_call(
-        self, client: _StubAPIClient
-    ) -> None:
+    async def test_records_timestamp_on_every_call(self, client: _StubAPIClient) -> None:
         assert client.request_times == []
         await client._wait_for_rate_limit()
         assert len(client.request_times) == 1
         await client._wait_for_rate_limit()
         assert len(client.request_times) == 2
 
-    async def test_evicts_timestamps_older_than_sixty_seconds(
-        self, client: _StubAPIClient
-    ) -> None:
+    async def test_evicts_timestamps_older_than_sixty_seconds(self, client: _StubAPIClient) -> None:
         """Timestamps outside the 60s window are purged before the check."""
         old = datetime.now() - timedelta(seconds=90)
         for _ in range(client.rate_limit_per_minute):
@@ -207,9 +203,7 @@ class TestMakeRequestSuccess:
         payload = {"created": "abc"}
         mock_http_client.post.return_value = _make_mock_response(200, payload)
 
-        result = await client._make_request(
-            "POST", "/things", params={"name": "widget"}
-        )
+        result = await client._make_request("POST", "/things", params={"name": "widget"})
 
         assert result == payload
         call_kwargs = mock_http_client.post.call_args[1]
@@ -290,9 +284,7 @@ class TestMakeRequestSuccess:
     ) -> None:
         mock_http_client.get.return_value = _make_mock_response(200, {})
 
-        await client._make_request(
-            "GET", "/things", headers={"User-Agent": "Custom/9.9"}
-        )
+        await client._make_request("GET", "/things", headers={"User-Agent": "Custom/9.9"})
 
         call_headers = mock_http_client.get.call_args[1]["headers"]
         assert call_headers["User-Agent"] == "Custom/9.9"

--- a/tests/unit/enrichers/test_chunked_enricher.py
+++ b/tests/unit/enrichers/test_chunked_enricher.py
@@ -45,7 +45,12 @@ class TestChunkedEnricherInitialization:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_initialization_with_checkpoint_dir(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test initialization with checkpoint directory."""
         mock_get_config.return_value = mock_config

--- a/tests/unit/enrichers/test_chunked_enrichment.py
+++ b/tests/unit/enrichers/test_chunked_enrichment.py
@@ -210,7 +210,12 @@ class TestChunkedEnricherInitialization:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_initialization_with_checkpoint_dir(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test initialization with checkpoint directory."""
         mock_get_config.return_value = mock_config
@@ -226,7 +231,12 @@ class TestChunkedEnricherInitialization:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_initialization_progress_tracking_disabled(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test initialization with progress tracking disabled."""
         mock_get_config.return_value = mock_config
@@ -668,7 +678,12 @@ class TestCheckpointManagement:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_load_last_checkpoint_empty_directory(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test load_last_checkpoint with empty directory."""
         mock_get_config.return_value = mock_config
@@ -682,7 +697,12 @@ class TestCheckpointManagement:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_load_last_checkpoint_success(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test successful checkpoint loading."""
         mock_get_config.return_value = mock_config
@@ -705,7 +725,12 @@ class TestCheckpointManagement:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_resume_from_checkpoint(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test resume from checkpoint."""
         mock_get_config.return_value = mock_config
@@ -729,7 +754,12 @@ class TestCheckpointManagement:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_clear_checkpoints(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test checkpoint cleanup."""
         mock_get_config.return_value = mock_config
@@ -960,7 +990,12 @@ class TestEdgeCases:
 
     @patch("sbir_etl.enrichers.chunked_enrichment.get_config")
     def test_load_checkpoint_corrupt_json(
-        self, mock_get_config, mock_config, enricher_sbir_df, enricher_recipient_df, temp_checkpoint_dir
+        self,
+        mock_get_config,
+        mock_config,
+        enricher_sbir_df,
+        enricher_recipient_df,
+        temp_checkpoint_dir,
     ):
         """Test load_last_checkpoint handles corrupt JSON."""
         mock_get_config.return_value = mock_config

--- a/tests/unit/enrichers/test_company_enrichment.py
+++ b/tests/unit/enrichers/test_company_enrichment.py
@@ -37,9 +37,7 @@ class TestUSAspendingAutocomplete:
     def test_match_with_uei(self, MockClient):
         client = MockClient.return_value
         client.autocomplete_recipient.return_value = {
-            "results": [
-                {"legal_business_name": "Acme Inc", "uei": "ABC123DEF456"}
-            ]
+            "results": [{"legal_business_name": "Acme Inc", "uei": "ABC123DEF456"}]
         }
 
         result = usaspending_autocomplete("Acme Inc")
@@ -51,9 +49,7 @@ class TestUSAspendingAutocomplete:
     def test_match_without_uei_returns_best_candidate(self, MockClient):
         client = MockClient.return_value
         client.autocomplete_recipient.return_value = {
-            "results": [
-                {"legal_business_name": "Acme Incorporated", "uei": None}
-            ]
+            "results": [{"legal_business_name": "Acme Incorporated", "uei": None}]
         }
 
         result = usaspending_autocomplete("Acme Inc")
@@ -142,16 +138,19 @@ class TestLookupCompanyFederalAwards:
     def test_name_fallback(self, mock_is_sbir, mock_search, mock_auto):
         mock_is_sbir.return_value = False
         # First call (UEI) returns None, second call (name) returns results
-        mock_search.side_effect = [None, [
-            {
-                "Awarding Agency": "NASA",
-                "Award Type": "Grant",
-                "Award Amount": 100000,
-                "Start Date": "2023-03-15",
-                "Description": "Space stuff",
-                "CFDA Number": "",
-            }
-        ]]
+        mock_search.side_effect = [
+            None,
+            [
+                {
+                    "Awarding Agency": "NASA",
+                    "Award Type": "Grant",
+                    "Award Amount": 100000,
+                    "Start Date": "2023-03-15",
+                    "Description": "Space stuff",
+                    "CFDA Number": "",
+                }
+            ],
+        ]
 
         result = lookup_company_federal_awards("Acme Corp", uei="ABC123")
 
@@ -204,9 +203,7 @@ class TestLookupUSAspendingRecipient:
     @patch(f"{MODULE}.SyncUSAspendingClient")
     def test_two_step_lookup(self, MockClient):
         client = MockClient.return_value
-        client.search_recipients.return_value = [
-            {"id": "hash-abc-123", "name": "Acme Corp"}
-        ]
+        client.search_recipients.return_value = [{"id": "hash-abc-123", "name": "Acme Corp"}]
         client.get_recipient_profile.return_value = {
             "name": "Acme Corp",
             "uei": "ABC123DEF456",
@@ -332,9 +329,7 @@ class TestFetchFPDSDescriptions:
     @patch(f"{MODULE}.SyncFPDSAtomClient")
     def test_success(self, MockClient):
         ctx = MockClient.return_value.__enter__.return_value
-        ctx.get_descriptions.return_value = {
-            "W911NF-20-1-0001": "Research on advanced materials"
-        }
+        ctx.get_descriptions.return_value = {"W911NF-20-1-0001": "Research on advanced materials"}
 
         result = fetch_fpds_descriptions(["W911NF-20-1-0001"])
         assert result == {"W911NF-20-1-0001": "Research on advanced materials"}
@@ -377,9 +372,7 @@ class TestFetchUSAspendingContractDescriptions:
         client.search_awards.side_effect = RuntimeError("API error")
         client.search_transactions.side_effect = RuntimeError("API error")
 
-        mock_fpds.return_value = {
-            "W911NF-20-1-0001": "Fallback description from FPDS"
-        }
+        mock_fpds.return_value = {"W911NF-20-1-0001": "Fallback description from FPDS"}
 
         awards = [{"Contract": "W911NF-20-1-0001"}]
         result = fetch_usaspending_contract_descriptions(awards)
@@ -403,12 +396,18 @@ class TestLookupSAMEntityWithFallback:
     @patch(f"{MODULE}.lookup_sam_entity")
     def test_returns_primary_when_available(self, mock_primary):
         record = SAMEntityRecord(
-            uei="ABC123DEF456", legal_business_name="Acme Inc",
-            dba_name=None, registration_status="Active",
-            expiration_date="2025-12-31", business_type="2X",
-            entity_structure="LLC", naics_codes=["541511"],
-            cage_code="1AB2C", exclusion_status="N",
-            state="VA", congressional_district="11",
+            uei="ABC123DEF456",
+            legal_business_name="Acme Inc",
+            dba_name=None,
+            registration_status="Active",
+            expiration_date="2025-12-31",
+            business_type="2X",
+            entity_structure="LLC",
+            naics_codes=["541511"],
+            cage_code="1AB2C",
+            exclusion_status="N",
+            state="VA",
+            congressional_district="11",
         )
         mock_primary.return_value = record
 
@@ -419,10 +418,15 @@ class TestLookupSAMEntityWithFallback:
     @patch(f"{MODULE}.lookup_sam_entity", return_value=None)
     def test_falls_back_to_usaspending_when_sam_returns_none(self, mock_sam, mock_usa):
         mock_usa.return_value = USARecipientProfile(
-            recipient_id="R123", name="Acme Inc", uei="ABC123DEF456",
-            parent_name=None, parent_uei=None,
-            location_state="VA", location_congressional_district="11",
-            business_types=["Small Business"], total_transaction_amount=1_000_000.0,
+            recipient_id="R123",
+            name="Acme Inc",
+            uei="ABC123DEF456",
+            parent_name=None,
+            parent_uei=None,
+            location_state="VA",
+            location_congressional_district="11",
+            business_types=["Small Business"],
+            total_transaction_amount=1_000_000.0,
             total_transactions=5,
         )
 
@@ -456,10 +460,15 @@ class TestLookupUSAspendingRecipientWithFallback:
     @patch(f"{MODULE}.lookup_usaspending_recipient")
     def test_returns_primary_when_available(self, mock_primary):
         record = USARecipientProfile(
-            recipient_id="R123", name="Acme Inc", uei="ABC123DEF456",
-            parent_name=None, parent_uei=None,
-            location_state="VA", location_congressional_district="11",
-            business_types=["Small Business"], total_transaction_amount=1_000_000.0,
+            recipient_id="R123",
+            name="Acme Inc",
+            uei="ABC123DEF456",
+            parent_name=None,
+            parent_uei=None,
+            location_state="VA",
+            location_congressional_district="11",
+            business_types=["Small Business"],
+            total_transaction_amount=1_000_000.0,
             total_transactions=5,
         )
         mock_primary.return_value = record
@@ -471,12 +480,18 @@ class TestLookupUSAspendingRecipientWithFallback:
     @patch(f"{MODULE}.lookup_usaspending_recipient", return_value=None)
     def test_falls_back_to_sam_when_usaspending_returns_none(self, mock_usa, mock_sam):
         mock_sam.return_value = SAMEntityRecord(
-            uei="ABC123DEF456", legal_business_name="Acme Inc",
-            dba_name=None, registration_status="Active",
-            expiration_date="2025-12-31", business_type="Small Business",
-            entity_structure="LLC", naics_codes=["541511"],
-            cage_code="1AB2C", exclusion_status="N",
-            state="VA", congressional_district="11",
+            uei="ABC123DEF456",
+            legal_business_name="Acme Inc",
+            dba_name=None,
+            registration_status="Active",
+            expiration_date="2025-12-31",
+            business_type="Small Business",
+            entity_structure="LLC",
+            naics_codes=["541511"],
+            cage_code="1AB2C",
+            exclusion_status="N",
+            state="VA",
+            congressional_district="11",
         )
 
         result = lookup_usaspending_recipient_with_fallback("Acme Inc")

--- a/tests/unit/enrichers/test_form_d_scoring.py
+++ b/tests/unit/enrichers/test_form_d_scoring.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import date
 
-import pytest
 
 from sbir_etl.enrichers.sec_edgar.form_d_scoring import (
     compute_form_d_confidence,
@@ -206,7 +205,9 @@ class TestComputeFormDConfidence:
         result = compute_form_d_confidence(
             name_score=0.50,
             pi_names=["Jane Smith"],
-            related_persons=[{"name": "Bob Johnson", "title": "Director", "city": "Dallas", "state": "TX"}],
+            related_persons=[
+                {"name": "Bob Johnson", "title": "Director", "city": "Dallas", "state": "TX"}
+            ],
             sbir_state="MA",
             biz_states=["TX"],
             earliest_sbir_award_year=2013,

--- a/tests/unit/enrichers/test_fpds_atom.py
+++ b/tests/unit/enrichers/test_fpds_atom.py
@@ -171,9 +171,7 @@ class TestInitialization:
 
 
 class TestSharedLimiterOverride:
-    async def test_shared_limiter_invoked(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_shared_limiter_invoked(self, mock_http_client: AsyncMock) -> None:
         shared = RateLimiter(rate_limit_per_minute=30)
         shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
         c = FPDSAtomClient(shared_limiter=shared, http_client=mock_http_client)
@@ -266,9 +264,7 @@ class TestSearchByPiid:
 
 
 class TestSearchByVendor:
-    async def test_with_uei(
-        self, client: FPDSAtomClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_with_uei(self, client: FPDSAtomClient, mock_http_client: AsyncMock) -> None:
         mock_http_client.get.return_value = _mock_response(200, SAMPLE_ATOM_ENTRY)
 
         records = await client.search_by_vendor(uei="ABC123DEF456")
@@ -277,9 +273,7 @@ class TestSearchByVendor:
         call_kwargs = mock_http_client.get.call_args[1]
         assert "VENDOR_UEI_NUMBER" in call_kwargs["params"]["q"]
 
-    async def test_with_name(
-        self, client: FPDSAtomClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_with_name(self, client: FPDSAtomClient, mock_http_client: AsyncMock) -> None:
         mock_http_client.get.return_value = _mock_response(200, EMPTY_FEED)
 
         await client.search_by_vendor(name="Acme Corp")

--- a/tests/unit/enrichers/test_lens_patents.py
+++ b/tests/unit/enrichers/test_lens_patents.py
@@ -107,9 +107,7 @@ class TestParseRecords:
 
     def test_string_applicant_coerced(self):
         """If applicant is a string (not dict), assignee gets str() form."""
-        records = _parse_records(
-            {"data": [{"lens_id": "x", "title": "t", "applicant": ["Acme"]}]}
-        )
+        records = _parse_records({"data": [{"lens_id": "x", "title": "t", "applicant": ["Acme"]}]})
         assert records[0].assignee == "Acme"
 
 
@@ -155,9 +153,7 @@ class TestInitialization:
         assert headers["Authorization"] == "Bearer test-token"
         assert headers["Content-Type"] == "application/json"
 
-    def test_no_token_no_auth_header(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    def test_no_token_no_auth_header(self, mock_http_client: AsyncMock) -> None:
         with patch.dict("os.environ", {}, clear=True):
             c = LensPatentClient(http_client=mock_http_client)
         headers = c._build_headers()
@@ -176,14 +172,10 @@ class TestInitialization:
 
 
 class TestSharedLimiter:
-    async def test_shared_limiter_invoked(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_shared_limiter_invoked(self, mock_http_client: AsyncMock) -> None:
         shared = RateLimiter(rate_limit_per_minute=50)
         shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
-        c = LensPatentClient(
-            api_token="t", shared_limiter=shared, http_client=mock_http_client
-        )
+        c = LensPatentClient(api_token="t", shared_limiter=shared, http_client=mock_http_client)
         mock_http_client.post.return_value = _mock_response(200, {"data": []})
 
         await c.search_patents_by_assignee("Acme")
@@ -226,9 +218,7 @@ class TestSearchByAssignee:
     async def test_success_returns_parsed_records(
         self, client: LensPatentClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.post.return_value = _mock_response(
-            200, SAMPLE_LENS_RESPONSE
-        )
+        mock_http_client.post.return_value = _mock_response(200, SAMPLE_LENS_RESPONSE)
 
         records = await client.search_patents_by_assignee("Acme")
 
@@ -297,12 +287,8 @@ class TestSearchByAssignee:
 
 
 class TestSearchByInventor:
-    async def test_success(
-        self, client: LensPatentClient, mock_http_client: AsyncMock
-    ) -> None:
-        mock_http_client.post.return_value = _mock_response(
-            200, SAMPLE_LENS_RESPONSE
-        )
+    async def test_success(self, client: LensPatentClient, mock_http_client: AsyncMock) -> None:
+        mock_http_client.post.return_value = _mock_response(200, SAMPLE_LENS_RESPONSE)
 
         records = await client.search_patents_by_inventor("Jane Doe")
 
@@ -354,9 +340,7 @@ class TestSyncFacade:
             result = client.search_patents_by_assignee("Acme Corp")
 
             assert result == expected
-            client._client.search_patents_by_assignee.assert_awaited_once_with(
-                "Acme Corp", 100
-            )
+            client._client.search_patents_by_assignee.assert_awaited_once_with("Acme Corp", 100)
 
     def test_shared_limiter_plumbs_through(self) -> None:
         shared = RateLimiter(rate_limit_per_minute=50)

--- a/tests/unit/enrichers/test_naics_strategies.py
+++ b/tests/unit/enrichers/test_naics_strategies.py
@@ -22,7 +22,9 @@ from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import Origina
 from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import SectorFallbackStrategy
 from sbir_etl.enrichers.naics.fiscal.strategies.text_inference import TextInferenceStrategy
 from sbir_etl.enrichers.naics.fiscal.strategies.simple_strategies import TopicCodeStrategy
-from sbir_etl.enrichers.naics.fiscal.strategies.usaspending_dataframe import USAspendingDataFrameStrategy
+from sbir_etl.enrichers.naics.fiscal.strategies.usaspending_dataframe import (
+    USAspendingDataFrameStrategy,
+)
 from sbir_etl.enrichers.naics.fiscal.utils import normalize_naics_code, validate_naics_code
 
 

--- a/tests/unit/enrichers/test_opencorporates.py
+++ b/tests/unit/enrichers/test_opencorporates.py
@@ -63,9 +63,7 @@ class TestDataClasses:
         assert o.position is None
 
     def test_corporate_record_defaults(self):
-        r = CorporateRecord(
-            company_name="Acme", jurisdiction="us_va", company_number="123"
-        )
+        r = CorporateRecord(company_name="Acme", jurisdiction="us_va", company_number="123")
         assert r.officers == []
         assert r.parent_company is None
 
@@ -97,9 +95,7 @@ class TestTokenInjection:
     async def test_token_appended_to_params(
         self, client: OpenCorporatesClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"results": {"companies": []}}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"results": {"companies": []}})
 
         await client.search_companies("Test Corp")
 
@@ -134,17 +130,11 @@ class TestTokenInjection:
 
 
 class TestSharedLimiter:
-    async def test_shared_limiter_invoked(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_shared_limiter_invoked(self, mock_http_client: AsyncMock) -> None:
         shared = RateLimiter(rate_limit_per_minute=30)
         shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
-        c = OpenCorporatesClient(
-            api_token="t", shared_limiter=shared, http_client=mock_http_client
-        )
-        mock_http_client.get.return_value = _mock_response(
-            200, {"results": {"companies": []}}
-        )
+        c = OpenCorporatesClient(api_token="t", shared_limiter=shared, http_client=mock_http_client)
+        mock_http_client.get.return_value = _mock_response(200, {"results": {"companies": []}})
 
         await c.search_companies("x")
 
@@ -158,9 +148,7 @@ class TestSearchCompanies:
     async def test_with_jurisdiction(
         self, client: OpenCorporatesClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"results": {"companies": []}}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"results": {"companies": []}})
 
         await client.search_companies("Test Corp", jurisdiction="us_va")
 
@@ -274,9 +262,7 @@ class TestLookupCompany:
     async def test_no_search_match_returns_none(
         self, client: OpenCorporatesClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"results": {"companies": []}}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"results": {"companies": []}})
 
         assert await client.lookup_company("Nonexistent") is None
 
@@ -354,9 +340,7 @@ class TestGetOfficers:
     async def test_empty_returns_empty_list(
         self, client: OpenCorporatesClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"results": {"officers": []}}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"results": {"officers": []}})
 
         officers = await client.get_officers("us_va", "123")
 

--- a/tests/unit/enrichers/test_orcid_client.py
+++ b/tests/unit/enrichers/test_orcid_client.py
@@ -43,9 +43,7 @@ SAMPLE_PROFILE = {
         },
         "fundings": {"group": [{"funding-summary": [{}]}]},
     },
-    "person": {
-        "keywords": {"keyword": [{"content": "AI"}, {"content": "ML"}]}
-    },
+    "person": {"keywords": {"keyword": [{"content": "AI"}, {"content": "ML"}]}},
 }
 
 
@@ -126,9 +124,7 @@ class TestInitialization:
         headers = c._build_headers()
         assert "Authorization" not in headers
 
-    def test_explicit_token_sets_bearer_header(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    def test_explicit_token_sets_bearer_header(self, mock_http_client: AsyncMock) -> None:
         c = ORCIDClient(access_token="abc-token", http_client=mock_http_client)
         headers = c._build_headers()
         assert headers["Authorization"] == "Bearer abc-token"
@@ -144,15 +140,11 @@ class TestInitialization:
 
 
 class TestSharedLimiterOverride:
-    async def test_shared_limiter_invoked(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_shared_limiter_invoked(self, mock_http_client: AsyncMock) -> None:
         shared = RateLimiter(rate_limit_per_minute=30)
         shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
         c = ORCIDClient(shared_limiter=shared, http_client=mock_http_client)
-        mock_http_client.get.return_value = _mock_response(
-            200, {"expanded-result": []}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"expanded-result": []})
 
         await c.search("Smith")
 
@@ -168,11 +160,7 @@ class TestSearch:
     ) -> None:
         mock_http_client.get.return_value = _mock_response(
             200,
-            {
-                "expanded-result": [
-                    {"orcid-id": "0000-0001", "given-names": "Jane"}
-                ]
-            },
+            {"expanded-result": [{"orcid-id": "0000-0001", "given-names": "Jane"}]},
         )
 
         result = await client.search("Doe", "Jane")
@@ -182,18 +170,14 @@ class TestSearch:
     async def test_empty_results_returns_empty_list(
         self, client: ORCIDClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"expanded-result": []}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"expanded-result": []})
 
         assert await client.search("Nobody") == []
 
     async def test_query_with_given_names(
         self, client: ORCIDClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"expanded-result": []}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"expanded-result": []})
 
         await client.search("Smith", "Jane")
 
@@ -206,9 +190,7 @@ class TestSearch:
     async def test_query_without_given_names(
         self, client: ORCIDClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"expanded-result": []}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"expanded-result": []})
 
         await client.search("Smith")
 
@@ -227,9 +209,7 @@ class TestSearch:
 
         assert await client.search("x") == []
 
-    async def test_5xx_propagates(
-        self, client: ORCIDClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_5xx_propagates(self, client: ORCIDClient, mock_http_client: AsyncMock) -> None:
         resp = Mock()
         resp.status_code = 500
         resp.text = "boom"
@@ -245,18 +225,14 @@ class TestSearch:
 
 
 class TestGetProfile:
-    async def test_returns_profile(
-        self, client: ORCIDClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_returns_profile(self, client: ORCIDClient, mock_http_client: AsyncMock) -> None:
         mock_http_client.get.return_value = _mock_response(200, SAMPLE_PROFILE)
 
         result = await client.get_profile("0000-0001")
 
         assert result == SAMPLE_PROFILE
 
-    async def test_404_returns_none(
-        self, client: ORCIDClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_404_returns_none(self, client: ORCIDClient, mock_http_client: AsyncMock) -> None:
         resp = Mock()
         resp.status_code = 404
         resp.text = "not found"
@@ -266,9 +242,7 @@ class TestGetProfile:
 
         assert await client.get_profile("GONE") is None
 
-    async def test_500_propagates(
-        self, client: ORCIDClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_500_propagates(self, client: ORCIDClient, mock_http_client: AsyncMock) -> None:
         resp = Mock()
         resp.status_code = 500
         resp.text = "boom"
@@ -284,9 +258,7 @@ class TestGetProfile:
 
 
 class TestLookup:
-    async def test_success_two_step(
-        self, client: ORCIDClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_success_two_step(self, client: ORCIDClient, mock_http_client: AsyncMock) -> None:
         mock_http_client.get.side_effect = [
             _mock_response(
                 200,
@@ -313,9 +285,7 @@ class TestLookup:
     async def test_no_search_match_returns_none(
         self, client: ORCIDClient, mock_http_client: AsyncMock
     ) -> None:
-        mock_http_client.get.return_value = _mock_response(
-            200, {"expanded-result": []}
-        )
+        mock_http_client.get.return_value = _mock_response(200, {"expanded-result": []})
 
         assert await client.lookup("Nobody") is None
 
@@ -343,11 +313,7 @@ class TestLookup:
         mock_http_client.get.side_effect = [
             _mock_response(
                 200,
-                {
-                    "expanded-result": [
-                        {"orcid-id": "0000-0001", "given-names": "Jane"}
-                    ]
-                },
+                {"expanded-result": [{"orcid-id": "0000-0001", "given-names": "Jane"}]},
             ),
             httpx.HTTPStatusError("404", request=Mock(), response=resp_404),
         ]

--- a/tests/unit/enrichers/test_patentsview.py
+++ b/tests/unit/enrichers/test_patentsview.py
@@ -99,7 +99,7 @@ class TestEscapeLuceneQuery:
     def test_escapes_common_special_chars(self):
         assert PatentsViewClient._escape_lucene_query("a+b") == r"a\+b"
         assert PatentsViewClient._escape_lucene_query("a:b") == r"a\:b"
-        assert PatentsViewClient._escape_lucene_query('a"b') == r'a\"b'
+        assert PatentsViewClient._escape_lucene_query('a"b') == r"a\"b"
 
     def test_leaves_plain_text_unchanged(self):
         assert PatentsViewClient._escape_lucene_query("Acme Corp") == "Acme Corp"

--- a/tests/unit/enrichers/test_pi_enrichment.py
+++ b/tests/unit/enrichers/test_pi_enrichment.py
@@ -224,7 +224,10 @@ class TestLookupPIPatentsWithFallback:
     @patch(f"{MODULE}.lookup_pi_patents")
     def test_returns_primary_when_available(self, mock_primary):
         record = PIPatentRecord(
-            total_patents=3, sample_titles=["A"], assignees=["Acme"], date_range=("2020-01-01", "2023-01-01"),
+            total_patents=3,
+            sample_titles=["A"],
+            assignees=["Acme"],
+            date_range=("2020-01-01", "2023-01-01"),
         )
         mock_primary.return_value = record
 
@@ -240,12 +243,16 @@ class TestLookupPIPatentsWithFallback:
         lens_ctx = MockLens.return_value.__enter__.return_value
         lens_ctx.search_patents_by_assignee.return_value = [
             LensPatentRecord(
-                patent_number="LENS-001", title="Smart Widget",
-                assignee="Acme Corp", filing_date="2021-03-15",
+                patent_number="LENS-001",
+                title="Smart Widget",
+                assignee="Acme Corp",
+                filing_date="2021-03-15",
             ),
             LensPatentRecord(
-                patent_number="LENS-002", title="Better Widget",
-                assignee="Acme Corp", filing_date="2023-07-01",
+                patent_number="LENS-002",
+                title="Better Widget",
+                assignee="Acme Corp",
+                filing_date="2023-07-01",
             ),
         ]
 
@@ -277,8 +284,11 @@ class TestLookupPIPublicationsWithFallback:
     @patch(f"{MODULE}.lookup_pi_publications")
     def test_returns_primary_when_available(self, mock_primary):
         record = PIPublicationRecord(
-            total_papers=10, h_index=5, citation_count=100,
-            sample_titles=["Paper A"], affiliations=["MIT"],
+            total_papers=10,
+            h_index=5,
+            citation_count=100,
+            sample_titles=["Paper A"],
+            affiliations=["MIT"],
         )
         mock_primary.return_value = record
 
@@ -289,10 +299,14 @@ class TestLookupPIPublicationsWithFallback:
     @patch(f"{MODULE}.lookup_pi_publications", return_value=None)
     def test_falls_back_to_orcid_when_primary_returns_none(self, mock_primary, mock_orcid):
         mock_orcid.return_value = ORCIDRecord(
-            orcid_id="0000-0001-2345-6789", given_name="Jane", family_name="Doe",
-            affiliations=["Stanford"], works_count=15,
+            orcid_id="0000-0001-2345-6789",
+            given_name="Jane",
+            family_name="Doe",
+            affiliations=["Stanford"],
+            works_count=15,
             sample_work_titles=["Study X", "Study Y"],
-            funding_count=2, keywords=["AI"],
+            funding_count=2,
+            keywords=["AI"],
         )
 
         result = lookup_pi_publications_with_fallback("Jane Doe")
@@ -321,9 +335,14 @@ class TestLookupPIOrcidWithFallback:
     @patch(f"{MODULE}.lookup_pi_orcid")
     def test_returns_primary_when_available(self, mock_primary):
         record = ORCIDRecord(
-            orcid_id="0000-0001-2345-6789", given_name="Jane", family_name="Doe",
-            affiliations=["MIT"], works_count=20, sample_work_titles=["Study X"],
-            funding_count=3, keywords=["AI"],
+            orcid_id="0000-0001-2345-6789",
+            given_name="Jane",
+            family_name="Doe",
+            affiliations=["MIT"],
+            works_count=20,
+            sample_work_titles=["Study X"],
+            funding_count=3,
+            keywords=["AI"],
         )
         mock_primary.return_value = record
 

--- a/tests/unit/enrichers/test_press_wire.py
+++ b/tests/unit/enrichers/test_press_wire.py
@@ -122,9 +122,7 @@ class TestInitialization:
 
         assert isinstance(client, BaseAsyncAPIClient)
 
-    def test_default_feeds_used_when_not_specified(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    def test_default_feeds_used_when_not_specified(self, mock_http_client: AsyncMock) -> None:
         c = PressWireClient(http_client=mock_http_client)
         assert "PRNewswire" in c._feeds
         assert "BusinessWire" in c._feeds
@@ -209,9 +207,7 @@ class TestPoll:
         assert len(matches1) == 1
         assert len(matches2) == 0  # Already seen
 
-    async def test_reset_seen(
-        self, client: PressWireClient, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_reset_seen(self, client: PressWireClient, mock_http_client: AsyncMock) -> None:
         client.set_watchlist(["Acme Defense Systems"])
         mock_http_client.get.return_value = _mock_response(200, SAMPLE_RSS)
 

--- a/tests/unit/enrichers/test_sec_edgar_client.py
+++ b/tests/unit/enrichers/test_sec_edgar_client.py
@@ -92,7 +92,12 @@ class TestSearchCompanies:
         mock_response = {
             "hits": {
                 "hits": [
-                    {"_source": {"ciks": [f"000000{i:04d}"], "display_names": [f"Co {i}  (CIK 000000{i:04d})"]}}
+                    {
+                        "_source": {
+                            "ciks": [f"000000{i:04d}"],
+                            "display_names": [f"Co {i}  (CIK 000000{i:04d})"],
+                        }
+                    }
                     for i in range(20)
                 ]
             }
@@ -148,7 +153,9 @@ class TestSearchFilingMentions:
         await client.search_filing_mentions("Acme Corp")
         call_args = client._make_request.call_args
         # _make_request(method, endpoint, params) — params is positional arg 3
-        params = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("params", {})
+        params = (
+            call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("params", {})
+        )
         assert params["q"] == '"Acme Corp"'
 
     @pytest.mark.asyncio

--- a/tests/unit/enrichers/test_sec_edgar_enricher.py
+++ b/tests/unit/enrichers/test_sec_edgar_enricher.py
@@ -76,9 +76,7 @@ class TestExtractLatestFact:
                 }
             }
         }
-        value, _ = _extract_latest_fact(
-            facts, ["Revenues", "SalesRevenueNet"]
-        )
+        value, _ = _extract_latest_fact(facts, ["Revenues", "SalesRevenueNet"])
         assert value == 2000000.0
 
 
@@ -88,19 +86,13 @@ class TestExtractFinancials:
             "facts": {
                 "us-gaap": {
                     "Revenues": {
-                        "units": {
-                            "USD": [{"val": 5000000, "end": "2024-12-31", "form": "10-K"}]
-                        }
+                        "units": {"USD": [{"val": 5000000, "end": "2024-12-31", "form": "10-K"}]}
                     },
                     "ResearchAndDevelopmentExpense": {
-                        "units": {
-                            "USD": [{"val": 1000000, "end": "2024-12-31", "form": "10-K"}]
-                        }
+                        "units": {"USD": [{"val": 1000000, "end": "2024-12-31", "form": "10-K"}]}
                     },
                     "Assets": {
-                        "units": {
-                            "USD": [{"val": 10000000, "end": "2024-12-31", "form": "10-K"}]
-                        }
+                        "units": {"USD": [{"val": 10000000, "end": "2024-12-31", "form": "10-K"}]}
                     },
                 }
             }
@@ -262,7 +254,10 @@ class TestEnrichCompany:
         )
 
         profile = await enrich_company(
-            mock_client, "Acme Corp", company_uei="UEI123", search_form_d=True,
+            mock_client,
+            "Acme Corp",
+            company_uei="UEI123",
+            search_form_d=True,
         )
         assert profile.company_uei == "UEI123"
         assert profile.mention_count == 1
@@ -286,12 +281,30 @@ class TestEnrichCompany:
         # Same filer appears in multiple 8-K hits
         mock_client.search_filing_mentions = AsyncMock(
             return_value=[
-                {"filer_cik": "99999", "filer_name": "Mercury Systems", "form_type": "8-K",
-                 "file_date": "2024-06-15", "accession_number": "001", "file_description": ""},
-                {"filer_cik": "99999", "filer_name": "Mercury Systems", "form_type": "8-K",
-                 "file_date": "2024-07-01", "accession_number": "002", "file_description": ""},
-                {"filer_cik": "88888", "filer_name": "Other Corp", "form_type": "8-K",
-                 "file_date": "2024-08-01", "accession_number": "003", "file_description": ""},
+                {
+                    "filer_cik": "99999",
+                    "filer_name": "Mercury Systems",
+                    "form_type": "8-K",
+                    "file_date": "2024-06-15",
+                    "accession_number": "001",
+                    "file_description": "",
+                },
+                {
+                    "filer_cik": "99999",
+                    "filer_name": "Mercury Systems",
+                    "form_type": "8-K",
+                    "file_date": "2024-07-01",
+                    "accession_number": "002",
+                    "file_description": "",
+                },
+                {
+                    "filer_cik": "88888",
+                    "filer_name": "Other Corp",
+                    "form_type": "8-K",
+                    "file_date": "2024-08-01",
+                    "accession_number": "003",
+                    "file_description": "",
+                },
             ]
         )
         mock_client.search_form_d_filings = AsyncMock(return_value=[])
@@ -325,9 +338,7 @@ class TestSearchInboundMAMentions:
             ]
         )
 
-        events = await _search_inbound_ma_mentions(
-            mock_client, "Small SBIR Company"
-        )
+        events = await _search_inbound_ma_mentions(mock_client, "Small SBIR Company")
         assert len(events) == 1
         assert events[0].is_target is True
         assert events[0].filer_name == "LOCKHEED MARTIN CORPORATION"
@@ -342,12 +353,24 @@ class TestSearchInboundMAMentions:
         mock_client.search_filing_mentions = AsyncMock(
             side_effect=[
                 [  # 8-K match
-                    {"filer_cik": "111", "filer_name": "ACQUIRER A", "form_type": "8-K",
-                     "file_date": "2024-06-15", "accession_number": "001", "file_description": ""},
+                    {
+                        "filer_cik": "111",
+                        "filer_name": "ACQUIRER A",
+                        "form_type": "8-K",
+                        "file_date": "2024-06-15",
+                        "accession_number": "001",
+                        "file_description": "",
+                    },
                 ],
                 [  # 10-K match from different filer
-                    {"filer_cik": "222", "filer_name": "ACQUIRER B", "form_type": "10-K",
-                     "file_date": "2024-03-01", "accession_number": "002", "file_description": ""},
+                    {
+                        "filer_cik": "222",
+                        "filer_name": "ACQUIRER B",
+                        "form_type": "10-K",
+                        "file_date": "2024-03-01",
+                        "accession_number": "002",
+                        "file_description": "",
+                    },
                 ],
                 [],  # No ownership filings
             ]
@@ -363,9 +386,14 @@ class TestSearchInboundMAMentions:
         mock_client.search_filing_mentions = AsyncMock(
             side_effect=[
                 [
-                    {"filer_cik": "11111", "filer_name": "ACME CORP",
-                     "form_type": "8-K", "file_date": "2024-03-01",
-                     "accession_number": "001", "file_description": "Something"},
+                    {
+                        "filer_cik": "11111",
+                        "filer_name": "ACME CORP",
+                        "form_type": "8-K",
+                        "file_date": "2024-03-01",
+                        "accession_number": "001",
+                        "file_description": "Something",
+                    },
                 ],
                 [],
                 [],
@@ -471,7 +499,9 @@ class TestEnrichCompanySignals:
         )
 
         profile = await enrich_company(
-            mock_client, "Venture Backed SBIR Inc", search_form_d=True,
+            mock_client,
+            "Venture Backed SBIR Inc",
+            search_form_d=True,
         )
         assert profile.has_form_d is True
         assert profile.form_d_cik == "77777"
@@ -542,9 +572,7 @@ class TestModels:
         from sbir_etl.models.sec_edgar import CompanyEdgarProfile
 
         with pytest.raises(ValueError):
-            CompanyEdgarProfile(
-                company_name="Test", match_confidence=1.5
-            )
+            CompanyEdgarProfile(company_name="Test", match_confidence=1.5)
 
     def test_edgar_ma_event_target_flag(self):
         from sbir_etl.models.sec_edgar import EdgarMAEvent
@@ -634,28 +662,34 @@ class TestIsNoise:
 
     def test_rejects_reit_by_sic(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _is_noise
+
         # SIC 6512 = real estate investment trusts
         assert _is_noise("VORNADO REALTY TRUST", "Aptima Inc", ["6512"]) is True
 
     def test_rejects_mortgage_by_sic(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _is_noise
+
         assert _is_noise("CSFB MORTGAGE TRUST", "Lynntech Inc", ["6159"]) is True
 
     def test_accepts_defense_company(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _is_noise
+
         assert _is_noise("MERCURY SYSTEMS INC", "Physical Optics Corp", ["3670"]) is False
 
     def test_rejects_name_containment(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _is_noise
+
         assert _is_noise("THERMO FIBERTEK INC", "Fibertek, Inc.", []) is True
 
     def test_accepts_exact_match(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _is_noise
+
         # Same name shouldn't be flagged as containment
         assert _is_noise("FIBERTEK INC", "Fibertek, Inc.", []) is False
 
     def test_accepts_no_sic(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _is_noise
+
         assert _is_noise("SOME COMPANY", "Target Co", []) is False
 
 
@@ -664,36 +698,44 @@ class TestClassifyMention:
 
     def test_ma_definitive_from_items(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention(["1.01", "9.01"], "8-K") == "ma_definitive"
         assert _classify_mention(["2.01"], "8-K") == "ma_definitive"
 
     def test_ma_proxy_from_form_type(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention([], "DEFM14A") == "ma_proxy"
         assert _classify_mention([], "PREM14A") == "ma_proxy"
 
     def test_ownership_active(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention([], "SC 13D") == "ownership_active"
 
     def test_ownership_passive(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention([], "SC 13G") == "ownership_passive"
 
     def test_tender_offer(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention([], "SC TO-T") == "ma_definitive"
 
     def test_financial_mention(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention(["2.02", "9.01"], "8-K") == "financial_mention"
 
     def test_disclosure(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention(["7.01", "9.01"], "8-K") == "disclosure"
 
     def test_generic_filing_mention(self):
         from sbir_etl.enrichers.sec_edgar.enricher import _classify_mention
+
         assert _classify_mention([], "10-K") == "filing_mention"
 
 
@@ -707,7 +749,7 @@ class TestExtractMentionContext:
         mock_client = AsyncMock()
         mock_client.fetch_filing_document = AsyncMock(
             return_value="...Mercury Systems announced today it has completed the acquisition of "
-                         "Physical Optics Corporation for approximately $310 million..."
+            "Physical Optics Corporation for approximately $310 million..."
         )
 
         mention = {"filer_cik": "1049521", "doc_id": "0001049521-20-000067:press.htm"}
@@ -721,7 +763,7 @@ class TestExtractMentionContext:
         mock_client = AsyncMock()
         mock_client.fetch_filing_document = AsyncMock(
             return_value="...Exhibit 21 - List of Subsidiaries\n"
-                         "Progeny Systems, LLC Virginia 100%..."
+            "Progeny Systems, LLC Virginia 100%..."
         )
 
         mention = {"filer_cik": "40533", "doc_id": "0000040533-23-000014:ex21.htm"}
@@ -735,7 +777,7 @@ class TestExtractMentionContext:
         mock_client = AsyncMock()
         mock_client.fetch_filing_document = AsyncMock(
             return_value="...Our primary competitors include Aerojet Rocketdyne, "
-                         "Busek Co. Inc., Blue Origin, and SpaceX in the propulsion market..."
+            "Busek Co. Inc., Blue Origin, and SpaceX in the propulsion market..."
         )
 
         mention = {"filer_cik": "40888", "doc_id": "0000040888-22-000005:10k.htm"}

--- a/tests/unit/enrichers/test_semantic_scholar.py
+++ b/tests/unit/enrichers/test_semantic_scholar.py
@@ -80,18 +80,14 @@ class TestInitialization:
 
         assert isinstance(client, BaseAsyncAPIClient)
 
-    def test_build_headers_without_api_key(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    def test_build_headers_without_api_key(self, mock_http_client: AsyncMock) -> None:
         with patch.dict("os.environ", {}, clear=True):
             c = SemanticScholarClient(http_client=mock_http_client)
         headers = c._build_headers()
         assert "x-api-key" not in headers
         assert headers["Accept"] == "application/json"
 
-    def test_build_headers_with_explicit_api_key(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    def test_build_headers_with_explicit_api_key(self, mock_http_client: AsyncMock) -> None:
         c = SemanticScholarClient(api_key="secret-123", http_client=mock_http_client)
         headers = c._build_headers()
         assert headers["x-api-key"] == "secret-123"
@@ -109,14 +105,10 @@ class TestInitialization:
 class TestSharedLimiterOverride:
     """When a shared sync limiter is injected, it should be used via to_thread."""
 
-    async def test_shared_limiter_called_via_to_thread(
-        self, mock_http_client: AsyncMock
-    ) -> None:
+    async def test_shared_limiter_called_via_to_thread(self, mock_http_client: AsyncMock) -> None:
         shared = RateLimiter(rate_limit_per_minute=50)
         shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
-        c = SemanticScholarClient(
-            shared_limiter=shared, http_client=mock_http_client
-        )
+        c = SemanticScholarClient(shared_limiter=shared, http_client=mock_http_client)
         mock_http_client.get.return_value = _mock_response(200, {"data": []})
 
         await c.search_author("Alice")
@@ -288,7 +280,8 @@ class TestLookupAuthor:
         self, client: SemanticScholarClient, mock_http_client: AsyncMock
     ) -> None:
         mock_http_client.get.return_value = _mock_response(
-            200, {"data": [{"name": "Jane"}]}  # missing authorId
+            200,
+            {"data": [{"name": "Jane"}]},  # missing authorId
         )
 
         rec = await client.lookup_author("Jane")

--- a/tests/unit/enrichers/usaspending/test_client.py
+++ b/tests/unit/enrichers/usaspending/test_client.py
@@ -94,7 +94,6 @@ def freshness_record():
     )
 
 
-
 # ==================== Initialization Tests ====================
 
 

--- a/tests/unit/extractors/test_sbir_gov_api.py
+++ b/tests/unit/extractors/test_sbir_gov_api.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.fast
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def sample_awards():
     """A small list of SBIR.gov award dicts with contract, UEI, and DUNS."""
@@ -152,7 +153,7 @@ class TestSbirGovLookupIndexLookup:
         """When contract matches one record and UEI matches another, contract wins."""
         hit = lookup_index.lookup(
             contract="W911NF-20-C-0001",  # → Acme Research
-            uei="DEF987654321",           # → Energy Solutions
+            uei="DEF987654321",  # → Energy Solutions
         )
         assert hit is not None
         assert hit["firm"] == "Acme Research Inc"
@@ -160,7 +161,7 @@ class TestSbirGovLookupIndexLookup:
     def test_lookup_contract_takes_precedence_over_duns(self, lookup_index):
         hit = lookup_index.lookup(
             contract="DE-SC0012345",  # → Energy Solutions
-            duns="123456789",         # → Acme Research
+            duns="123456789",  # → Acme Research
         )
         assert hit is not None
         assert hit["firm"] == "Energy Solutions LLC"
@@ -169,7 +170,7 @@ class TestSbirGovLookupIndexLookup:
         """When contract is None but UEI and DUNS both present, UEI wins."""
         hit = lookup_index.lookup(
             uei="GHI111222333",  # → Space Widgets
-            duns="123456789",    # → Acme Research
+            duns="123456789",  # → Acme Research
         )
         assert hit is not None
         assert hit["firm"] == "Space Widgets Corp"
@@ -242,11 +243,13 @@ class TestCrossrefDataframeWithSbirGov:
 
     def test_matching_and_nonmatching_rows(self):
         index = self._make_index()
-        df = pd.DataFrame({
-            "award_id": ["AWARD-001", "AWARD-002", "NO-MATCH"],
-            "recipient_uei": ["UEI111", "UEI222", "UEIXXX"],
-            "recipient_duns": ["111111111", "222222222", "999999999"],
-        })
+        df = pd.DataFrame(
+            {
+                "award_id": ["AWARD-001", "AWARD-002", "NO-MATCH"],
+                "recipient_uei": ["UEI111", "UEI222", "UEIXXX"],
+                "recipient_duns": ["111111111", "222222222", "999999999"],
+            }
+        )
         result = _crossref_dataframe_with_sbir_gov(df, index)
 
         assert result["sbir_gov_confirmed"].tolist() == [True, True, False]
@@ -257,11 +260,13 @@ class TestCrossrefDataframeWithSbirGov:
 
     def test_all_five_output_columns_added(self):
         index = self._make_index()
-        df = pd.DataFrame({
-            "award_id": ["AWARD-001"],
-            "recipient_uei": ["UEI111"],
-            "recipient_duns": ["111111111"],
-        })
+        df = pd.DataFrame(
+            {
+                "award_id": ["AWARD-001"],
+                "recipient_uei": ["UEI111"],
+                "recipient_duns": ["111111111"],
+            }
+        )
         result = _crossref_dataframe_with_sbir_gov(df, index)
 
         expected_cols = {
@@ -276,27 +281,37 @@ class TestCrossrefDataframeWithSbirGov:
     def test_nan_none_values_handled(self):
         """NaN / None in award_id, uei, duns should not raise."""
         index = self._make_index()
-        df = pd.DataFrame({
-            "award_id": [None, np.nan, "AWARD-001"],
-            "recipient_uei": [np.nan, None, "UEI111"],
-            "recipient_duns": [np.nan, np.nan, "111111111"],
-        })
+        df = pd.DataFrame(
+            {
+                "award_id": [None, np.nan, "AWARD-001"],
+                "recipient_uei": [np.nan, None, "UEI111"],
+                "recipient_duns": [np.nan, np.nan, "111111111"],
+            }
+        )
         result = _crossref_dataframe_with_sbir_gov(df, index)
 
         assert len(result) == 3
         # First two rows should not match
-        assert result["sbir_gov_confirmed"].iloc[0] is False or result["sbir_gov_confirmed"].iloc[0] == False  # noqa: E712
-        assert result["sbir_gov_confirmed"].iloc[1] is False or result["sbir_gov_confirmed"].iloc[1] == False  # noqa: E712
+        assert (
+            result["sbir_gov_confirmed"].iloc[0] is False
+            or result["sbir_gov_confirmed"].iloc[0] == False  # noqa: E712
+        )
+        assert (
+            result["sbir_gov_confirmed"].iloc[1] is False
+            or result["sbir_gov_confirmed"].iloc[1] == False  # noqa: E712
+        )
         # Third row should match
         assert result["sbir_gov_confirmed"].iloc[2] == True  # noqa: E712
 
     def test_empty_dataframe_returns_empty_with_new_columns(self):
         index = self._make_index()
-        df = pd.DataFrame({
-            "award_id": pd.Series([], dtype="object"),
-            "recipient_uei": pd.Series([], dtype="object"),
-            "recipient_duns": pd.Series([], dtype="object"),
-        })
+        df = pd.DataFrame(
+            {
+                "award_id": pd.Series([], dtype="object"),
+                "recipient_uei": pd.Series([], dtype="object"),
+                "recipient_duns": pd.Series([], dtype="object"),
+            }
+        )
         result = _crossref_dataframe_with_sbir_gov(df, index)
 
         assert len(result) == 0
@@ -312,11 +327,13 @@ class TestCrossrefDataframeWithSbirGov:
     def test_custom_column_name_parameters(self):
         """Custom col names for award_id, uei, duns should work."""
         index = self._make_index()
-        df = pd.DataFrame({
-            "my_award": ["AWARD-001", "NO-MATCH"],
-            "my_uei": ["UEI111", "UEIXXX"],
-            "my_duns": ["111111111", "999999999"],
-        })
+        df = pd.DataFrame(
+            {
+                "my_award": ["AWARD-001", "NO-MATCH"],
+                "my_uei": ["UEI111", "UEIXXX"],
+                "my_duns": ["111111111", "999999999"],
+            }
+        )
         result = _crossref_dataframe_with_sbir_gov(
             df,
             index,
@@ -331,11 +348,13 @@ class TestCrossrefDataframeWithSbirGov:
     def test_does_not_mutate_original_dataframe(self):
         """The function returns a copy; original should be untouched."""
         index = self._make_index()
-        df = pd.DataFrame({
-            "award_id": ["AWARD-001"],
-            "recipient_uei": ["UEI111"],
-            "recipient_duns": ["111111111"],
-        })
+        df = pd.DataFrame(
+            {
+                "award_id": ["AWARD-001"],
+                "recipient_uei": ["UEI111"],
+                "recipient_duns": ["111111111"],
+            }
+        )
         original_cols = set(df.columns)
         _crossref_dataframe_with_sbir_gov(df, index)
         assert set(df.columns) == original_cols

--- a/tests/unit/extractors/test_solicitation.py
+++ b/tests/unit/extractors/test_solicitation.py
@@ -28,9 +28,11 @@ def _ok_response(data):
 
 class TestQueryByKeyword:
     def test_returns_matching_topics(self, extractor, mock_client):
-        mock_client.get.return_value = _ok_response([
-            {"topicCode": "AF241-001", "topicTitle": "Sensor Fusion"},
-        ])
+        mock_client.get.return_value = _ok_response(
+            [
+                {"topicCode": "AF241-001", "topicTitle": "Sensor Fusion"},
+            ]
+        )
         results = extractor.query_by_keyword("AF241-001")
         assert len(results) == 1
         assert results[0]["topicCode"] == "AF241-001"
@@ -48,10 +50,16 @@ class TestQueryByKeyword:
 
 class TestQueryAwardsForTopic:
     def test_finds_matching_award(self, extractor, mock_client):
-        mock_client.get.return_value = _ok_response([
-            {"topicCode": "AF241-001", "topicTitle": "Sensor", "abstract": "Research on sensors"},
-            {"topicCode": "AF241-002", "topicTitle": "Other"},
-        ])
+        mock_client.get.return_value = _ok_response(
+            [
+                {
+                    "topicCode": "AF241-001",
+                    "topicTitle": "Sensor",
+                    "abstract": "Research on sensors",
+                },
+                {"topicCode": "AF241-002", "topicTitle": "Other"},
+            ]
+        )
         result = extractor.query_awards_for_topic("AF241-001")
         assert result is not None
         assert result["topic_code"] == "AF241-001"
@@ -59,9 +67,11 @@ class TestQueryAwardsForTopic:
         assert result["description"] == "Research on sensors"
 
     def test_returns_none_when_no_match(self, extractor, mock_client):
-        mock_client.get.return_value = _ok_response([
-            {"topicCode": "OTHER", "topicTitle": "Unrelated"},
-        ])
+        mock_client.get.return_value = _ok_response(
+            [
+                {"topicCode": "OTHER", "topicTitle": "Unrelated"},
+            ]
+        )
         result = extractor.query_awards_for_topic("AF241-001")
         assert result is None
 
@@ -76,21 +86,25 @@ class TestQueryAwardsForTopic:
         assert result is None
 
     def test_prefers_topic_description(self, extractor, mock_client):
-        mock_client.get.return_value = _ok_response([
-            {
-                "topicCode": "TC1",
-                "topicTitle": "Title",
-                "topicDescription": "Full topic desc",
-                "abstract": "Award abstract",
-            },
-        ])
+        mock_client.get.return_value = _ok_response(
+            [
+                {
+                    "topicCode": "TC1",
+                    "topicTitle": "Title",
+                    "topicDescription": "Full topic desc",
+                    "abstract": "Award abstract",
+                },
+            ]
+        )
         result = extractor.query_awards_for_topic("TC1")
         assert result["description"] == "Full topic desc"
 
     def test_falls_back_to_abstract(self, extractor, mock_client):
-        mock_client.get.return_value = _ok_response([
-            {"topicCode": "TC1", "awardTitle": "Award", "abstract": "Abstract text"},
-        ])
+        mock_client.get.return_value = _ok_response(
+            [
+                {"topicCode": "TC1", "awardTitle": "Award", "abstract": "Abstract text"},
+            ]
+        )
         result = extractor.query_awards_for_topic("TC1")
         assert result["description"] == "Abstract text"
         assert result["title"] == "Award"

--- a/tests/unit/extractors/test_usaspending_extractor.py
+++ b/tests/unit/extractors/test_usaspending_extractor.py
@@ -5,7 +5,10 @@ from unittest.mock import Mock, patch
 import pandas as pd
 import pytest
 
-from sbir_etl.extractors.usaspending import DuckDBUSAspendingExtractor, extract_usaspending_from_config
+from sbir_etl.extractors.usaspending import (
+    DuckDBUSAspendingExtractor,
+    extract_usaspending_from_config,
+)
 from tests.mocks import DuckDBMocks
 
 

--- a/tests/unit/ml/test_evidence_extractor.py
+++ b/tests/unit/ml/test_evidence_extractor.py
@@ -18,7 +18,12 @@ import pytest
 
 from sbir_etl.exceptions import ValidationError
 from sbir_ml.ml.features.evidence_extractor import EvidenceExtractor
-from sbir_etl.models.cet_models import CETArea, CETClassification, ClassificationLevel, EvidenceStatement
+from sbir_etl.models.cet_models import (
+    CETArea,
+    CETClassification,
+    ClassificationLevel,
+    EvidenceStatement,
+)
 
 
 pytestmark = pytest.mark.fast

--- a/tests/unit/models/test_fiscal_models.py
+++ b/tests/unit/models/test_fiscal_models.py
@@ -10,11 +10,8 @@ from pydantic import ValidationError
 pytestmark = pytest.mark.fast
 
 from sbir_etl.models.fiscal_models import (
-    EconomicShock,
-    FiscalReturnSummary,
     GeographicResolution,
     InflationAdjustment,
-    NAICSMapping,
     TaxImpactEstimate,
 )
 from tests.factories import EconomicShockFactory, FiscalReturnSummaryFactory, NAICSMappingFactory

--- a/tests/unit/models/test_sbir_identification.py
+++ b/tests/unit/models/test_sbir_identification.py
@@ -131,16 +131,16 @@ class TestIsSbirGrant:
     @pytest.mark.parametrize(
         "aln",
         [
-            "10.212",   # USDA
-            "12.910",   # DOD
-            "12.911",   # DOD
-            "43.002",   # NASA
-            "43.003",   # NASA
-            "47.041",   # NSF
-            "47.084",   # NSF
-            "66.511",   # EPA
-            "66.512",   # EPA
-            "97.077",   # DHS
+            "10.212",  # USDA
+            "12.910",  # DOD
+            "12.911",  # DOD
+            "43.002",  # NASA
+            "43.003",  # NASA
+            "47.041",  # NSF
+            "47.084",  # NSF
+            "66.511",  # EPA
+            "66.512",  # EPA
+            "97.077",  # DHS
         ],
     )
     def test_exclusive_alns_match(self, aln):
@@ -160,10 +160,10 @@ class TestIsSbirGrant:
     @pytest.mark.parametrize(
         "aln",
         [
-            "81.049",   # DOE
-            "20.701",   # DOT
-            "84.133",   # ED
-            "93.855",   # HHS
+            "81.049",  # DOE
+            "20.701",  # DOT
+            "84.133",  # ED
+            "93.855",  # HHS
         ],
     )
     def test_shared_alns_match_non_strict(self, aln):
@@ -172,10 +172,10 @@ class TestIsSbirGrant:
     @pytest.mark.parametrize(
         "aln",
         [
-            "81.049",   # DOE
-            "20.701",   # DOT
-            "84.133",   # ED
-            "93.855",   # HHS
+            "81.049",  # DOE
+            "20.701",  # DOT
+            "84.133",  # ED
+            "93.855",  # HHS
         ],
     )
     def test_shared_alns_rejected_strict(self, aln):

--- a/tests/unit/phase_transition/test_phase_transition_assets.py
+++ b/tests/unit/phase_transition/test_phase_transition_assets.py
@@ -216,9 +216,7 @@ def test_pairs_and_survival_end_to_end():
     assert bool(lookup["C_II_1"]["same_agency"]) is True
 
     # Negative latency must be preserved (not clipped).
-    assert lookup["C_II_3"]["latency_days"] == (
-        date(2023, 9, 1) - date(2024, 1, 1)
-    ).days
+    assert lookup["C_II_3"]["latency_days"] == (date(2023, 9, 1) - date(2024, 1, 1)).days
     assert lookup["C_II_3"]["latency_days"] < 0
 
     # DUNS fallback path.
@@ -235,9 +233,7 @@ def test_pairs_and_survival_end_to_end():
     # Censored row's event_date equals the data-cut date.
     assert s.loc["C_II_2", "event_date"] == data_cut
     # time_days for censored row = data_cut - phase_ii_end_date.
-    assert s.loc["C_II_2", "time_days"] == (
-        data_cut - date(2023, 6, 30)
-    ).days
+    assert s.loc["C_II_2", "time_days"] == (data_cut - date(2023, 6, 30)).days
 
 
 def test_build_pairs_no_double_counting_on_duns_when_uei_already_matched():

--- a/tests/unit/scripts/test_detect_ma_events.py
+++ b/tests/unit/scripts/test_detect_ma_events.py
@@ -24,9 +24,7 @@ def test_extract_form_d_signals_finds_business_combination():
                     "filing_date": "2019-03-15",
                     "is_business_combination": True,
                     "total_amount_sold": 25_000_000,
-                    "related_persons": [
-                        {"name": "Jane Doe", "title": "Executive Officer"}
-                    ],
+                    "related_persons": [{"name": "Jane Doe", "title": "Executive Officer"}],
                 },
                 {
                     "filing_date": "2020-01-01",
@@ -139,12 +137,32 @@ def test_extract_efts_signals_no_ma_types():
 
 
 def test_merge_events_both_sources():
-    fd = [{"company_name": "ACME", "event_date": "2020-03-01", "source": "form_d",
-           "form_d_detail": {"filing_date": "2020-03-01", "total_amount_sold": 1e6,
-                             "combo_count": 1, "related_persons": []}}]
-    efts = [{"company_name": "ACME", "event_date": "2020-01-15", "source": "efts",
-             "efts_detail": {"mention_filers": ["BIG CO"], "mention_types": ["ma_definitive"],
-                             "latest_mention_date": "2020-01-15", "efts_tier": "medium"}}]
+    fd = [
+        {
+            "company_name": "ACME",
+            "event_date": "2020-03-01",
+            "source": "form_d",
+            "form_d_detail": {
+                "filing_date": "2020-03-01",
+                "total_amount_sold": 1e6,
+                "combo_count": 1,
+                "related_persons": [],
+            },
+        }
+    ]
+    efts = [
+        {
+            "company_name": "ACME",
+            "event_date": "2020-01-15",
+            "source": "efts",
+            "efts_detail": {
+                "mention_filers": ["BIG CO"],
+                "mention_types": ["ma_definitive"],
+                "latest_mention_date": "2020-01-15",
+                "efts_tier": "medium",
+            },
+        }
+    ]
     merged = merge_events(fd, efts)
     assert len(merged) == 1
     assert merged[0]["form_d_detail"] is not None
@@ -153,12 +171,32 @@ def test_merge_events_both_sources():
 
 
 def test_merge_events_separate_companies():
-    fd = [{"company_name": "A", "event_date": "2020-01-01", "source": "form_d",
-           "form_d_detail": {"filing_date": "2020-01-01", "total_amount_sold": None,
-                             "combo_count": 1, "related_persons": []}}]
-    efts = [{"company_name": "B", "event_date": "2021-06-01", "source": "efts",
-             "efts_detail": {"mention_filers": ["X"], "mention_types": ["subsidiary"],
-                             "latest_mention_date": "2021-06-01", "efts_tier": "high"}}]
+    fd = [
+        {
+            "company_name": "A",
+            "event_date": "2020-01-01",
+            "source": "form_d",
+            "form_d_detail": {
+                "filing_date": "2020-01-01",
+                "total_amount_sold": None,
+                "combo_count": 1,
+                "related_persons": [],
+            },
+        }
+    ]
+    efts = [
+        {
+            "company_name": "B",
+            "event_date": "2021-06-01",
+            "source": "efts",
+            "efts_detail": {
+                "mention_filers": ["X"],
+                "mention_types": ["subsidiary"],
+                "latest_mention_date": "2021-06-01",
+                "efts_tier": "high",
+            },
+        }
+    ]
     merged = merge_events(fd, efts)
     assert len(merged) == 2
 
@@ -172,26 +210,25 @@ def test_assign_confidence_form_d_is_high():
 
 
 def test_assign_confidence_subsidiary_is_high():
-    event = {"form_d_detail": None,
-             "efts_detail": {"mention_types": ["subsidiary", "ma_definitive"]}}
+    event = {
+        "form_d_detail": None,
+        "efts_detail": {"mention_types": ["subsidiary", "ma_definitive"]},
+    }
     assert assign_confidence(event) == "high"
 
 
 def test_assign_confidence_acquisition_text_is_medium():
-    event = {"form_d_detail": None,
-             "efts_detail": {"mention_types": ["acquisition"]}}
+    event = {"form_d_detail": None, "efts_detail": {"mention_types": ["acquisition"]}}
     assert assign_confidence(event) == "medium"
 
 
 def test_assign_confidence_ma_definitive_alone_is_low():
-    event = {"form_d_detail": None,
-             "efts_detail": {"mention_types": ["ma_definitive"]}}
+    event = {"form_d_detail": None, "efts_detail": {"mention_types": ["ma_definitive"]}}
     assert assign_confidence(event) == "low"
 
 
 def test_assign_confidence_ownership_only_is_low():
-    event = {"form_d_detail": None,
-             "efts_detail": {"mention_types": ["ownership_active"]}}
+    event = {"form_d_detail": None, "efts_detail": {"mention_types": ["ownership_active"]}}
     assert assign_confidence(event) == "low"
 
 

--- a/tests/unit/test_benchmark_evaluator.py
+++ b/tests/unit/test_benchmark_evaluator.py
@@ -206,11 +206,15 @@ class TestCommercializationRateBenchmark:
         df = _make_awards_df(records)
 
         # Commercialization data: $2.5M total for 20 Phase II = $125K avg
-        comm_df = pd.DataFrame([{
-            "company_id": "uei:UEI000000011",
-            "total_sales_and_investment": 2_500_000,
-            "patent_count": 0,
-        }])
+        comm_df = pd.DataFrame(
+            [
+                {
+                    "company_id": "uei:UEI000000011",
+                    "total_sales_and_investment": 2_500_000,
+                    "patent_count": 0,
+                }
+            ]
+        )
 
         evaluator = BenchmarkEligibilityEvaluator(evaluation_fy=2025)
         summary = evaluator.evaluate(df, comm_df)
@@ -225,11 +229,15 @@ class TestCommercializationRateBenchmark:
         df = _make_awards_df(records)
 
         # 4 patents / 20 Phase II = 20% >= 15%
-        comm_df = pd.DataFrame([{
-            "company_id": "uei:UEI000000012",
-            "total_sales_and_investment": 0,
-            "patent_count": 4,
-        }])
+        comm_df = pd.DataFrame(
+            [
+                {
+                    "company_id": "uei:UEI000000012",
+                    "total_sales_and_investment": 0,
+                    "patent_count": 4,
+                }
+            ]
+        )
 
         evaluator = BenchmarkEligibilityEvaluator(evaluation_fy=2025)
         summary = evaluator.evaluate(df, comm_df)
@@ -245,11 +253,15 @@ class TestCommercializationRateBenchmark:
         df = _make_awards_df(records)
 
         # Has patents but not enough sales
-        comm_df = pd.DataFrame([{
-            "company_id": "uei:UEI000000013",
-            "total_sales_and_investment": 1_000_000,  # ~18K avg < 250K
-            "patent_count": 20,  # 36% rate, but patents path not available
-        }])
+        comm_df = pd.DataFrame(
+            [
+                {
+                    "company_id": "uei:UEI000000013",
+                    "total_sales_and_investment": 1_000_000,  # ~18K avg < 250K
+                    "patent_count": 20,  # 36% rate, but patents path not available
+                }
+            ]
+        )
 
         evaluator = BenchmarkEligibilityEvaluator(evaluation_fy=2025)
         summary = evaluator.evaluate(df, comm_df)
@@ -269,9 +281,7 @@ class TestSensitivityAnalysis:
         records = _phase1_awards("AlmostCo", "UEI000000020", 18, 2019)
         df = _make_awards_df(records)
 
-        evaluator = BenchmarkEligibilityEvaluator(
-            evaluation_fy=2025, sensitivity_margin_awards=5
-        )
+        evaluator = BenchmarkEligibilityEvaluator(evaluation_fy=2025, sensitivity_margin_awards=5)
         summary = evaluator.evaluate(df)
 
         at_risk = [s for s in summary.sensitivity_results if s.at_risk_transition]
@@ -285,9 +295,7 @@ class TestSensitivityAnalysis:
         records += _phase2_awards("NarrowCo", "UEI000000021", 7, 2020)
         df = _make_awards_df(records)
 
-        evaluator = BenchmarkEligibilityEvaluator(
-            evaluation_fy=2025, sensitivity_margin_ratio=0.05
-        )
+        evaluator = BenchmarkEligibilityEvaluator(evaluation_fy=2025, sensitivity_margin_ratio=0.05)
         summary = evaluator.evaluate(df)
 
         at_risk = [s for s in summary.sensitivity_results if s.at_risk_transition]
@@ -302,9 +310,7 @@ class TestSensitivityAnalysis:
         records += _phase2_awards("SafeCo", "UEI000000022", 20, 2020)
         df = _make_awards_df(records)
 
-        evaluator = BenchmarkEligibilityEvaluator(
-            evaluation_fy=2025, sensitivity_margin_ratio=0.05
-        )
+        evaluator = BenchmarkEligibilityEvaluator(evaluation_fy=2025, sensitivity_margin_ratio=0.05)
         summary = evaluator.evaluate(df)
 
         # Should still be in sensitivity results (subject to benchmark) but not flagged at-risk
@@ -380,9 +386,8 @@ class TestEdgeCases:
 
     def test_report_generation(self):
         """Report generation should produce valid markdown."""
-        records = (
-            _phase1_awards("ReportCo", "UEI000000060", 25, 2019)
-            + _phase2_awards("ReportCo", "UEI000000060", 8, 2020)
+        records = _phase1_awards("ReportCo", "UEI000000060", 25, 2019) + _phase2_awards(
+            "ReportCo", "UEI000000060", 8, 2020
         )
         df = _make_awards_df(records)
 

--- a/tests/unit/test_cet_award_relationships.py
+++ b/tests/unit/test_cet_award_relationships.py
@@ -193,13 +193,16 @@ def test_asset_neo4j_award_cet_relationships_invokes_loader(monkeypatch, tmp_pat
             pass
 
     # Patch asset internals in the loading module where they're used
-    monkeypatch.setattr("sbir_analytics.assets.cet.loading._get_neo4j_client", lambda: FakeLoader(None, None))
+    monkeypatch.setattr(
+        "sbir_analytics.assets.cet.loading._get_neo4j_client", lambda: FakeLoader(None, None)
+    )
     monkeypatch.setattr(
         "sbir_analytics.assets.cet.loading._read_parquet_or_ndjson", lambda *args, **kwargs: rows
     )
     monkeypatch.setattr("sbir_analytics.assets.cet.loading.CETLoader", FakeLoader)
     monkeypatch.setattr(
-        "sbir_analytics.assets.cet.loading.CETLoaderConfig", lambda batch_size: {"batch_size": batch_size}
+        "sbir_analytics.assets.cet.loading.CETLoaderConfig",
+        lambda batch_size: {"batch_size": batch_size},
     )
 
     # Execute asset using Dagster's materialization with mocked dependencies

--- a/tests/unit/test_cet_company_relationships.py
+++ b/tests/unit/test_cet_company_relationships.py
@@ -262,13 +262,16 @@ def test_asset_neo4j_company_cet_relationships_invokes_loader(monkeypatch, tmp_p
             pass
 
     # Patch asset internals to avoid real IO/Neo4j
-    monkeypatch.setattr("sbir_analytics.assets.cet.loading._get_neo4j_client", lambda: FakeLoader(None, None))
+    monkeypatch.setattr(
+        "sbir_analytics.assets.cet.loading._get_neo4j_client", lambda: FakeLoader(None, None)
+    )
     monkeypatch.setattr(
         "sbir_analytics.assets.cet.loading._read_parquet_or_ndjson", lambda *args, **kwargs: rows
     )
     monkeypatch.setattr("sbir_analytics.assets.cet.loading.CETLoader", FakeLoader)
     monkeypatch.setattr(
-        "sbir_analytics.assets.cet.loading.CETLoaderConfig", lambda batch_size: {"batch_size": batch_size}
+        "sbir_analytics.assets.cet.loading.CETLoaderConfig",
+        lambda batch_size: {"batch_size": batch_size},
     )
 
     # Execute asset using Dagster's proper context

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -161,10 +161,17 @@ class TestComponentExceptions:
 class TestInheritance:
     def test_all_inherit_from_base(self):
         for cls in [
-            ExtractionError, ValidationError, EnrichmentError,
-            TransformationError, APIError, RateLimitError,
-            ConfigurationError, FileSystemError, CETClassificationError,
-            DependencyError, RFunctionError,
+            ExtractionError,
+            ValidationError,
+            EnrichmentError,
+            TransformationError,
+            APIError,
+            RateLimitError,
+            ConfigurationError,
+            FileSystemError,
+            CETClassificationError,
+            DependencyError,
+            RFunctionError,
         ]:
             assert issubclass(cls, SBIRETLError), f"{cls.__name__} must inherit SBIRETLError"
 

--- a/tests/unit/tools/test_base.py
+++ b/tests/unit/tools/test_base.py
@@ -34,8 +34,11 @@ class FailingTool(BaseTool):
 class TestDataSourceRef:
     def test_to_dict(self):
         ref = DataSourceRef(
-            name="SBIR.gov", url="https://sbir.gov", version="2024-01",
-            record_count=100, access_method="api",
+            name="SBIR.gov",
+            url="https://sbir.gov",
+            version="2024-01",
+            record_count=100,
+            access_method="api",
         )
         d = ref.to_dict()
         assert d["name"] == "SBIR.gov"
@@ -45,26 +48,33 @@ class TestDataSourceRef:
 class TestToolMetadata:
     def test_duration_seconds(self):
         from datetime import datetime, timedelta
+
         start = datetime(2024, 1, 1, 12, 0, 0)
         end = start + timedelta(seconds=5)
         meta = ToolMetadata(
-            tool_name="test", tool_version="1.0",
-            execution_start=start, execution_end=end,
+            tool_name="test",
+            tool_version="1.0",
+            execution_start=start,
+            execution_end=end,
         )
         assert meta.duration_seconds == 5.0
 
     def test_duration_none_when_not_finished(self):
         from datetime import datetime
+
         meta = ToolMetadata(
-            tool_name="test", tool_version="1.0",
+            tool_name="test",
+            tool_version="1.0",
             execution_start=datetime.utcnow(),
         )
         assert meta.duration_seconds is None
 
     def test_to_dict(self):
         from datetime import datetime
+
         meta = ToolMetadata(
-            tool_name="test", tool_version="1.0",
+            tool_name="test",
+            tool_version="1.0",
             execution_start=datetime(2024, 1, 1),
             execution_end=datetime(2024, 1, 1, 0, 0, 5),
             record_count=42,
@@ -80,16 +90,19 @@ class TestToolMetadata:
 class TestToolResult:
     def test_chain_metadata(self):
         from datetime import datetime
+
         upstream = ToolResult(
             data=pd.DataFrame(),
             metadata=ToolMetadata(
-                tool_name="upstream_tool", tool_version="1.0",
+                tool_name="upstream_tool",
+                tool_version="1.0",
                 execution_start=datetime.utcnow(),
                 data_sources=[DataSourceRef(name="Source A", url="https://a.com")],
             ),
         )
         downstream_meta = ToolMetadata(
-            tool_name="downstream_tool", tool_version="1.0",
+            tool_name="downstream_tool",
+            tool_version="1.0",
             execution_start=datetime.utcnow(),
         )
         chained = upstream.chain_metadata(downstream_meta)
@@ -99,10 +112,12 @@ class TestToolResult:
 
     def test_to_dict_with_dataframe(self):
         from datetime import datetime
+
         result = ToolResult(
             data=pd.DataFrame({"x": [1, 2]}),
             metadata=ToolMetadata(
-                tool_name="test", tool_version="1.0",
+                tool_name="test",
+                tool_version="1.0",
                 execution_start=datetime.utcnow(),
             ),
         )
@@ -112,10 +127,12 @@ class TestToolResult:
 
     def test_to_dict_with_dict(self):
         from datetime import datetime
+
         result = ToolResult(
             data={"key": "value"},
             metadata=ToolMetadata(
-                tool_name="test", tool_version="1.0",
+                tool_name="test",
+                tool_version="1.0",
                 execution_start=datetime.utcnow(),
             ),
         )

--- a/tests/unit/tools/test_mission_a.py
+++ b/tests/unit/tools/test_mission_a.py
@@ -7,21 +7,27 @@ import pandas as pd
 from sbir_analytics.tools.mission_a.extract_topics import ExtractTopicsTool
 from sbir_analytics.tools.mission_a.cluster_topics import ClusterTopicsTool
 from sbir_analytics.tools.mission_a.detect_gaps import DetectGapsTool, NSTC_CET_AREAS
-from sbir_analytics.tools.mission_a.compute_portfolio_metrics import ComputePortfolioMetricsTool, _compute_hhi
+from sbir_analytics.tools.mission_a.compute_portfolio_metrics import (
+    ComputePortfolioMetricsTool,
+    _compute_hhi,
+)
 
 
 # ---- extract_topics ----
 
+
 class TestExtractTopicsTool:
     def test_basic_extraction(self):
-        awards = pd.DataFrame({
-            "solicitation_topic": ["T001", "T001", "T002"],
-            "agency": ["DoD", "DoD", "DOE"],
-            "abstract": ["Battery research", "Battery development", "Solar panel tech"],
-            "award_amount": [100000, 150000, 200000],
-            "fiscal_year": [2023, 2024, 2024],
-            "company": ["Acme", "Widget", "Solar Co"],
-        })
+        awards = pd.DataFrame(
+            {
+                "solicitation_topic": ["T001", "T001", "T002"],
+                "agency": ["DoD", "DoD", "DOE"],
+                "abstract": ["Battery research", "Battery development", "Solar panel tech"],
+                "award_amount": [100000, 150000, 200000],
+                "fiscal_year": [2023, 2024, 2024],
+                "company": ["Acme", "Widget", "Solar Co"],
+            }
+        )
         tool = ExtractTopicsTool()
         result = tool.run(awards_df=awards)
         assert result.metadata.tool_name == "extract_topics"
@@ -29,12 +35,14 @@ class TestExtractTopicsTool:
         assert len(result.data) == 2  # 2 topics
 
     def test_fiscal_year_filter(self):
-        awards = pd.DataFrame({
-            "solicitation_topic": ["T001", "T002"],
-            "agency": ["DoD", "DOE"],
-            "abstract": ["Test 1", "Test 2"],
-            "fiscal_year": [2022, 2024],
-        })
+        awards = pd.DataFrame(
+            {
+                "solicitation_topic": ["T001", "T002"],
+                "agency": ["DoD", "DOE"],
+                "abstract": ["Test 1", "Test 2"],
+                "fiscal_year": [2022, 2024],
+            }
+        )
         tool = ExtractTopicsTool()
         result = tool.run(awards_df=awards, fiscal_years=[2024])
         assert len(result.data) == 1
@@ -48,24 +56,29 @@ class TestExtractTopicsTool:
 
 # ---- cluster_topics ----
 
+
 class TestClusterTopicsTool:
     def test_basic_clustering(self):
-        topics = pd.DataFrame({
-            "topic_id": ["T1", "T2", "T3"],
-            "agency": ["DoD", "DOE", "NIH"],
-            "title": ["Battery tech", "Battery storage", "Cancer treatment"],
-            "description": [
-                "Advanced lithium batteries for military use",
-                "Grid-scale battery storage solutions",
-                "Novel cancer immunotherapy approach",
-            ],
-        })
+        topics = pd.DataFrame(
+            {
+                "topic_id": ["T1", "T2", "T3"],
+                "agency": ["DoD", "DOE", "NIH"],
+                "title": ["Battery tech", "Battery storage", "Cancer treatment"],
+                "description": [
+                    "Advanced lithium batteries for military use",
+                    "Grid-scale battery storage solutions",
+                    "Novel cancer immunotherapy approach",
+                ],
+            }
+        )
         # Create embeddings where T1 and T2 are similar
-        embeddings = np.array([
-            [1.0, 0.1, 0.0],  # T1: battery-ish
-            [0.9, 0.2, 0.0],  # T2: also battery-ish
-            [0.0, 0.0, 1.0],  # T3: completely different
-        ])
+        embeddings = np.array(
+            [
+                [1.0, 0.1, 0.0],  # T1: battery-ish
+                [0.9, 0.2, 0.0],  # T2: also battery-ish
+                [0.0, 0.0, 1.0],  # T3: completely different
+            ]
+        )
         tool = ClusterTopicsTool()
         result = tool.run(
             topics_df=topics,
@@ -82,11 +95,13 @@ class TestClusterTopicsTool:
         assert any("No topics provided" in w for w in result.metadata.warnings)
 
     def test_cross_agency_filter(self):
-        topics = pd.DataFrame({
-            "topic_id": ["T1", "T2"],
-            "agency": ["DoD", "DoD"],  # Same agency
-            "title": ["Battery 1", "Battery 2"],
-        })
+        topics = pd.DataFrame(
+            {
+                "topic_id": ["T1", "T2"],
+                "agency": ["DoD", "DoD"],  # Same agency
+                "title": ["Battery 1", "Battery 2"],
+            }
+        )
         embeddings = np.array([[1.0, 0.0], [0.99, 0.01]])
         tool = ClusterTopicsTool()
         result = tool.run(
@@ -100,14 +115,17 @@ class TestClusterTopicsTool:
 
 # ---- detect_gaps ----
 
+
 class TestDetectGapsTool:
     def test_detects_unfunded_areas(self):
-        awards = pd.DataFrame({
-            "cet_primary": ["Artificial Intelligence"] * 5,
-            "fiscal_year": [2021, 2022, 2023, 2024, 2025],
-            "agency": ["DoD"] * 5,
-            "award_amount": [100000] * 5,
-        })
+        awards = pd.DataFrame(
+            {
+                "cet_primary": ["Artificial Intelligence"] * 5,
+                "fiscal_year": [2021, 2022, 2023, 2024, 2025],
+                "agency": ["DoD"] * 5,
+                "award_amount": [100000] * 5,
+            }
+        )
         tool = DetectGapsTool()
         result = tool.run(classified_awards=awards)
         unfunded = result.data["unfunded_cet_areas"]
@@ -115,12 +133,14 @@ class TestDetectGapsTool:
         assert len(unfunded) == len(NSTC_CET_AREAS) - 1
 
     def test_detects_single_agency_dependency(self):
-        awards = pd.DataFrame({
-            "cet_primary": ["Quantum Information Technologies"] * 10,
-            "fiscal_year": [2023] * 10,
-            "agency": ["DoD"] * 10,
-            "award_amount": [50000] * 10,
-        })
+        awards = pd.DataFrame(
+            {
+                "cet_primary": ["Quantum Information Technologies"] * 10,
+                "fiscal_year": [2023] * 10,
+                "agency": ["DoD"] * 10,
+                "award_amount": [50000] * 10,
+            }
+        )
         tool = DetectGapsTool()
         result = tool.run(classified_awards=awards)
         single_deps = result.data["single_agency_dependencies"]
@@ -140,6 +160,7 @@ class TestDetectGapsTool:
 
 # ---- compute_portfolio_metrics ----
 
+
 class TestComputeHHI:
     def test_monopoly(self):
         assert _compute_hhi([100.0]) == pytest.approx(1.0)
@@ -154,14 +175,16 @@ class TestComputeHHI:
 
 class TestComputePortfolioMetricsTool:
     def test_agency_hhi(self):
-        awards = pd.DataFrame({
-            "cet_primary": ["AI"] * 6,
-            "agency": ["DoD", "DoD", "DoD", "DOE", "NIH", "NIH"],
-            "company": ["A", "B", "C", "D", "E", "F"],
-            "state": ["CA", "MA", "TX", "NY", "CA", "MA"],
-            "fiscal_year": [2024] * 6,
-            "award_amount": [100000] * 6,
-        })
+        awards = pd.DataFrame(
+            {
+                "cet_primary": ["AI"] * 6,
+                "agency": ["DoD", "DoD", "DoD", "DOE", "NIH", "NIH"],
+                "company": ["A", "B", "C", "D", "E", "F"],
+                "state": ["CA", "MA", "TX", "NY", "CA", "MA"],
+                "fiscal_year": [2024] * 6,
+                "award_amount": [100000] * 6,
+            }
+        )
         tool = ComputePortfolioMetricsTool()
         result = tool.run(classified_awards=awards)
         assert isinstance(result.data, dict)
@@ -170,13 +193,15 @@ class TestComputePortfolioMetricsTool:
         assert 0 < hhi < 1  # Not monopoly, not perfect competition
 
     def test_cross_agency_companies(self):
-        awards = pd.DataFrame({
-            "cet_primary": ["AI", "AI"],
-            "agency": ["DoD", "DOE"],
-            "company": ["Acme", "Acme"],  # Same company, different agencies
-            "state": ["CA", "CA"],
-            "fiscal_year": [2024, 2024],
-        })
+        awards = pd.DataFrame(
+            {
+                "cet_primary": ["AI", "AI"],
+                "agency": ["DoD", "DOE"],
+                "company": ["Acme", "Acme"],  # Same company, different agencies
+                "state": ["CA", "CA"],
+                "fiscal_year": [2024, 2024],
+            }
+        )
         tool = ComputePortfolioMetricsTool()
         result = tool.run(classified_awards=awards)
         assert result.data["cross_agency_company_count"] == 1

--- a/tests/unit/tools/test_mission_b.py
+++ b/tests/unit/tools/test_mission_b.py
@@ -17,20 +17,27 @@ from sbir_analytics.tools.mission_b.compute_observable_commercialization import 
 
 # ---- compute_transition_rate ----
 
+
 class TestComputeTransitionRateTool:
     def _make_awards(self, company, p1_count, p2_count, fy_start=2021, fy_end=2025):
         """Helper to create award records for a company."""
         records = []
         for i in range(p1_count):
-            records.append({
-                "company": company, "phase": "I",
-                "fiscal_year": fy_start + (i % (fy_end - fy_start + 1)),
-            })
+            records.append(
+                {
+                    "company": company,
+                    "phase": "I",
+                    "fiscal_year": fy_start + (i % (fy_end - fy_start + 1)),
+                }
+            )
         for i in range(p2_count):
-            records.append({
-                "company": company, "phase": "II",
-                "fiscal_year": fy_start + (i % (fy_end - fy_start + 1)),
-            })
+            records.append(
+                {
+                    "company": company,
+                    "phase": "II",
+                    "fiscal_year": fy_start + (i % (fy_end - fy_start + 1)),
+                }
+            )
         return records
 
     def test_below_threshold(self):
@@ -72,9 +79,9 @@ class TestComputeTransitionRateTool:
 
     def test_summary_stats(self):
         records = (
-            self._make_awards("Co1", 25, 10) +
-            self._make_awards("Co2", 5, 2) +
-            self._make_awards("Co3", 25, 2)
+            self._make_awards("Co1", 25, 10)
+            + self._make_awards("Co2", 5, 2)
+            + self._make_awards("Co3", 25, 2)
         )
         awards = pd.DataFrame(records)
         tool = ComputeTransitionRateTool()
@@ -95,32 +102,45 @@ class TestComputeTransitionRateTool:
 
 # ---- compute_observable_commercialization ----
 
+
 class TestComputeObservableCommercializationTool:
     def _make_p2_awards(self, company, count, fy_start=2016, fy_end=2024):
-        return [{
-            "company": company, "phase": "II",
-            "fiscal_year": fy_start + (i % (fy_end - fy_start + 1)),
-        } for i in range(count)]
+        return [
+            {
+                "company": company,
+                "phase": "II",
+                "fiscal_year": fy_start + (i % (fy_end - fy_start + 1)),
+            }
+            for i in range(count)
+        ]
 
     def test_qualifying_company(self):
         records = self._make_p2_awards("QualCo", 20)
         awards = pd.DataFrame(records)
-        fpds = pd.DataFrame({
-            "company": ["QualCo"],
-            "obligation_amount": [5_000_000],
-        })
-        patents = pd.DataFrame({
-            "company": ["QualCo"] * 5,
-        })
-        sam = pd.DataFrame({
-            "unique_entity_id": ["QualCo"],
-            "registration_status": ["ACTIVE"],
-        })
+        fpds = pd.DataFrame(
+            {
+                "company": ["QualCo"],
+                "obligation_amount": [5_000_000],
+            }
+        )
+        patents = pd.DataFrame(
+            {
+                "company": ["QualCo"] * 5,
+            }
+        )
+        sam = pd.DataFrame(
+            {
+                "unique_entity_id": ["QualCo"],
+                "registration_status": ["ACTIVE"],
+            }
+        )
 
         tool = ComputeObservableCommercializationTool()
         result = tool.run(
-            awards_df=awards, fpds_contracts=fpds,
-            patent_data=patents, sam_entities=sam,
+            awards_df=awards,
+            fpds_contracts=fpds,
+            patent_data=patents,
+            sam_entities=sam,
         )
         results_df = result.data["results"]
         assert len(results_df) == 1

--- a/tests/unit/tools/test_mission_c.py
+++ b/tests/unit/tools/test_mission_c.py
@@ -15,12 +15,15 @@ from sbir_analytics.tools.mission_c.tax_estimation import (
 
 # ---- naics_to_bea_crosswalk ----
 
+
 class TestNAICSToBEACrosswalkTool:
     def test_basic_mapping(self):
-        awards = pd.DataFrame({
-            "naics_code": ["541511", "236220", ""],
-            "company": ["TechCo", "BuildCo", "NullCo"],
-        })
+        awards = pd.DataFrame(
+            {
+                "naics_code": ["541511", "236220", ""],
+                "company": ["TechCo", "BuildCo", "NullCo"],
+            }
+        )
         tool = NAICSToBEACrosswalkTool()
         result = tool.run(awards_df=awards)
         assert isinstance(result.data, dict)
@@ -34,10 +37,12 @@ class TestNAICSToBEACrosswalkTool:
         assert len(result.data) == 0
 
     def test_metadata_warnings_for_unmapped(self):
-        awards = pd.DataFrame({
-            "naics_code": ["999999"],  # Unlikely to map
-            "company": ["UnknownCo"],
-        })
+        awards = pd.DataFrame(
+            {
+                "naics_code": ["999999"],  # Unlikely to map
+                "company": ["UnknownCo"],
+            }
+        )
         tool = NAICSToBEACrosswalkTool()
         result = tool.run(awards_df=awards)
         stats = result.data["mapping_stats"]
@@ -46,6 +51,7 @@ class TestNAICSToBEACrosswalkTool:
 
 
 # ---- stateio_multipliers ----
+
 
 class TestStateIOMultipliersTool:
     def test_default_fallback(self):
@@ -57,10 +63,12 @@ class TestStateIOMultipliersTool:
         assert "output_multiplier" in result.data.columns
 
     def test_from_awards_df(self):
-        awards = pd.DataFrame({
-            "state": ["CA", "MA"],
-            "bea_sector": ["Manufacturing", "Information"],
-        })
+        awards = pd.DataFrame(
+            {
+                "state": ["CA", "MA"],
+                "bea_sector": ["Manufacturing", "Information"],
+            }
+        )
         tool = StateIOMultipliersTool()
         result = tool.run(awards_df=awards)
         assert len(result.data) == 2
@@ -73,21 +81,26 @@ class TestStateIOMultipliersTool:
 
 # ---- tax_estimation ----
 
+
 class TestTaxEstimationTool:
     def test_basic_estimation(self):
-        awards = pd.DataFrame({
-            "bea_sector": ["Manufacturing", "Information"],
-            "state": ["CA", "MA"],
-            "award_amount": [500000, 300000],
-            "fiscal_year": [2023, 2023],
-            "canonical_id": ["co1", "co2"],
-        })
-        multipliers = pd.DataFrame({
-            "state": ["CA", "MA"],
-            "bea_sector": ["Manufacturing", "Information"],
-            "output_multiplier": [1.8, 1.5],
-            "value_added_multiplier": [1.2, 1.1],
-        })
+        awards = pd.DataFrame(
+            {
+                "bea_sector": ["Manufacturing", "Information"],
+                "state": ["CA", "MA"],
+                "award_amount": [500000, 300000],
+                "fiscal_year": [2023, 2023],
+                "canonical_id": ["co1", "co2"],
+            }
+        )
+        multipliers = pd.DataFrame(
+            {
+                "state": ["CA", "MA"],
+                "bea_sector": ["Manufacturing", "Information"],
+                "output_multiplier": [1.8, 1.5],
+                "value_added_multiplier": [1.2, 1.1],
+            }
+        )
         tool = TaxEstimationTool()
         result = tool.run(awards_df=awards, multipliers_df=multipliers)
         assert isinstance(result.data, dict)
@@ -99,19 +112,23 @@ class TestTaxEstimationTool:
         assert track_a["total_estimated_tax"].sum() > 0
 
     def test_tax_components(self):
-        awards = pd.DataFrame({
-            "bea_sector": ["Manufacturing"],
-            "state": ["CA"],
-            "award_amount": [1_000_000],
-            "fiscal_year": [2023],
-            "canonical_id": ["co1"],
-        })
-        multipliers = pd.DataFrame({
-            "state": ["CA"],
-            "bea_sector": ["Manufacturing"],
-            "output_multiplier": [2.0],
-            "value_added_multiplier": [1.5],
-        })
+        awards = pd.DataFrame(
+            {
+                "bea_sector": ["Manufacturing"],
+                "state": ["CA"],
+                "award_amount": [1_000_000],
+                "fiscal_year": [2023],
+                "canonical_id": ["co1"],
+            }
+        )
+        multipliers = pd.DataFrame(
+            {
+                "state": ["CA"],
+                "bea_sector": ["Manufacturing"],
+                "output_multiplier": [2.0],
+                "value_added_multiplier": [1.5],
+            }
+        )
         tool = TaxEstimationTool()
         result = tool.run(awards_df=awards, multipliers_df=multipliers)
         row = result.data["track_a_estimates"].iloc[0]
@@ -124,26 +141,28 @@ class TestTaxEstimationTool:
 
         # Total should be sum of components
         expected_total = (
-            row["individual_income_tax"] +
-            row["payroll_tax"] +
-            row["corporate_income_tax"]
+            row["individual_income_tax"] + row["payroll_tax"] + row["corporate_income_tax"]
         )
         assert row["total_estimated_tax"] == pytest.approx(expected_total, rel=0.01)
 
     def test_roi_calculation(self):
-        awards = pd.DataFrame({
-            "bea_sector": ["Manufacturing"],
-            "state": ["CA"],
-            "award_amount": [1_000_000],
-            "fiscal_year": [2023],
-            "canonical_id": ["co1"],
-        })
-        multipliers = pd.DataFrame({
-            "state": ["CA"],
-            "bea_sector": ["Manufacturing"],
-            "output_multiplier": [2.0],
-            "value_added_multiplier": [1.5],
-        })
+        awards = pd.DataFrame(
+            {
+                "bea_sector": ["Manufacturing"],
+                "state": ["CA"],
+                "award_amount": [1_000_000],
+                "fiscal_year": [2023],
+                "canonical_id": ["co1"],
+            }
+        )
+        multipliers = pd.DataFrame(
+            {
+                "state": ["CA"],
+                "bea_sector": ["Manufacturing"],
+                "output_multiplier": [2.0],
+                "value_added_multiplier": [1.5],
+            }
+        )
         tool = TaxEstimationTool()
         result = tool.run(awards_df=awards, multipliers_df=multipliers)
         summary = result.data["summary"]
@@ -170,17 +189,21 @@ class TestTaxEstimationTool:
 
     def test_track_b_integration(self):
         """Test Track B data flows through when provided."""
-        awards = pd.DataFrame({
-            "bea_sector": ["Manufacturing"],
-            "state": ["CA"],
-            "award_amount": [500000],
-            "fiscal_year": [2023],
-            "canonical_id": ["co1"],
-        })
-        fpds = pd.DataFrame({
-            "company_id": ["co1"],
-            "fpds_total_revenue": [2_000_000],
-        })
+        awards = pd.DataFrame(
+            {
+                "bea_sector": ["Manufacturing"],
+                "state": ["CA"],
+                "award_amount": [500000],
+                "fiscal_year": [2023],
+                "canonical_id": ["co1"],
+            }
+        )
+        fpds = pd.DataFrame(
+            {
+                "company_id": ["co1"],
+                "fpds_total_revenue": [2_000_000],
+            }
+        )
         tool = TaxEstimationTool()
         result = tool.run(awards_df=awards, fpds_revenue=fpds)
         assert result.data["track_b_observed"]["total_fpds_revenue"] == 2_000_000

--- a/tests/unit/tools/test_phase0.py
+++ b/tests/unit/tools/test_phase0.py
@@ -3,7 +3,11 @@
 import pytest
 import pandas as pd
 
-from sbir_analytics.tools.phase0.resolve_entities import ResolveEntitiesTool, _normalize_name, _generate_canonical_id
+from sbir_analytics.tools.phase0.resolve_entities import (
+    ResolveEntitiesTool,
+    _normalize_name,
+    _generate_canonical_id,
+)
 
 
 class TestNormalizeName:
@@ -50,18 +54,22 @@ class TestResolveEntitiesTool:
     def test_basic_resolution(self):
         tool = ResolveEntitiesTool()
 
-        sam = pd.DataFrame({
-            "unique_entity_id": ["UEI001", "UEI002"],
-            "legal_business_name": ["Acme Corp", "Widget Inc"],
-            "physical_address_state": ["CA", "MA"],
-            "naics_code": ["541511", "541512"],
-        })
+        sam = pd.DataFrame(
+            {
+                "unique_entity_id": ["UEI001", "UEI002"],
+                "legal_business_name": ["Acme Corp", "Widget Inc"],
+                "physical_address_state": ["CA", "MA"],
+                "naics_code": ["541511", "541512"],
+            }
+        )
 
-        sbir = pd.DataFrame({
-            "company": ["Acme Corporation", "Widget Inc", "Unknown Co"],
-            "state": ["CA", "MA", "TX"],
-            "uei": ["UEI001", "UEI002", ""],
-        })
+        sbir = pd.DataFrame(
+            {
+                "company": ["Acme Corporation", "Widget Inc", "Unknown Co"],
+                "state": ["CA", "MA", "TX"],
+                "uei": ["UEI001", "UEI002", ""],
+            }
+        )
 
         result = tool.run(sam_entities=sam, sbir_companies=sbir)
         assert result.metadata.tool_name == "resolve_entities"
@@ -72,17 +80,21 @@ class TestResolveEntitiesTool:
     def test_uei_exact_match(self):
         tool = ResolveEntitiesTool()
 
-        sam = pd.DataFrame({
-            "unique_entity_id": ["UEI001"],
-            "legal_business_name": ["Acme Corp"],
-            "physical_address_state": ["CA"],
-        })
+        sam = pd.DataFrame(
+            {
+                "unique_entity_id": ["UEI001"],
+                "legal_business_name": ["Acme Corp"],
+                "physical_address_state": ["CA"],
+            }
+        )
 
-        sbir = pd.DataFrame({
-            "company": ["ACME CORPORATION"],
-            "state": ["CA"],
-            "uei": ["UEI001"],
-        })
+        sbir = pd.DataFrame(
+            {
+                "company": ["ACME CORPORATION"],
+                "state": ["CA"],
+                "uei": ["UEI001"],
+            }
+        )
 
         result = tool.run(sam_entities=sam, sbir_companies=sbir)
         stats = result.data["stats"]
@@ -97,11 +109,13 @@ class TestResolveEntitiesTool:
 
     def test_metadata_populated(self):
         tool = ResolveEntitiesTool()
-        sam = pd.DataFrame({
-            "unique_entity_id": ["UEI001"],
-            "legal_business_name": ["Acme Corp"],
-            "physical_address_state": ["CA"],
-        })
+        sam = pd.DataFrame(
+            {
+                "unique_entity_id": ["UEI001"],
+                "legal_business_name": ["Acme Corp"],
+                "physical_address_state": ["CA"],
+            }
+        )
         result = tool.run(sam_entities=sam)
         assert len(result.metadata.data_sources) >= 1
         assert result.metadata.data_sources[0].name == "SAM.gov Entity Data"
@@ -111,18 +125,22 @@ class TestResolveEntitiesTool:
         tool = ResolveEntitiesTool()
 
         # Provide SAM data so fuzzy matching path is exercised
-        sam = pd.DataFrame({
-            "unique_entity_id": ["UEI999"],
-            "legal_business_name": ["Completely Different Corp"],
-            "physical_address_state": ["NY"],
-        })
+        sam = pd.DataFrame(
+            {
+                "unique_entity_id": ["UEI999"],
+                "legal_business_name": ["Completely Different Corp"],
+                "physical_address_state": ["NY"],
+            }
+        )
 
-        sbir = pd.DataFrame({
-            "company": ["Totally New Company"],
-            "state": ["TX"],
-            "uei": [""],
-            "duns": [""],
-        })
+        sbir = pd.DataFrame(
+            {
+                "company": ["Totally New Company"],
+                "state": ["TX"],
+                "uei": [""],
+                "duns": [""],
+            }
+        )
 
         result = tool.run(sam_entities=sam, sbir_companies=sbir)
         stats = result.data["stats"]
@@ -134,6 +152,7 @@ class TestExtractSAMEntitiesTool:
 
     def test_import(self):
         from sbir_analytics.tools.phase0.extract_sam_entities import ExtractSAMEntitiesTool
+
         tool = ExtractSAMEntitiesTool()
         assert tool.name == "extract_sam_entities"
         assert tool.version == "1.0.0"
@@ -144,11 +163,13 @@ class TestExtractFPDSContractsTool:
 
     def test_import(self):
         from sbir_analytics.tools.phase0.extract_fpds_contracts import ExtractFPDSContractsTool
+
         tool = ExtractFPDSContractsTool()
         assert tool.name == "extract_fpds_contracts"
 
     def test_requires_input(self):
         from sbir_analytics.tools.phase0.extract_fpds_contracts import ExtractFPDSContractsTool
+
         tool = ExtractFPDSContractsTool()
         with pytest.raises(ValueError, match="Must provide either"):
             tool.run()

--- a/tests/unit/transformers/test_bea_api_client.py
+++ b/tests/unit/transformers/test_bea_api_client.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import MagicMock, patch
 
-import pandas as pd
 import pytest
 
 from sbir_etl.exceptions import APIError, ConfigurationError
@@ -78,11 +77,7 @@ class TestBEAApiClientRequests:
 
         mock_response = MagicMock()
         mock_response.json.return_value = {
-            "BEAAPI": {
-                "Results": {
-                    "Data": [{"RowCode": "11", "DataValue": "100"}]
-                }
-            }
+            "BEAAPI": {"Results": {"Data": [{"RowCode": "11", "DataValue": "100"}]}}
         }
         mock_response.raise_for_status = MagicMock()
         mock_get.return_value = mock_response
@@ -101,9 +96,7 @@ class TestBEAApiClientRequests:
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "BEAAPI": {
-                "Results": {
-                    "Error": {"APIErrorCode": "40", "APIErrorDescription": "Invalid table"}
-                }
+                "Results": {"Error": {"APIErrorCode": "40", "APIErrorDescription": "Invalid table"}}
             }
         }
         mock_response.raise_for_status = MagicMock()

--- a/tests/unit/transformers/test_bea_io_adapter.py
+++ b/tests/unit/transformers/test_bea_io_adapter.py
@@ -56,9 +56,9 @@ class TestBEAIOAdapterInitialization:
 
     @patch(
         "sbir_etl.transformers.bea_io_adapter.BEAApiClient",
-        side_effect=__import__("sbir_etl.exceptions", fromlist=["ConfigurationError"]).ConfigurationError(
-            "BEA_API_KEY not set", component="test", operation="test"
-        ),
+        side_effect=__import__(
+            "sbir_etl.exceptions", fromlist=["ConfigurationError"]
+        ).ConfigurationError("BEA_API_KEY not set", component="test", operation="test"),
     )
     def test_init_no_api_key(self, mock_client_cls, mock_config):
         """Test initialization falls back when BEA_API_KEY not set."""
@@ -250,9 +250,7 @@ class TestBEAIOAdapterIntegration:
 
         from sbir_etl.transformers.bea_io_adapter import BEAIOAdapter
 
-        adapter = BEAIOAdapter(
-            config=mock_config, cache_enabled=True, cache_dir=str(tmp_path)
-        )
+        adapter = BEAIOAdapter(config=mock_config, cache_enabled=True, cache_dir=str(tmp_path))
 
         result1 = adapter.compute_impacts(sample_shocks)
         assert len(result1) == 3

--- a/tests/unit/transformers/test_bea_io_functions.py
+++ b/tests/unit/transformers/test_bea_io_functions.py
@@ -1,6 +1,6 @@
 """Tests for BEA I-O functions."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -76,12 +76,14 @@ class TestValueAddedRatioCalculation:
 
     def test_calculate_ratios_with_zero_total(self):
         """Test ratio calculation handles zero total value added gracefully."""
-        va_df = pd.DataFrame([
-            {"ColCode": "11", "RowDescription": "Compensation of employees", "DataValue": "0"},
-            {"ColCode": "11", "RowDescription": "Gross operating surplus", "DataValue": "0"},
-            {"ColCode": "11", "RowDescription": "Taxes on production", "DataValue": "0"},
-            {"ColCode": "11", "RowDescription": "Total value added", "DataValue": "0"},
-        ])
+        va_df = pd.DataFrame(
+            [
+                {"ColCode": "11", "RowDescription": "Compensation of employees", "DataValue": "0"},
+                {"ColCode": "11", "RowDescription": "Gross operating surplus", "DataValue": "0"},
+                {"ColCode": "11", "RowDescription": "Taxes on production", "DataValue": "0"},
+                {"ColCode": "11", "RowDescription": "Total value added", "DataValue": "0"},
+            ]
+        )
         result = bea_io.calculate_value_added_ratios(va_df)
         assert isinstance(result, pd.DataFrame)
 
@@ -179,10 +181,12 @@ class TestMatrixCalculations:
             index=["11", "21"],
             columns=["11", "21"],
         )
-        shocks_df = pd.DataFrame({
-            "bea_sector": ["11", "21"],
-            "shock_amount": [1000.0, 500.0],
-        })
+        shocks_df = pd.DataFrame(
+            {
+                "bea_sector": ["11", "21"],
+                "shock_amount": [1000.0, 500.0],
+            }
+        )
 
         production = bea_io.apply_demand_shocks(leontief_inv, shocks_df)
 
@@ -222,15 +226,17 @@ class TestEmploymentFromProduction:
         Production is in millions (BEA units), coefficients are jobs per $1M.
         """
         production = pd.Series([1.0, 0.5], index=["11", "21"])  # $1M, $0.5M
-        coefficients = pd.DataFrame({
-            "sector": ["11", "21"],
-            "employment": [2000, 1000],
-            "employment_coefficient": [20.0, 10.0],  # jobs per $1M
-        })
+        coefficients = pd.DataFrame(
+            {
+                "sector": ["11", "21"],
+                "employment": [2000, 1000],
+                "employment_coefficient": [20.0, 10.0],  # jobs per $1M
+            }
+        )
 
         jobs = bea_io.calculate_employment_from_production(production, coefficients)
         assert jobs["11"] == 20.0  # 1.0 * 20
-        assert jobs["21"] == 5.0   # 0.5 * 10
+        assert jobs["21"] == 5.0  # 0.5 * 10
 
     def test_without_coefficients(self):
         """Test employment calculation falls back to default (~10 jobs/$1M)."""

--- a/tests/unit/transformers/test_company_categorization.py
+++ b/tests/unit/transformers/test_company_categorization.py
@@ -261,7 +261,12 @@ class TestAggregateCompanyClassification:
     def test_psc_diversity_override_to_mixed(self):
         # >6 PSC families should trigger Mixed override
         contracts = [
-            {"award_id": f"C{i}", "classification": "Product", "award_amount": 100000, "psc": f"{chr(65 + i)}123"}
+            {
+                "award_id": f"C{i}",
+                "classification": "Product",
+                "award_amount": 100000,
+                "psc": f"{chr(65 + i)}123",
+            }
             for i in range(8)  # 8 different PSC families (A-H)
         ]
         result = aggregate_company_classification(contracts, "UEI005", "Diverse Corp")
@@ -282,7 +287,12 @@ class TestAggregateConfidenceLevels:
 
     def test_medium_confidence_three_to_five_awards(self):
         contracts = [
-            {"award_id": f"C{i}", "classification": "Product", "award_amount": 100000, "psc": "1234"}
+            {
+                "award_id": f"C{i}",
+                "classification": "Product",
+                "award_amount": 100000,
+                "psc": "1234",
+            }
             for i in range(4)
         ]
         result = aggregate_company_classification(contracts, "UEI011", "Med Co")
@@ -290,7 +300,12 @@ class TestAggregateConfidenceLevels:
 
     def test_high_confidence_more_than_five_awards(self):
         contracts = [
-            {"award_id": f"C{i}", "classification": "Product", "award_amount": 100000, "psc": "1234"}
+            {
+                "award_id": f"C{i}",
+                "classification": "Product",
+                "award_amount": 100000,
+                "psc": "1234",
+            }
             for i in range(7)
         ]
         result = aggregate_company_classification(contracts, "UEI012", "High Co")
@@ -330,7 +345,12 @@ class TestAggregateOutputFields:
 
     def test_award_count_matches_input(self):
         contracts = [
-            {"award_id": f"C{i}", "classification": "Product", "award_amount": 100000, "psc": "1234"}
+            {
+                "award_id": f"C{i}",
+                "classification": "Product",
+                "award_amount": 100000,
+                "psc": "1234",
+            }
             for i in range(5)
         ]
         result = aggregate_company_classification(contracts, "UEI023", "Test Co")
@@ -339,9 +359,24 @@ class TestAggregateOutputFields:
     def test_company_identifiers_stored(self):
         result = aggregate_company_classification(
             [
-                {"award_id": "C1", "classification": "Product", "award_amount": 100000, "psc": "1234"},
-                {"award_id": "C2", "classification": "Product", "award_amount": 100000, "psc": "5678"},
-                {"award_id": "C3", "classification": "Product", "award_amount": 100000, "psc": "9012"},
+                {
+                    "award_id": "C1",
+                    "classification": "Product",
+                    "award_amount": 100000,
+                    "psc": "1234",
+                },
+                {
+                    "award_id": "C2",
+                    "classification": "Product",
+                    "award_amount": 100000,
+                    "psc": "5678",
+                },
+                {
+                    "award_id": "C3",
+                    "classification": "Product",
+                    "award_amount": 100000,
+                    "psc": "9012",
+                },
             ],
             "MY_UEI_123",
             "Acme Corp",
@@ -414,20 +449,22 @@ class TestRetrieveCompanyContracts:
     def test_uei_query_returns_contracts(self):
         """When UEI is provided, extractor is called and results returned."""
         mock_extractor = MagicMock()
-        sample_data = pd.DataFrame({
-            "award_id": ["AWD001", "AWD002"],
-            "psc": ["1234", "R425"],
-            "contract_type": ["FFP", "CPFF"],
-            "pricing": ["FFP", "CPFF"],
-            "description": ["Prototype device", "Consulting services"],
-            "award_amount": [100000.0, 200000.0],
-            "recipient_uei": ["UEI123", "UEI123"],
-            "awardee_or_recipient_uei": ["UEI123", "UEI123"],
-            "recipient_duns": [None, None],
-            "cage_code": [None, None],
-            "action_date": ["2024-01-01", "2024-02-01"],
-            "fiscal_year": [2024, 2024],
-        })
+        sample_data = pd.DataFrame(
+            {
+                "award_id": ["AWD001", "AWD002"],
+                "psc": ["1234", "R425"],
+                "contract_type": ["FFP", "CPFF"],
+                "pricing": ["FFP", "CPFF"],
+                "description": ["Prototype device", "Consulting services"],
+                "award_amount": [100000.0, 200000.0],
+                "recipient_uei": ["UEI123", "UEI123"],
+                "awardee_or_recipient_uei": ["UEI123", "UEI123"],
+                "recipient_duns": [None, None],
+                "cage_code": [None, None],
+                "action_date": ["2024-01-01", "2024-02-01"],
+                "fiscal_year": [2024, 2024],
+            }
+        )
         mock_conn = MagicMock()
         mock_conn.execute.return_value.fetchdf.return_value = sample_data
         mock_extractor.connect.return_value = mock_conn

--- a/tests/unit/transformers/test_company_cet_aggregator.py
+++ b/tests/unit/transformers/test_company_cet_aggregator.py
@@ -571,9 +571,7 @@ class TestToDataframe:
         assert pytest.approx(row["dominant_score"]) == 80.0
 
         # HHI: (0.8^2 + 0.2^2) = 0.64 + 0.04 = 0.68
-        assert pytest.approx(row["specialization_score"], rel=1e-6) == pytest.approx(
-            0.68, rel=1e-6
-        )
+        assert pytest.approx(row["specialization_score"], rel=1e-6) == pytest.approx(0.68, rel=1e-6)
 
         assert pd.to_datetime(row["first_award_date"]).date() == datetime(2020, 1, 15).date()
         assert pd.to_datetime(row["last_award_date"]).date() == datetime(2022, 3, 10).date()
@@ -609,15 +607,23 @@ class TestToDataframe:
         assert pytest.approx(cet_scores["cet_x"]) == 40.0
         assert pytest.approx(cet_scores["cet_y"]) == 40.0
 
-        assert pytest.approx(row["specialization_score"], rel=1e-6) == pytest.approx(
-            0.5, rel=1e-6
-        )
+        assert pytest.approx(row["specialization_score"], rel=1e-6) == pytest.approx(0.5, rel=1e-6)
 
     def test_no_cets_results_in_empty_scores_and_zero_coverage(self):
         """Company with no CETs produces coverage=0, empty cet_scores, no dominant CET."""
         data = [
-            {"award_id": "C1", "company_id": "C3", "company_name": "Gamma Inc", "primary_cet": None},
-            {"award_id": "C2", "company_id": "C3", "company_name": "Gamma Inc", "primary_cet": None},
+            {
+                "award_id": "C1",
+                "company_id": "C3",
+                "company_name": "Gamma Inc",
+                "primary_cet": None,
+            },
+            {
+                "award_id": "C2",
+                "company_id": "C3",
+                "company_name": "Gamma Inc",
+                "primary_cet": None,
+            },
         ]
         df = pd.DataFrame(data)
         agg = CompanyCETAggregator(df)

--- a/tests/unit/transformers/test_economic_model_interface.py
+++ b/tests/unit/transformers/test_economic_model_interface.py
@@ -6,7 +6,10 @@ import pandas as pd
 import pytest
 
 from sbir_etl.exceptions import ValidationError
-from sbir_etl.transformers.economic_model_interface import EconomicImpactResult, validate_shocks_input
+from sbir_etl.transformers.economic_model_interface import (
+    EconomicImpactResult,
+    validate_shocks_input,
+)
 
 
 pytestmark = pytest.mark.fast

--- a/tests/unit/transformers/test_fiscal_component_calculator.py
+++ b/tests/unit/transformers/test_fiscal_component_calculator.py
@@ -8,7 +8,10 @@ import pytest
 
 pytestmark = pytest.mark.fast
 
-from sbir_etl.transformers.fiscal.components import ComponentValidationResult, FiscalComponentCalculator
+from sbir_etl.transformers.fiscal.components import (
+    ComponentValidationResult,
+    FiscalComponentCalculator,
+)
 
 
 # sample_impacts_df fixture is now in tests/unit/transformers/conftest.py

--- a/tests/unit/transformers/test_patent_transformer.py
+++ b/tests/unit/transformers/test_patent_transformer.py
@@ -5,7 +5,10 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from sbir_etl.transformers.patent_transformer import PatentAssignmentTransformer, PatentTransformOptions
+from sbir_etl.transformers.patent_transformer import (
+    PatentAssignmentTransformer,
+    PatentTransformOptions,
+)
 
 
 pytestmark = pytest.mark.fast

--- a/tests/unit/transition/detection/test_detector.py
+++ b/tests/unit/transition/detection/test_detector.py
@@ -158,7 +158,9 @@ class TestMatchVendor:
         mock_record.name = "Acme Corporation"
         mock_record.metadata = {"vendor_id": "VENDOR004"}
         mock_vendor_resolver.resolve_by_name.return_value = Mock(
-            record=mock_record, score=0.92, method="name_fuzzy",
+            record=mock_record,
+            score=0.92,
+            method="name_fuzzy",
         )
 
         detector = TransitionDetector(config=default_config, vendor_resolver=mock_vendor_resolver)

--- a/tests/unit/transition/features/test_patent_analyzer.py
+++ b/tests/unit/transition/features/test_patent_analyzer.py
@@ -337,10 +337,20 @@ class TestCalculateTopicSimilarity:
     @pytest.mark.parametrize(
         "patent_title,patent_abstract,contract_desc,min_sim,max_sim",
         [
-            ("Machine Learning System", "Advanced machine learning for data analysis",
-             "Machine learning data analysis system", 0.5, 1.0),
-            ("Medical Device Innovation", "Novel approach to medical diagnostics",
-             "Software development for financial systems", 0.0, 0.5),
+            (
+                "Machine Learning System",
+                "Advanced machine learning for data analysis",
+                "Machine learning data analysis system",
+                0.5,
+                1.0,
+            ),
+            (
+                "Medical Device Innovation",
+                "Novel approach to medical diagnostics",
+                "Software development for financial systems",
+                0.0,
+                0.5,
+            ),
         ],
         ids=["similar_content", "different_content"],
     )
@@ -426,7 +436,9 @@ class TestCalculateTopicSimilarity:
         ],
         ids=["no_patents", "no_description"],
     )
-    def test_calculate_topic_similarity_edge_cases(self, extractor, patents, contract_desc, expected):
+    def test_calculate_topic_similarity_edge_cases(
+        self, extractor, patents, contract_desc, expected
+    ):
         """Test topic similarity returns None for edge cases."""
         if patents is None:
             patents = [

--- a/tests/unit/transition/test_transition_assets_unit.py
+++ b/tests/unit/transition/test_transition_assets_unit.py
@@ -220,7 +220,10 @@ def test_transition_scores_and_evidence(monkeypatch, tmp_path):
     # Run all outputs into a temp working directory
     monkeypatch.chdir(tmp_path)
 
-    from sbir_analytics.assets.transition import transformed_transition_evidence, transformed_transition_scores
+    from sbir_analytics.assets.transition import (
+        transformed_transition_evidence,
+        transformed_transition_scores,
+    )
 
     # Reuse consistent fixtures (contracts + awards + vendor_resolution outputs)
     contracts_df = pd.DataFrame(

--- a/tests/unit/utils/test_async_tools.py
+++ b/tests/unit/utils/test_async_tools.py
@@ -57,6 +57,7 @@ class TestRunSync:
 
     def test_run_sync_thread_safety(self):
         """Test that run_sync can be called safely from multiple threads."""
+
         def call_from_thread(val: int) -> int:
             return run_sync(simple_coro(val))
 

--- a/tests/unit/utils/test_cloud_storage.py
+++ b/tests/unit/utils/test_cloud_storage.py
@@ -154,7 +154,9 @@ class TestBuildS3Path:
 
     def test_build_s3_path_with_env_bucket(self):
         """Test build_s3_path uses env var when bucket not provided."""
-        with patch("sbir_etl.utils.cloud_storage.get_s3_bucket_from_env", return_value="env-bucket"):
+        with patch(
+            "sbir_etl.utils.cloud_storage.get_s3_bucket_from_env", return_value="env-bucket"
+        ):
             result = build_s3_path("data/raw/file.csv")
 
             assert result == "s3://env-bucket/data/raw/file.csv"
@@ -232,9 +234,7 @@ class TestCheckSbirDataFreshness:
         assert len(warnings_default) == 1
 
         # With slack=10, 12 days < 7+10=17 → fresh
-        warnings_custom = check_sbir_data_freshness(
-            source, None, days=7, s3_slack_days=10
-        )
+        warnings_custom = check_sbir_data_freshness(source, None, days=7, s3_slack_days=10)
         assert warnings_custom == []
 
     def test_edge_case_exactly_at_threshold(self):

--- a/tests/unit/utils/test_statistical_reporter.py
+++ b/tests/unit/utils/test_statistical_reporter.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import os
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
@@ -12,7 +11,12 @@ import pytest
 
 pytestmark = pytest.mark.fast
 
-from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics, ModuleReport, StatisticalReport
+from sbir_etl.models.quality import (
+    ChangesSummary,
+    DataHygieneMetrics,
+    ModuleReport,
+    StatisticalReport,
+)
 from sbir_etl.models.statistical_reports import (
     ModuleMetrics,
     PerformanceMetrics,
@@ -423,8 +427,6 @@ class TestReportAggregation:
 # ==================== Format Generation Tests ====================
 
 
-
-
 # ==================== Pipeline Metrics Tests ====================
 
 
@@ -611,4 +613,3 @@ class TestEdgeCases:
             pipeline_metrics = reporter._collect_pipeline_metrics("run_123", run_context)
 
         assert pipeline_metrics.run_id == "run_123"
-

--- a/tests/utils/config_mocks.py
+++ b/tests/utils/config_mocks.py
@@ -242,7 +242,7 @@ def create_mock_enrichment_performance_config(
     low_confidence_threshold: float = 0.85,
     enable_memory_monitoring: bool = True,
     enable_fuzzy_matching: bool = True,
-) -> "PipelineConfig":
+) -> PipelineConfig:
     """Create a mock PipelineConfig with enrichment.performance attributes set.
 
     This consolidates the repeated pattern across chunked enrichment test files.


### PR DESCRIPTION
## Summary

Apply the autofixable lint and format passes that CI's Code Quality job runs on `tests/`. Unblocks the `Code Quality (Lint + Type Check)` step which has been silently failing on every PR (now surfaced after #296 fixed the gating).

## Changes

- **17 lint errors fixed automatically:**
  - `F401` — unused imports
  - `UP037` — quoted type annotations that don't need quoting under Python 3.11
- **61 files reformatted** to ruff format's canonical style
- **2 remaining `E712` noqa comments** moved from the closing `)` to the line containing the `== False` comparison (ruff requires the noqa on the line it reports). These are intentional — testing pandas Series values that may not be Python's literal `False`.

No `src/`-side changes — the repo doesn't have that directory anymore, so `ruff check src tests` effectively only checks `tests/`.

## Verification

- `uv run ruff check tests` — clean
- `uv run ruff format --check tests` — clean
- `uv run pytest tests/unit` — 4,109 passed, 8 skipped, 4 failed. The 4 are the pre-existing `test_duckdb_client.py` DuckDB type-name assertions; same set that fails on `main`.

## Test plan

- [ ] CI's `Code Quality (Lint + Type Check)` job's Ruff steps pass
- [ ] MyPy step (separate concern) — likely still red on its own merit, won't be fixed here

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur

---
_Generated by [Claude Code](https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur)_