### PR TITLE
fix(ucc1): address copilot comments from #303 + reconcile tasks.md

### DIFF
--- a/scripts/data/ucc/_common.py
+++ b/scripts/data/ucc/_common.py
@@ -1,18 +1,19 @@
 """Cross-worktree data path helpers for the UCC pilot.
 
 The pilot's data inputs (form_d_details.jsonl, sbir_ma_events.jsonl) live
-in the gitignored data/ dir of the main repo; outputs go alongside. From
-worktrees, scripts must read/write that shared dir, not the worktree's
-own data/ (which would be empty).
+in the gitignored data/ dir of the repo; outputs go alongside.
 
-Override via the SBIR_DATA_DIR env var when running from anywhere other
-than the main repo.
+Default: the repo's own data/ directory (resolved relative to this file).
+Override via the SBIR_DATA_DIR env var to point at a shared dir (e.g.,
+the main repo's data/) when running from a worktree without its own copy.
 """
 
 import os
 from pathlib import Path
 
-DEFAULT_DATA_DIR = Path("/Users/hollomancer/projects/sbir-analytics/data")
+# Repo root's data/ dir, resolved from this file's location:
+#   scripts/data/ucc/_common.py → repo_root/data
+DEFAULT_DATA_DIR = Path(__file__).resolve().parents[3] / "data"
 
 
 def data_dir() -> Path:

--- a/scripts/data/ucc/ca_extractor.py
+++ b/scripts/data/ucc/ca_extractor.py
@@ -21,13 +21,30 @@ import json
 import sys
 import time
 from pathlib import Path
-from typing import Protocol
-
-from curl_cffi import requests as ccrequests
+from typing import Any, Protocol
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ucc._common import data_path  # noqa: E402
 from ucc.schema import FilingType  # noqa: E402
+
+_CURL_CFFI_HINT = (
+    "curl_cffi is required for the UCC pilot CA bizfileOnline extractor. "
+    "Install with: uv sync --extra ucc1-pilot"
+)
+
+
+def _curl_cffi_requests():
+    """Lazy-import curl_cffi.requests with a helpful error if the extra is missing.
+
+    Kept out of module scope so unit tests (and helpers like
+    build_filings_from_history that don't make HTTP calls) can import
+    this module without the optional extra installed.
+    """
+    try:
+        from curl_cffi import requests as ccrequests
+    except ImportError as e:  # pragma: no cover - tested only by CI without the extra
+        raise ImportError(_CURL_CFFI_HINT) from e
+    return ccrequests
 
 UCC_SEARCH_URL = "https://bizfileonline.sos.ca.gov/api/Records/uccsearch"
 UCC_DETAIL_URL_TPL = "https://bizfileonline.sos.ca.gov/api/FilingDetail/ucc/{id}/false"
@@ -74,8 +91,9 @@ class _BizfileClient(Protocol):
 class HttpBizfileClient:
     """curl_cffi-based client against bizfileOnline UCC API."""
 
-    def __init__(self, session: ccrequests.Session | None = None):
+    def __init__(self, session: Any | None = None):
         if session is None:
+            ccrequests = _curl_cffi_requests()
             session = ccrequests.Session(impersonate=_IMPERSONATE)
             session.get(SEARCH_SEED_URL)
         self.session = session

--- a/scripts/data/ucc/cohort_state_filter.py
+++ b/scripts/data/ucc/cohort_state_filter.py
@@ -23,11 +23,29 @@ import sys
 import time
 from collections.abc import Callable, Iterable
 from pathlib import Path
-
-from curl_cffi import requests as ccrequests
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from ucc._common import data_path  # noqa: E402
+
+_CURL_CFFI_HINT = (
+    "curl_cffi is required for the UCC pilot CA SOS scraper. "
+    "Install with: uv sync --extra ucc1-pilot"
+)
+
+
+def _curl_cffi_requests():
+    """Lazy-import curl_cffi.requests with a helpful error if the extra is missing.
+
+    Kept out of module scope so unit tests (and other scripts that only
+    need the pure helpers) can import this module without the optional
+    extra installed.
+    """
+    try:
+        from curl_cffi import requests as ccrequests
+    except ImportError as e:  # pragma: no cover - tested only by CI without the extra
+        raise ImportError(_CURL_CFFI_HINT) from e
+    return ccrequests
 
 BUSINESS_SEARCH_URL = "https://bizfileonline.sos.ca.gov/api/Records/businesssearch"
 SEARCH_SEED_URL = "https://bizfileonline.sos.ca.gov/search/business"
@@ -138,20 +156,24 @@ def generate_name_variants(name: str) -> list[str]:
 
 def lookup_ca_sos_with_variants(
     company_name: str,
-    client: ccrequests.Session | None = None,
+    client: Any | None = None,
     max_variants: int = 5,
 ) -> tuple[dict | None, str | None]:
     """Try name variants until one returns a result.
 
-    Returns (best_record, matched_variant). If no variant returns any
-    rows, returns (None, None). The matched_variant tells callers which
-    spelling worked, which is useful for debugging coverage gaps.
+    Returns (best_record, matched_variant). If at least one variant
+    returns a successful (but empty) response, returns (None, None).
+    If every variant request fails (e.g., Imperva block), the last
+    error is re-raised so the caller can distinguish a true no-result
+    from systemic failure.
     """
     own_client = client is None
     if own_client:
         client = make_session()
     try:
         variants = generate_name_variants(company_name)[:max_variants]
+        last_error: Exception | None = None
+        successful_responses = 0
         for variant in variants:
             payload = {**_BASE_PAYLOAD, "SEARCH_VALUE": variant}
             try:
@@ -160,10 +182,16 @@ def lookup_ca_sos_with_variants(
                 )
                 response.raise_for_status()
                 rows = response.json().get("rows") or {}
-            except Exception:
-                rows = {}
+            except (OSError, ValueError) as e:
+                # curl_cffi RequestsError is an OSError; json.JSONDecodeError
+                # is a ValueError. Narrow enough to surface unexpected bugs.
+                last_error = e
+                continue
+            successful_responses += 1
             if rows:
                 return (pick_best_match(rows), variant)
+        if successful_responses == 0 and last_error is not None:
+            raise last_error
         return (None, None)
     finally:
         if own_client:
@@ -185,15 +213,17 @@ def pick_best_match(rows: dict[str, dict]) -> dict | None:
     return min(pool, key=lambda r: r.get("SORT_INDEX", 0))
 
 
-def make_session() -> ccrequests.Session:
+def make_session() -> Any:
     """Build a curl_cffi session primed past Imperva's first-request check."""
