### PR TITLE
fix(tests): DuckDB pandas 3 ingest + isolate Neo4j env from config tests

### DIFF
--- a/sbir_etl/utils/data/duckdb_client.py
+++ b/sbir_etl/utils/data/duckdb_client.py
@@ -321,8 +321,12 @@ class DuckDBClient:
 
             try:
                 with self.connection() as conn:  # type: Any
-                    # Register DataFrame
-                    conn.register("temp_df", df)
+                    # Register via PyArrow so pandas 3's StringDtype columns (which
+                    # DuckDB doesn't introspect) survive the trip. PyArrow handles
+                    # all pandas dtype edge cases uniformly.
+                    import pyarrow as pa
+
+                    conn.register("temp_df", pa.Table.from_pandas(df))
                     table_identifier = self.escape_identifier(table_name)
                     conn.execute(f"CREATE TABLE {table_identifier} AS SELECT * FROM temp_df")  # nosec B608
 
@@ -487,7 +491,10 @@ class DuckDBClient:
                         header=0 if header else None,
                         encoding=encoding,
                         chunksize=batch_size,
-                        dtype=str,  # read as strings to avoid type surprises; downstream logic can cast
+                        # Use numpy `object` rather than `str`: under pandas 3 the
+                        # latter resolves to StringDtype, which DuckDB doesn't
+                        # know how to ingest via register().
+                        dtype=object,
                         low_memory=False,
                         quoting=csv.QUOTE_MINIMAL,
                         quotechar='"',

--- a/sbir_etl/utils/data/duckdb_client.py
+++ b/sbir_etl/utils/data/duckdb_client.py
@@ -324,9 +324,12 @@ class DuckDBClient:
                     # Register via PyArrow so pandas 3's StringDtype columns (which
                     # DuckDB doesn't introspect) survive the trip. PyArrow handles
                     # all pandas dtype edge cases uniformly.
+                    # `preserve_index=False` matches the pre-Arrow behavior of
+                    # `conn.register(name, df)` — non-RangeIndex frames would
+                    # otherwise materialize an extra `__index_level_0__` column.
                     import pyarrow as pa
 
-                    conn.register("temp_df", pa.Table.from_pandas(df))
+                    conn.register("temp_df", pa.Table.from_pandas(df, preserve_index=False))
                     table_identifier = self.escape_identifier(table_name)
                     conn.execute(f"CREATE TABLE {table_identifier} AS SELECT * FROM temp_df")  # nosec B608
 

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -24,8 +24,16 @@ pytestmark = pytest.mark.fast
 
 
 @pytest.fixture(autouse=True)
-def clear_config_cache():
-    """Clear config cache before each test to ensure isolation."""
+def clear_config_cache(monkeypatch):
+    """Clear config cache and runtime env overrides before each test.
+
+    CI sets NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD on test jobs, which
+    the loader picks up and uses to override the configured defaults.
+    These tests assert on the configured defaults, so the env vars need
+    to be cleared for the assertions to be meaningful.
+    """
+    for var in ("NEO4J_URI", "NEO4J_USER", "NEO4J_USERNAME", "NEO4J_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
     get_config.cache_clear()
     yield
     get_config.cache_clear()


### PR DESCRIPTION
## Summary

Two independent test failures that were hidden by the `docs-only` CI gating bug (fixed in #296). Together these get the unit suite to **4,113 passing, 0 failed** under a CI-like environment (`NEO4J_URI=bolt://localhost:7687`).

## 1. DuckDB / pandas 3 StringDtype mismatch (4 tests)

`DuckDBClient.create_table_from_df` and `import_csv_incremental` both register pandas DataFrames with DuckDB via `conn.register()`. Under pandas 3, string columns default to `StringDtype` which DuckDB 1.4 doesn't recognize:

```
Not implemented Error: Data type 'str' not recognized
```

**Fix:**
- `create_table_from_df`: register via `pyarrow.Table.from_pandas(df)` instead of the raw DataFrame. PyArrow handles all pandas dtype edge cases uniformly and DuckDB ingests Arrow tables natively.
- `import_csv_incremental`: switch `pd.read_csv(..., dtype=str)` → `dtype=object` so the chunks are produced with numpy `object` dtype rather than `StringDtype`.

Fixes:
- `test_create_table_from_df`
- `test_fetch_df_chunks_paginates_correctly`
- `test_import_csv_incremental_creates_and_counts_rows`
- `test_import_csv_incremental_appends_when_table_exists`

## 2. Neo4j env leak into config tests (1 test)

`get_config()` respects `NEO4J_URI` from the environment, but `tests/unit/config/test_loader.py::test_get_config_uses_production_defaults` asserts the configured production default `bolt://prod-neo4j:7687`. CI's unit-test jobs set `NEO4J_URI: bolt://localhost:7687`, which the loader surfaces as the resolved URI and breaks the assertion.

**Fix:** extend the existing autouse `clear_config_cache` fixture to `monkeypatch.delenv(...)` the four Neo4j env vars before each test in this module, restoring meaningful default-behavior assertions regardless of the caller's env.

## Verification

```
NEO4J_URI=bolt://localhost:7687 uv run pytest tests/unit
# → 4,113 passed, 8 skipped, 0 failed
```

## Test plan

- [ ] CI's `Tests (unit-fast)` and `Tests (unit-slow)` jobs pass (or at least: pass the DuckDB and Neo4j-config cases)

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur

---
_Generated by [Claude Code](https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur)_