### PR TITLE
fix(ci): point transition path filter at canonical packages/* paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,11 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
             transition:
-              - 'src/assets/transition/**'
-              - 'src/assets/jobs/transition_job.py'
+              - 'packages/sbir-analytics/sbir_analytics/assets/phase_transition/**'
+              - 'packages/sbir-analytics/sbir_analytics/assets/jobs/phase_transition_job.py'
+              - 'packages/sbir-ml/sbir_ml/transition/**'
               - 'tests/e2e/transition/**'
-              - 'tests/integration/transition/**'
+              - 'tests/integration/test_transition_*.py'
               - 'docs/transition/**'
             docker:
               - 'Dockerfile*'


### PR DESCRIPTION
## Summary

The `transition` path filter in `.github/workflows/ci.yml` under `detect-changes` still lists legacy `src/assets/transition/**` and `src/assets/jobs/transition_job.py` paths left over from the repo restructure into `packages/`. None of those paths exist anymore, so the `transition-mvp` job has been silently skipped on every transition-only PR since the restructure (visible in any recent transition PR's check list — "Run Transition MVP" → `skipped`).

This one-file change points the filter at the actual code locations:

- `packages/sbir-analytics/sbir_analytics/assets/phase_transition/**`
- `packages/sbir-analytics/sbir_analytics/assets/jobs/phase_transition_job.py`
- `packages/sbir-ml/sbir_ml/transition/**`

The `tests/integration/transition/**` entry also didn't match anything — transition integration tests are flat files (`test_transition_integration.py`, `test_transition_mvp_chain.py`, etc.). Replaced with `tests/integration/test_transition_*.py`.

## Observation, not fixed here

The adjacent `performance` and `cet` filters above appear to suffer from the same restructure rot (`src/enrichers/**`, `src/assets/**`, `src/ml/config/**`, `src/assets/jobs/cet_*.py`, `src/utils/performance_monitor.py`, `src/extractors/**` — all stale). Worth a follow-up sweep, but kept out of this PR's scope.

## Test plan

- [ ] On merge to `main`, push a transition-only commit and confirm `Run Transition MVP (shim) and gate on validation summary` actually runs instead of skipping
- [ ] PR #287 (phase-III prototype) will re-trigger and the gate should fire (its branch separately extends the same filter for phase-III paths)

https://claude.ai/code/session_01Cj4kvNR8fVCtXuRwnT8qpU

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cj4kvNR8fVCtXuRwnT8qpU)_