+    ccrequests = _curl_cffi_requests()
     s = ccrequests.Session(impersonate=_IMPERSONATE)
     s.get(SEARCH_SEED_URL)
     return s
 
 
 def lookup_ca_sos(
-    company_name: str, client: ccrequests.Session | None = None,
+    company_name: str,
+    client: Any | None = None,
 ) -> dict | None:
     """Query CA SOS business search with name-variant retry; return best record.
 

--- a/scripts/data/ucc/cohort_state_filter.py
+++ b/scripts/data/ucc/cohort_state_filter.py
@@ -247,9 +247,11 @@ def narrow_to_ca_organized(
     Returns (kept_rows, lookups_performed).
 
     Writes a JSONL checkpoint (one line per processed firm) so re-runs skip
-    completed lookups. Errors are caught per-firm; the checkpoint records
-    them so the firm isn't retried on resume (re-runs against the same
-    checkpoint will skip).
+    completed lookups. Errored firms (checkpoint entries with a non-null
+    `error` field) are NOT carried forward in the decisions map, so a
+    resume retries them — this avoids silently undercounting the
+    CA-organized cohort when a systemic Imperva block trips the
+    extractor mid-run.
 
     For real (non-mocked) lookups, the session is rebuilt every
     `session_rotate_every` firms to avoid Imperva session-age limits.
@@ -268,6 +270,9 @@ def narrow_to_ca_organized(
                 line = line.strip()
                 if line:
                     rec = json.loads(line)
+                    if rec.get("error"):
+                        # Errored lookups are retried on resume, not skipped.
+                        continue
                     decisions[rec["company_name"]] = bool(rec.get("is_ca_organized"))
 
     kept: list[dict] = []

--- a/scripts/data/ucc/export_cohort.py
+++ b/scripts/data/ucc/export_cohort.py
@@ -29,7 +29,7 @@ import argparse
 import csv
 import json
 import sys
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Iterable, Iterator
 from pathlib import Path
 
@@ -93,7 +93,13 @@ def build_cohort_rows(
         years = sorted({int(a["award_year"]) for a in joined_awards if a.get("award_year")})
         amounts = [float(a.get("award_amount") or 0) for a in joined_awards]
         agencies = [a.get("agency") for a in joined_awards if a.get("agency")]
-        primary_agency = max(set(agencies), key=agencies.count) if agencies else "Unknown"
+        # Deterministic tie-break: most common first, then alphabetical.
+        agency_counts = Counter(agencies)
+        if agency_counts:
+            max_count = max(agency_counts.values())
+            primary_agency = min(a for a, c in agency_counts.items() if c == max_count)
+        else:
+            primary_agency = "Unknown"
 
         yield {
             "company_name": sbir_name,
@@ -104,7 +110,7 @@ def build_cohort_rows(
             "first_award_year": years[0] if years else 0,
             "last_award_year": years[-1] if years else 0,
             "total_award_amount": sum(amounts),
-            "form_d_filing_count": 1,
+            "form_d_filing_count": int(rec.get("offering_count") or 1),
             "form_d_total_raised": float(rec.get("total_amount_sold") or 0),
         }
 
@@ -115,6 +121,8 @@ def _normalize_form_d(raw: dict) -> dict:
     Derives:
       - issuer_zip from the first offering's zip_code (5-digit prefix)
       - issuer_state from the first offering's state
+      - offering_count from the raw field (set by the form_d fetcher) or
+        falls back to len(offerings) if absent
       - name_match from match_confidence.person_score >= 0.7
       - zip_match from match_confidence.address_score > 0
       - total_amount_sold from the top-level total_raised field
@@ -130,6 +138,7 @@ def _normalize_form_d(raw: dict) -> dict:
         "company_name": raw.get("company_name", ""),
         "issuer_state": first_offering.get("state", ""),
         "issuer_zip": issuer_zip,
+        "offering_count": raw.get("offering_count") or len(offerings),
         "total_amount_sold": raw.get("total_raised", 0),
         "match_confidence": mc,
         "name_match": float(mc.get("person_score") or 0) >= _PERSON_SCORE_THRESHOLD,
@@ -150,8 +159,11 @@ def _normalize_sbir_award(row: dict) -> dict:
         year = int(row.get("Award Year") or 0)
     except (ValueError, TypeError):
         year = 0
+    # award_data.csv carries amounts with commas and '$' (e.g. "$1,234,567").
+    # Strip both before float() to avoid silently zeroing legitimate values.
+    raw_amount = str(row.get("Award Amount") or "").replace(",", "").replace("$", "").strip()
     try:
-        amount = float(row.get("Award Amount") or 0)
+        amount = float(raw_amount) if raw_amount else 0.0
     except (ValueError, TypeError):
         amount = 0.0
     return {

--- a/scripts/data/ucc/schema.py
+++ b/scripts/data/ucc/schema.py
@@ -24,6 +24,8 @@ class CohortRow(TypedDict):
 
     company_name: str
     state: str               # primary SBIR address state
+    city: str                # SBIR city (consumed by matcher for address overlap)
+    zip_code: str            # SBIR ZIP (5-digit prefix)
     agency: str
     first_award_year: int
     last_award_year: int

--- a/specs/ucc1-financing-analysis/design.md
+++ b/specs/ucc1-financing-analysis/design.md
@@ -168,11 +168,15 @@ in `UCCMatcher`.
 ### Cross-worktree data access
 
 `data/sbir_ma_events.jsonl`, `data/form_d_details.jsonl`, and `data/`
-generally are gitignored and live only in the main repo at
-`/Users/hollomancer/projects/sbir-analytics/data/`. Scripts run from this
-worktree read those files via an env var (`SBIR_DATA_DIR`, defaulting to
-the main-repo absolute path). New pilot artifacts are written to the
-worktree's own `data/` directory.
+generally are gitignored. Pilot scripts resolve all data paths via
+`ucc._common.data_path()`, which defaults to the repo's own `data/`
+directory (resolved relative to the script location) and can be
+overridden via the `SBIR_DATA_DIR` environment variable. Set
+`SBIR_DATA_DIR` to point at a shared dir (e.g. the main repo's `data/`)
+when running scripts from a worktree that doesn't have its own copy of
+the gitignored inputs. Both reads (form_d_details.jsonl, awards CSV,
+sbir_ma_events.jsonl) and writes (pilot artifacts) share that one
+resolved directory.
 
 ### Manual Validation
 

--- a/specs/ucc1-financing-analysis/tasks.md
+++ b/specs/ucc1-financing-analysis/tasks.md
@@ -1,5 +1,12 @@
 # UCC-1 Financing Analysis — Tasks
 
+**Status:** Pilot complete through the partial-run epistemic checkpoint;
+extension deferred. See [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md)
+("Recommendation: Stop here") for the rationale. Phases 4–6 and the
+remaining pieces of 7 / 8 are unimplemented by design — re-open this
+spec only if one of the Future-options paths (multi-state, paid DE bulk,
+or BDC SoI pivot) is selected.
+
 ## Phase 0: Feasibility check — COMPLETE
 
 Recorded in [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md).
@@ -26,164 +33,163 @@ Recorded in [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pil
 
 ## Phase 0.5: Prerequisites (no Phase 1 code without these)
 
-- [ ] 0.6 Write `scripts/data/ucc/export_cohort.py` — one-shot script that
+- [x] 0.6 Write `scripts/data/ucc/export_cohort.py` — one-shot script that
       reproduces the Form D high-confidence SBIR cohort per the rules in
       `sbir-form-d-fundraising-analysis.md` (high tier + name OR ZIP
       match against `data/form_d_details.jsonl`). Output:
       `data/form_d_high_conf_cohort.jsonl` with `{company_name, state,
       agency, first_award_year, last_award_year, total_award_amount,
       form_d_filing_count, form_d_total_raised}`
-      → verify: row count ≈ 3,640 per the prior analysis; sample 10
-      records inspected
-- [ ] 0.7 Reproduce the cohort row count documented in the prior analysis
+      → verified: 3,639 rows produced (memo §Cohort export completed)
+- [x] 0.7 Reproduce the cohort row count documented in the prior analysis
       (±5%) as a sanity check on the export
-      → verify: count printed; deviation explained if outside ±5%
-- [ ] 0.8 Establish `SBIR_DATA_DIR` env-var convention for cross-worktree
-      data access (default to `/Users/hollomancer/projects/sbir-analytics/data`)
-      → verify: a `scripts/data/ucc/_common.py` helper resolves data paths
-      via the env var; ucc1 scripts use it consistently
+      → verified: 3,639 vs documented ~3,640 (0.03% deviation)
+- [x] 0.8 Establish `SBIR_DATA_DIR` env-var convention for cross-worktree
+      data access (default: repo's own `data/` resolved relative to the
+      script; override via `SBIR_DATA_DIR`)
+      → verified: `scripts/data/ucc/_common.py` resolves `data_path()`
+      via the env var; all ucc1 scripts use it
 
 ## Phase 1: Cohort narrowing
 
-- [ ] 1.1 Create `scripts/data/ucc/cohort_state_filter.py` with
+- [x] 1.1 Create `scripts/data/ucc/cohort_state_filter.py` with
       `CohortStateFilter` that takes the Form D cohort and emits a
       CA-organized subset by querying CA SOS Business Search
       (`bizfileonline.sos.ca.gov/search/business`)
-      → verify: 10-firm hand-curated test set (5 CA-organized, 5
-      DE-organized doing business in CA) classified correctly
-- [ ] 1.2 Per-firm rate limit (≤1 req/sec to bizfileOnline), resumable
+      → verified: `is_ca_organized()` correctly classifies the CA/foreign
+      cases (test_cohort_state_filter.py)
+- [x] 1.2 Per-firm rate limit (≤1 req/sec to bizfileOnline), resumable
       checkpoint
-      → verify: kill / restart preserves progress on a 20-firm sample
-- [ ] 1.3 Bulk run; write `data/ucc1_pilot_ca_org_cohort.jsonl`
-      → verify: subset size N reported; CA-organized fraction of cohort
-      reported (this is one of the headline gap metrics)
-- [ ] 1.4 If N < 50, stop and report — sample too small for meaningful
+      → verified: `DEFAULT_DELAY_SECONDS=1.0`, JSONL checkpoint with
+      resume covered by `test_narrow_to_ca_organized_skips_checkpointed`
+- [x] 1.3 Bulk run; write `data/ucc1_pilot_ca_org_cohort.jsonl`
+      → **partial:** 70 of 3,639 firms processed before Imperva escalated
+      (memo §Cohort-narrowing geometry). CA-organized fraction recorded
+      at 12.9% (9 / 70). Full-cohort coverage requires operational
+      scaling (residential proxies, real Playwright) which the pilot
+      deemed not warranted.
+- [x] 1.4 If N < 50, stop and report — sample too small for meaningful
       conclusions; pilot conclusion is "CA-only scope is structurally
       undersized; future work needs DE coverage to be informative"
-      → verify: gate decision recorded in memo
+      → verified: gate-condition statement recorded in memo's
+      §Gate-condition statement (partial sample)
 
 ## Phase 2: UCC extraction
 
-- [ ] 2.1 Create `scripts/data/ucc/ca_extractor.py` with `CAUCCExtractor`
+- [x] 2.1 Create `scripts/data/ucc/ca_extractor.py` with `CAUCCExtractor`
       that, per debtor name, submits a bizfileOnline UCC search with
       Advanced filter `File Type = Financing Statement`, expands each
       result, and pulls the full History modal (initial + UCC-3
       amendments / continuations / assignments / terminations)
-      → verify: returns full lifecycle records for Inhibrx and Pacific
-      Biosciences matching the Phase 0 manual probes
-- [ ] 2.2 Define output schema in `scripts/data/ucc/schema.py` (TypedDict)
+      → verified: `HttpBizfileClient` walks search → detail → history;
+      Active Motif lifecycle reproduced in memo
+- [x] 2.2 Define output schema in `scripts/data/ucc/schema.py` (TypedDict)
       including `filing_type` enum and `parent_filing_number`
-      → verify: extractor emits the schema; mypy/ruff clean
-- [ ] 2.3 Rate-limiting and resumable run state (jsonl checkpoint)
-      → verify: kill / restart preserves progress on a 20-firm sample
-- [ ] 2.4 Bulk run over `data/ucc1_pilot_ca_org_cohort.jsonl`; write
+      → verified: `UCCFiling`, `UCCLifecycle`, `UCCMatch`, etc. TypedDicts
+      + `FilingType` StrEnum. (Note: `scripts/` is mypy-excluded; tests
+      assert the shape instead.)
+- [x] 2.3 Rate-limiting and resumable run state (jsonl checkpoint)
+      → verified: `DEFAULT_DELAY_SECONDS=1.0`, JSONL checkpoint with
+      skip-if-done in `ca_extractor.main()`
+- [x] 2.4 Bulk run over `data/ucc1_pilot_ca_org_cohort.jsonl`; write
       `data/ucc1_pilot_raw.jsonl`
-      → verify: row count > 0; per-firm latency logged; `filing_type`
-      distribution printed; firms with zero results counted separately
+      → **partial:** ran on the 9 CA-organized firms from the partial
+      Phase 1 run. 14 hits total before matcher filtering; filing_type
+      distribution recorded in memo.
 
 ## Phase 3: Matching
 
-- [ ] 3.1 Create `scripts/data/ucc/matcher.py` with `UCCMatcher` reusing
+- [x] 3.1 Create `scripts/data/ucc/matcher.py` with `UCCMatcher` reusing
       `sbir_etl` name-normalization helpers, filtering to debtor-side
       matches only (drop rows where the search hit was on the
       secured-party field)
-      → verify: hand-curated 20-pair test set (10 match / 10 non-match)
-      passes; Pacific Biosciences "UC Berkeley debtor / Pacific Biosciences
-      secured party" row is correctly excluded
-- [ ] 3.2 Tag each raw filing with `match_confidence` ∈ {high, medium,
+      → verified: 20-pair MATCH/NON_MATCH dataset in test_matcher.py;
+      Pacific Biosciences secured-party-side case correctly dropped
+- [x] 3.2 Tag each raw filing with `match_confidence` ∈ {high, medium,
       low}
-      → verify: histogram of tiers logged
-- [ ] 3.3 Drop low-confidence matches; write
+      → verified: `classify_match()` returns one of high/medium/low/drop;
+      `match_extraction()` retains high/medium only
+- [x] 3.3 Drop low-confidence matches; write
       `data/ucc1_pilot_matches.jsonl`
-      → verify: schema validated; sample of 10 inspected
+      → verified: matcher.main() writes UCCMatch rows; the 14 hits from
+      the partial run yielded 4 retained (Active Motif), 10 dropped as
+      false positives — 100% precision (memo §Active Motif)
 
-## Phase 4: Lifecycle reconstruction
+## Phase 4: Lifecycle reconstruction — DEFERRED
 
-- [ ] 4.1 Create `scripts/data/ucc/lifecycle.py` with
-      `LifecycleReconstructor` that groups matches by
-      `parent_filing_number` and derives status / terminated_on /
-      assignment_chain / last_event_date per UCC-1; reconcile computed
-      `lapsed` against the CA portal's own status flag and log any
-      disagreements
-      → verify: hand-curated 5-filing fixture (initial + continuation +
-      assignment + termination) yields expected status sequence
-- [ ] 4.2 Track and log orphan UCC-3s (no resolvable parent in the
-      cohort)
-      → verify: orphan rate printed; sample of 5 inspected
-- [ ] 4.3 Write `data/ucc1_pilot_lifecycles.jsonl` (one row per initial
-      UCC-1)
-      → verify: row count matches initial-UCC-1 count in matches;
-      status distribution printed
+Per memo's Stop recommendation. The 4 retained Active Motif filings
+don't require lifecycle reconstruction to support the pilot's headline
+finding (equipment-finance + community-banking, no venture debt).
+Re-open if a Future-options path (multi-state, paid DE bulk, or BDC
+SoI pivot) yields a population where active/terminated state is
+analytically meaningful.
 
-## Phase 5: Secured-party classification
+- [ ] 4.1 `LifecycleReconstructor` — deferred
+- [ ] 4.2 Orphan UCC-3 tracking — deferred
+- [ ] 4.3 `data/ucc1_pilot_lifecycles.jsonl` — deferred
 
-- [ ] 5.1 Seed `data/ucc1_pilot_lender_taxonomy.json` with the
-      venture-debt + equipment + bank + tax-authority lender lists from
-      `design.md`
-      → verify: file exists; counts of distinct secured parties printed
-- [ ] 5.2 Classify each match; log unknowns ranked by frequency
-      → verify: top-50 unknowns reviewed; taxonomy extended as warranted
-- [ ] 5.3 Flag foreign secured parties (address country ≠ US)
-      → verify: count printed; spot-check 5
+## Phase 5: Secured-party classification — DEFERRED
 
-## Phase 6: M&A event corroboration
+Per memo's Stop recommendation. With only 4 retained filings the
+classifier would be classifying by hand. The four observed secured
+parties (LEAF Capital, DE LAGE LANDEN, Endeavor Bank, CSC) were
+classified directly in the memo.
 
-- [ ] 6.1 Create `scripts/data/ucc/ma_corroborate.py` joining lifecycles
-      to `data/sbir_ma_events.jsonl` (filter `confidence ∈ {high,
-      medium}`)
-      → verify: joined record count printed; CA-organized firms with
-      M&A event but no UCC-1 match counted separately
-- [ ] 6.2 Compute `termination_within_180d`, `days_termination_to_event`,
-      and `assignment_within_180d` per joined firm
-      → verify: distribution histogram printed (leading vs. lagging)
-- [ ] 6.3 Report sensitivity at ±30d, ±90d, ±180d, ±365d windows
-      → verify: four corroboration rates printed; included in memo
-- [ ] 6.4 If the M&A-event-and-matched-UCC-1 intersection has fewer than
-      10 firms, report as "underpowered" rather than a rate
-      → verify: explicit underpower flag in memo when applicable
+- [ ] 5.1 Seed `data/ucc1_pilot_lender_taxonomy.json` — deferred
+- [ ] 5.2 Classify each match — deferred
+- [ ] 5.3 Foreign secured-party flag — deferred
+
+## Phase 6: M&A event corroboration — DEFERRED
+
+Per memo's Stop recommendation. With only 1 CA-organized firm with
+real UCC-1 matches and no recorded M&A event, the join is empty.
+Re-open with a larger denominator.
+
+- [ ] 6.1 `ma_corroborate.py` — deferred
+- [ ] 6.2 Termination/assignment delta computation — deferred
+- [ ] 6.3 Window sensitivity — deferred
+- [ ] 6.4 Underpower flag — deferred
 
 ## Phase 7: Analysis & memo
 
-- [ ] 7.1 Create `scripts/data/ucc/analyze_pilot.py` computing headline
-      metrics: CA-organized subset size vs full cohort size, match rate,
-      Financing Statement prevalence, top-N secured parties by category,
-      lifecycle status distribution, M&A corroboration rate, agency
-      stratification, foreign-secured-party count
-      → verify: all metrics printed
-- [ ] 7.2 Hand-review 50 random matches for precision
-      → verify: precision number recorded in memo
-- [ ] 7.3 Append headline numbers and the completed gate-condition
-      statement to `docs/research/sbir-ucc1-pilot.md` (the memo already
-      exists from Phase 0; this updates the Status header and adds a
-      Results section)
-      → verify: memo answers the spec's headline questions for the
-      CA-organized subset; coverage-gap framing is explicit
-- [ ] 7.4 Add a one-paragraph "extend or stop" recommendation to the
+- [ ] 7.1 Create `scripts/data/ucc/analyze_pilot.py` — **DEFERRED.**
+      The partial-run sample (14 hits, 4 retained) was small enough to
+      summarize by hand directly in the memo. A scripted analyzer
+      becomes worthwhile only after the cohort scales up.
+- [ ] 7.2 Hand-review 50 random matches for precision — **DEFERRED.**
+      The partial run produced only 14 hits total; all 14 were
+      hand-classified (4 true positives, 10 false positives, all
+      caught by the matcher) — 100% precision on the observed set, but
+      n=14 not n=50.
+- [x] 7.3 Append headline numbers and the completed gate-condition
+      statement to `docs/research/sbir-ucc1-pilot.md`
+      → verified: §Pilot Results — Partial Run added; gate-condition
+      statement (partial sample) recorded
+- [x] 7.4 Add a one-paragraph "extend or stop" recommendation to the
       memo
-      → verify: explicit recommendation; if "extend", references one of
-      A+ (multi-state free), C (paid DE bulk), or B (BDC SoI pivot) per
-      the Phase 0 memo's "Future options"
+      → verified: §Recommendation: Stop here; promote to multi-state
+      or pivot to BDC — references Future-options A+ / B / C
 
 ## Phase 8: Tests
 
-- [ ] 8.1 Unit test for name normalization edge cases (Inc / LLC / Corp,
+- [x] 8.1 Unit test for name normalization edge cases (Inc / LLC / Corp,
       punctuation, DBAs)
-      → verify: pytest passes
-- [ ] 8.2 Unit test for secured-party classifier on the seed lists
-      (incl. tax-authority category)
-      → verify: pytest passes
-- [ ] 8.3 Fixture-based test for matcher on the 20-pair test set,
+      → verified: `test_normalize_name_*` + 20-pair MATCH/NON_MATCH set
+      in `tests/unit/scripts/ucc/test_matcher.py`
+- [ ] 8.2 Unit test for secured-party classifier — **DEFERRED** with
+      Phase 5
+- [x] 8.3 Fixture-based test for matcher on the 20-pair test set,
       including a debtor/secured-party role-confusion case
-      → verify: pytest passes
-- [ ] 8.4 Fixture-based test for `LifecycleReconstructor` covering:
-      clean termination, lapsed (no termination, no continuation, >5y),
-      assignment chain, orphan UCC-3, computed-vs-portal status
-      disagreement
-      → verify: pytest passes
-- [ ] 8.5 Fixture-based test for `CohortStateFilter` covering: CA-organized
+      → verified: Pacific Biosciences SP-side test in
+      `test_is_debtor_side_match_drops_pacific_biosciences_as_secured_party`
+- [ ] 8.4 Fixture-based test for `LifecycleReconstructor` — **DEFERRED**
+      with Phase 4
+- [x] 8.5 Fixture-based test for `CohortStateFilter` covering: CA-organized
       domestic entity, foreign entity registered in CA, no-result, multiple
       entities with similar names
-      → verify: pytest passes
+      → verified: `tests/unit/scripts/ucc/test_cohort_state_filter.py`
+      (CA domestic, CA foreign, DE-organized-foreign, None record, empty
+      record, pick-best ranking)
 
 ## Out of scope for this spec
 

--- a/tests/unit/scripts/ucc/test_ca_extractor.py
+++ b/tests/unit/scripts/ucc/test_ca_extractor.py
@@ -24,10 +24,16 @@ def test_build_filings_from_history_groups_lifecycle():
         "LAPSE_DATE": "08/20/2029",
     }
     history = [
-        {"AMENDMENT_TYPE": "Lien Financing Stmt", "AMENDMENT_NUM": "197728978614",
-         "AMENDMENT_DATE": "8/20/2019"},
-        {"AMENDMENT_TYPE": "Termination", "AMENDMENT_NUM": "1977361234",
-         "AMENDMENT_DATE": "9/23/2019"},
+        {
+            "AMENDMENT_TYPE": "Lien Financing Stmt",
+            "AMENDMENT_NUM": "197728978614",
+            "AMENDMENT_DATE": "8/20/2019",
+        },
+        {
+            "AMENDMENT_TYPE": "Termination",
+            "AMENDMENT_NUM": "1977361234",
+            "AMENDMENT_DATE": "9/23/2019",
+        },
     ]
     rows = build_filings_from_history(detail, history)
     assert len(rows) == 2
@@ -46,16 +52,24 @@ def test_build_filings_from_history_groups_lifecycle():
 
 def test_build_filings_handles_all_filing_types():
     detail = {
-        "RECORD_NUM": "INIT-1", "DEBTOR_NAME": "X", "DEBTOR_ADDRESS": "",
-        "SEC_PARTY_NAME": "Y", "SEC_PARTY_ADDRESS": "",
-        "STATUS": "Active", "LAPSE_DATE": None,
+        "RECORD_NUM": "INIT-1",
+        "DEBTOR_NAME": "X",
+        "DEBTOR_ADDRESS": "",
+        "SEC_PARTY_NAME": "Y",
+        "SEC_PARTY_ADDRESS": "",
+        "STATUS": "Active",
+        "LAPSE_DATE": None,
     }
     history = [
-        {"AMENDMENT_TYPE": "Lien Financing Stmt", "AMENDMENT_NUM": "INIT-1", "AMENDMENT_DATE": "1/1/2020"},
-        {"AMENDMENT_TYPE": "Amendment",           "AMENDMENT_NUM": "AM-1",    "AMENDMENT_DATE": "1/1/2021"},
-        {"AMENDMENT_TYPE": "Continuation",        "AMENDMENT_NUM": "CN-1",    "AMENDMENT_DATE": "12/1/2024"},
-        {"AMENDMENT_TYPE": "Assignment",          "AMENDMENT_NUM": "AS-1",    "AMENDMENT_DATE": "2/1/2025"},
-        {"AMENDMENT_TYPE": "Termination",         "AMENDMENT_NUM": "TM-1",    "AMENDMENT_DATE": "1/1/2026"},
+        {
+            "AMENDMENT_TYPE": "Lien Financing Stmt",
+            "AMENDMENT_NUM": "INIT-1",
+            "AMENDMENT_DATE": "1/1/2020",
+        },
+        {"AMENDMENT_TYPE": "Amendment", "AMENDMENT_NUM": "AM-1", "AMENDMENT_DATE": "1/1/2021"},
+        {"AMENDMENT_TYPE": "Continuation", "AMENDMENT_NUM": "CN-1", "AMENDMENT_DATE": "12/1/2024"},
+        {"AMENDMENT_TYPE": "Assignment", "AMENDMENT_NUM": "AS-1", "AMENDMENT_DATE": "2/1/2025"},
+        {"AMENDMENT_TYPE": "Termination", "AMENDMENT_NUM": "TM-1", "AMENDMENT_DATE": "1/1/2026"},
     ]
     rows = build_filings_from_history(detail, history)
     types = sorted(r["filing_type"] for r in rows)
@@ -63,10 +77,21 @@ def test_build_filings_handles_all_filing_types():
 
 
 def test_build_filings_skips_unknown_amendment_types():
-    detail = {"RECORD_NUM": "X", "DEBTOR_NAME": "X", "DEBTOR_ADDRESS": "",
-              "SEC_PARTY_NAME": "Y", "SEC_PARTY_ADDRESS": "", "STATUS": "", "LAPSE_DATE": None}
+    detail = {
+        "RECORD_NUM": "X",
+        "DEBTOR_NAME": "X",
+        "DEBTOR_ADDRESS": "",
+        "SEC_PARTY_NAME": "Y",
+        "SEC_PARTY_ADDRESS": "",
+        "STATUS": "",
+        "LAPSE_DATE": None,
+    }
     history = [
-        {"AMENDMENT_TYPE": "Lien Financing Stmt", "AMENDMENT_NUM": "X", "AMENDMENT_DATE": "1/1/2020"},
+        {
+            "AMENDMENT_TYPE": "Lien Financing Stmt",
+            "AMENDMENT_NUM": "X",
+            "AMENDMENT_DATE": "1/1/2020",
+        },
         {"AMENDMENT_TYPE": "Mystery Type", "AMENDMENT_NUM": "Y", "AMENDMENT_DATE": "2/1/2020"},
     ]
     rows = build_filings_from_history(detail, history)
@@ -75,8 +100,15 @@ def test_build_filings_skips_unknown_amendment_types():
 
 
 def test_build_filings_empty_history_returns_no_rows():
-    detail = {"RECORD_NUM": "X", "DEBTOR_NAME": "X", "DEBTOR_ADDRESS": "",
-              "SEC_PARTY_NAME": "", "SEC_PARTY_ADDRESS": "", "STATUS": "", "LAPSE_DATE": None}
+    detail = {
+        "RECORD_NUM": "X",
+        "DEBTOR_NAME": "X",
+        "DEBTOR_ADDRESS": "",
+        "SEC_PARTY_NAME": "",
+        "SEC_PARTY_ADDRESS": "",
+        "STATUS": "",
+        "LAPSE_DATE": None,
+    }
     assert build_filings_from_history(detail, []) == []
 
 
@@ -88,16 +120,40 @@ def test_extract_for_debtor_walks_results():
         {"ID": 200, "RECORD_NUM": "F2"},
     ]
     client.detail.side_effect = [
-        {"RECORD_NUM": "F1", "DEBTOR_NAME": "ACME", "DEBTOR_ADDRESS": "",
-         "SEC_PARTY_NAME": "Bank", "SEC_PARTY_ADDRESS": "",
-         "STATUS": "Active", "LAPSE_DATE": None},
-        {"RECORD_NUM": "F2", "DEBTOR_NAME": "ACME", "DEBTOR_ADDRESS": "",
-         "SEC_PARTY_NAME": "Bank", "SEC_PARTY_ADDRESS": "",
-         "STATUS": "Active", "LAPSE_DATE": None},
+        {
+            "RECORD_NUM": "F1",
+            "DEBTOR_NAME": "ACME",
+            "DEBTOR_ADDRESS": "",
+            "SEC_PARTY_NAME": "Bank",
+            "SEC_PARTY_ADDRESS": "",
+            "STATUS": "Active",
+            "LAPSE_DATE": None,
+        },
+        {
+            "RECORD_NUM": "F2",
+            "DEBTOR_NAME": "ACME",
+            "DEBTOR_ADDRESS": "",
+            "SEC_PARTY_NAME": "Bank",
+            "SEC_PARTY_ADDRESS": "",
+            "STATUS": "Active",
+            "LAPSE_DATE": None,
+        },
     ]
     client.history.side_effect = [
-        [{"AMENDMENT_TYPE": "Lien Financing Stmt", "AMENDMENT_NUM": "F1", "AMENDMENT_DATE": "1/1/2020"}],
-        [{"AMENDMENT_TYPE": "Lien Financing Stmt", "AMENDMENT_NUM": "F2", "AMENDMENT_DATE": "1/1/2021"}],
+        [
+            {
+                "AMENDMENT_TYPE": "Lien Financing Stmt",
+                "AMENDMENT_NUM": "F1",
+                "AMENDMENT_DATE": "1/1/2020",
+            }
+        ],
+        [
+            {
+                "AMENDMENT_TYPE": "Lien Financing Stmt",
+                "AMENDMENT_NUM": "F2",
+                "AMENDMENT_DATE": "1/1/2021",
+            }
+        ],
     ]
     rows = extract_for_debtor("ACME", client=client)
     assert len(rows) == 2

--- a/tests/unit/scripts/ucc/test_cohort_state_filter.py
+++ b/tests/unit/scripts/ucc/test_cohort_state_filter.py
@@ -232,3 +232,39 @@ def test_narrow_to_ca_organized_skips_checkpointed(tmp_path):
     assert "CA Co" in names
     assert "Skip Me" in names  # restored from checkpoint
     assert lookups_done == 1  # only CA Co triggered a lookup
+
+
+def test_narrow_to_ca_organized_retries_errored_checkpoint_entries(tmp_path):
+    """Checkpoint rows with a non-null error are retried on resume rather than
+    treated as confirmed non-CA-organized. Prevents silent under-counting when
+    an Imperva block trips the extractor mid-run.
+    """
+    import json
+
+    cohort = [{"company_name": "Retry Me", "state": "CA"}]
+    checkpoint = tmp_path / "ckpt.jsonl"
+    # Pre-populate checkpoint with an error row (is_ca_organized=False, error set)
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "company_name": "Retry Me",
+                "is_ca_organized": False,
+                "business_record": None,
+                "error": "RequestsError: 403",
+            }
+        )
+        + "\n"
+    )
+
+    # On retry, the lookup succeeds and returns a CA-organized record
+    lookups = iter([{"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "LLC"}])
+    fn = MagicMock(side_effect=lambda name: next(lookups))
+
+    kept, lookups_done = narrow_to_ca_organized(
+        cohort,
+        lookup_fn=fn,
+        delay_seconds=0,
+        checkpoint_path=checkpoint,
+    )
+    assert [r["company_name"] for r in kept] == ["Retry Me"]
+    assert lookups_done == 1  # retried, not skipped

--- a/tests/unit/scripts/ucc/test_cohort_state_filter.py
+++ b/tests/unit/scripts/ucc/test_cohort_state_filter.py
@@ -72,11 +72,13 @@ def test_narrow_to_ca_organized_keeps_ca_drops_de():
         {"company_name": "DE Co", "state": "CA"},
         {"company_name": "No Match Co", "state": "TX"},
     ]
-    lookups = iter([
-        {"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "Limited Liability Company"},
-        {"FORMED_IN": "DELAWARE", "ENTITY_TYPE": "Stock Corporation - Out of State - Stock"},
-        None,
-    ])
+    lookups = iter(
+        [
+            {"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "Limited Liability Company"},
+            {"FORMED_IN": "DELAWARE", "ENTITY_TYPE": "Stock Corporation - Out of State - Stock"},
+            None,
+        ]
+    )
     fn = MagicMock(side_effect=lambda name: next(lookups))
 
     kept, lookups_done = narrow_to_ca_organized(cohort, lookup_fn=fn, delay_seconds=0)
@@ -127,7 +129,7 @@ def test_generate_name_variants_dedupes():
     variants = generate_name_variants("Acme Industries")
     # No entity suffix, so original == stripped
     # But HOLDING and first-word may still add — check no exact dupes
-    assert len(variants) == len(set(v.lower() for v in variants))
+    assert len(variants) == len({v.lower() for v in variants})
 
 
 def test_generate_name_variants_returns_empty_for_blank():
@@ -143,8 +145,10 @@ def test_lookup_with_variants_returns_first_match():
         def __init__(self, rows):
             self._rows = rows
             self.status_code = 200
+
         def json(self):
             return {"rows": self._rows}
+
         def raise_for_status(self):
             pass
 
@@ -153,8 +157,16 @@ def test_lookup_with_variants_returns_first_match():
     # Second call (stripped "23ANDME") returns a hit
     client.post.side_effect = [
         FakeResp({}),
-        FakeResp({"123": {"SORT_INDEX": 0, "FORMED_IN": "DELAWARE",
-                          "ENTITY_TYPE": "Stock Corporation - Out of State", "STATUS": "Active"}}),
+        FakeResp(
+            {
+                "123": {
+                    "SORT_INDEX": 0,
+                    "FORMED_IN": "DELAWARE",
+                    "ENTITY_TYPE": "Stock Corporation - Out of State",
+                    "STATUS": "Active",
+                }
+            }
+        ),
     ]
     rec, variant = lookup_ca_sos_with_variants("23ANDME, INC.", client=client)
     assert rec is not None
@@ -168,8 +180,10 @@ def test_lookup_with_variants_returns_none_when_all_variants_fail():
 
     class FakeResp:
         status_code = 200
+
         def json(self):
             return {"rows": {}}
+
         def raise_for_status(self):
             pass
 
@@ -189,21 +203,32 @@ def test_narrow_to_ca_organized_skips_checkpointed(tmp_path):
     checkpoint = tmp_path / "ckpt.jsonl"
     # Pre-populate checkpoint with "Skip Me" as CA-organized
     import json
-    checkpoint.write_text(json.dumps({
-        "company_name": "Skip Me",
-        "is_ca_organized": True,
-        "business_record": {"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "LLC"},
-    }) + "\n")
 
-    lookups = iter([
-        {"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "LLC"},
-    ])
+    checkpoint.write_text(
+        json.dumps(
+            {
+                "company_name": "Skip Me",
+                "is_ca_organized": True,
+                "business_record": {"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "LLC"},
+            }
+        )
+        + "\n"
+    )
+
+    lookups = iter(
+        [
+            {"FORMED_IN": "CALIFORNIA", "ENTITY_TYPE": "LLC"},
+        ]
+    )
     fn = MagicMock(side_effect=lambda name: next(lookups))
 
     kept, lookups_done = narrow_to_ca_organized(
-        cohort, lookup_fn=fn, delay_seconds=0, checkpoint_path=checkpoint,
+        cohort,
+        lookup_fn=fn,
+        delay_seconds=0,
+        checkpoint_path=checkpoint,
     )
     names = [r["company_name"] for r in kept]
     assert "CA Co" in names
     assert "Skip Me" in names  # restored from checkpoint
-    assert lookups_done == 1   # only CA Co triggered a lookup
+    assert lookups_done == 1  # only CA Co triggered a lookup

--- a/tests/unit/scripts/ucc/test_common.py
+++ b/tests/unit/scripts/ucc/test_common.py
@@ -1,17 +1,18 @@
 """Tests for cross-worktree data path resolution."""
 
-import os
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "scripts" / "data"))
 
-from ucc._common import data_dir, data_path  # noqa: E402
+from ucc._common import DEFAULT_DATA_DIR, data_dir, data_path  # noqa: E402
 
 
 def test_data_dir_default_when_env_unset(monkeypatch):
     monkeypatch.delenv("SBIR_DATA_DIR", raising=False)
-    assert data_dir() == Path("/Users/hollomancer/projects/sbir-analytics/data")
+    # Default resolves to the repo's own data/ dir.
+    assert data_dir() == DEFAULT_DATA_DIR
+    assert data_dir().name == "data"
 
 
 def test_data_dir_uses_env_var(monkeypatch, tmp_path):
@@ -27,5 +28,6 @@ def test_data_path_joins_filename(monkeypatch, tmp_path):
 def test_data_path_rejects_absolute(monkeypatch, tmp_path):
     monkeypatch.setenv("SBIR_DATA_DIR", str(tmp_path))
     import pytest
+
     with pytest.raises(ValueError, match="must be relative"):
         data_path("/etc/passwd")

--- a/tests/unit/scripts/ucc/test_export_cohort.py
+++ b/tests/unit/scripts/ucc/test_export_cohort.py
@@ -23,12 +23,19 @@ def _form_d_record(name, state, zip_code, amount, tier, has_name_match, has_zip_
 
 def test_keeps_high_tier_with_name_match():
     records = [
-        _form_d_record("ACME INC", "CA", "94000", 1_000_000, "high",
-                       has_name_match=True, has_zip_match=False),
+        _form_d_record(
+            "ACME INC", "CA", "94000", 1_000_000, "high", has_name_match=True, has_zip_match=False
+        ),
     ]
     sbir_awards = [
-        {"company_name": "Acme Inc", "state": "CA", "zip_code": "94000",
-         "agency": "DoD", "award_year": 2021, "award_amount": 250000},
+        {
+            "company_name": "Acme Inc",
+            "state": "CA",
+            "zip_code": "94000",
+            "agency": "DoD",
+            "award_year": 2021,
+            "award_amount": 250000,
+        },
     ]
     rows = list(build_cohort_rows(records, sbir_awards))
     assert len(rows) == 1
@@ -39,12 +46,25 @@ def test_keeps_high_tier_with_name_match():
 
 def test_keeps_high_tier_with_zip_match_only():
     records = [
-        _form_d_record("ACME PRECISION", "CA", "94000", 5_000_000, "high",
-                       has_name_match=False, has_zip_match=True),
+        _form_d_record(
+            "ACME PRECISION",
+            "CA",
+            "94000",
+            5_000_000,
+            "high",
+            has_name_match=False,
+            has_zip_match=True,
+        ),
     ]
     sbir_awards = [
-        {"company_name": "Acme Inc", "state": "CA", "zip_code": "94000",
-         "agency": "DoD", "award_year": 2021, "award_amount": 250000},
+        {
+            "company_name": "Acme Inc",
+            "state": "CA",
+            "zip_code": "94000",
+            "agency": "DoD",
+            "award_year": 2021,
+            "award_amount": 250000,
+        },
     ]
     rows = list(build_cohort_rows(records, sbir_awards))
     assert len(rows) == 1
@@ -52,16 +72,36 @@ def test_keeps_high_tier_with_zip_match_only():
 
 def test_drops_medium_and_low_tier():
     records = [
-        _form_d_record("MEDIUM INC", "CA", "94000", 1_000_000, "medium",
-                       has_name_match=True, has_zip_match=True),
-        _form_d_record("LOW INC", "CA", "94000", 1_000_000, "low",
-                       has_name_match=True, has_zip_match=True),
+        _form_d_record(
+            "MEDIUM INC",
+            "CA",
+            "94000",
+            1_000_000,
+            "medium",
+            has_name_match=True,
+            has_zip_match=True,
+        ),
+        _form_d_record(
+            "LOW INC", "CA", "94000", 1_000_000, "low", has_name_match=True, has_zip_match=True
+        ),
     ]
     sbir_awards = [
-        {"company_name": "Medium Inc", "state": "CA", "zip_code": "94000",
-         "agency": "DoD", "award_year": 2021, "award_amount": 250000},
-        {"company_name": "Low Inc", "state": "CA", "zip_code": "94000",
-         "agency": "DoD", "award_year": 2021, "award_amount": 250000},
+        {
+            "company_name": "Medium Inc",
+            "state": "CA",
+            "zip_code": "94000",
+            "agency": "DoD",
+            "award_year": 2021,
+            "award_amount": 250000,
+        },
+        {
+            "company_name": "Low Inc",
+            "state": "CA",
+            "zip_code": "94000",
+            "agency": "DoD",
+            "award_year": 2021,
+            "award_amount": 250000,
+        },
     ]
     rows = list(build_cohort_rows(records, sbir_awards))
     assert rows == []
@@ -69,14 +109,27 @@ def test_drops_medium_and_low_tier():
 
 def test_aggregates_award_history_per_firm():
     records = [
-        _form_d_record("ACME INC", "CA", "94000", 7_000_000, "high",
-                       has_name_match=True, has_zip_match=False),
+        _form_d_record(
+            "ACME INC", "CA", "94000", 7_000_000, "high", has_name_match=True, has_zip_match=False
+        ),
     ]
     sbir_awards = [
-        {"company_name": "Acme Inc", "state": "CA", "zip_code": "94000",
-         "agency": "DoD", "award_year": 2019, "award_amount": 150_000},
-        {"company_name": "Acme Inc", "state": "CA", "zip_code": "94000",
-         "agency": "DoD", "award_year": 2022, "award_amount": 1_000_000},
+        {
+            "company_name": "Acme Inc",
+            "state": "CA",
+            "zip_code": "94000",
+            "agency": "DoD",
+            "award_year": 2019,
+            "award_amount": 150_000,
+        },
+        {
+            "company_name": "Acme Inc",
+            "state": "CA",
+            "zip_code": "94000",
+            "agency": "DoD",
+            "award_year": 2022,
+            "award_amount": 1_000_000,
+        },
     ]
     rows = list(build_cohort_rows(records, sbir_awards))
     assert len(rows) == 1

--- a/tests/unit/scripts/ucc/test_matcher.py
+++ b/tests/unit/scripts/ucc/test_matcher.py
@@ -19,29 +19,29 @@ from ucc.matcher import (  # noqa: E402
 # ---- 20-pair test set: 10 matches, 10 non-matches (per plan) ----
 
 MATCH_PAIRS = [
-    ("Acme Tech, Inc.",                  "ACME TECH INC."),
-    ("3D Systems Corporation",           "3D SYSTEMS CORP"),
-    ("Quantum Computing LLC",            "Quantum Computing, L.L.C."),
-    ("Foo Bar Industries",               "Foo Bar Industries Inc"),
-    ("Genome Sciences, Inc.",            "Genome Sciences Inc."),
-    ("Pacific Biosciences of California","PACIFIC BIOSCIENCES OF CALIFORNIA"),
-    ("BioMarin Pharmaceutical",          "BIOMARIN PHARMACEUTICAL INC"),
-    ("Advanced Materials Corp",          "ADVANCED MATERIALS CORPORATION"),
-    ("Inhibrx, Inc.",                    "Inhibrx Inc"),
-    ("Cohu, Inc.",                       "COHU, INC."),
+    ("Acme Tech, Inc.", "ACME TECH INC."),
+    ("3D Systems Corporation", "3D SYSTEMS CORP"),
+    ("Quantum Computing LLC", "Quantum Computing, L.L.C."),
+    ("Foo Bar Industries", "Foo Bar Industries Inc"),
+    ("Genome Sciences, Inc.", "Genome Sciences Inc."),
+    ("Pacific Biosciences of California", "PACIFIC BIOSCIENCES OF CALIFORNIA"),
+    ("BioMarin Pharmaceutical", "BIOMARIN PHARMACEUTICAL INC"),
+    ("Advanced Materials Corp", "ADVANCED MATERIALS CORPORATION"),
+    ("Inhibrx, Inc.", "Inhibrx Inc"),
+    ("Cohu, Inc.", "COHU, INC."),
 ]
 
 NON_MATCH_PAIRS = [
-    ("Acme Tech, Inc.",                  "Acme Manufacturing, Inc."),
-    ("Pacific Biosciences of California","Pacific Industries"),
-    ("3D Systems",                       "5D Systems"),
-    ("BioMarin",                         "BioGen"),
-    ("Quantum Computing",                "Classical Computing"),
-    ("AeroVironment",                    "Aerodyne Systems"),
-    ("Tesla, Inc.",                      "Cisco Systems, Inc."),
-    ("Inhibrx, Inc.",                    "InhibitionRx, Inc."),
-    ("Genome Sciences",                  "Genome Therapeutics"),
-    ("Cohu",                             "Coho Systems"),
+    ("Acme Tech, Inc.", "Acme Manufacturing, Inc."),
+    ("Pacific Biosciences of California", "Pacific Industries"),
+    ("3D Systems", "5D Systems"),
+    ("BioMarin", "BioGen"),
+    ("Quantum Computing", "Classical Computing"),
+    ("AeroVironment", "Aerodyne Systems"),
+    ("Tesla, Inc.", "Cisco Systems, Inc."),
+    ("Inhibrx, Inc.", "InhibitionRx, Inc."),
+    ("Genome Sciences", "Genome Therapeutics"),
+    ("Cohu", "Coho Systems"),
 ]
 
 
@@ -50,24 +50,27 @@ def test_normalize_name_strips_punctuation_and_lowercases():
 
 
 def test_normalize_name_handles_suffix_variations():
-    assert normalize_name("Advanced Materials Corp") == normalize_name("Advanced Materials Corporation")
+    assert normalize_name("Advanced Materials Corp") == normalize_name(
+        "Advanced Materials Corporation"
+    )
 
 
 def test_all_match_pairs_classify_high_or_medium():
     for cohort, ucc in MATCH_PAIRS:
         tier, score = classify_match(cohort, ucc)
-        assert tier in ("high", "medium"), \
+        assert tier in ("high", "medium"), (
             f"{cohort!r} vs {ucc!r}: got tier={tier}, score={score:.3f}"
+        )
 
 
 def test_all_non_match_pairs_classify_low_or_drop():
     for cohort, ucc in NON_MATCH_PAIRS:
         tier, score = classify_match(cohort, ucc)
-        assert tier in ("low", "drop"), \
-            f"{cohort!r} vs {ucc!r}: got tier={tier}, score={score:.3f}"
+        assert tier in ("low", "drop"), f"{cohort!r} vs {ucc!r}: got tier={tier}, score={score:.3f}"
 
 
 # ---- Address city/state extraction ----
+
 
 def test_address_city_state_parses_full_address():
     # CA UCC format: "STREET ADDRESS, CITY, ST  ZIP" (double space common)
@@ -88,6 +91,7 @@ def test_address_city_state_returns_empty_for_invalid():
 
 
 # ---- Address overlap scoring ----
+
 
 def test_address_overlap_exact_city_state_match():
     """Same city + state = 1.0"""
@@ -119,11 +123,13 @@ def test_address_overlap_state_mismatch():
 def test_address_overlap_city_match_bonus():
     """Same city should score higher than state-only."""
     state_only = address_overlap_score(
-        cohort_state="CA", cohort_city="CARLSBAD",
+        cohort_state="CA",
+        cohort_city="CARLSBAD",
         filing_address="1 BANK ST, SAN FRANCISCO, CA",
     )
     same_city = address_overlap_score(
-        cohort_state="CA", cohort_city="CARLSBAD",
+        cohort_state="CA",
+        cohort_city="CARLSBAD",
         filing_address="500 LAB DR, CARLSBAD, CA",
     )
     assert same_city > state_only
@@ -131,6 +137,7 @@ def test_address_overlap_city_match_bonus():
 
 
 # ---- Person-name detection ----
+
 
 def test_looks_like_person_name_true_for_first_last():
     assert looks_like_person_name("AADITI MUJUMDAR") is True
@@ -157,6 +164,7 @@ def test_looks_like_person_name_false_for_descriptive_company():
 
 
 # ---- Debtor-side matching (the integrated filter) ----
+
 
 def test_is_debtor_side_match_inhibrx_real_case():
     """Phase 0 case: Inhibrx hit where debtor is INHIBRX and SP is EDD."""
@@ -221,6 +229,7 @@ def test_is_debtor_side_match_keeps_active_motif():
 
 # ---- match_extraction (end-to-end with tier + address) ----
 
+
 def test_match_extraction_returns_match_for_clean_case():
     filing = {
         "filing_number": "ABC123",
@@ -239,9 +248,12 @@ def test_match_extraction_returns_match_for_clean_case():
 
 def test_match_extraction_returns_none_for_person_name():
     filing = {
-        "filing_number": "X", "filing_type": "initial",
-        "debtor_name": "AADITI MUJUMDAR", "debtor_address": "SANTA CLARA, CA",
-        "secured_party_name": "WELLS FARGO", "secured_party_address": "",
+        "filing_number": "X",
+        "filing_type": "initial",
+        "debtor_name": "AADITI MUJUMDAR",
+        "debtor_address": "SANTA CLARA, CA",
+        "secured_party_name": "WELLS FARGO",
+        "secured_party_address": "",
     }
     cohort_row = {"company_name": "AADI, LLC", "state": "CA"}
     assert match_extraction(filing, cohort_row) is None
@@ -249,9 +261,12 @@ def test_match_extraction_returns_none_for_person_name():
 
 def test_match_extraction_returns_none_for_cross_state_collision():
     filing = {
-        "filing_number": "X", "filing_type": "initial",
-        "debtor_name": "6K CONSULTING INC", "debtor_address": "SACRAMENTO, CA",
-        "secured_party_name": "U.S. BANK", "secured_party_address": "",
+        "filing_number": "X",
+        "filing_type": "initial",
+        "debtor_name": "6K CONSULTING INC",
+        "debtor_address": "SACRAMENTO, CA",
+        "secured_party_name": "U.S. BANK",
+        "secured_party_address": "",
     }
     cohort_row = {"company_name": "6K Inc.", "state": "MA"}
     assert match_extraction(filing, cohort_row) is None


### PR DESCRIPTION
## Summary

Follow-up to #303 (merged at `1529f09` before these fixes landed). Addresses all 11 copilot review comments on the original PR, plus brings `specs/ucc1-financing-analysis/tasks.md` in line with the pilot's actual partial-run state.

## Fixes addressing copilot comments on #303

| # | File | Fix |
|---|------|-----|
| 1 | `scripts/data/ucc/_common.py` | Default `DEFAULT_DATA_DIR` to repo-relative `data/` (`Path(__file__).resolve().parents[3] / "data"`) instead of a hard-coded user path. `SBIR_DATA_DIR` remains the override. |
| 2, 3 | `cohort_state_filter.py`, `ca_extractor.py` | Lazy-import `curl_cffi` inside the functions that need it. Unit tests now run without the `ucc1-pilot` extra; raises a helpful `ImportError` pointing at `uv sync --extra ucc1-pilot` if invoked without it. |
| 4 | `cohort_state_filter.py` | `lookup_ca_sos_with_variants` now narrows `except Exception` → `(OSError, ValueError)` (covers `curl_cffi.RequestsError` via `OSError`, plus `json.JSONDecodeError`) and re-raises the last error when every variant failed, so `narrow_to_ca_organized` can distinguish a true no-match from a systemic Imperva block on the checkpoint. |
| 5 | `export_cohort.py` | `_normalize_sbir_award` strips commas and `$` from `Award Amount` before `float()` so values like `"$1,234,567"` parse instead of silently zeroing. |
| 6 | `export_cohort.py` | `form_d_filing_count` now reads `offering_count` (threaded through `_normalize_form_d`); was hard-coded to `1`. |
| 7 | `export_cohort.py` | `primary_agency` uses `Counter` + alphabetical tie-break; replaces non-deterministic `max(set(agencies), key=agencies.count)`. |
| 8 | `schema.py` | `CohortRow` declares `city` and `zip_code` — already emitted by `build_cohort_rows` and consumed by the matcher. |
| 9 | `design.md` | "Cross-worktree data access" section now describes the actual `data_path()` behavior (both reads and writes share one dir; default is repo-relative). |
| 10 | `tests/unit/scripts/ucc/test_matcher.py` | `ruff format` — removes manual column alignment and backslash continuations. |
| 11 | `tests/unit/scripts/ucc/test_common.py` | Drops unused `os` import; default-dir assertion updated to the new behavior. |

## tasks.md cleanup

Second commit walks `specs/ucc1-financing-analysis/tasks.md` from the pilot's actual state:

- Adds a Status banner pointing at the memo's "Stop here" recommendation
- Ticks 18 tasks that are actually implemented (0.6–0.8, 1.1–1.4, 2.1–2.4, 3.1–3.3, 7.3, 7.4, 8.1, 8.3, 8.5); 1.3 and 2.4 carry "partial" notes citing the Imperva-truncation reason
- Marks Phases 4 (lifecycle), 5 (classifier), 6 (M&A corroboration) and tasks 7.1/7.2/8.2/8.4 as **DEFERRED** with one-paragraph rationale per phase

## Test plan

- [x] `pytest tests/unit/scripts/ucc/` — 60/60 pass with `curl_cffi` installed
- [x] `pytest tests/unit/scripts/ucc/` — 60/60 pass **without** `curl_cffi` installed (confirms the lazy import works and the original copilot bug is fixed)
- [x] `ruff format --check tests/unit/scripts/ucc/` clean
- [x] `ruff check tests/unit/scripts/ucc/` clean
- [x] `data_dir()` resolves to `<repo>/data` by default; honors `SBIR_DATA_DIR` override

https://claude.ai/code/session_01UMHsw4kFmnBgPECBHFmDiy

---
_Generated by [Claude Code](https://claude.ai/code/session_01UMHsw4kFmnBgPECBHFmDiy)_