### PR TITLE
fix(ci): seed cdk.context.json with dummy VPC for CI account

### DIFF
--- a/infrastructure/cdk/cdk.context.json
+++ b/infrastructure/cdk/cdk.context.json
@@ -30,5 +30,69 @@
         ]
       }
     ]
+  },
+  "vpc-provider:account=123456789012:filter.isDefault=true:region=us-east-2:returnAsymmetricSubnets=true": {
+    "vpcId": "vpc-ci-dummy",
+    "vpcCidrBlock": "10.0.0.0/16",
+    "ownerAccountId": "123456789012",
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "Public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-ci-a",
+            "cidr": "10.0.0.0/20",
+            "availabilityZone": "us-east-2a",
+            "routeTableId": "rtb-ci"
+          },
+          {
+            "subnetId": "subnet-ci-b",
+            "cidr": "10.0.16.0/20",
+            "availabilityZone": "us-east-2b",
+            "routeTableId": "rtb-ci"
+          },
+          {
+            "subnetId": "subnet-ci-c",
+            "cidr": "10.0.32.0/20",
+            "availabilityZone": "us-east-2c",
+            "routeTableId": "rtb-ci"
+          }
+        ]
+      }
+    ]
+  },
+  "vpc-provider:account=123456789012:filter.isDefault=true:region=us-east-1:returnAsymmetricSubnets=true": {
+    "vpcId": "vpc-ci-dummy",
+    "vpcCidrBlock": "10.0.0.0/16",
+    "ownerAccountId": "123456789012",
+    "availabilityZones": [],
+    "subnetGroups": [
+      {
+        "name": "Public",
+        "type": "Public",
+        "subnets": [
+          {
+            "subnetId": "subnet-ci-a",
+            "cidr": "10.0.0.0/20",
+            "availabilityZone": "us-east-1a",
+            "routeTableId": "rtb-ci"
+          },
+          {
+            "subnetId": "subnet-ci-b",
+            "cidr": "10.0.16.0/20",
+            "availabilityZone": "us-east-1b",
+            "routeTableId": "rtb-ci"
+          },
+          {
+            "subnetId": "subnet-ci-c",
+            "cidr": "10.0.32.0/20",
+            "availabilityZone": "us-east-1c",
+            "routeTableId": "rtb-ci"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Unblock CI's `Validate CDK Infrastructure` job by seeding `cdk.context.json` with dummy VPC lookup entries for the documentation-only AWS account CI uses (`123456789012`).

## Why

`BatchStack` calls `ec2.Vpc.from_lookup(..., is_default=True)`, which requires either real AWS credentials or a cached lookup entry in `cdk.context.json` for the active account/region. The committed context only had the real production account (`161066624831`, `us-east-2`), so CI synth failed with:

```
[Error at /sbir-analytics-batch] Need to perform AWS calls for
account 123456789012, but no credentials have been configured
```

## Fix

Add dummy VPC entries for the CI account `123456789012` in both `us-east-2` (the stack's declared region) and `us-east-1` (where the CDK CLI's lookup actually queries when the account is overridden — observed in `cdk synth -v`). Deployment-time lookups for the real account are untouched.

## Verified locally

```
CDK_DEFAULT_ACCOUNT=123456789012 CDK_DEFAULT_REGION=us-east-2 \
  cdk synth --app "python app.py" --quiet
# → Successfully synthesized to .../cdk.out
```

## Background

This failure was masked for an unknown time by the previous `docs-only` gating bug (fixed in #296), which skipped the CDK validation step on PRs that touched any docs files.

## Test plan

- [ ] On this PR's CI: `Validate CDK Infrastructure` passes
- [ ] Production CDK deployment unaffected (the real-account entry is unchanged)

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur

---
_Generated by [Claude Code](https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur)_