### PR TITLE
fix: clear mypy errors + cure Neo4j auth race in CI integration

### DIFF
--- a/.github/actions/start-neo4j/action.yml
+++ b/.github/actions/start-neo4j/action.yml
@@ -46,6 +46,31 @@ runs:
         port: "7687"
         timeout: ${{ inputs.timeout }}
 
+    # Neo4j's bolt port opens BEFORE auth is fully initialized. Without this
+    # probe, the first integration-test connection can land in the gap and
+    # fail with Neo.ClientError.Security.Unauthorized — which then rate-limits
+    # subsequent attempts (Neo.ClientError.Security.AuthenticationRateLimit).
+    # Poll cypher-shell over docker exec until an authenticated RETURN succeeds.
+    - name: Wait for Neo4j auth to initialize
+      shell: bash
+      run: |
+        set -eu
+        TIMEOUT=${{ inputs.timeout }}
+        ELAPSED=0
+        echo "Probing Neo4j auth as ${{ inputs.neo4j-user }}..."
+        until docker exec ${{ inputs.container-name }} \
+                cypher-shell -u "${{ inputs.neo4j-user }}" -p "${{ inputs.neo4j-password }}" \
+                "RETURN 1" >/dev/null 2>&1; do
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "❌ Neo4j auth did not initialize within ${TIMEOUT}s"
+            docker logs ${{ inputs.container-name }} | tail -50 || true
+            exit 1
+          fi
+          sleep 2
+          ELAPSED=$((ELAPSED + 2))
+        done
+        echo "✅ Neo4j auth ready (waited ${ELAPSED}s)"
+
     - name: Set environment variables
       shell: bash
       run: |

--- a/sbir_etl/enrichers/award_history.py
+++ b/sbir_etl/enrichers/award_history.py
@@ -8,7 +8,7 @@ diligence and trend analysis.
 from __future__ import annotations
 
 import csv
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from loguru import logger
 
