### PR TITLE
fix(ci): point Code Quality job at sbir_etl instead of nonexistent src/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,13 +124,13 @@ jobs:
           cache-venv: "true"
 
       - name: Run Ruff lint
-        run: uv run python -m ruff check src tests
+        run: uv run python -m ruff check sbir_etl tests
 
       - name: Run Ruff format check
-        run: uv run python -m ruff format --check src tests
+        run: uv run python -m ruff format --check sbir_etl tests
 
       - name: Run MyPy type checker
-        run: uv run python -m mypy src
+        run: uv run python -m mypy sbir_etl
 
   verify-setup-script:
     name: Verify Setup Script

--- a/sbir_etl/config/schemas/data.py
+++ b/sbir_etl/config/schemas/data.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field, field_validator
 # Helpers (inlined from former common.py mixins)
 # ---------------------------------------------------------------------------
 
+
 def _coerce_percentage_mapping(
     values: Mapping[str, Any],
     *,
@@ -37,9 +38,7 @@ def _coerce_percentage_mapping(
         except (TypeError, ValueError) as exc:
             raise ValueError(f"{key} must be numeric, got {value!r}") from exc
         if not (lower_bound <= number <= upper_bound):
-            raise ValueError(
-                f"{key} must be between {lower_bound} and {upper_bound}, got {number}"
-            )
+            raise ValueError(f"{key} must be between {lower_bound} and {upper_bound}, got {number}")
         normalized[key] = number
     return normalized
 
@@ -314,11 +313,15 @@ class CompanyCategorizationConfig(BaseModel):
     """Configuration for company categorization system."""
 
     product_leaning_pct: float = Field(
-        default=51.0, ge=0.0, le=100.0,
+        default=51.0,
+        ge=0.0,
+        le=100.0,
         description="Product percentage threshold for Product-leaning classification",
     )
     service_leaning_pct: float = Field(
-        default=51.0, ge=0.0, le=100.0,
+        default=51.0,
+        ge=0.0,
+        le=100.0,
         description="Service percentage threshold for Service-leaning classification",
     )
     psc_family_diversity_threshold: int = Field(

--- a/sbir_etl/config/schemas/domain.py
+++ b/sbir_etl/config/schemas/domain.py
@@ -195,8 +195,12 @@ class TaxParameterConfig(BaseModel):
         default_factory=lambda: {
             "effective_rate": 0.22,
             "progressive_rates": {
-                "10_percent": 0.10, "12_percent": 0.12, "22_percent": 0.22,
-                "24_percent": 0.24, "32_percent": 0.32, "35_percent": 0.35,
+                "10_percent": 0.10,
+                "12_percent": 0.12,
+                "22_percent": 0.22,
+                "24_percent": 0.24,
+                "32_percent": 0.32,
+                "35_percent": 0.35,
                 "37_percent": 0.37,
             },
             "standard_deduction": 13850,
@@ -391,7 +395,6 @@ class PaECTERTextConfig(BaseModel):
     )
 
 
-
 class PaECTERConfig(BaseModel):
     """Configuration for PaECTER patent-award similarity embeddings."""
 
@@ -405,16 +408,22 @@ class PaECTERConfig(BaseModel):
     text: PaECTERTextConfig = Field(default_factory=PaECTERTextConfig)
 
     similarity_threshold: float = Field(
-        default=0.80, ge=0.0, le=1.0,
+        default=0.80,
+        ge=0.0,
+        le=1.0,
         description="Minimum similarity score to include in results",
     )
     top_k: int = Field(default=10, ge=1, description="Number of top matches per award")
     coverage_threshold_awards: float = Field(
-        default=0.95, ge=0.0, le=1.0,
+        default=0.95,
+        ge=0.0,
+        le=1.0,
         description="Minimum fraction of awards with valid embeddings",
     )
     coverage_threshold_patents: float = Field(
-        default=0.98, ge=0.0, le=1.0,
+        default=0.98,
+        ge=0.0,
+        le=1.0,
         description="Minimum fraction of patents with valid embeddings",
     )
     enable_cache: bool = Field(default=False, description="Enable embedding caching to disk")
@@ -441,16 +450,22 @@ class StatisticalReportingConfig(BaseModel):
     output_directory: str = Field(default="reports/statistics")
     report_types: list[str] = Field(
         default_factory=lambda: [
-            "data_quality", "enrichment_performance", "pipeline_performance",
-            "anomaly_detection", "success_metrics",
+            "data_quality",
+            "enrichment_performance",
+            "pipeline_performance",
+            "anomaly_detection",
+            "success_metrics",
         ]
     )
     schedules: dict[str, Any] = Field(
         default_factory=lambda: {
             "daily": {"enabled": True, "hour": 2, "minute": 0, "include_summary": True},
             "weekly": {
-                "enabled": True, "weekday": "monday", "hour": 6,
-                "minute": 0, "include_trends": True,
+                "enabled": True,
+                "weekday": "monday",
+                "hour": 6,
+                "minute": 0,
+                "include_trends": True,
             },
         }
     )
@@ -471,15 +486,18 @@ class StatisticalReportingConfig(BaseModel):
     sections: dict[str, Any] = Field(
         default_factory=lambda: {
             "pipeline_health": {
-                "enabled": True, "include_validation_details": True,
+                "enabled": True,
+                "include_validation_details": True,
                 "include_loading_statistics": True,
             },
             "cet_classification": {
-                "enabled": True, "include_confidence_distribution": True,
+                "enabled": True,
+                "include_confidence_distribution": True,
                 "include_taxonomy_breakdown": True,
             },
             "transition_detection": {
-                "enabled": True, "include_success_stories": True,
+                "enabled": True,
+                "include_success_stories": True,
                 "include_trend_analysis": True,
             },
         }
@@ -493,20 +511,30 @@ class StatisticalReportingConfig(BaseModel):
     )
     formats: dict[str, Any] = Field(
         default_factory=lambda: {
-            "html": {"include_interactive_charts": True, "chart_library": "plotly", "theme": "default"},
+            "html": {
+                "include_interactive_charts": True,
+                "chart_library": "plotly",
+                "theme": "default",
+            },
             "json": {"include_raw_data": False, "pretty_print": True},
             "markdown": {"max_length": 2000, "include_links": True},
-            "executive": {"include_visualizations": True, "focus_areas": ["impact", "quality", "trends"]},
+            "executive": {
+                "include_visualizations": True,
+                "focus_areas": ["impact", "quality", "trends"],
+            },
         }
     )
     cicd: dict[str, Any] = Field(
         default_factory=lambda: {
             "github_actions": {
-                "enabled": True, "upload_artifacts": True,
-                "post_pr_comments": True, "artifact_retention_days": 30,
+                "enabled": True,
+                "upload_artifacts": True,
+                "post_pr_comments": True,
+                "artifact_retention_days": 30,
             },
             "report_comparison": {
-                "enabled": True, "baseline_comparison": True,
+                "enabled": True,
+                "baseline_comparison": True,
                 "trend_analysis_periods": [7, 30, 90],
             },
         }

--- a/sbir_etl/enrichers/award_history.py
+++ b/sbir_etl/enrichers/award_history.py
@@ -80,9 +80,7 @@ def _build_history_from_df(
         if extra_set_cols:
             for col in extra_set_cols:
                 col_key = pluralize_col_key(col)
-                entry[col_key] = sorted(
-                    {v for v in group_df[col].astype(str).str.strip() if v}
-                )
+                entry[col_key] = sorted({v for v in group_df[col].astype(str).str.strip() if v})
 
         history[name] = entry
 
@@ -123,7 +121,11 @@ def _build_history_from_csv(
 
             h = history[name]
             h["total_awards"] += 1
-            for field, set_key in [("Phase", "phases"), ("Agency", "agencies"), ("Program", "programs")]:
+            for field, set_key in [
+                ("Phase", "phases"),
+                ("Agency", "agencies"),
+                ("Program", "programs"),
+            ]:
                 val = str(row.get(field, "")).strip()
                 if val:
                     h[set_key].add(val)
@@ -184,7 +186,7 @@ def get_company_history(
 
     if extractor is not None and table is not None:
         # Build IN clause with escaped names
-        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(company_names)]
+        escaped = [f"'{n.replace(chr(39), chr(39) + chr(39))}'" for n in sorted(company_names)]
         in_clause = ", ".join(escaped)
         query = (
             f'SELECT UPPER("Company") AS _group_key, "Phase", "Agency", '
@@ -229,7 +231,7 @@ def get_pi_history(
         return {}
 
     if extractor is not None and table is not None:
-        escaped = [f"'{n.replace(chr(39), chr(39)+chr(39))}'" for n in sorted(pi_names)]
+        escaped = [f"'{n.replace(chr(39), chr(39) + chr(39))}'" for n in sorted(pi_names)]
         in_clause = ", ".join(escaped)
         query = (
             f'SELECT UPPER("PI Name") AS _group_key, "Company", "Phase", "Agency", '

--- a/sbir_etl/enrichers/base_client.py
+++ b/sbir_etl/enrichers/base_client.py
@@ -127,23 +127,16 @@ class BaseAsyncAPIClient:
             if endpoint_str.startswith(("http://", "https://")):
                 url = endpoint_str
             else:
-                url = (
-                    f"{str(self.base_url).rstrip('/')}/"
-                    f"{endpoint_str.lstrip('/')}"
-                )
+                url = f"{str(self.base_url).rstrip('/')}/{endpoint_str.lstrip('/')}"
             request_headers = self._build_headers()
             if headers:
                 request_headers.update(headers)
 
             try:
                 if method.upper() == "GET":
-                    response = await self._client.get(
-                        url, params=params, headers=request_headers
-                    )
+                    response = await self._client.get(url, params=params, headers=request_headers)
                 elif method.upper() == "POST":
-                    response = await self._client.post(
-                        url, json=params, headers=request_headers
-                    )
+                    response = await self._client.post(url, json=params, headers=request_headers)
                 else:
                     raise ConfigurationError(f"Unsupported HTTP method: {method}")
 
@@ -226,7 +219,5 @@ class BaseAsyncAPIClient:
             APIError: If request fails after retries
             RateLimitError: If rate limit exceeded
         """
-        response = await self._request_raw(
-            method, endpoint, params=params, headers=headers
-        )
+        response = await self._request_raw(method, endpoint, params=params, headers=headers)
         return response.json()

--- a/sbir_etl/enrichers/company_categorization.py
+++ b/sbir_etl/enrichers/company_categorization.py
@@ -1009,9 +1009,7 @@ def retrieve_company_contracts_api(
         return pd.DataFrame()
 
 
-def _fetch_award_details(
-    award_id: str, client: USAspendingAPIClient
-) -> dict[str, Any] | None:
+def _fetch_award_details(award_id: str, client: USAspendingAPIClient) -> dict[str, Any] | None:
     """Fetch detailed award information including PSC code as a fallback.
 
     Args:
@@ -1274,7 +1272,9 @@ def retrieve_sbir_awards_api(
         )
     except Exception as e:
         logger.debug(f"Could not initialize cache, proceeding without caching: {e}")
-        cache = APICache(cache_dir="data/cache/usaspending", default_cache_type="contracts", enabled=False)
+        cache = APICache(
+            cache_dir="data/cache/usaspending", default_cache_type="contracts", enabled=False
+        )
 
     # Check cache first (SBIR awards only)
     cached_result = cache.get(uei=uei, duns=duns, company_name=company_name, cache_type="sbir")

--- a/sbir_etl/enrichers/company_enrichment.py
+++ b/sbir_etl/enrichers/company_enrichment.py
@@ -134,10 +134,17 @@ def usaspending_autocomplete(
         variations.append(normalized)
 
     # Remove legal suffixes for broadest match
-    base = re.sub(
-        r",?\s*(Inc\.?|Incorporated|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?)$",
-        "", normalized, flags=re.IGNORECASE,
-    ).strip().rstrip(",").strip()
+    base = (
+        re.sub(
+            r",?\s*(Inc\.?|Incorporated|LLC|Ltd\.?|Limited|Corp\.?|Corporation|Company|Co\.?)$",
+            "",
+            normalized,
+            flags=re.IGNORECASE,
+        )
+        .strip()
+        .rstrip(",")
+        .strip()
+    )
     if base and base not in variations and len(base) >= 10:
         variations.append(base)
 
@@ -156,7 +163,8 @@ def usaspending_autocomplete(
 
     logger.debug(
         "USAspending autocomplete: {} name variations for '{}'",
-        len(unique), company_name,
+        len(unique),
+        company_name,
     )
 
     best_candidate = None
@@ -176,9 +184,12 @@ def usaspending_autocomplete(
                 matched_uei = match.get("uei")
                 if matched_uei and str(matched_uei).strip().lower() not in ("", "nan", "none"):
                     logger.debug(
-                        "USAspending autocomplete matched '{}' "
-                        "(variation {}: '{}') → '{}' UEI={}",
-                        company_name, idx, name, matched_name, matched_uei,
+                        "USAspending autocomplete matched '{}' (variation {}: '{}') → '{}' UEI={}",
+                        company_name,
+                        idx,
+                        name,
+                        matched_name,
+                        matched_uei,
                     )
                     return {"uei": matched_uei, "name": matched_name}
                 if matched_name and best_candidate is None:
@@ -191,13 +202,15 @@ def usaspending_autocomplete(
     if best_candidate:
         logger.debug(
             "USAspending autocomplete: best candidate for '{}' → '{}' (no UEI)",
-            company_name, best_candidate["name"],
+            company_name,
+            best_candidate["name"],
         )
         return best_candidate
 
     logger.debug(
         "USAspending autocomplete: no match for '{}' after {} variations",
-        company_name, len(unique),
+        company_name,
+        len(unique),
     )
     return None
 
@@ -240,7 +253,9 @@ def usaspending_search(
     all_results: list[dict] = []
     logger.debug(
         "USAspending query for '{}' ({}='{}'): POST /search/spending_by_award/",
-        company_name, label, search_text,
+        company_name,
+        label,
+        search_text,
     )
 
     usa = SyncUSAspendingClient()
@@ -261,13 +276,19 @@ def usaspending_search(
                 group_results = data.get("results", [])
                 logger.debug(
                     "USAspending [{} via {}/{}]: {} results",
-                    company_name, label, group_name, len(group_results),
+                    company_name,
+                    label,
+                    group_name,
+                    len(group_results),
                 )
                 all_results.extend(group_results)
             except Exception as e:
                 logger.debug(
                     "USAspending [{}] {}/{} error: {}",
-                    company_name, label, group_name, e,
+                    company_name,
+                    label,
+                    group_name,
+                    e,
                 )
                 continue
     finally:
@@ -275,7 +296,9 @@ def usaspending_search(
 
     logger.debug(
         "USAspending [{} via {}]: {} total results",
-        company_name, label, len(all_results),
+        company_name,
+        label,
+        len(all_results),
     )
     return all_results if all_results else None
 
@@ -359,9 +382,7 @@ def lookup_company_federal_awards(
             if desc and len(non_sbir_descriptions) < 5:
                 if len(desc) > 200:
                     desc = desc[:200] + "..."
-                non_sbir_descriptions.append(
-                    f"{desc} ({ag}, {at}, ${amount:,.0f})"
-                )
+                non_sbir_descriptions.append(f"{desc} ({ag}, {at}, ${amount:,.0f})")
 
     return FederalAwardSummary(
         total_awards=len(results),
@@ -417,7 +438,9 @@ def lookup_usaspending_recipient(
                     recipient_id = results[0].get("id")
                     logger.debug(
                         "USAspending recipient matched '{}' → '{}' id={}",
-                        term, results[0].get("name"), recipient_id,
+                        term,
+                        results[0].get("name"),
+                        recipient_id,
                     )
                     break
             except Exception as e:
@@ -526,7 +549,8 @@ def lookup_sam_entity(
         methods_tried.append(f"name='{company_name}'")
         logger.info(
             "SAM.gov: no entity found for {} (tried: {})",
-            company_name, ", ".join(methods_tried),
+            company_name,
+            ", ".join(methods_tried),
         )
         return None
 
@@ -537,9 +561,7 @@ def lookup_sam_entity(
 
     naics_list = entity.get("coreData", {}).get("naicsCodeList", [])
     if isinstance(naics_list, list):
-        naics_codes = [
-            str(n.get("naicsCode", "")) for n in naics_list if n.get("naicsCode")
-        ]
+        naics_codes = [str(n.get("naicsCode", "")) for n in naics_list if n.get("naicsCode")]
     else:
         naics_codes = []
 
@@ -580,7 +602,10 @@ def lookup_sam_entity_with_fallback(
     SAM.gov maintenance windows.
     """
     result = lookup_sam_entity(
-        company_name, uei=uei, cage=cage, rate_limiter=rate_limiter,
+        company_name,
+        uei=uei,
+        cage=cage,
+        rate_limiter=rate_limiter,
     )
     if result is not None:
         return result
@@ -591,7 +616,9 @@ def lookup_sam_entity_with_fallback(
     )
 
     profile = lookup_usaspending_recipient(
-        company_name, uei=uei, rate_limiter=fallback_rate_limiter,
+        company_name,
+        uei=uei,
+        rate_limiter=fallback_rate_limiter,
     )
     if profile is None:
         return None
@@ -627,7 +654,9 @@ def lookup_usaspending_recipient_with_fallback(
     when USAspending is unavailable.
     """
     result = lookup_usaspending_recipient(
-        company_name, uei=uei, rate_limiter=rate_limiter,
+        company_name,
+        uei=uei,
+        rate_limiter=rate_limiter,
     )
     if result is not None:
         return result
@@ -638,7 +667,9 @@ def lookup_usaspending_recipient_with_fallback(
     )
 
     entity = lookup_sam_entity(
-        company_name, uei=uei, rate_limiter=fallback_rate_limiter,
+        company_name,
+        uei=uei,
+        rate_limiter=fallback_rate_limiter,
     )
     if entity is None:
         return None
@@ -704,6 +735,7 @@ def fetch_usaspending_contract_descriptions(
     try:
         from sbir_etl.enrichers.usaspending.client import build_award_type_groups
     except ImportError:
+
         def build_award_type_groups(ids):  # type: ignore[misc]
             piids, fains, unknown = [], [], []
             seen: set[str] = set()
@@ -738,7 +770,8 @@ def fetch_usaspending_contract_descriptions(
 
     logger.debug(
         "USAspending contract desc: {} IDs in {} groups",
-        len(all_ids), len(requests_to_make),
+        len(all_ids),
+        len(requests_to_make),
     )
     results: dict[str, str] = {}
     failed_ids: set[str] = set()
@@ -771,7 +804,9 @@ def fetch_usaspending_contract_descriptions(
             filters = {"award_ids": list(ids), "award_type_codes": codes}
             logger.debug(
                 "USAspending contract desc: {} ({} IDs: {})",
-                group_name, len(ids), ids[:3],
+                group_name,
+                len(ids),
+                ids[:3],
             )
             data = None
             used_method = "search_awards"
@@ -790,7 +825,9 @@ def fetch_usaspending_contract_descriptions(
                     num_results = len(data.get("results", []))
                     logger.debug(
                         "USAspending {}/{}: {} results",
-                        method, group_name, num_results,
+                        method,
+                        group_name,
+                        num_results,
                     )
                     used_method = method
                     break
@@ -809,26 +846,31 @@ def fetch_usaspending_contract_descriptions(
 
     # FPDS Atom Feed fallback for contract PIIDs that failed at USAspending.
     fpds_eligible = [
-        cid for cid in failed_ids
+        cid
+        for cid in failed_ids
         if cid not in results and not re.match(r"^DE-", cid, re.IGNORECASE)
     ]
     if fpds_eligible:
         logger.debug(
             "USAspending failed for {} IDs, {} eligible for FPDS fallback",
-            len(failed_ids), len(fpds_eligible),
+            len(failed_ids),
+            len(fpds_eligible),
         )
         fpds_results = fetch_fpds_descriptions(
-            fpds_eligible, rate_limiter=fpds_rate_limiter or rate_limiter,
+            fpds_eligible,
+            rate_limiter=fpds_rate_limiter or rate_limiter,
         )
         if fpds_results:
             results.update(fpds_results)
             logger.info(
                 "FPDS fallback recovered {}/{} descriptions",
-                len(fpds_results), len(fpds_eligible),
+                len(fpds_results),
+                len(fpds_eligible),
             )
 
     logger.debug(
         "Contract descriptions: {}/{} found (USAspending + FPDS)",
-        len(results), len(all_ids),
+        len(results),
+        len(all_ids),
     )
     return results

--- a/sbir_etl/enrichers/company_fuzzy_matcher.py
+++ b/sbir_etl/enrichers/company_fuzzy_matcher.py
@@ -586,7 +586,11 @@ def enrich_awards_with_companies(
 
         if best_score >= high_threshold:
             _set_award_match(
-                awards, ai, method="fuzzy-auto", score=best_score, company_idx=best_idx,
+                awards,
+                ai,
+                method="fuzzy-auto",
+                score=best_score,
+                company_idx=best_idx,
             )
         elif best_score >= low_threshold:
             _set_award_match(awards, ai, method="fuzzy-candidate", score=best_score)

--- a/sbir_etl/enrichers/fpds_atom.py
+++ b/sbir_etl/enrichers/fpds_atom.py
@@ -238,9 +238,7 @@ class FPDSAtomClient(BaseAsyncAPIClient):
         catch :class:`APIError` from :meth:`_request_raw` directly.
         """
         try:
-            response = await self._request_raw(
-                "GET", FPDS_ENDPOINT, params=params
-            )
+            response = await self._request_raw("GET", FPDS_ENDPOINT, params=params)
         except APIError as e:
             logger.debug("FPDS API error: {}", e)
             return None

--- a/sbir_etl/enrichers/geographic_resolver.py
+++ b/sbir_etl/enrichers/geographic_resolver.py
@@ -177,43 +177,67 @@ class GeographicResolver:
         # Source: USPS Publication 65, National Five-Digit ZIP Code & Post Office Directory
         ranges: list[tuple[int, int, str]] = [
             # New England
-            (10, 27, "MA"), (28, 29, "RI"), (30, 38, "NH"),
-            (39, 49, "ME"), (50, 54, "VT"), (60, 69, "CT"),
+            (10, 27, "MA"),
+            (28, 29, "RI"),
+            (30, 38, "NH"),
+            (39, 49, "ME"),
+            (50, 54, "VT"),
+            (60, 69, "CT"),
             # Mid-Atlantic
-            (1, 5, "NY"), (6, 9, "PR"),
+            (1, 5, "NY"),
+            (6, 9, "PR"),
             (100, 149, "NY"),
             (150, 196, "PA"),
             # DC / Maryland / Virginia / West Virginia
-            (200, 205, "DC"), (206, 219, "MD"),
-            (220, 246, "VA"), (247, 268, "WV"),
+            (200, 205, "DC"),
+            (206, 219, "MD"),
+            (220, 246, "VA"),
+            (247, 268, "WV"),
             # Carolinas
-            (270, 289, "NC"), (290, 299, "SC"),
+            (270, 289, "NC"),
+            (290, 299, "SC"),
             # Southeast
-            (300, 319, "GA"), (320, 349, "FL"),
-            (350, 369, "AL"), (370, 385, "TN"),
+            (300, 319, "GA"),
+            (320, 349, "FL"),
+            (350, 369, "AL"),
+            (370, 385, "TN"),
             (386, 397, "MS"),
             # Central
-            (400, 427, "KY"), (430, 459, "OH"),
-            (460, 479, "IN"), (480, 499, "MI"),
+            (400, 427, "KY"),
+            (430, 459, "OH"),
+            (460, 479, "IN"),
+            (480, 499, "MI"),
             # Upper Midwest
-            (500, 528, "IA"), (530, 549, "WI"),
-            (550, 567, "MN"), (570, 577, "SD"),
-            (580, 588, "ND"), (590, 599, "MT"),
+            (500, 528, "IA"),
+            (530, 549, "WI"),
+            (550, 567, "MN"),
+            (570, 577, "SD"),
+            (580, 588, "ND"),
+            (590, 599, "MT"),
             # Illinois / Missouri / Kansas / Nebraska
-            (600, 629, "IL"), (630, 658, "MO"),
-            (660, 679, "KS"), (680, 693, "NE"),
+            (600, 629, "IL"),
+            (630, 658, "MO"),
+            (660, 679, "KS"),
+            (680, 693, "NE"),
             # South Central
-            (700, 714, "LA"), (716, 729, "AR"),
-            (730, 749, "OK"), (750, 799, "TX"),
+            (700, 714, "LA"),
+            (716, 729, "AR"),
+            (730, 749, "OK"),
+            (750, 799, "TX"),
             # Mountain West
-            (800, 816, "CO"), (820, 831, "WY"),
-            (832, 838, "ID"), (840, 847, "UT"),
-            (850, 865, "AZ"), (870, 884, "NM"),
+            (800, 816, "CO"),
+            (820, 831, "WY"),
+            (832, 838, "ID"),
+            (840, 847, "UT"),
+            (850, 865, "AZ"),
+            (870, 884, "NM"),
             (889, 898, "NV"),
             # Pacific
-            (900, 961, "CA"), (967, 968, "HI"),
+            (900, 961, "CA"),
+            (967, 968, "HI"),
             (962, 966, "CA"),  # military/misc CA
-            (970, 979, "OR"), (980, 994, "WA"),
+            (970, 979, "OR"),
+            (980, 994, "WA"),
             (995, 999, "AK"),
         ]
 
@@ -460,9 +484,7 @@ class GeographicResolver:
                         state_code = self._zip3_to_state.get(prefix)
                         if state_code and state_code in self.valid_state_codes:
                             state_name = self.state_mappings.get(state_code)
-                            logger.debug(
-                                f"Resolved state {state_code} from ZIP prefix {prefix}"
-                            )
+                            logger.debug(f"Resolved state {state_code} from ZIP prefix {prefix}")
                             return GeographicResolutionResult(
                                 state_code=state_code,
                                 state_name=state_name,

--- a/sbir_etl/enrichers/lens_patents.py
+++ b/sbir_etl/enrichers/lens_patents.py
@@ -72,9 +72,7 @@ def _parse_records(data: dict) -> list[LensPatentRecord]:
         applicants = hit.get("applicant", [])
         if applicants and isinstance(applicants, list):
             first = applicants[0]
-            assignee = (
-                first.get("name") if isinstance(first, dict) else str(first)
-            )
+            assignee = first.get("name") if isinstance(first, dict) else str(first)
 
         # Extract inventors
         inventor_names: list[str] = []
@@ -143,9 +141,7 @@ class LensPatentClient(BaseAsyncAPIClient):
         self.rate_limit_per_minute = rate_limit_per_minute
         self._token = api_token or os.environ.get("LENS_API_TOKEN", "")
         if not self._token:
-            logger.debug(
-                "LENS_API_TOKEN not set — Lens.org patent lookups will short-circuit"
-            )
+            logger.debug("LENS_API_TOKEN not set — Lens.org patent lookups will short-circuit")
         self._client = http_client or httpx.AsyncClient(timeout=timeout)
 
     def _build_headers(self) -> dict[str, str]:

--- a/sbir_etl/enrichers/openai_client.py
+++ b/sbir_etl/enrichers/openai_client.py
@@ -75,7 +75,7 @@ class OpenAIClient:
     def close(self) -> None:
         self._client.close()
 
-    def __enter__(self) -> "OpenAIClient":
+    def __enter__(self) -> OpenAIClient:
         return self
 
     def __exit__(self, *exc: object) -> None:
@@ -102,7 +102,10 @@ class OpenAIClient:
             self._semaphore.acquire()
             try:
                 resp = self._client.request(
-                    method, url, headers=self._headers(), json=payload,
+                    method,
+                    url,
+                    headers=self._headers(),
+                    json=payload,
                     timeout=effective_timeout,
                 )
             finally:
@@ -124,9 +127,7 @@ class OpenAIClient:
             except httpx.HTTPStatusError:
                 if attempt < MAX_RETRIES:
                     continue
-                logger.warning(
-                    f"OpenAI API error after {MAX_RETRIES} retries: {resp.status_code}"
-                )
+                logger.warning(f"OpenAI API error after {MAX_RETRIES} retries: {resp.status_code}")
                 return None
 
         return None

--- a/sbir_etl/enrichers/opencorporates.py
+++ b/sbir_etl/enrichers/opencorporates.py
@@ -113,9 +113,7 @@ class OpenCorporatesClient(BaseAsyncAPIClient):
         super().__init__(shared_limiter=shared_limiter)
         self.base_url = OPENCORPORATES_API_URL
         self.rate_limit_per_minute = rate_limit_per_minute
-        self._token = api_token or os.environ.get(
-            "OPENCORPORATES_API_TOKEN", ""
-        )
+        self._token = api_token or os.environ.get("OPENCORPORATES_API_TOKEN", "")
         self._client = http_client or httpx.AsyncClient(timeout=timeout)
 
     async def _get(
@@ -155,9 +153,7 @@ class OpenCorporatesClient(BaseAsyncAPIClient):
         (search requires a token).
         """
         if not self._token:
-            logger.debug(
-                "OpenCorporates: no API token configured, skipping search"
-            )
+            logger.debug("OpenCorporates: no API token configured, skipping search")
             return []
         params: dict[str, Any] = {"q": name, "per_page": limit}
         if jurisdiction:
@@ -173,19 +169,13 @@ class OpenCorporatesClient(BaseAsyncAPIClient):
     # Company details
     # ------------------------------------------------------------------
 
-    async def get_company(
-        self, jurisdiction: str, company_number: str
-    ) -> dict[str, Any] | None:
+    async def get_company(self, jurisdiction: str, company_number: str) -> dict[str, Any] | None:
         """Fetch full company details by jurisdiction and company number."""
         return await self._get(f"companies/{jurisdiction}/{company_number}")
 
-    async def get_officers(
-        self, jurisdiction: str, company_number: str
-    ) -> list[Officer]:
+    async def get_officers(self, jurisdiction: str, company_number: str) -> list[Officer]:
         """Fetch officers for a company."""
-        data = await self._get(
-            f"companies/{jurisdiction}/{company_number}/officers"
-        )
+        data = await self._get(f"companies/{jurisdiction}/{company_number}/officers")
         if data is None:
             return []
 
@@ -237,9 +227,7 @@ class OpenCorporatesClient(BaseAsyncAPIClient):
         Returns ``None`` if no match found. Propagates :class:`APIError`
         on transport/server failures so callers can distinguish.
         """
-        results = await self.search_companies(
-            name, jurisdiction=jurisdiction, limit=3
-        )
+        results = await self.search_companies(name, jurisdiction=jurisdiction, limit=3)
         if not results:
             return None
 
@@ -263,10 +251,7 @@ class OpenCorporatesClient(BaseAsyncAPIClient):
         detail_data = await self.get_company(jur, num)
         company = {}
         if detail_data:
-            company = (
-                detail_data.get("results", {})
-                .get("company", detail_data.get("company", {}))
-            )
+            company = detail_data.get("results", {}).get("company", detail_data.get("company", {}))
 
         # Officers
         officers = await self.get_officers(jur, num)

--- a/sbir_etl/enrichers/orcid_client.py
+++ b/sbir_etl/enrichers/orcid_client.py
@@ -52,57 +52,35 @@ class ORCIDRecord:
     keywords: list[str] = field(default_factory=list)
 
 
-def _parse_profile(
-    orcid_id: str, search_result: dict, profile: dict
-) -> ORCIDRecord:
+def _parse_profile(orcid_id: str, search_result: dict, profile: dict) -> ORCIDRecord:
     """Parse an ORCID profile response into an :class:`ORCIDRecord`."""
     # Affiliations
     affiliations: list[str] = []
     affiliation_groups = (
-        profile.get("activities-summary", {})
-        .get("employments", {})
-        .get("affiliation-group", [])
+        profile.get("activities-summary", {}).get("employments", {}).get("affiliation-group", [])
     )
     for group in affiliation_groups[:10]:
         for s in group.get("summaries", []):
-            org_name = (
-                s.get("employment-summary", {})
-                .get("organization", {})
-                .get("name", "")
-            )
+            org_name = s.get("employment-summary", {}).get("organization", {}).get("name", "")
             if org_name and org_name not in affiliations:
                 affiliations.append(org_name)
 
     # Works
-    works_group = (
-        profile.get("activities-summary", {})
-        .get("works", {})
-        .get("group", [])
-    )
+    works_group = profile.get("activities-summary", {}).get("works", {}).get("group", [])
     sample_titles: list[str] = []
     for wg in works_group[:5]:
         summaries = wg.get("work-summary", [])
         if summaries:
-            title_val = (
-                summaries[0].get("title", {}).get("title", {}).get("value", "")
-            )
+            title_val = summaries[0].get("title", {}).get("title", {}).get("value", "")
             if title_val:
                 sample_titles.append(title_val)
 
     # Funding
-    funding_group = (
-        profile.get("activities-summary", {})
-        .get("fundings", {})
-        .get("group", [])
-    )
+    funding_group = profile.get("activities-summary", {}).get("fundings", {}).get("group", [])
 
     # Keywords
-    keyword_list = (
-        profile.get("person", {}).get("keywords", {}).get("keyword", [])
-    )
-    keywords = [
-        kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")
-    ]
+    keyword_list = profile.get("person", {}).get("keywords", {}).get("keyword", [])
+    keywords = [kw.get("content", "") for kw in keyword_list[:10] if kw.get("content")]
 
     return ORCIDRecord(
         orcid_id=orcid_id,
@@ -150,9 +128,7 @@ class ORCIDClient(BaseAsyncAPIClient):
         super().__init__(shared_limiter=shared_limiter)
         self.base_url = ORCID_API_URL
         self.rate_limit_per_minute = rate_limit_per_minute
-        self._access_token = access_token or os.environ.get(
-            "ORCID_ACCESS_TOKEN", ""
-        )
+        self._access_token = access_token or os.environ.get("ORCID_ACCESS_TOKEN", "")
         self._client = http_client or httpx.AsyncClient(timeout=timeout)
 
     def _build_headers(self) -> dict[str, str]:

--- a/sbir_etl/enrichers/patentsview.py
+++ b/sbir_etl/enrichers/patentsview.py
@@ -58,19 +58,9 @@ def parse_patent_record(record: dict[str, Any]) -> dict[str, Any]:
         or record.get("patentNumber")
         or record.get("applicationNumberText")
     )
-    patent_title = (
-        record.get("inventionTitle")
-        or metadata.get("inventionTitle")
-        or ""
-    )
-    filing_date = (
-        record.get("filingDate")
-        or metadata.get("filingDate")
-    )
-    grant_date = (
-        metadata.get("grantDate")
-        or record.get("grantDate")
-    )
+    patent_title = record.get("inventionTitle") or metadata.get("inventionTitle") or ""
+    filing_date = record.get("filingDate") or metadata.get("filingDate")
+    grant_date = metadata.get("grantDate") or record.get("grantDate")
 
     # Extract assignee information
     assignees = record.get("assignees", []) or []
@@ -430,11 +420,13 @@ class PatentsViewClient:
                         org_name = assignee.get("assigneeName") or assignee.get("orgName")
                         if org_name and org_name.lower() not in seen_orgs:
                             seen_orgs.add(org_name.lower())
-                            assignees.append({
-                                "assignee_id": assignee.get("assigneeEntityId"),
-                                "assignee_organization": org_name,
-                                "assignee_type": assignee.get("assigneeTypeCategory"),
-                            })
+                            assignees.append(
+                                {
+                                    "assignee_id": assignee.get("assigneeEntityId"),
+                                    "assignee_organization": org_name,
+                                    "assignee_type": assignee.get("assigneeTypeCategory"),
+                                }
+                            )
 
             logger.debug(f"Found {len(assignees)} assignee matches for {company_name}")
             return assignees
@@ -481,18 +473,18 @@ class PatentsViewClient:
                 # Fall back to extracting assignee from the search result
                 parsed = self._parse_patent_record(records[0])
                 if parsed.get("assignee_organization"):
-                    return [{
-                        "patent_number": clean_patent_number,
-                        "assignee": parsed["assignee_organization"],
-                        "assignee_id": parsed.get("assignee_id"),
-                        "assignor": None,
-                    }]
+                    return [
+                        {
+                            "patent_number": clean_patent_number,
+                            "assignee": parsed["assignee_organization"],
+                            "assignee_id": parsed.get("assignee_id"),
+                            "assignor": None,
+                        }
+                    ]
                 return []
 
             # Fetch assignment data for this application
-            assignment_response = self._make_request(
-                f"/{app_number}/assignment", method="GET"
-            )
+            assignment_response = self._make_request(f"/{app_number}/assignment", method="GET")
 
             assignments = []
             assignment_records = assignment_response.get("patentAssignmentDataBag", [])
@@ -502,31 +494,33 @@ class PatentsViewClient:
 
             for assignment in assignment_records:
                 if isinstance(assignment, dict):
-                    assignee_name = (
-                        assignment.get("assigneeName")
-                        or assignment.get("assigneeEntityName")
+                    assignee_name = assignment.get("assigneeName") or assignment.get(
+                        "assigneeEntityName"
                     )
-                    assignor_name = (
-                        assignment.get("assignorName")
-                        or assignment.get("assignorEntityName")
+                    assignor_name = assignment.get("assignorName") or assignment.get(
+                        "assignorEntityName"
                     )
-                    assignments.append({
-                        "patent_number": clean_patent_number,
-                        "assignee": assignee_name,
-                        "assignee_id": assignment.get("assigneeEntityId"),
-                        "assignor": assignor_name,
-                    })
+                    assignments.append(
+                        {
+                            "patent_number": clean_patent_number,
+                            "assignee": assignee_name,
+                            "assignee_id": assignment.get("assigneeEntityId"),
+                            "assignor": assignor_name,
+                        }
+                    )
 
             # If no assignment endpoint data, fall back to patent record assignee
             if not assignments:
                 parsed = self._parse_patent_record(records[0])
                 if parsed.get("assignee_organization"):
-                    assignments.append({
-                        "patent_number": clean_patent_number,
-                        "assignee": parsed["assignee_organization"],
-                        "assignee_id": parsed.get("assignee_id"),
-                        "assignor": None,
-                    })
+                    assignments.append(
+                        {
+                            "patent_number": clean_patent_number,
+                            "assignee": parsed["assignee_organization"],
+                            "assignee_id": parsed.get("assignee_id"),
+                            "assignor": None,
+                        }
+                    )
 
             logger.debug(f"Found {len(assignments)} assignment records for patent {patent_number}")
             return assignments
@@ -547,7 +541,7 @@ class PatentsViewClient:
         """
         # Lucene special characters: + - && || ! ( ) { } [ ] ^ " ~ * ? : \ /
         special_chars = r'([+\-&|!(){}\[\]^"~*?:\\/])'
-        return re.sub(special_chars, r'\\\1', text)
+        return re.sub(special_chars, r"\\\1", text)
 
     def close(self) -> None:
         """Close the HTTP client."""

--- a/sbir_etl/enrichers/pi_enrichment.py
+++ b/sbir_etl/enrichers/pi_enrichment.py
@@ -167,9 +167,7 @@ def lookup_pi_patents_with_fallback(
     if result is not None:
         return result
 
-    logger.info(
-        "No PatentsView data for '{}'; falling back to Lens.org", pi_name
-    )
+    logger.info("No PatentsView data for '{}'; falling back to Lens.org", pi_name)
 
     try:
         with SyncLensPatentClient(shared_limiter=lens_rate_limiter) as lens:

--- a/sbir_etl/enrichers/press_wire.py
+++ b/sbir_etl/enrichers/press_wire.py
@@ -97,9 +97,19 @@ def _normalize(name: str) -> str:
     """
     lower = name.lower().strip()
     for suffix in (
-        " inc", " inc.", " llc", " corp", " corp.",
-        " corporation", " company", " co.", " ltd", " ltd.",
-        " lp", " l.p.", " plc",
+        " inc",
+        " inc.",
+        " llc",
+        " corp",
+        " corp.",
+        " corporation",
+        " company",
+        " co.",
+        " ltd",
+        " ltd.",
+        " lp",
+        " l.p.",
+        " plc",
     ):
         if lower.endswith(suffix):
             lower = lower[: -len(suffix)].rstrip(" ,")
@@ -186,17 +196,13 @@ class PressWireClient(BaseAsyncAPIClient):
     # Parsing — handles both RSS 2.0 and Atom formats
     # ------------------------------------------------------------------
 
-    def _parse_rss_items(
-        self, root: ET.Element, source: str
-    ) -> list[PressRelease]:
+    def _parse_rss_items(self, root: ET.Element, source: str) -> list[PressRelease]:
         """Parse RSS 2.0 ``<item>`` elements."""
         items: list[PressRelease] = []
         for item in root.iter("item"):
             title = (item.findtext("title") or "").strip()
             link = (item.findtext("link") or "").strip()
-            pub_date = item.findtext("pubDate") or item.findtext(
-                "dc:date", namespaces=NS
-            )
+            pub_date = item.findtext("pubDate") or item.findtext("dc:date", namespaces=NS)
             summary = (item.findtext("description") or "").strip()
 
             if not title:
@@ -214,9 +220,7 @@ class PressWireClient(BaseAsyncAPIClient):
             )
         return items
 
-    def _parse_atom_entries(
-        self, root: ET.Element, source: str
-    ) -> list[PressRelease]:
+    def _parse_atom_entries(self, root: ET.Element, source: str) -> list[PressRelease]:
         """Parse Atom ``<entry>`` elements."""
         items: list[PressRelease] = []
         for entry in root.iter(f"{{{NS['atom']}}}entry"):
@@ -228,9 +232,8 @@ class PressWireClient(BaseAsyncAPIClient):
             if link_el is not None:
                 link = link_el.get("href", "")
 
-            pub_el = (
-                entry.find(f"{{{NS['atom']}}}published")
-                or entry.find(f"{{{NS['atom']}}}updated")
+            pub_el = entry.find(f"{{{NS['atom']}}}published") or entry.find(
+                f"{{{NS['atom']}}}updated"
             )
             pub_date = pub_el.text if pub_el is not None else None
 
@@ -276,9 +279,7 @@ class PressWireClient(BaseAsyncAPIClient):
 
         Uses normalized substring matching against title and summary.
         """
-        searchable = _normalize(
-            f"{item.title} {item.summary or ''}"
-        )
+        searchable = _normalize(f"{item.title} {item.summary or ''}")
         for normalized_name, original_name in self._watchlist.items():
             if normalized_name in searchable:
                 return original_name
@@ -320,9 +321,7 @@ class PressWireClient(BaseAsyncAPIClient):
                     self._seen_hashes.add(item.content_hash)
                     all_matches.append(item)
 
-        logger.info(
-            f"Press wire poll complete: {len(all_matches)} matches"
-        )
+        logger.info(f"Press wire poll complete: {len(all_matches)} matches")
         return all_matches
 
     async def poll_all_unfiltered(self) -> list[PressRelease]:

--- a/sbir_etl/enrichers/sam_gov/client.py
+++ b/sbir_etl/enrichers/sam_gov/client.py
@@ -88,9 +88,7 @@ class SAMGovAPIClient(BaseAsyncAPIClient):
         """
         try:
             # SAM.gov Entity Information API v3: UEI is a query parameter
-            response = await self._make_request(
-                "GET", "/entities", params={"ueiSAM": uei}
-            )
+            response = await self._make_request("GET", "/entities", params={"ueiSAM": uei})
             if isinstance(response, dict) and "entityData" in response:
                 entities = response["entityData"]
                 return entities[0] if entities else None
@@ -114,9 +112,7 @@ class SAMGovAPIClient(BaseAsyncAPIClient):
         """
         try:
             # SAM.gov Entity Information API v3: CAGE is a query parameter
-            response = await self._make_request(
-                "GET", "/entities", params={"cageCode": cage}
-            )
+            response = await self._make_request("GET", "/entities", params={"cageCode": cage})
             if isinstance(response, dict) and "entityData" in response:
                 entities = response["entityData"]
                 return entities[0] if entities else None

--- a/sbir_etl/enrichers/sec_edgar/client.py
+++ b/sbir_etl/enrichers/sec_edgar/client.py
@@ -120,9 +120,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
         else:
             self.api_config = config
 
-        self.base_url = str(
-            self.api_config.get("base_url", "https://efts.sec.gov/LATEST")
-        )
+        self.base_url = str(self.api_config.get("base_url", "https://efts.sec.gov/LATEST"))
         self.facts_base_url = str(
             self.api_config.get("facts_base_url", "https://data.sec.gov/api/xbrl")
         )
@@ -130,9 +128,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             self.api_config.get("filings_base_url", "https://data.sec.gov/submissions")
         )
         self.timeout = cast(int, self.api_config.get("timeout_seconds", 30))
-        self.rate_limit_per_minute = cast(
-            int, self.api_config.get("rate_limit_per_minute", 600)
-        )
+        self.rate_limit_per_minute = cast(int, self.api_config.get("rate_limit_per_minute", 600))
 
         # SEC requires a User-Agent with contact info for fair access.
         # Accept contact_email directly from config, or look it up from env.
@@ -208,9 +204,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             "forms": "10-K",
         }
         try:
-            response = await self._make_request(
-                "GET", "/search-index", params=params
-            )
+            response = await self._make_request("GET", "/search-index", params=params)
             hits = response.get("hits", {}).get("hits", [])
             results = []
             seen_ciks: set[str] = set()
@@ -227,17 +221,17 @@ class EdgarAPIClient(BaseAsyncAPIClient):
                     continue
                 seen_ciks.add(cik)
 
-                entity_name, ticker = _parse_display_name(
-                    display_names[0] if display_names else ""
-                )
+                entity_name, ticker = _parse_display_name(display_names[0] if display_names else "")
 
-                results.append({
-                    "cik": cik,
-                    "entity_name": entity_name,
-                    "ticker": ticker,
-                    "file_date": source.get("file_date", None),
-                    "form_type": source.get("root_forms", [None])[0],
-                })
+                results.append(
+                    {
+                        "cik": cik,
+                        "entity_name": entity_name,
+                        "ticker": ticker,
+                        "file_date": source.get("file_date", None),
+                        "form_type": source.get("root_forms", [None])[0],
+                    }
+                )
                 if len(results) >= limit:
                     break
             return results
@@ -277,9 +271,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             "forms": forms,
         }
         try:
-            response = await self._make_request(
-                "GET", "/search-index", params=params
-            )
+            response = await self._make_request("GET", "/search-index", params=params)
             hits = response.get("hits", {}).get("hits", [])
             results = []
             for hit in hits[:limit]:
@@ -287,27 +279,29 @@ class EdgarAPIClient(BaseAsyncAPIClient):
                 ciks = source.get("ciks", [])
                 display_names = source.get("display_names", [])
                 filer_cik = ciks[0].lstrip("0") or "0" if ciks else ""
-                filer_name, _ = _parse_display_name(
-                    display_names[0] if display_names else ""
+                filer_name, _ = _parse_display_name(display_names[0] if display_names else "")
+                results.append(
+                    {
+                        "filer_cik": filer_cik,
+                        "filer_name": filer_name,
+                        "form_type": source.get("root_forms", [""])[0]
+                        if source.get("root_forms")
+                        else "",
+                        "file_date": source.get("file_date", None),
+                        "accession_number": (
+                            source.get("file_num", [""])[0]
+                            if isinstance(source.get("file_num"), list)
+                            else source.get("file_num", "")
+                        ),
+                        "file_description": source.get("file_description", ""),
+                        "items": source.get("items", []),
+                        "sics": source.get("sics", []),
+                        "doc_id": hit.get("_id", ""),  # accession:filename for document fetch
+                    }
                 )
-                results.append({
-                    "filer_cik": filer_cik,
-                    "filer_name": filer_name,
-                    "form_type": source.get("root_forms", [""])[0] if source.get("root_forms") else "",
-                    "file_date": source.get("file_date", None),
-                    "accession_number": (source.get("file_num", [""])[0]
-                                        if isinstance(source.get("file_num"), list)
-                                        else source.get("file_num", "")),
-                    "file_description": source.get("file_description", ""),
-                    "items": source.get("items", []),
-                    "sics": source.get("sics", []),
-                    "doc_id": hit.get("_id", ""),  # accession:filename for document fetch
-                })
             return results
         except APIError as e:
-            logger.warning(
-                f"EDGAR filing mention search failed for '{company_name}': {e}"
-            )
+            logger.warning(f"EDGAR filing mention search failed for '{company_name}': {e}")
             return []
 
     async def search_form_d_filings(
@@ -337,9 +331,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             "enddt": "2026-12-31",
         }
         try:
-            response = await self._make_request(
-                "GET", "/search-index", params=params
-            )
+            response = await self._make_request("GET", "/search-index", params=params)
             hits = response.get("hits", {}).get("hits", [])
             results = []
             for hit in hits[:limit]:
@@ -347,22 +339,20 @@ class EdgarAPIClient(BaseAsyncAPIClient):
                 ciks = source.get("ciks", [])
                 display_names = source.get("display_names", [])
                 cik = ciks[0].lstrip("0") or "0" if ciks else ""
-                entity_name, _ = _parse_display_name(
-                    display_names[0] if display_names else ""
+                entity_name, _ = _parse_display_name(display_names[0] if display_names else "")
+                results.append(
+                    {
+                        "cik": cik,
+                        "entity_name": entity_name,
+                        "file_date": source.get("file_date", None),
+                        "form_type": "D",
+                        "biz_locations": source.get("biz_locations", []),
+                        "biz_states": source.get("biz_states", []),
+                    }
                 )
-                results.append({
-                    "cik": cik,
-                    "entity_name": entity_name,
-                    "file_date": source.get("file_date", None),
-                    "form_type": "D",
-                    "biz_locations": source.get("biz_locations", []),
-                    "biz_states": source.get("biz_states", []),
-                })
             return results
         except APIError as e:
-            logger.warning(
-                f"EDGAR Form D search failed for '{company_name}': {e}"
-            )
+            logger.warning(f"EDGAR Form D search failed for '{company_name}': {e}")
             return []
 
     async def fetch_filing_document(
@@ -398,9 +388,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             await self._wait_for_rate_limit()
             headers = self._build_headers()
             headers["Accept"] = "text/html, application/xhtml+xml, */*"
-            response = await self._client.get(
-                url, headers=headers, follow_redirects=True
-            )
+            response = await self._client.get(url, headers=headers, follow_redirects=True)
             # Raise on 429/5xx so tenacity retries them
             if response.status_code in (429, 500, 502, 503):
                 response.raise_for_status()
@@ -432,8 +420,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
         accession_path = accession.replace("-", "")
         cik_padded = cik.zfill(10)
         url = (
-            f"https://www.sec.gov/Archives/edgar/data/"
-            f"{cik_padded}/{accession_path}/primary_doc.xml"
+            f"https://www.sec.gov/Archives/edgar/data/{cik_padded}/{accession_path}/primary_doc.xml"
         )
 
         retry_attempts = cast(int, self.api_config.get("retry_attempts", 3))
@@ -449,9 +436,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             await self._wait_for_rate_limit()
             headers = self._build_headers()
             headers["Accept"] = "application/xml, text/xml, */*"
-            response = await self._client.get(
-                url, headers=headers, follow_redirects=True
-            )
+            response = await self._client.get(url, headers=headers, follow_redirects=True)
             # Raise on 429/5xx so tenacity retries them
             if response.status_code in (429, 500, 502, 503):
                 response.raise_for_status()
@@ -558,13 +543,15 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             for i in range(len(forms)):
                 if filing_types and forms[i] not in filing_types:
                     continue
-                filings.append({
-                    "form_type": forms[i],
-                    "filing_date": dates[i] if i < len(dates) else None,
-                    "accession_number": accessions[i] if i < len(accessions) else None,
-                    "primary_document": primary_docs[i] if i < len(primary_docs) else None,
-                    "description": descriptions[i] if i < len(descriptions) else None,
-                })
+                filings.append(
+                    {
+                        "form_type": forms[i],
+                        "filing_date": dates[i] if i < len(dates) else None,
+                        "accession_number": accessions[i] if i < len(accessions) else None,
+                        "primary_document": primary_docs[i] if i < len(primary_docs) else None,
+                        "description": descriptions[i] if i < len(descriptions) else None,
+                    }
+                )
             return filings
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -80,9 +80,9 @@ def _extract_latest_fact(
             continue
         # Filter to annual (10-K) or quarterly (10-Q) filings
         annual_entries = [
-            e for e in usd_entries
-            if e.get("form") in ("10-K", "10-Q", "20-F")
-            and e.get("val") is not None
+            e
+            for e in usd_entries
+            if e.get("form") in ("10-K", "10-Q", "20-F") and e.get("val") is not None
         ]
         if not annual_entries:
             continue
@@ -97,9 +97,7 @@ def _extract_latest_fact(
     return None, None
 
 
-def _extract_financials(
-    cik: str, facts: dict[str, Any]
-) -> EdgarFinancials | None:
+def _extract_financials(cik: str, facts: dict[str, Any]) -> EdgarFinancials | None:
     """Extract standardized financials from EDGAR company facts."""
     revenue, rev_date = _extract_latest_fact(facts, _REVENUE_CONCEPTS)
     net_income, ni_date = _extract_latest_fact(facts, _NET_INCOME_CONCEPTS)
@@ -135,9 +133,7 @@ def _extract_financials(
     )
 
 
-def _detect_ma_events(
-    cik: str, filings: list[dict[str, Any]]
-) -> list[EdgarMAEvent]:
+def _detect_ma_events(cik: str, filings: list[dict[str, Any]]) -> list[EdgarMAEvent]:
     """Detect M&A events from 8-K filings.
 
     Looks for Item 1.01 (material definitive agreements) and
@@ -196,9 +192,9 @@ _NOISE_SIC_RANGES = {
 }
 
 # 8-K item codes that indicate M&A activity.
-_MA_ITEMS = {"1.01", "2.01"}            # definitive agreement, completion of acquisition
-_FINANCIAL_ITEMS = {"2.02", "2.05"}     # results of operations, delisting
-_DISCLOSURE_ITEMS = {"7.01", "8.01"}    # Reg FD, other events
+_MA_ITEMS = {"1.01", "2.01"}  # definitive agreement, completion of acquisition
+_FINANCIAL_ITEMS = {"2.02", "2.05"}  # results of operations, delisting
+_DISCLOSURE_ITEMS = {"7.01", "8.01"}  # Reg FD, other events
 
 _CORP_SUFFIX = re.compile(
     r",?\s*(Inc\.?|Corp\.?|LLC|Ltd\.?|Co\.?|L\.?P\.?|/DE|/NV|/MD|CORP|INC)$",
@@ -235,23 +231,87 @@ _COMPETITOR_KEYWORDS = re.compile(
 
 
 # Words that appear in many filings as common English, not as company identifiers.
-_COMMON_ENGLISH_WORDS = frozenset({
-    "sediment", "informed", "ideas", "menara", "elkins", "bai", "nil",
-    "merit", "quest", "delta", "alpha", "summit", "pioneer", "atlas",
-    "nexus", "pulse", "prism", "forge", "apex", "core", "edge",
-    "relay", "array", "signal", "matrix", "tensor", "vector", "orbit",
-    "cipher", "helix", "locus", "verge", "haven", "arbor", "cadre",
-})
+_COMMON_ENGLISH_WORDS = frozenset(
+    {
+        "sediment",
+        "informed",
+        "ideas",
+        "menara",
+        "elkins",
+        "bai",
+        "nil",
+        "merit",
+        "quest",
+        "delta",
+        "alpha",
+        "summit",
+        "pioneer",
+        "atlas",
+        "nexus",
+        "pulse",
+        "prism",
+        "forge",
+        "apex",
+        "core",
+        "edge",
+        "relay",
+        "array",
+        "signal",
+        "matrix",
+        "tensor",
+        "vector",
+        "orbit",
+        "cipher",
+        "helix",
+        "locus",
+        "verge",
+        "haven",
+        "arbor",
+        "cadre",
+    }
+)
 
 # Generic business/tech words that don't distinguish one company from another.
-_GENERIC_NAME_WORDS = frozenset({
-    "advanced", "applied", "central", "digital", "first", "general",
-    "global", "good", "health", "information", "integrated", "management",
-    "material", "national", "new", "process", "quality", "research",
-    "risk", "smith", "systems", "training", "development", "engineering",
-    "computer", "methods", "programs", "services", "consulting", "park",
-    "west", "east", "north", "south", "project", "transfer",
-})
+_GENERIC_NAME_WORDS = frozenset(
+    {
+        "advanced",
+        "applied",
+        "central",
+        "digital",
+        "first",
+        "general",
+        "global",
+        "good",
+        "health",
+        "information",
+        "integrated",
+        "management",
+        "material",
+        "national",
+        "new",
+        "process",
+        "quality",
+        "research",
+        "risk",
+        "smith",
+        "systems",
+        "training",
+        "development",
+        "engineering",
+        "computer",
+        "methods",
+        "programs",
+        "services",
+        "consulting",
+        "park",
+        "west",
+        "east",
+        "north",
+        "south",
+        "project",
+        "transfer",
+    }
+)
 
 
 def compute_mention_noise_score(
@@ -284,9 +344,7 @@ def compute_mention_noise_score(
     elif len(words) == 1:
         # Single longer word — mildly suspicious
         score += 1
-    elif all(
-        w.lower() in _GENERIC_NAME_WORDS for w in words if len(w) > 2
-    ):
+    elif all(w.lower() in _GENERIC_NAME_WORDS for w in words if len(w) > 2):
         # All words are generic business terms (Risk Management Systems)
         score += 2
 
@@ -381,7 +439,9 @@ def _classify_mention(items: list[str], form_type: str) -> str:
 
 
 def _is_noise(
-    filer_name: str, target_name: str, sics: list[str],
+    filer_name: str,
+    target_name: str,
+    sics: list[str],
 ) -> bool:
     """Return True if this mention is likely noise.
 
@@ -426,9 +486,7 @@ async def _search_filing_mentions_filtered(
     - Real estate / mortgage filers (by SIC code)
     - Name collisions (target name is substring of a different company)
     """
-    mentions = await client.search_filing_mentions(
-        company_name, forms=forms, limit=limit
-    )
+    mentions = await client.search_filing_mentions(company_name, forms=forms, limit=limit)
     if not mentions:
         return []
 
@@ -461,9 +519,7 @@ async def _search_filing_mentions_filtered(
         # For ambiguous mentions, try to fetch the filing and classify
         # from surrounding text.  This costs one HTTP request per mention.
         if mention_type == "filing_mention":
-            text_context = await _extract_mention_context(
-                client, company_name, mention
-            )
+            text_context = await _extract_mention_context(client, company_name, mention)
             if text_context:
                 mention_type = text_context
 
@@ -500,18 +556,28 @@ async def _search_inbound_ma_mentions(
     """
     # Run all three searches concurrently
     import asyncio
+
     strong, annual, ownership = await asyncio.gather(
         _search_filing_mentions_filtered(
-            client, company_name, _MA_FILING_TYPES,
-            name_match_threshold=name_match_threshold, limit=20,
+            client,
+            company_name,
+            _MA_FILING_TYPES,
+            name_match_threshold=name_match_threshold,
+            limit=20,
         ),
         _search_filing_mentions_filtered(
-            client, company_name, _ANNUAL_FILING_TYPES,
-            name_match_threshold=name_match_threshold, limit=10,
+            client,
+            company_name,
+            _ANNUAL_FILING_TYPES,
+            name_match_threshold=name_match_threshold,
+            limit=10,
         ),
         _search_filing_mentions_filtered(
-            client, company_name, _OWNERSHIP_FILING_TYPES,
-            name_match_threshold=name_match_threshold, limit=10,
+            client,
+            company_name,
+            _OWNERSHIP_FILING_TYPES,
+            name_match_threshold=name_match_threshold,
+            limit=10,
         ),
     )
     return strong + annual + ownership
@@ -575,15 +641,45 @@ async def _search_form_d_filings(
 # Words that appear in many company names but don't distinguish one company
 # from another.  Used by CIK resolution to require at least one distinctive
 # word overlap between query and candidate.
-_GENERIC_WORDS = frozenset({
-    "TECHNOLOGIES", "TECHNOLOGY", "SYSTEMS", "SCIENCES", "RESEARCH",
-    "ENGINEERING", "SOLUTIONS", "ANALYTICS", "DYNAMICS", "INDUSTRIES",
-    "ASSOCIATES", "CONSULTING", "SERVICES", "GROUP", "INTERNATIONAL",
-    "LABORATORIES", "INSTRUMENTS", "MATERIALS", "DEVICES", "APPLICATIONS",
-    "ADVANCED", "APPLIED", "DIGITAL", "GENERAL", "NATIONAL", "AMERICAN",
-    "GLOBAL", "INTEGRATED", "PRECISION", "SCIENTIFIC", "TECHNICAL",
-    "INNOVATIONS", "CORPORATION", "COMPANY", "ENTERPRISES",
-})
+_GENERIC_WORDS = frozenset(
+    {
+        "TECHNOLOGIES",
+        "TECHNOLOGY",
+        "SYSTEMS",
+        "SCIENCES",
+        "RESEARCH",
+        "ENGINEERING",
+        "SOLUTIONS",
+        "ANALYTICS",
+        "DYNAMICS",
+        "INDUSTRIES",
+        "ASSOCIATES",
+        "CONSULTING",
+        "SERVICES",
+        "GROUP",
+        "INTERNATIONAL",
+        "LABORATORIES",
+        "INSTRUMENTS",
+        "MATERIALS",
+        "DEVICES",
+        "APPLICATIONS",
+        "ADVANCED",
+        "APPLIED",
+        "DIGITAL",
+        "GENERAL",
+        "NATIONAL",
+        "AMERICAN",
+        "GLOBAL",
+        "INTEGRATED",
+        "PRECISION",
+        "SCIENTIFIC",
+        "TECHNICAL",
+        "INNOVATIONS",
+        "CORPORATION",
+        "COMPANY",
+        "ENTERPRISES",
+    }
+)
 
 
 def _clean_company_name(name: str) -> str:
@@ -760,9 +856,7 @@ async def enrich_company(
         profile.mention_count = len(deduped)
         if deduped:
             profile.mention_filers = [e.filer_name for e in deduped if e.filer_name]
-            profile.mention_types = sorted({
-                e.mention_type for e in deduped if e.mention_type
-            })
+            profile.mention_types = sorted({e.mention_type for e in deduped if e.mention_type})
             profile.latest_mention_date = max(e.filing_date for e in deduped)
 
     # Form D search — private capital raises under Regulation D
@@ -777,7 +871,9 @@ async def enrich_company(
     # Compute mention noise score (requires mention_count to be set)
     if profile.mention_count > 0:
         profile.mention_noise_score = compute_mention_noise_score(
-            company_name, profile.mention_count, award_count,
+            company_name,
+            profile.mention_count,
+            award_count,
         )
 
     return profile
@@ -822,10 +918,7 @@ async def enrich_companies_with_edgar(
     try:
         # De-duplicate by company name to minimize API calls
         unique_companies = companies_df[[company_name_col]].drop_duplicates()
-        has_uei = (
-            company_uei_col in companies_df.columns
-            and company_uei_col != company_name_col
-        )
+        has_uei = company_uei_col in companies_df.columns and company_uei_col != company_name_col
         if has_uei:
             # Get first UEI per company for linking
             uei_lookup = (
@@ -843,7 +936,7 @@ async def enrich_companies_with_edgar(
         profiles: list[dict[str, Any]] = []
         matched_count = 0
 
-        for idx, row in unique_companies.iterrows():
+        for _idx, row in unique_companies.iterrows():
             name = row[company_name_col]
             uei = uei_lookup.get(name)
 
@@ -881,8 +974,7 @@ async def enrich_companies_with_edgar(
         rename_map = {
             col: f"sec_{col}"
             for col in enrichment_df.columns
-            if col not in (company_name_col, "company_name")
-            and not col.startswith("sec_")
+            if col not in (company_name_col, "company_name") and not col.startswith("sec_")
         }
         enrichment_df = enrichment_df.rename(columns=rename_map)
 

--- a/sbir_etl/enrichers/sec_edgar/form_d_scoring.py
+++ b/sbir_etl/enrichers/sec_edgar/form_d_scoring.py
@@ -15,9 +15,7 @@ from rapidfuzz import fuzz
 from ...models.sec_edgar import FormDMatchConfidence
 
 # Titles that should be stripped from PI names before matching
-_STRIP_TITLES = re.compile(
-    r"\b(Dr\.|Ph\.D\.|M\.D\.|Mr\.|Mrs\.|Ms\.|Jr\.|Sr\.)\b", re.IGNORECASE
-)
+_STRIP_TITLES = re.compile(r"\b(Dr\.|Ph\.D\.|M\.D\.|Mr\.|Mrs\.|Ms\.|Jr\.|Sr\.)\b", re.IGNORECASE)
 # Single-letter initials like "R." (but not "Jr." etc., already handled above)
 _STRIP_INITIALS = re.compile(r"\b[A-Z]\.\s*")
 
@@ -30,15 +28,17 @@ _STRIP_INITIALS = re.compile(r"\b[A-Z]\.\s*")
 # vehicles, not operating company raises.  Some funds are linked to real
 # SBIR companies via shared persons/CIKs (71 cross-links found) — worth
 # revisiting for investor-company relationship mapping.
-EXCLUDED_INDUSTRY_GROUPS: frozenset[str] = frozenset({
-    "Insurance",
-    "Lodging and Conventions",
-    "Other Travel",
-    "Pooled Investment Fund",
-    "Restaurants",
-    "Retailing",
-    "Tourism and Travel Services",
-})
+EXCLUDED_INDUSTRY_GROUPS: frozenset[str] = frozenset(
+    {
+        "Insurance",
+        "Lodging and Conventions",
+        "Other Travel",
+        "Pooled Investment Fund",
+        "Restaurants",
+        "Retailing",
+        "Tourism and Travel Services",
+    }
+)
 
 _SECURITIES_MAP = {
     "isDebtType": "debt",
@@ -199,19 +199,41 @@ def parse_form_d_xml(
         "state": _text(addr, "stateOrCountry") if addr is not None else None,
         "zip_code": _text(addr, "zipCode") if addr is not None else None,
         "phone": _text(issuer, "issuerPhoneNumber"),
-        "industry_group": _text(offering, "industryGroup/industryGroupType") if offering is not None else None,
-        "revenue_range": _text(offering, "issuerSize/revenueRange") if offering is not None else None,
+        "industry_group": _text(offering, "industryGroup/industryGroupType")
+        if offering is not None
+        else None,
+        "revenue_range": _text(offering, "issuerSize/revenueRange")
+        if offering is not None
+        else None,
         "date_of_first_sale": date_of_first_sale,
         "securities_types": securities_types,
         "federal_exemption": fed_exemption,
-        "total_offering_amount": _float(offering, "offeringSalesAmounts/totalOfferingAmount") if offering is not None else None,
-        "total_amount_sold": _float(offering, "offeringSalesAmounts/totalAmountSold") if offering is not None else None,
-        "total_remaining": _float(offering, "offeringSalesAmounts/totalRemaining") if offering is not None else None,
-        "minimum_investment": _float(offering, "minimumInvestmentAccepted") if offering is not None else None,
-        "num_investors": _int(offering, "investors/totalNumberAlreadyInvested") if offering is not None else None,
-        "has_non_accredited": _bool(offering, "investors/hasNonAccreditedInvestors") if offering is not None else None,
-        "is_amendment": _bool(offering, "typeOfFiling/newOrAmendment/isAmendment") if offering is not None else False,
-        "is_business_combination": _bool(offering, "businessCombinationTransaction/isBusinessCombinationTransaction") if offering is not None else False,
+        "total_offering_amount": _float(offering, "offeringSalesAmounts/totalOfferingAmount")
+        if offering is not None
+        else None,
+        "total_amount_sold": _float(offering, "offeringSalesAmounts/totalAmountSold")
+        if offering is not None
+        else None,
+        "total_remaining": _float(offering, "offeringSalesAmounts/totalRemaining")
+        if offering is not None
+        else None,
+        "minimum_investment": _float(offering, "minimumInvestmentAccepted")
+        if offering is not None
+        else None,
+        "num_investors": _int(offering, "investors/totalNumberAlreadyInvested")
+        if offering is not None
+        else None,
+        "has_non_accredited": _bool(offering, "investors/hasNonAccreditedInvestors")
+        if offering is not None
+        else None,
+        "is_amendment": _bool(offering, "typeOfFiling/newOrAmendment/isAmendment")
+        if offering is not None
+        else False,
+        "is_business_combination": _bool(
+            offering, "businessCombinationTransaction/isBusinessCombinationTransaction"
+        )
+        if offering is not None
+        else False,
         "related_persons": related_persons,
     }
 
@@ -262,9 +284,7 @@ def compute_form_d_confidence(
                     best_score = score
                     title = rp.get("title", "")
                     role_label = title.split(",")[0] if title else "Person"
-                    best_detail = (
-                        f"PI '{pi}' <> {role_label} '{rp_name}' ({int(score * 100)}%)"
-                    )
+                    best_detail = f"PI '{pi}' <> {role_label} '{rp_name}' ({int(score * 100)}%)"
 
         if best_detail is not None:
             person_score = best_score
@@ -279,11 +299,7 @@ def compute_form_d_confidence(
     address_score: float | None = None
     if sbir_zip and form_d_zips:
         sbir_zip_5 = sbir_zip.strip()[:5]
-        address_score = (
-            1.0
-            if any(z.strip()[:5] == sbir_zip_5 for z in form_d_zips if z)
-            else 0.0
-        )
+        address_score = 1.0 if any(z.strip()[:5] == sbir_zip_5 for z in form_d_zips if z) else 0.0
 
     # --- Signal 4: Temporal plausibility ---
     temporal_score: float | None = None

--- a/sbir_etl/enrichers/semantic_scholar.py
+++ b/sbir_etl/enrichers/semantic_scholar.py
@@ -103,9 +103,7 @@ class SemanticScholarClient(BaseAsyncAPIClient):
             headers["x-api-key"] = self._api_key
         return headers
 
-    async def search_author(
-        self, name: str, limit: int = 5
-    ) -> list[dict[str, Any]]:
+    async def search_author(self, name: str, limit: int = 5) -> list[dict[str, Any]]:
         """Search for authors by name.
 
         Returns the ``data`` list from the API response (possibly empty).
@@ -124,9 +122,7 @@ class SemanticScholarClient(BaseAsyncAPIClient):
             raise
         return data.get("data", [])
 
-    async def get_author_details(
-        self, author_id: str
-    ) -> dict[str, Any] | None:
+    async def get_author_details(self, author_id: str) -> dict[str, Any] | None:
         """Fetch author details including papers, h-index, and affiliations.
 
         Returns ``None`` if the author is not found (404); propagates
@@ -137,10 +133,7 @@ class SemanticScholarClient(BaseAsyncAPIClient):
                 "GET",
                 f"author/{author_id}",
                 params={
-                    "fields": (
-                        "name,hIndex,citationCount,affiliations,"
-                        "papers.title,papers.year"
-                    ),
+                    "fields": ("name,hIndex,citationCount,affiliations,papers.title,papers.year"),
                 },
             )
         except APIError as e:

--- a/sbir_etl/enrichers/sync_wrappers.py
+++ b/sbir_etl/enrichers/sync_wrappers.py
@@ -80,9 +80,7 @@ class SyncUSAspendingClient(_SyncFacade):
     def get_award_by_piid(self, piid: str) -> dict[str, Any] | None:
         return run_sync(self._client.get_award_by_piid(piid))
 
-    def autocomplete_recipient(
-        self, search_text: str, limit: int = 5
-    ) -> dict[str, Any]:
+    def autocomplete_recipient(self, search_text: str, limit: int = 5) -> dict[str, Any]:
         return run_sync(self._client.autocomplete_recipient(search_text, limit))
 
     def search_transactions(
@@ -115,14 +113,10 @@ class SyncUSAspendingClient(_SyncFacade):
             )
         )
 
-    def search_recipients(
-        self, keyword: str, limit: int = 5
-    ) -> list[dict[str, Any]]:
+    def search_recipients(self, keyword: str, limit: int = 5) -> list[dict[str, Any]]:
         return run_sync(self._client.search_recipients(keyword, limit))
 
-    def get_recipient_profile(
-        self, recipient_id: str, year: str = "all"
-    ) -> dict[str, Any] | None:
+    def get_recipient_profile(self, recipient_id: str, year: str = "all") -> dict[str, Any] | None:
         return run_sync(self._client.get_recipient_profile(recipient_id, year))
 
     def fetch_award_details(self, award_id: str) -> dict[str, Any] | None:
@@ -298,26 +292,18 @@ class SyncOpenCorporatesClient(_SyncFacade):
         jurisdiction: str | None = None,
         limit: int = 5,
     ) -> list[dict[str, Any]]:
-        return run_sync(
-            self._client.search_companies(name, jurisdiction, limit)
-        )
+        return run_sync(self._client.search_companies(name, jurisdiction, limit))
 
-    def get_company(
-        self, jurisdiction: str, company_number: str
-    ) -> dict[str, Any] | None:
+    def get_company(self, jurisdiction: str, company_number: str) -> dict[str, Any] | None:
         return run_sync(self._client.get_company(jurisdiction, company_number))
 
-    def get_officers(
-        self, jurisdiction: str, company_number: str
-    ) -> list[Officer]:
+    def get_officers(self, jurisdiction: str, company_number: str) -> list[Officer]:
         return run_sync(self._client.get_officers(jurisdiction, company_number))
 
     def get_corporate_grouping(
         self, jurisdiction: str, company_number: str
     ) -> tuple[str | None, str | None]:
-        return run_sync(
-            self._client.get_corporate_grouping(jurisdiction, company_number)
-        )
+        return run_sync(self._client.get_corporate_grouping(jurisdiction, company_number))
 
     def lookup_company(
         self,
@@ -390,13 +376,9 @@ class SyncLensPatentClient(_SyncFacade):
     def search_patents_by_assignee(
         self, company_name: str, max_results: int = 100
     ) -> list[LensPatentRecord]:
-        return run_sync(
-            self._client.search_patents_by_assignee(company_name, max_results)
-        )
+        return run_sync(self._client.search_patents_by_assignee(company_name, max_results))
 
     def search_patents_by_inventor(
         self, inventor_name: str, max_results: int = 50
     ) -> list[LensPatentRecord]:
-        return run_sync(
-            self._client.search_patents_by_inventor(inventor_name, max_results)
-        )
+        return run_sync(self._client.search_patents_by_inventor(inventor_name, max_results))

--- a/sbir_etl/enrichers/usaspending/client.py
+++ b/sbir_etl/enrichers/usaspending/client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -96,7 +97,6 @@ def build_award_type_groups(
         groups.append(([uid], "contracts", list(CONTRACT_TYPE_CODES)))
         groups.append(([uid], "assistance", list(ASSISTANCE_TYPE_CODES)))
     return groups
-
 
 
 class USAspendingAPIClient(BaseAsyncAPIClient):
@@ -487,8 +487,7 @@ class USAspendingAPIClient(BaseAsyncAPIClient):
                             results[aid] = record
                 except APIError as e:
                     logger.warning(
-                        f"Batch search failed for {group_name} group "
-                        f"({len(chunk)} ids): {e}"
+                        f"Batch search failed for {group_name} group ({len(chunk)} ids): {e}"
                     )
 
         logger.info(

--- a/sbir_etl/extractors/sbir.py
+++ b/sbir_etl/extractors/sbir.py
@@ -134,7 +134,9 @@ class SbirDuckDBExtractor:
             # Force native DuckDB import — pandas chunking and fallback
             # modes require a local file and will fail on s3:// URLs.
             if incremental:
-                logger.warning("Incremental mode not supported for S3 paths; using native DuckDB import")
+                logger.warning(
+                    "Incremental mode not supported for S3 paths; using native DuckDB import"
+                )
                 incremental = False
         elif not Path(self.csv_path).exists():
             raise FileNotFoundError(f"CSV file not found: {self.csv_path}")
@@ -199,7 +201,9 @@ class SbirDuckDBExtractor:
                 # If native import appears to be wrong, try pandas-based import as fallback.
                 # Skip fallback for S3 paths — pandas can't read s3:// URLs directly.
                 expected_column_count = 42
-                if not _using_s3 and (row_count_check == 0 or len(discovered_columns) != expected_column_count):
+                if not _using_s3 and (
+                    row_count_check == 0 or len(discovered_columns) != expected_column_count
+                ):
                     logger.warning(
                         "Native DuckDB CSV import produced unexpected results; trying pandas fallback",
                         row_count=row_count_check,

--- a/sbir_etl/extractors/sbir_gov_api.py
+++ b/sbir_etl/extractors/sbir_gov_api.py
@@ -190,7 +190,7 @@ class SbirGovClient:
     @staticmethod
     def build_lookup_index(
         awards: list[dict[str, Any]],
-    ) -> "SbirGovLookupIndex":
+    ) -> SbirGovLookupIndex:
         """Build a multi-key lookup index from SBIR.gov award data.
 
         Creates indexes keyed by contract/award number, UEI, and DUNS for

--- a/sbir_etl/models/award.py
+++ b/sbir_etl/models/award.py
@@ -1,6 +1,6 @@
 """Pydantic models for SBIR award data."""
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, UTC
 from typing import Any
 
 from pydantic import (
@@ -182,8 +182,8 @@ class Award(BaseModel):
             return None
         if isinstance(v, datetime):
             if v.tzinfo is None:
-                return v.replace(tzinfo=timezone.utc)
-            return v.astimezone(timezone.utc)
+                return v.replace(tzinfo=UTC)
+            return v.astimezone(UTC)
         return v
 
     @field_validator("award_amount", mode="before")

--- a/sbir_etl/models/benchmark_models.py
+++ b/sbir_etl/models/benchmark_models.py
@@ -72,8 +72,8 @@ class TransitionRateThresholds:
     """Thresholds for the Phase I→II transition rate benchmark."""
 
     lookback_years: int = 5
-    phase1_exclude_recent_years: int = 1   # Exclude most recently completed FY
-    phase2_exclude_recent_years: int = 0   # Phase II count includes most recent FY
+    phase1_exclude_recent_years: int = 1  # Exclude most recently completed FY
+    phase2_exclude_recent_years: int = 0  # Phase II count includes most recent FY
     standard_min_phase1: int = 21
     standard_min_ratio: float = 0.25
     increased_min_phase1: int = 51
@@ -85,7 +85,7 @@ class CommercializationRateThresholds:
     """Thresholds for the commercialization rate benchmark."""
 
     lookback_years: int = 10
-    exclude_recent_years: int = 2          # Exclude 2 most recently completed FYs
+    exclude_recent_years: int = 2  # Exclude 2 most recently completed FYs
     standard_min_phase2: int = 16
     standard_min_avg_sales: float = 100_000.0
     standard_min_patent_rate: float = 0.15  # Patents path only for standard tier

--- a/sbir_etl/models/sbir_identification.py
+++ b/sbir_etl/models/sbir_identification.py
@@ -78,6 +78,7 @@ def parse_research_code(code: str | None) -> tuple[str, int] | None:
 # Assistance Listing Numbers (ALN / CFDA) for SBIR/STTR grants
 # ---------------------------------------------------------------------------
 
+
 class AgencyAlnInfo(TypedDict):
     """Typed schema for per-agency SBIR/STTR ALN metadata."""
 

--- a/sbir_etl/models/sec_edgar.py
+++ b/sbir_etl/models/sec_edgar.py
@@ -136,9 +136,7 @@ class EdgarFormDFiling(BaseModel):
     cik: str = Field(..., description="CIK assigned to the Form D filer")
     entity_name: str = Field(..., description="Entity name on the Form D filing")
     filing_date: date = Field(..., description="Date of the Form D filing")
-    match_confidence: float = Field(
-        ..., ge=0.0, le=1.0, description="Name match confidence (0-1)"
-    )
+    match_confidence: float = Field(..., ge=0.0, le=1.0, description="Name match confidence (0-1)")
 
     model_config = ConfigDict(validate_assignment=True)
 
@@ -165,10 +163,14 @@ class FormDOffering(BaseModel):
     phone: str | None = Field(None, description="Issuer phone number")
 
     # Offering details
-    industry_group: str | None = Field(None, description="e.g., 'Other Technology', 'Biotechnology'")
+    industry_group: str | None = Field(
+        None, description="e.g., 'Other Technology', 'Biotechnology'"
+    )
     revenue_range: str | None = Field(None, description="e.g., 'Decline to Disclose', '$1-$5M'")
     date_of_first_sale: date | None = Field(None, description="When securities were first sold")
-    securities_types: list[str] = Field(default_factory=list, description="e.g., ['debt', 'equity']")
+    securities_types: list[str] = Field(
+        default_factory=list, description="e.g., ['debt', 'equity']"
+    )
     federal_exemption: str | None = Field(None, description="Reg D rule: '06'=506(b), '06b'=506(c)")
 
     # Amounts
@@ -179,7 +181,9 @@ class FormDOffering(BaseModel):
 
     # Investors
     num_investors: int | None = Field(None, description="Number of investors")
-    has_non_accredited: bool | None = Field(None, description="Whether non-accredited investors participated")
+    has_non_accredited: bool | None = Field(
+        None, description="Whether non-accredited investors participated"
+    )
 
     # People
     related_persons: list[dict] = Field(
@@ -189,7 +193,9 @@ class FormDOffering(BaseModel):
 
     # Flags
     is_amendment: bool = Field(default=False, description="Whether this is a D/A amendment")
-    is_business_combination: bool = Field(default=False, description="Business combination transaction flag")
+    is_business_combination: bool = Field(
+        default=False, description="Business combination transaction flag"
+    )
 
     model_config = ConfigDict(validate_assignment=True)
 
@@ -203,11 +209,19 @@ class FormDMatchConfidence(BaseModel):
     # Individual signals (None if not evaluable)
     name_score: float = Field(..., description="Fuzzy name match score")
     person_score: float | None = Field(None, description="Best PI-to-related-person match")
-    person_match_detail: str | None = Field(None, description="e.g., \"PI 'J Smith' <> Dir 'John Smith' (92%)\"")
+    person_match_detail: str | None = Field(
+        None, description="e.g., \"PI 'J Smith' <> Dir 'John Smith' (92%)\""
+    )
     state_score: float | None = Field(None, description="biz_states overlap with SBIR state")
-    address_score: float | None = Field(None, description="ZIP code match between SBIR and Form D address")
-    temporal_score: float | None = Field(None, description="Form D date vs SBIR award date plausibility")
-    year_of_inc_score: float | None = Field(None, description="year_of_inc vs earliest SBIR award year")
+    address_score: float | None = Field(
+        None, description="ZIP code match between SBIR and Form D address"
+    )
+    temporal_score: float | None = Field(
+        None, description="Form D date vs SBIR award date plausibility"
+    )
+    year_of_inc_score: float | None = Field(
+        None, description="year_of_inc vs earliest SBIR award year"
+    )
 
     model_config = ConfigDict(validate_assignment=True)
 
@@ -227,9 +241,7 @@ class CompanyEdgarProfile(BaseModel):
     is_publicly_traded: bool = Field(
         default=False, description="Whether a public filing match was found"
     )
-    match_confidence: float = Field(
-        default=0.0, ge=0.0, le=1.0, description="CIK match confidence"
-    )
+    match_confidence: float = Field(default=0.0, ge=0.0, le=1.0, description="CIK match confidence")
     match_method: str | None = Field(None, description="CIK resolution method")
     ticker: str | None = Field(None, description="Stock ticker if matched")
     sic_code: str | None = Field(None, description="SIC code from EDGAR")
@@ -259,7 +271,7 @@ class CompanyEdgarProfile(BaseModel):
     mention_types: list[str] = Field(
         default_factory=list,
         description="Classified mention types: ma_definitive, ma_proxy, ownership_active, "
-                    "ownership_passive, financial_mention, disclosure, filing_mention",
+        "ownership_passive, financial_mention, disclosure, filing_mention",
     )
     latest_mention_date: date | None = Field(
         None, description="Most recent date this company was mentioned in a filing"
@@ -279,7 +291,7 @@ class CompanyEdgarProfile(BaseModel):
     mention_noise_score: int = Field(
         default=0,
         description="Noise likelihood for filing mentions (0=clean, >=2=likely noise). "
-                    "Based on name distinctiveness and mention-to-award ratio.",
+        "Based on name distinctiveness and mention-to-award ratio.",
     )
 
     # Filing activity

--- a/sbir_etl/quality/__init__.py
+++ b/sbir_etl/quality/__init__.py
@@ -3,5 +3,7 @@
 Submodules: uspto_validators, baseline, dashboard, checks.
 """
 
-# Only re-export symbols that are actually imported via `from sbir_etl.quality import ...`
 from .uspto_validators import USPTODataQualityValidator, USPTOValidationConfig
+
+
+__all__ = ["USPTODataQualityValidator", "USPTOValidationConfig"]

--- a/sbir_etl/transformers/bea_api_client.py
+++ b/sbir_etl/transformers/bea_api_client.py
@@ -25,11 +25,11 @@ BEA_API_BASE_URL = "https://apps.bea.gov/api/data"
 # BEA I-O table IDs used for economic impact analysis
 # See: https://apps.bea.gov/api/_pdf/bea_web_service_api_user_guide.pdf
 TABLE_IDS = {
-    "use_summary": "259",       # Use table (Summary level, after redefinitions)
-    "make_summary": "260",      # Make table (Summary level, after redefinitions)
-    "va_summary": "261",        # Value Added by Industry (Summary)
-    "employment": "262",        # Employment by Industry (Summary)
-    "supply_summary": "256",    # Supply table (Summary)
+    "use_summary": "259",  # Use table (Summary level, after redefinitions)
+    "make_summary": "260",  # Make table (Summary level, after redefinitions)
+    "va_summary": "261",  # Value Added by Industry (Summary)
+    "employment": "262",  # Employment by Industry (Summary)
+    "supply_summary": "256",  # Supply table (Summary)
 }
 
 
@@ -103,10 +103,7 @@ class BEAApiClient:
             f"year={params.get('Year', 'N/A')}"
         )
         resp = self._client.get(self.base_url, params=full_params)
-        logger.debug(
-            f"BEA API response: HTTP {resp.status_code} | "
-            f"{len(resp.content)} bytes"
-        )
+        logger.debug(f"BEA API response: HTTP {resp.status_code} | {len(resp.content)} bytes")
         resp.raise_for_status()
         data = resp.json()
 
@@ -114,10 +111,7 @@ class BEAApiClient:
         bea_resp = data.get("BEAAPI", {}).get("Results", {})
         if "Error" in bea_resp:
             error_detail = bea_resp["Error"]
-            logger.error(
-                f"BEA API returned error: {error_detail} | "
-                f"params: {params}"
-            )
+            logger.error(f"BEA API returned error: {error_detail} | params: {params}")
             raise APIError(
                 f"BEA API error: {error_detail}",
                 component="transformer.bea_api_client",
@@ -181,9 +175,7 @@ class BEAApiClient:
             return pd.DataFrame()
 
         df = pd.DataFrame(rows)
-        logger.debug(
-            f"BEA data extracted: {len(df)} rows, columns: {list(df.columns)}"
-        )
+        logger.debug(f"BEA data extracted: {len(df)} rows, columns: {list(df.columns)}")
         return df
 
     # ------------------------------------------------------------------
@@ -284,15 +276,56 @@ class BEAApiClient:
 
 # State abbreviation → FIPS code mapping (for regional queries)
 STATE_FIPS: dict[str, str] = {
-    "AL": "01", "AK": "02", "AZ": "04", "AR": "05", "CA": "06",
-    "CO": "08", "CT": "09", "DE": "10", "FL": "12", "GA": "13",
-    "HI": "15", "ID": "16", "IL": "17", "IN": "18", "IA": "19",
-    "KS": "20", "KY": "21", "LA": "22", "ME": "23", "MD": "24",
-    "MA": "25", "MI": "26", "MN": "27", "MS": "28", "MO": "29",
-    "MT": "30", "NE": "31", "NV": "32", "NH": "33", "NJ": "34",
-    "NM": "35", "NY": "36", "NC": "37", "ND": "38", "OH": "39",
-    "OK": "40", "OR": "41", "PA": "42", "RI": "44", "SC": "45",
-    "SD": "46", "TN": "47", "TX": "48", "UT": "49", "VT": "50",
-    "VA": "51", "WA": "53", "WV": "54", "WI": "55", "WY": "56",
-    "DC": "11", "PR": "72",
+    "AL": "01",
+    "AK": "02",
+    "AZ": "04",
+    "AR": "05",
+    "CA": "06",
+    "CO": "08",
+    "CT": "09",
+    "DE": "10",
+    "FL": "12",
+    "GA": "13",
+    "HI": "15",
+    "ID": "16",
+    "IL": "17",
+    "IN": "18",
+    "IA": "19",
+    "KS": "20",
+    "KY": "21",
+    "LA": "22",
+    "ME": "23",
+    "MD": "24",
+    "MA": "25",
+    "MI": "26",
+    "MN": "27",
+    "MS": "28",
+    "MO": "29",
+    "MT": "30",
+    "NE": "31",
+    "NV": "32",
+    "NH": "33",
+    "NJ": "34",
+    "NM": "35",
+    "NY": "36",
+    "NC": "37",
+    "ND": "38",
+    "OH": "39",
+    "OK": "40",
+    "OR": "41",
+    "PA": "42",
+    "RI": "44",
+    "SC": "45",
+    "SD": "46",
+    "TN": "47",
+    "TX": "48",
+    "UT": "49",
+    "VT": "50",
+    "VA": "51",
+    "WA": "53",
+    "WV": "54",
+    "WI": "55",
+    "WY": "56",
+    "DC": "11",
+    "PR": "72",
 }

--- a/sbir_etl/transformers/bea_io_adapter.py
+++ b/sbir_etl/transformers/bea_io_adapter.py
@@ -218,9 +218,7 @@ class BEAIOAdapter:
                 "Set BEA_API_KEY for real I-O analysis. "
                 "Register at https://apps.bea.gov/API/signup/"
             )
-            return self._compute_placeholder_impacts(
-                shocks_df, model_version or self.model_version
-            )
+            return self._compute_placeholder_impacts(shocks_df, model_version or self.model_version)
 
         self._validate_bea_sectors(shocks_df)
         model_ver = model_version or self.model_version
@@ -229,9 +227,9 @@ class BEAIOAdapter:
             result = self._compute_impacts_via_bea(shocks_df, model_ver)
             # Check if the result actually used real BEA data or fell back
             if "quality_flags" in result.columns:
-                placeholder_count = result["quality_flags"].str.contains(
-                    "placeholder|failed", na=False
-                ).sum()
+                placeholder_count = (
+                    result["quality_flags"].str.contains("placeholder|failed", na=False).sum()
+                )
                 if placeholder_count > 0:
                     logger.warning(
                         f"BEA I-O computation: {placeholder_count}/{len(result)} "
@@ -248,9 +246,7 @@ class BEAIOAdapter:
             )
             return self._compute_placeholder_impacts(shocks_df, model_ver)
 
-    def _compute_impacts_via_bea(
-        self, shocks_df: pd.DataFrame, model_version: str
-    ) -> pd.DataFrame:
+    def _compute_impacts_via_bea(self, shocks_df: pd.DataFrame, model_version: str) -> pd.DataFrame:
         """Core Leontief computation using BEA Use tables."""
         # Handle multi-year inputs by splitting into per-year groups
         fiscal_years = shocks_df["fiscal_year"].dropna().unique().tolist()
@@ -296,14 +292,12 @@ class BEAIOAdapter:
                 # before the matrix multiplication, then convert back to dollars.
                 state_shocks_millions = state_shocks.copy()
                 state_shocks_millions["shock_amount"] = (
-                    pd.to_numeric(
-                        state_shocks_millions["shock_amount"], errors="coerce"
-                    ).fillna(0.0)
+                    pd.to_numeric(state_shocks_millions["shock_amount"], errors="coerce").fillna(
+                        0.0
+                    )
                     / 1_000_000.0
                 )
-                production_by_sector = apply_demand_shocks(
-                    leontief_inv, state_shocks_millions
-                )
+                production_by_sector = apply_demand_shocks(leontief_inv, state_shocks_millions)
 
                 # Compute employment impacts (jobs) from production vector
                 employment_by_sector = calculate_employment_from_production(
@@ -355,9 +349,7 @@ class BEAIOAdapter:
                         employment_impact = production_millions * 10.0
 
                     quality_flags = (
-                        "bea_api_with_ratios"
-                        if used_actual_ratios
-                        else "bea_api_default_ratios"
+                        "bea_api_with_ratios" if used_actual_ratios else "bea_api_default_ratios"
                     )
 
                     all_results.append(
@@ -469,9 +461,7 @@ class BEAIOAdapter:
         result_df["consumption_impact"] = result_df["shock_amount"] * Decimal("0.2") * multiplier  # type: ignore[operator]
         result_df["tax_impact"] = result_df["shock_amount"] * Decimal("0.15") * multiplier  # type: ignore[operator]
         result_df["production_impact"] = result_df["shock_amount"] * multiplier
-        result_df["employment_impact"] = (
-            result_df["wage_impact"].astype(float) / 100_000
-        )
+        result_df["employment_impact"] = result_df["wage_impact"].astype(float) / 100_000
         result_df["model_version"] = model_version
         result_df["confidence"] = Decimal("0.75")
         result_df["quality_flags"] = "placeholder_computation"

--- a/sbir_etl/transformers/bea_io_functions.py
+++ b/sbir_etl/transformers/bea_io_functions.py
@@ -123,10 +123,7 @@ def fetch_value_added(
     df = raw.copy()
     df["DataValue"] = pd.to_numeric(df["DataValue"], errors="coerce").fillna(0.0)
 
-    logger.info(
-        f"BEA Value Added: {len(df)} rows for year {year}, "
-        f"columns: {list(df.columns)}"
-    )
+    logger.info(f"BEA Value Added: {len(df)} rows for year {year}, columns: {list(df.columns)}")
     return df
 
 
@@ -154,10 +151,7 @@ def fetch_employment(
     df = raw.copy()
     df["DataValue"] = pd.to_numeric(df["DataValue"], errors="coerce").fillna(0.0)
 
-    logger.info(
-        f"BEA Employment: {len(df)} rows for year {year}, "
-        f"columns: {list(df.columns)}"
-    )
+    logger.info(f"BEA Employment: {len(df)} rows for year {year}, columns: {list(df.columns)}")
     return df
 
 
@@ -250,9 +244,7 @@ def calculate_value_added_ratios(
             )
 
         if ratios_data:
-            logger.info(
-                f"BEA VA ratios computed for {len(ratios_data)} sectors"
-            )
+            logger.info(f"BEA VA ratios computed for {len(ratios_data)} sectors")
             return pd.DataFrame(ratios_data)
 
         logger.warning(
@@ -315,9 +307,7 @@ def calculate_employment_coefficients(
                     )
 
         if coefficients:
-            logger.info(
-                f"Employment coefficients computed for {len(coefficients)} sectors"
-            )
+            logger.info(f"Employment coefficients computed for {len(coefficients)} sectors")
         else:
             logger.warning(
                 "Employment coefficients: 0 sectors matched between "
@@ -478,9 +468,7 @@ def calculate_employment_from_production(
 
         for sector in production_by_sector.index:
             production_val = production_by_sector[sector]
-            sector_coeff = employment_coefficients[
-                employment_coefficients["sector"] == str(sector)
-            ]
+            sector_coeff = employment_coefficients[employment_coefficients["sector"] == str(sector)]
 
             if not sector_coeff.empty:
                 coeff = sector_coeff["employment_coefficient"].iloc[0]

--- a/sbir_etl/utils/async_tools.py
+++ b/sbir_etl/utils/async_tools.py
@@ -53,7 +53,5 @@ def run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
     multiple threads (e.g. ``ThreadPoolExecutor`` workers).
     """
     loop = _get_loop()
-    future = asyncio.run_coroutine_threadsafe(
-        cast(Coroutine[Any, Any, Any], coro), loop
-    )
+    future = asyncio.run_coroutine_threadsafe(cast(Coroutine[Any, Any, Any], coro), loop)
     return future.result()

--- a/sbir_etl/utils/cache/api_cache.py
+++ b/sbir_etl/utils/cache/api_cache.py
@@ -41,9 +41,7 @@ class APICache:
             from sbir_etl.utils.path_utils import ensure_dir
 
             ensure_dir(self.cache_dir)
-            logger.debug(
-                f"APICache initialized at {self.cache_dir} (TTL: {ttl_hours}h)"
-            )
+            logger.debug(f"APICache initialized at {self.cache_dir} (TTL: {ttl_hours}h)")
 
     def _generate_cache_key(
         self,

--- a/sbir_etl/utils/cloud_storage.py
+++ b/sbir_etl/utils/cloud_storage.py
@@ -59,9 +59,7 @@ def resolve_data_path(
 
     if is_s3:
         if S3Path is None:
-            raise ImportError(
-                "S3 support requires the 'cloud' extra: pip install sbir-etl[cloud]"
-            )
+            raise ImportError("S3 support requires the 'cloud' extra: pip install sbir-etl[cloud]")
         # Try S3 first
         try:
             s3_path = S3Path(cloud_str)
@@ -489,9 +487,7 @@ def resolve_sbir_awards_csv(
         try:
             s3_url = find_latest_sbir_awards(bucket)
         except (ImportError, ModuleNotFoundError) as e:
-            logger.warning(
-                f"S3 lookup unavailable (missing cloud dependencies): {e}"
-            )
+            logger.warning(f"S3 lookup unavailable (missing cloud dependencies): {e}")
             s3_url = None
         if s3_url:
             logger.info(f"Using S3-cached CSV: {s3_url}")
@@ -500,9 +496,7 @@ def resolve_sbir_awards_csv(
             # Download S3 object to a local temp file so downstream code
             # (DuckDB, pandas) can read it without special S3 handling.
             local_path_resolved = resolve_data_path(s3_url)
-            return SbirAwardsSource(
-                path=local_path_resolved, origin="s3", s3_key_date=key_date
-            )
+            return SbirAwardsSource(path=local_path_resolved, origin="s3", s3_key_date=key_date)
 
     # 2. Download from URL
     logger.info(f"S3 not available; downloading from {download_url}")
@@ -512,7 +506,10 @@ def resolve_sbir_awards_csv(
             response.raise_for_status()
 
         with tempfile.NamedTemporaryFile(
-            mode="wb", suffix=".csv", prefix="sbir_awards_", delete=False,
+            mode="wb",
+            suffix=".csv",
+            prefix="sbir_awards_",
+            delete=False,
         ) as tmp_file:
             tmp_file.write(response.content)
             tmp = Path(tmp_file.name)

--- a/sbir_etl/utils/reporting/formats/base.py
+++ b/sbir_etl/utils/reporting/formats/base.py
@@ -109,5 +109,3 @@ class BaseReportProcessor(ABC):
         """
         # Override in subclasses that include visualizations
         return False
-
-

--- a/sbir_etl/utils/statistical_reporter.py
+++ b/sbir_etl/utils/statistical_reporter.py
@@ -623,5 +623,3 @@ class StatisticalReporter:
 
         collection.pr_comment_generated = True
         logger.info("PR comment content generated")
-
-


### PR DESCRIPTION
## Summary

CI's Code Quality job has been failing because it runs:

```yaml
- run: uv run python -m ruff check src tests
- run: uv run python -m ruff format --check src tests
- run: uv run python -m mypy src
```

`src/` doesn't exist in this repo — the code lives in `sbir_etl/`. Ruff exited 1 immediately with `E902 No such file or directory`, blocking both lint and format from ever evaluating real code. This was hidden until #296 fixed the docs-only gating; before then the job was always skipped.

## Changes

1. **`.github/workflows/ci.yml`**: point the three commands at `sbir_etl` instead of `src`.
2. **`ruff check --fix sbir_etl`** — 5 autofixed, then 5 hand-fixed:
   - Add `from datetime import datetime` to `usaspending/client.py` (F821 — annotation refers to undefined name).
   - Rename `for idx, row` → `for _idx, row` in `sec_edgar/enricher.py` (B007 unused loop var).
   - Add `__all__` to `sbir_etl/quality/__init__.py` so the re-exports are explicit (F401 × 2).
3. **`ruff format sbir_etl`** — 35 files reformatted to canonical style. No semantic changes.

## Out of scope

`mypy sbir_etl` still surfaces **~10 pre-existing type errors across 7 files** (real bugs in `award_history.py`, `patentsview.py`, type narrowing in `usaspending/client.py`, etc.). These need per-call review — fixing blind risks regressions. **Deferred to a separate follow-up PR.** With this PR landed, Code Quality's lint and format steps go green; the mypy step will continue to fail until that follow-up.

## Verification

```
uv run ruff check sbir_etl tests
# → All checks passed!

uv run ruff format --check sbir_etl tests
# → 423 files already formatted
```

Sanity test sweep: 4,108 unit tests pass, 5 pre-existing failures unchanged (the 4 DuckDB + 1 prod-neo4j failures that #300 fixes).

## Test plan

- [ ] On this PR's CI: `Ruff lint` and `Ruff format check` steps pass
- [ ] Mypy step still fails (expected, follow-up)
- [ ] No new failures elsewhere

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur

---
_Generated by [Claude Code](https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur)_