@@ -150,8 +150,7 @@ def _build_history_from_csv(
     # Normalize sets to sorted lists and parse dates
     for _name, h in history.items():
         raw_dates = h.pop("dates", [])
-        parsed_dates = [_parse_date_safe(d) for d in raw_dates]
-        parsed_dates = [d for d in parsed_dates if d]
+        parsed_dates: list[str] = [d for d in (_parse_date_safe(d) for d in raw_dates) if d]
         h["earliest_date"] = min(parsed_dates) if parsed_dates else None
         h["latest_date"] = max(parsed_dates) if parsed_dates else None
         for key in ["phases", "agencies", "programs"]:
@@ -169,7 +168,7 @@ def _build_history_from_csv(
 def get_company_history(
     awards: list[dict],
     source: SbirAwardsSource | None = None,
-    extractor: object | None = None,
+    extractor: Any = None,
     table: str | None = None,
 ) -> dict[str, dict]:
     """Extract historical SBIR award context per company from the full dataset.
@@ -211,7 +210,7 @@ def get_company_history(
 def get_pi_history(
     awards: list[dict],
     source: SbirAwardsSource | None = None,
-    extractor: object | None = None,
+    extractor: Any = None,
     table: str | None = None,
 ) -> dict[str, dict]:
     """Extract historical SBIR context per Principal Investigator.

--- a/sbir_etl/enrichers/company_categorization.py
+++ b/sbir_etl/enrichers/company_categorization.py
@@ -124,8 +124,8 @@ def _normalize_company_name_for_search(company_name: str) -> list[str]:
         variations.append(normalized)
 
     base = normalized
-    for pattern in _SUFFIX_STRIPS:
-        base = pattern.sub("", base)
+    for suffix_pat in _SUFFIX_STRIPS:
+        base = suffix_pat.sub("", base)
     base = base.strip().rstrip(",").strip()
     if base and len(base) >= 10 and base not in variations:
         variations.append(base)

--- a/sbir_etl/enrichers/company_enrichment.py
+++ b/sbir_etl/enrichers/company_enrichment.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Any
 
 from loguru import logger
 
@@ -481,24 +482,26 @@ def lookup_sam_entity(
     sam = SyncSAMGovClient()
     try:
         # Try each identifier in priority order; stop on first hit.
-        attempts: list[tuple[str, object, callable]] = []  # type: ignore[valid-type]
+        attempts: list[tuple[str, object, Callable[[], Any]]] = []
         if uei:
             attempts.append(("UEI", uei, lambda: sam.get_entity_by_uei(uei)))
         if cage:
             attempts.append(("CAGE", cage, lambda: sam.get_entity_by_cage(cage)))
         if company_name:
+
+            def _name_lookup() -> Any:
+                results = sam.search_entities(
+                    legal_business_name=company_name,
+                    registration_status="A",
+                    limit=1,
+                )
+                return results[0] if results else None
+
             attempts.append(
                 (
                     "name",
                     company_name,
-                    lambda: (
-                        sam.search_entities(
-                            legal_business_name=company_name,
-                            registration_status="A",
-                            limit=1,
-                        )
-                        or [None]
-                    )[0],
+                    _name_lookup,
                 )
             )
 

--- a/sbir_etl/enrichers/patentsview.py
+++ b/sbir_etl/enrichers/patentsview.py
@@ -255,7 +255,8 @@ class PatentsViewClient:
             response = _do_request()
             return response.json()
         except APIError as e:
-            if e.http_status == 404:
+            # APIError stores http_status under `details`, not as a direct attr.
+            if e.details.get("http_status") == 404:
                 # ODP returns 404 when a search query matches no records
                 logger.debug("USPTO ODP {}: 404 (no results)", endpoint)
                 return {}

--- a/sbir_etl/enrichers/pi_enrichment.py
+++ b/sbir_etl/enrichers/pi_enrichment.py
@@ -126,7 +126,7 @@ def lookup_pi_patents(
         if not patents:
             return None
 
-        titles = []
+        titles: list[str] = []
         assignees: set[str] = set()
         dates: list[str] = []
         for p in patents:

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -631,7 +631,7 @@ async def _resolve_cik(
     query_is_multiword = len(query_clean.split()) > 1
 
     best_match: dict[str, Any] | None = None
-    best_score = 0
+    best_score: float = 0
 
     for result in results:
         entity_name = result.get("entity_name", "")

--- a/sbir_etl/enrichers/usaspending/client.py
+++ b/sbir_etl/enrichers/usaspending/client.py
@@ -126,7 +126,8 @@ class USAspendingAPIClient(BaseAsyncAPIClient):
             self.config = config
             self.api_config = config.get("usaspending_api", {})
 
-        self.base_url = self.api_config.get("base_url", "https://api.usaspending.gov/api/v2")
+        # api_config is typed dict[str, object]; the URL is always a str in practice.
+        self.base_url = str(self.api_config.get("base_url", "https://api.usaspending.gov/api/v2"))
         self.timeout = self.config.get("timeout_seconds", 30)
         self.rate_limit_per_minute = self.config.get("rate_limit_per_minute", 120)
 

--- a/sbir_etl/quality/uspto_validators.py
+++ b/sbir_etl/quality/uspto_validators.py
@@ -430,7 +430,7 @@ def validate_duplicate_records(
 
         for row in iter_rows_from_path(file_path, chunk_size=chunk_size):
             total += 1
-            parts = []
+            parts: list[str] = []
             for f in key_fields:
                 v = row.get(f)
                 if not _nonempty(v):

--- a/sbir_etl/validators/sbir_awards.py
+++ b/sbir_etl/validators/sbir_awards.py
@@ -566,7 +566,7 @@ def validate_sbir_awards(
         logger.error(f"Missing essential columns: {missing_columns}")
         # All rows fail when essential columns are absent
         all_indices = set(df.index.tolist())
-        issues = [
+        issues: list[QualityIssue] = [
             QualityIssue(
                 severity=QualitySeverity.ERROR,
                 field=col,
@@ -595,7 +595,7 @@ def validate_sbir_awards(
     # failing_row_indices stores raw DataFrame index values for filtering.
     # QualityIssue.row_index is typed int|None — coerce safely so non-integer
     # indexes (unlikely but possible) degrade to None rather than crashing.
-    issues: list[QualityIssue] = []
+    issues = []
     failing_row_indices: set[Any] = set()
     for col in essential_columns:
         null_mask = df[col].isna()


### PR DESCRIPTION
Two independent surfaced failures, both addressed:

## mypy (14 → 0 errors)

Pre-existing errors made visible after #298 and #301 landed. Most are
small annotation fixes; a couple are real bugs.

- validators/sbir_awards.py: annotate the if-branch `issues` list
  (mypy treated the inferred type as redefining the explicit
  annotation later in the function).
- quality/uspto_validators.py: annotate the local `parts: list[str]`.
- enrichers/pi_enrichment.py: annotate `titles: list[str]`.
- enrichers/patentsview.py: real bug — `APIError` stores `http_status`
  under `e.details`, not as a direct attribute. The previous
  `e.http_status == 404` check was an `AttributeError` waiting to
  happen on the 404-no-results path.
- enrichers/usaspending/client.py: `api_config` is typed
  `dict[str, object]`; coerce the `.get("base_url")` result through
  `str(...)` so the attribute stays typed.
- enrichers/sec_edgar/enricher.py: `best_score` starts at `0` (int)
  but receives float-valued `score` values; annotate as `float`.
- enrichers/company_categorization.py: the loop variable `pattern`
  was reused for both `_NAME_ABBREVIATIONS` (str) and `_SUFFIX_STRIPS`
  (re.Pattern[str]); rename the second loop to `suffix_pat`.
- enrichers/company_enrichment.py: replace the lowercase `callable`
  annotation (always invalid) with `Callable[[], Any]`. Convert the
  inline `(sam.search_entities(...) or [None])[0]` lambda into a
  named helper that returns the proper `dict | None`.
- enrichers/award_history.py: type `parsed_dates` as `list[str]`
  after the None-filter (so min/max accept it); switch the
  `extractor: object | None` parameters to `Any` since callers do
  attribute access on `extractor.duckdb_client`.

## Neo4j auth race in CI integration tests

The `start-neo4j` action waited for the bolt port to open via TCP
only, then handed off to tests. But Neo4j opens the port before auth
is fully initialized — the first connection lands in the gap and
fails with `Neo.ClientError.Security.Unauthorized`, which then
rate-limits subsequent attempts (`AuthenticationRateLimit`). That's
the source of the 17 integration-test failures the previous CI run
surfaced.

Add a post-port-wait probe in `start-neo4j/action.yml` that polls
`cypher-shell -u <user> -p <password> "RETURN 1"` via `docker exec`
until it succeeds. Once auth is initialized, hand off to tests.

## Verification

- `uv run mypy sbir_etl` → Success: no issues
- `uv run ruff check sbir_etl tests` → clean
- `uv run ruff format --check sbir_etl tests` → clean
- `uv run pytest tests/unit` → 4,113 passed, 0 failed

https://claude.ai/code/session_013y2rnYU32snpyvZE8DyAur