### PR TITLE
style(capital-events): ruff format on test files

### DIFF
--- a/tests/unit/scripts/capital_events/test_common.py
+++ b/tests/unit/scripts/capital_events/test_common.py
@@ -13,9 +13,7 @@ def test_data_dir_default_when_env_unset(monkeypatch):
     monkeypatch.delenv("SBIR_DATA_DIR", raising=False)
     # _common.py lives at scripts/data/capital_events/_common.py
     # parents[3] from there is the repo root; data is sibling of scripts/
-    expected = (
-        Path(__file__).resolve().parents[4] / "data"
-    )
+    expected = Path(__file__).resolve().parents[4] / "data"
     assert data_dir() == expected
 
 
@@ -57,6 +55,7 @@ def test_normalize_date_invalid_returns_empty():
 
 def test_data_path_rejects_absolute(monkeypatch, tmp_path):
     import pytest
+
     monkeypatch.setenv("SBIR_DATA_DIR", str(tmp_path))
     with pytest.raises(ValueError, match="must be relative"):
         data_path("/absolute/path.jsonl")

--- a/tests/unit/scripts/capital_events/test_form_d.py
+++ b/tests/unit/scripts/capital_events/test_form_d.py
@@ -41,7 +41,10 @@ def _offering(accession, filing_date, amount, securities=None, is_combo=False, *
 def test_classify_securities_types():
     assert classify_securities_types(["Equity"]) == "equity"
     assert classify_securities_types(["Debt"]) == "debt"
-    assert classify_securities_types(["Option, Warrant or Other Right to Acquire Another Security"]) == "option_warrant"
+    assert (
+        classify_securities_types(["Option, Warrant or Other Right to Acquire Another Security"])
+        == "option_warrant"
+    )
     assert classify_securities_types(["Equity", "Debt"]) == "other"
     assert classify_securities_types([]) == "other"
     assert classify_securities_types(None) == "other"
@@ -49,10 +52,19 @@ def test_classify_securities_types():
 
 def test_emits_one_event_per_offering(cohort, tmp_path):
     src = tmp_path / "form_d.jsonl"
-    src.write_text(json.dumps(_form_d("ACME INC", "high", [
-        _offering("ACC-1", "2023-01-15", 5_000_000.0),
-        _offering("ACC-2", "2023-08-22", 10_000_000.0, securities=["Debt"]),
-    ])) + "\n")
+    src.write_text(
+        json.dumps(
+            _form_d(
+                "ACME INC",
+                "high",
+                [
+                    _offering("ACC-1", "2023-01-15", 5_000_000.0),
+                    _offering("ACC-2", "2023-08-22", 10_000_000.0, securities=["Debt"]),
+                ],
+            )
+        )
+        + "\n"
+    )
 
     events = list(build_form_d_events(cohort, src))
     assert len(events) == 2
@@ -71,19 +83,41 @@ def test_emits_one_event_per_offering(cohort, tmp_path):
 
 def test_business_combination_overrides_subtype(cohort, tmp_path):
     src = tmp_path / "form_d.jsonl"
-    src.write_text(json.dumps(_form_d("ACME INC", "high", [
-        _offering("ACC-3", "2024-05-01", 50_000_000.0, securities=["Equity"], is_combo=True),
-    ])) + "\n")
+    src.write_text(
+        json.dumps(
+            _form_d(
+                "ACME INC",
+                "high",
+                [
+                    _offering(
+                        "ACC-3", "2024-05-01", 50_000_000.0, securities=["Equity"], is_combo=True
+                    ),
+                ],
+            )
+        )
+        + "\n"
+    )
     events = list(build_form_d_events(cohort, src))
     assert events[0]["event_subtype"] == "combination"
 
 
 def test_drops_non_high_tier_records(cohort, tmp_path):
     src = tmp_path / "form_d.jsonl"
-    src.write_text("\n".join([
-        json.dumps(_form_d("ACME INC", "medium", [_offering("ACC-A", "2024-01-01", 1_000_000.0)])),
-        json.dumps(_form_d("OUT-OF-STATE CORP", "high", [_offering("ACC-B", "2023-01-01", 5_000_000.0)])),
-    ]) + "\n")
+    src.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    _form_d("ACME INC", "medium", [_offering("ACC-A", "2024-01-01", 1_000_000.0)])
+                ),
+                json.dumps(
+                    _form_d(
+                        "OUT-OF-STATE CORP", "high", [_offering("ACC-B", "2023-01-01", 5_000_000.0)]
+                    )
+                ),
+            ]
+        )
+        + "\n"
+    )
     events = list(build_form_d_events(cohort, src))
     assert len(events) == 1
     assert events[0]["company_name"] == "OUT-OF-STATE CORP"
@@ -91,17 +125,41 @@ def test_drops_non_high_tier_records(cohort, tmp_path):
 
 def test_skips_non_cohort_firms(cohort, tmp_path):
     src = tmp_path / "form_d.jsonl"
-    src.write_text(json.dumps(_form_d("UNRELATED INC", "high", [
-        _offering("ACC-X", "2024-01-01", 1_000_000.0),
-    ])) + "\n")
+    src.write_text(
+        json.dumps(
+            _form_d(
+                "UNRELATED INC",
+                "high",
+                [
+                    _offering("ACC-X", "2024-01-01", 1_000_000.0),
+                ],
+            )
+        )
+        + "\n"
+    )
     assert list(build_form_d_events(cohort, src)) == []
 
 
 def test_metadata_carries_offering_extras(cohort, tmp_path):
     src = tmp_path / "form_d.jsonl"
-    src.write_text(json.dumps(_form_d("ACME INC", "high", [
-        _offering("ACC-1", "2024-01-01", 5_000_000.0, minimum_investment=50000, num_investors=8),
-    ])) + "\n")
+    src.write_text(
+        json.dumps(
+            _form_d(
+                "ACME INC",
+                "high",
+                [
+                    _offering(
+                        "ACC-1",
+                        "2024-01-01",
+                        5_000_000.0,
+                        minimum_investment=50000,
+                        num_investors=8,
+                    ),
+                ],
+            )
+        )
+        + "\n"
+    )
     events = list(build_form_d_events(cohort, src))
     meta = json.loads(events[0]["metadata"])
     assert meta["minimum_investment"] == 50000

--- a/tests/unit/scripts/capital_events/test_ma_events.py
+++ b/tests/unit/scripts/capital_events/test_ma_events.py
@@ -27,11 +27,17 @@ def _ma_row(name, date, confidence, acquirer=None, signals=None, press=None):
 
 def test_emits_high_and_medium_drops_low(cohort, tmp_path):
     src = tmp_path / "ma.jsonl"
-    src.write_text("\n".join(json.dumps(r) for r in [
-        _ma_row("ACME INC", "2023-06-15", "high", acquirer="GiantCo"),
-        _ma_row("OUT-OF-STATE CORP", "2022-11-01", "medium"),
-        _ma_row("ACME INC", "2024-02-01", "low"),
-    ]) + "\n")
+    src.write_text(
+        "\n".join(
+            json.dumps(r)
+            for r in [
+                _ma_row("ACME INC", "2023-06-15", "high", acquirer="GiantCo"),
+                _ma_row("OUT-OF-STATE CORP", "2022-11-01", "medium"),
+                _ma_row("ACME INC", "2024-02-01", "low"),
+            ]
+        )
+        + "\n"
+    )
 
     events = list(build_ma_events(cohort, src))
     assert len(events) == 2
@@ -57,11 +63,18 @@ def test_returns_empty_when_file_missing(cohort, tmp_path):
 
 def test_metadata_carries_signals_and_press_wire(cohort, tmp_path):
     src = tmp_path / "ma.jsonl"
-    src.write_text(json.dumps(_ma_row(
-        "ACME INC", "2023-06-15", "high",
-        signals={"form_d_business_combination": True},
-        press={"acquisition_announcement_count": 3},
-    )) + "\n")
+    src.write_text(
+        json.dumps(
+            _ma_row(
+                "ACME INC",
+                "2023-06-15",
+                "high",
+                signals={"form_d_business_combination": True},
+                press={"acquisition_announcement_count": 3},
+            )
+        )
+        + "\n"
+    )
     events = list(build_ma_events(cohort, src))
     meta = json.loads(events[0]["metadata"])
     assert meta["signals"]["form_d_business_combination"] is True

--- a/tests/unit/scripts/capital_events/test_orchestrator.py
+++ b/tests/unit/scripts/capital_events/test_orchestrator.py
@@ -20,76 +20,161 @@ def test_orchestrator_end_to_end(tmp_path, monkeypatch):
     monkeypatch.setenv("SBIR_DATA_DIR", str(tmp_path))
 
     cohort_path = tmp_path / "form_d_high_conf_cohort.jsonl"
-    _write_cohort(cohort_path, [{
-        "company_name": "ACME INC", "state": "California", "city": "SAN DIEGO",
-        "zip_code": "92101", "agency": "Department of Defense",
-        "first_award_year": 2018, "last_award_year": 2023,
-        "total_award_amount": 1_500_000.0, "form_d_filing_count": 1,
-        "form_d_total_raised": 25_000_000.0,
-    }])
+    _write_cohort(
+        cohort_path,
+        [
+            {
+                "company_name": "ACME INC",
+                "state": "California",
+                "city": "SAN DIEGO",
+                "zip_code": "92101",
+                "agency": "Department of Defense",
+                "first_award_year": 2018,
+                "last_award_year": 2023,
+                "total_award_amount": 1_500_000.0,
+                "form_d_filing_count": 1,
+                "form_d_total_raised": 25_000_000.0,
+            }
+        ],
+    )
 
     awards_path = tmp_path / "raw" / "sbir" / "award_data.csv"
     awards_path.parent.mkdir(parents=True, exist_ok=True)
     with awards_path.open("w", newline="") as f:
-        w = csv.DictWriter(f, fieldnames=[
-            "Company", "Agency", "Branch", "Phase", "Award Year", "Award Amount",
-            "Proposal Award Date", "Agency Tracking Number", "Solicitation Number",
-            "Solicitation Year", "City", "State", "Zip", "Contract",
-        ])
+        w = csv.DictWriter(
+            f,
+            fieldnames=[
+                "Company",
+                "Agency",
+                "Branch",
+                "Phase",
+                "Award Year",
+                "Award Amount",
+                "Proposal Award Date",
+                "Agency Tracking Number",
+                "Solicitation Number",
+                "Solicitation Year",
+                "City",
+                "State",
+                "Zip",
+                "Contract",
+            ],
+        )
         w.writeheader()
-        w.writerow({"Company": "Acme Inc", "Agency": "Department of Defense",
-                    "Branch": "Army", "Phase": "Phase II", "Award Year": "2020",
-                    "Award Amount": "1000000", "Proposal Award Date": "2020-09-01",
-                    "Agency Tracking Number": "ATN-1", "Solicitation Number": "S1",
-                    "Solicitation Year": "2020", "City": "San Diego",
-                    "State": "California", "Zip": "92101", "Contract": "C1"})
+        w.writerow(
+            {
+                "Company": "Acme Inc",
+                "Agency": "Department of Defense",
+                "Branch": "Army",
+                "Phase": "Phase II",
+                "Award Year": "2020",
+                "Award Amount": "1000000",
+                "Proposal Award Date": "2020-09-01",
+                "Agency Tracking Number": "ATN-1",
+                "Solicitation Number": "S1",
+                "Solicitation Year": "2020",
+                "City": "San Diego",
+                "State": "California",
+                "Zip": "92101",
+                "Contract": "C1",
+            }
+        )
 
     form_d_path = tmp_path / "form_d_details.jsonl"
-    form_d_path.write_text(json.dumps({
-        "company_name": "ACME INC",
-        "match_confidence": {"tier": "high", "person_score": 1.0, "address_score": 1},
-        "total_raised": 5_000_000.0, "offering_count": 1, "form_d_cik": "0001",
-        "offerings": [{
-            "accession_number": "A1", "filing_date": "2023-01-15",
-            "total_amount_sold": 5_000_000.0, "securities_types": ["Equity"],
-            "is_business_combination": False, "is_amendment": False,
-            "minimum_investment": 25000, "num_investors": 5, "related_persons": [],
-        }],
-    }) + "\n")
+    form_d_path.write_text(
+        json.dumps(
+            {
+                "company_name": "ACME INC",
+                "match_confidence": {"tier": "high", "person_score": 1.0, "address_score": 1},
+                "total_raised": 5_000_000.0,
+                "offering_count": 1,
+                "form_d_cik": "0001",
+                "offerings": [
+                    {
+                        "accession_number": "A1",
+                        "filing_date": "2023-01-15",
+                        "total_amount_sold": 5_000_000.0,
+                        "securities_types": ["Equity"],
+                        "is_business_combination": False,
+                        "is_amendment": False,
+                        "minimum_investment": 25000,
+                        "num_investors": 5,
+                        "related_persons": [],
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
 
     ma_path = tmp_path / "enriched_sbir_ma_events.jsonl"
-    ma_path.write_text(json.dumps({
-        "company_name": "ACME INC", "event_date": "2024-02-01",
-        "confidence": "high", "acquirer": "GiantCo", "signals": {},
-        "press_wire_signals": {}, "signal_count": 1, "form_d_detail": None,
-        "efts_detail": None, "sbir_context": {"agency": "DoD"}, "enriched": True,
-    }) + "\n")
+    ma_path.write_text(
+        json.dumps(
+            {
+                "company_name": "ACME INC",
+                "event_date": "2024-02-01",
+                "confidence": "high",
+                "acquirer": "GiantCo",
+                "signals": {},
+                "press_wire_signals": {},
+                "signal_count": 1,
+                "form_d_detail": None,
+                "efts_detail": None,
+                "sbir_context": {"agency": "DoD"},
+                "enriched": True,
+            }
+        )
+        + "\n"
+    )
 
     us_dir = tmp_path / "processed" / "sbir_phase3"
     us_dir.mkdir(parents=True, exist_ok=True)
-    (us_dir / "usaspending_phase3_contracts.jsonl").write_text(json.dumps({
-        "Recipient Name": "ACME INC", "Award ID": "AW1",
-        "Award Amount": 2_000_000.0, "Start Date": "2022-06-01", "End Date": "",
-        "Funding Agency": "Department of Defense", "Funding Sub Agency": "Army",
-        "Awarding Agency": "Department of Defense", "Awarding Sub Agency": "Army",
-        "Description": "Phase III", "NAICS": "541715",
-        "generated_internal_id": "GEN1", "internal_id": "INT1",
-        "agency_slug": "dod", "awarding_agency_id": 9700,
-    }) + "\n")
+    (us_dir / "usaspending_phase3_contracts.jsonl").write_text(
+        json.dumps(
+            {
+                "Recipient Name": "ACME INC",
+                "Award ID": "AW1",
+                "Award Amount": 2_000_000.0,
+                "Start Date": "2022-06-01",
+                "End Date": "",
+                "Funding Agency": "Department of Defense",
+                "Funding Sub Agency": "Army",
+                "Awarding Agency": "Department of Defense",
+                "Awarding Sub Agency": "Army",
+                "Description": "Phase III",
+                "NAICS": "541715",
+                "generated_internal_id": "GEN1",
+                "internal_id": "INT1",
+                "agency_slug": "dod",
+                "awarding_agency_id": 9700,
+            }
+        )
+        + "\n"
+    )
 
     pat_dir = tmp_path / "transformed" / "uspto"
     pat_dir.mkdir(parents=True, exist_ok=True)
-    (pat_dir / "patents_20260418T142224.jsonl").write_text(json.dumps({
-        "grant_number": "11000001", "latest_recorded_date": "2023-05-15",
-        "title": "Test", "language": "en",
-        "assignee_names": ["ACME INC"], "assignor_names": [],
-        "assignment_count": 0, "linked_companies": ["ACME INC"],
-    }) + "\n")
+    (pat_dir / "patents_20260418T142224.jsonl").write_text(
+        json.dumps(
+            {
+                "grant_number": "11000001",
+                "latest_recorded_date": "2023-05-15",
+                "title": "Test",
+                "language": "en",
+                "assignee_names": ["ACME INC"],
+                "assignor_names": [],
+                "assignment_count": 0,
+                "linked_companies": ["ACME INC"],
+            }
+        )
+        + "\n"
+    )
 
     result = subprocess.run(
         [sys.executable, "scripts/data/build_capital_events.py"],
         env={"SBIR_DATA_DIR": str(tmp_path), "PATH": "/usr/bin:/bin"},
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     assert result.returncode == 0, f"orchestrator failed:\n{result.stderr}"
 
@@ -102,13 +187,22 @@ def test_orchestrator_end_to_end(tmp_path, monkeypatch):
 
     events = pd.read_parquet(events_parquet)
     assert set(events.columns) == {
-        "company_name", "event_date", "event_type", "event_subtype",
-        "amount_usd", "counterparty", "source_id", "metadata",
+        "company_name",
+        "event_date",
+        "event_type",
+        "event_subtype",
+        "amount_usd",
+        "counterparty",
+        "source_id",
+        "metadata",
     }
     assert len(events) == 5
     assert set(events["event_type"]) == {
-        "sbir_award", "form_d_filing", "ma_event",
-        "usaspending_contract", "patent_grant",
+        "sbir_award",
+        "form_d_filing",
+        "ma_event",
+        "usaspending_contract",
+        "patent_grant",
     }
     assert events["event_date"].is_monotonic_increasing  # all same firm
 

--- a/tests/unit/scripts/capital_events/test_patents.py
+++ b/tests/unit/scripts/capital_events/test_patents.py
@@ -41,10 +41,18 @@ def test_newest_patent_file_returns_none_when_no_files(tmp_path):
 
 def test_emits_one_event_per_linked_patent(cohort, tmp_path):
     src = tmp_path / "patents_20260418T142224.jsonl"
-    src.write_text("\n".join(json.dumps(p) for p in [
-        _patent("11000001", "2023-05-15", linked_companies=["ACME INC"]),
-        _patent("11000002", "2024-02-01", linked_companies=["ACME INC"], title="Better patent"),
-    ]) + "\n")
+    src.write_text(
+        "\n".join(
+            json.dumps(p)
+            for p in [
+                _patent("11000001", "2023-05-15", linked_companies=["ACME INC"]),
+                _patent(
+                    "11000002", "2024-02-01", linked_companies=["ACME INC"], title="Better patent"
+                ),
+            ]
+        )
+        + "\n"
+    )
     events = list(build_patent_events(cohort, src))
     assert len(events) == 2
     e = events[0]
@@ -62,10 +70,16 @@ def test_emits_one_event_per_linked_patent(cohort, tmp_path):
 def test_emits_one_event_per_cohort_firm_when_multiple_linked(cohort, tmp_path):
     """A patent linked to two cohort firms produces two events (joint assignment)."""
     src = tmp_path / "patents_20260418T142224.jsonl"
-    src.write_text(json.dumps(_patent(
-        "11000003", "2024-01-01",
-        linked_companies=["ACME INC", "OUT-OF-STATE CORP"],
-    )) + "\n")
+    src.write_text(
+        json.dumps(
+            _patent(
+                "11000003",
+                "2024-01-01",
+                linked_companies=["ACME INC", "OUT-OF-STATE CORP"],
+            )
+        )
+        + "\n"
+    )
     events = list(build_patent_events(cohort, src))
     assert len(events) == 2
     assert {e["company_name"] for e in events} == {"ACME INC", "OUT-OF-STATE CORP"}
@@ -73,9 +87,16 @@ def test_emits_one_event_per_cohort_firm_when_multiple_linked(cohort, tmp_path):
 
 def test_skips_patents_not_linked_to_cohort(cohort, tmp_path):
     src = tmp_path / "patents_20260418T142224.jsonl"
-    src.write_text(json.dumps(_patent(
-        "11000004", "2024-01-01", linked_companies=["UNRELATED INC"],
-    )) + "\n")
+    src.write_text(
+        json.dumps(
+            _patent(
+                "11000004",
+                "2024-01-01",
+                linked_companies=["UNRELATED INC"],
+            )
+        )
+        + "\n"
+    )
     assert list(build_patent_events(cohort, src)) == []
 
 

--- a/tests/unit/scripts/capital_events/test_sbir_awards.py
+++ b/tests/unit/scripts/capital_events/test_sbir_awards.py
@@ -15,9 +15,20 @@ from capital_events.sources.sbir_awards import (  # noqa: E402
 
 def _write_awards_csv(path: Path, rows: list[dict]) -> None:
     headers = [
-        "Company", "Agency", "Branch", "Phase", "Award Year", "Award Amount",
-        "Proposal Award Date", "Agency Tracking Number", "Solicitation Number",
-        "Solicitation Year", "City", "State", "Zip", "Contract",
+        "Company",
+        "Agency",
+        "Branch",
+        "Phase",
+        "Award Year",
+        "Award Amount",
+        "Proposal Award Date",
+        "Agency Tracking Number",
+        "Solicitation Number",
+        "Solicitation Year",
+        "City",
+        "State",
+        "Zip",
+        "Contract",
     ]
     with path.open("w", newline="") as f:
         w = csv.DictWriter(f, fieldnames=headers)
@@ -38,20 +49,43 @@ def test_classify_phase():
 
 def test_emits_one_event_per_matching_award(cohort, tmp_path):
     csv_path = tmp_path / "awards.csv"
-    _write_awards_csv(csv_path, [
-        {"Company": "Acme Inc", "Agency": "Department of Defense", "Branch": "Army",
-         "Phase": "Phase I", "Award Year": "2018", "Award Amount": "150000",
-         "Proposal Award Date": "2018-06-15", "Agency Tracking Number": "ATN-001",
-         "Solicitation Number": "SBIR-18-001", "Solicitation Year": "2018",
-         "City": "San Diego", "State": "California", "Zip": "92101",
-         "Contract": "W56HZV-18-C-0001"},
-        {"Company": "Acme Inc", "Agency": "Department of Defense", "Branch": "Army",
-         "Phase": "Phase II", "Award Year": "2020", "Award Amount": "1000000",
-         "Proposal Award Date": "2020-09-01", "Agency Tracking Number": "ATN-002",
-         "Solicitation Number": "SBIR-20-002", "Solicitation Year": "2020",
-         "City": "San Diego", "State": "California", "Zip": "92101",
-         "Contract": "W56HZV-20-C-0002"},
-    ])
+    _write_awards_csv(
+        csv_path,
+        [
+            {
+                "Company": "Acme Inc",
+                "Agency": "Department of Defense",
+                "Branch": "Army",
+                "Phase": "Phase I",
+                "Award Year": "2018",
+                "Award Amount": "150000",
+                "Proposal Award Date": "2018-06-15",
+                "Agency Tracking Number": "ATN-001",
+                "Solicitation Number": "SBIR-18-001",
+                "Solicitation Year": "2018",
+                "City": "San Diego",
+                "State": "California",
+                "Zip": "92101",
+                "Contract": "W56HZV-18-C-0001",
+            },
+            {
+                "Company": "Acme Inc",
+                "Agency": "Department of Defense",
+                "Branch": "Army",
+                "Phase": "Phase II",
+                "Award Year": "2020",
+                "Award Amount": "1000000",
+                "Proposal Award Date": "2020-09-01",
+                "Agency Tracking Number": "ATN-002",
+                "Solicitation Number": "SBIR-20-002",
+                "Solicitation Year": "2020",
+                "City": "San Diego",
+                "State": "California",
+                "Zip": "92101",
+                "Contract": "W56HZV-20-C-0002",
+            },
+        ],
+    )
     events = list(build_sbir_award_events(cohort, csv_path))
     assert len(events) == 2
     by_phase = {e["event_subtype"]: e for e in events}
@@ -69,14 +103,27 @@ def test_emits_one_event_per_matching_award(cohort, tmp_path):
 
 def test_falls_back_to_contract_id_when_atn_missing(cohort, tmp_path):
     csv_path = tmp_path / "awards.csv"
-    _write_awards_csv(csv_path, [
-        {"Company": "Boring LLC", "Agency": "National Science Foundation", "Branch": "",
-         "Phase": "Phase I", "Award Year": "2020", "Award Amount": "250000",
-         "Proposal Award Date": "2020-04-01", "Agency Tracking Number": "",
-         "Solicitation Number": "NSF-20-501", "Solicitation Year": "2020",
-         "City": "Austin", "State": "Texas", "Zip": "73301",
-         "Contract": "NSF-2020-100"},
-    ])
+    _write_awards_csv(
+        csv_path,
+        [
+            {
+                "Company": "Boring LLC",
+                "Agency": "National Science Foundation",
+                "Branch": "",
+                "Phase": "Phase I",
+                "Award Year": "2020",
+                "Award Amount": "250000",
+                "Proposal Award Date": "2020-04-01",
+                "Agency Tracking Number": "",
+                "Solicitation Number": "NSF-20-501",
+                "Solicitation Year": "2020",
+                "City": "Austin",
+                "State": "Texas",
+                "Zip": "73301",
+                "Contract": "NSF-2020-100",
+            },
+        ],
+    )
     events = list(build_sbir_award_events(cohort, csv_path))
     assert len(events) == 1
     assert events[0]["source_id"] == "NSF-2020-100"
@@ -84,12 +131,27 @@ def test_falls_back_to_contract_id_when_atn_missing(cohort, tmp_path):
 
 def test_skips_non_cohort_firms(cohort, tmp_path):
     csv_path = tmp_path / "awards.csv"
-    _write_awards_csv(csv_path, [
-        {"Company": "Unrelated Inc", "Agency": "DoD", "Branch": "", "Phase": "Phase I",
-         "Award Year": "2020", "Award Amount": "100000", "Proposal Award Date": "2020-01-01",
-         "Agency Tracking Number": "X", "Solicitation Number": "", "Solicitation Year": "",
-         "City": "", "State": "", "Zip": "", "Contract": ""},
-    ])
+    _write_awards_csv(
+        csv_path,
+        [
+            {
+                "Company": "Unrelated Inc",
+                "Agency": "DoD",
+                "Branch": "",
+                "Phase": "Phase I",
+                "Award Year": "2020",
+                "Award Amount": "100000",
+                "Proposal Award Date": "2020-01-01",
+                "Agency Tracking Number": "X",
+                "Solicitation Number": "",
+                "Solicitation Year": "",
+                "City": "",
+                "State": "",
+                "Zip": "",
+                "Contract": "",
+            },
+        ],
+    )
     assert list(build_sbir_award_events(cohort, csv_path)) == []
 
 

--- a/tests/unit/scripts/capital_events/test_schema.py
+++ b/tests/unit/scripts/capital_events/test_schema.py
@@ -23,8 +23,14 @@ def test_event_type_values():
 
 def test_event_table_columns_match_typeddict():
     expected = {
-        "company_name", "event_date", "event_type", "event_subtype",
-        "amount_usd", "counterparty", "source_id", "metadata",
+        "company_name",
+        "event_date",
+        "event_type",
+        "event_subtype",
+        "amount_usd",
+        "counterparty",
+        "source_id",
+        "metadata",
     }
     assert set(EVENT_TABLE_COLUMNS) == expected
     assert EVENT_TABLE_COLUMNS[0] == "company_name"
@@ -34,6 +40,7 @@ def test_event_table_columns_match_typeddict():
 
 def test_capital_event_can_round_trip_as_json():
     import json
+
     row: CapitalEvent = {
         "company_name": "Acme Inc",
         "event_date": "2024-03-15",

--- a/tests/unit/scripts/capital_events/test_summarize.py
+++ b/tests/unit/scripts/capital_events/test_summarize.py
@@ -11,18 +11,33 @@ from capital_events.summarize import summarize_per_firm  # noqa: E402
 
 
 def _events_df(rows: list[dict]) -> pd.DataFrame:
-    return pd.DataFrame(rows, columns=[
-        "company_name", "event_date", "event_type", "event_subtype",
-        "amount_usd", "counterparty", "source_id", "metadata",
-    ])
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "company_name",
+            "event_date",
+            "event_type",
+            "event_subtype",
+            "amount_usd",
+            "counterparty",
+            "source_id",
+            "metadata",
+        ],
+    )
 
 
-def _event(company, date, etype, subtype=None, amount=None, counterparty=None,
-           source_id="X", metadata="{}"):
+def _event(
+    company, date, etype, subtype=None, amount=None, counterparty=None, source_id="X", metadata="{}"
+):
     return {
-        "company_name": company, "event_date": date, "event_type": etype,
-        "event_subtype": subtype, "amount_usd": amount,
-        "counterparty": counterparty, "source_id": source_id, "metadata": metadata,
+        "company_name": company,
+        "event_date": date,
+        "event_type": etype,
+        "event_subtype": subtype,
+        "amount_usd": amount,
+        "counterparty": counterparty,
+        "source_id": source_id,
+        "metadata": metadata,
     }
 
 
@@ -34,11 +49,13 @@ def test_summary_includes_one_row_per_cohort_firm(cohort):
 
 
 def test_summary_counts_and_sums_sbir_events(cohort):
-    events = _events_df([
-        _event("ACME INC", "2018-06-15", "sbir_award", "sbir_phase_i", 150000.0),
-        _event("ACME INC", "2020-09-01", "sbir_award", "sbir_phase_ii", 1000000.0),
-        _event("BORING LLC", "2020-04-01", "sbir_award", "sbir_phase_i", 250000.0),
-    ])
+    events = _events_df(
+        [
+            _event("ACME INC", "2018-06-15", "sbir_award", "sbir_phase_i", 150000.0),
+            _event("ACME INC", "2020-09-01", "sbir_award", "sbir_phase_ii", 1000000.0),
+            _event("BORING LLC", "2020-04-01", "sbir_award", "sbir_phase_i", 250000.0),
+        ]
+    )
     summary = summarize_per_firm(events, cohort)
     acme = summary[summary.company_name == "ACME INC"].iloc[0]
     assert acme["sbir_award_count"] == 2
@@ -46,10 +63,12 @@ def test_summary_counts_and_sums_sbir_events(cohort):
 
 
 def test_summary_form_d_aggregations(cohort):
-    events = _events_df([
-        _event("ACME INC", "2023-01-15", "form_d_filing", "equity", 5_000_000.0),
-        _event("ACME INC", "2023-08-22", "form_d_filing", "debt", 10_000_000.0),
-    ])
+    events = _events_df(
+        [
+            _event("ACME INC", "2023-01-15", "form_d_filing", "equity", 5_000_000.0),
+            _event("ACME INC", "2023-08-22", "form_d_filing", "debt", 10_000_000.0),
+        ]
+    )
     summary = summarize_per_firm(events, cohort)
     acme = summary[summary.company_name == "ACME INC"].iloc[0]
     assert acme["form_d_filing_count"] == 2
@@ -57,10 +76,12 @@ def test_summary_form_d_aggregations(cohort):
 
 
 def test_summary_ma_flags_and_dates(cohort):
-    events = _events_df([
-        _event("ACME INC", "2024-02-01", "ma_event", "medium"),
-        _event("ACME INC", "2024-03-01", "ma_event", "high"),
-    ])
+    events = _events_df(
+        [
+            _event("ACME INC", "2024-02-01", "ma_event", "medium"),
+            _event("ACME INC", "2024-03-01", "ma_event", "high"),
+        ]
+    )
     summary = summarize_per_firm(events, cohort)
     acme = summary[summary.company_name == "ACME INC"].iloc[0]
     assert bool(acme["has_ma_event"]) is True
@@ -69,11 +90,13 @@ def test_summary_ma_flags_and_dates(cohort):
 
 
 def test_summary_first_and_last_event_dates(cohort):
-    events = _events_df([
-        _event("ACME INC", "2018-06-15", "sbir_award", "sbir_phase_i", 150000.0),
-        _event("ACME INC", "2024-02-01", "ma_event", "high"),
-        _event("ACME INC", "2023-08-22", "form_d_filing", "equity", 10_000_000.0),
-    ])
+    events = _events_df(
+        [
+            _event("ACME INC", "2018-06-15", "sbir_award", "sbir_phase_i", 150000.0),
+            _event("ACME INC", "2024-02-01", "ma_event", "high"),
+            _event("ACME INC", "2023-08-22", "form_d_filing", "equity", 10_000_000.0),
+        ]
+    )
     summary = summarize_per_firm(events, cohort)
     acme = summary[summary.company_name == "ACME INC"].iloc[0]
     assert acme["first_event_date"] == "2018-06-15"

--- a/tests/unit/scripts/capital_events/test_ucc.py
+++ b/tests/unit/scripts/capital_events/test_ucc.py
@@ -17,23 +17,28 @@ def test_returns_empty_when_file_missing(cohort, tmp_path):
 
 def test_yields_one_event_per_match(cohort, tmp_path):
     src = tmp_path / "ucc1_pilot_matches.jsonl"
-    src.write_text(json.dumps({
-        "cohort_company_name": "ACME INC",
-        "match_confidence": "high",
-        "match_score": 1.0,
-        "filing": {
-            "filing_number": "U240107248023",
-            "filing_type": "initial",
-            "filing_date": "2024-01-30",
-            "debtor_name": "ACME INC",
-            "debtor_address": "SAN DIEGO, CA",
-            "secured_party_name": "LEAF CAPITAL FUNDING, LLC",
-            "secured_party_address": "PHILADELPHIA, PA",
-            "status_portal": "Active",
-            "lapse_date": "2029-01-30",
-            "source": "CA",
-        },
-    }) + "\n")
+    src.write_text(
+        json.dumps(
+            {
+                "cohort_company_name": "ACME INC",
+                "match_confidence": "high",
+                "match_score": 1.0,
+                "filing": {
+                    "filing_number": "U240107248023",
+                    "filing_type": "initial",
+                    "filing_date": "2024-01-30",
+                    "debtor_name": "ACME INC",
+                    "debtor_address": "SAN DIEGO, CA",
+                    "secured_party_name": "LEAF CAPITAL FUNDING, LLC",
+                    "secured_party_address": "PHILADELPHIA, PA",
+                    "status_portal": "Active",
+                    "lapse_date": "2029-01-30",
+                    "source": "CA",
+                },
+            }
+        )
+        + "\n"
+    )
 
     events = list(build_ucc_events(cohort, src))
     assert len(events) == 1
@@ -52,15 +57,26 @@ def test_yields_one_event_per_match(cohort, tmp_path):
 
 def test_skips_filings_for_non_cohort_firms(cohort, tmp_path):
     src = tmp_path / "ucc1_pilot_matches.jsonl"
-    src.write_text(json.dumps({
-        "cohort_company_name": "UNRELATED INC",
-        "match_confidence": "high", "match_score": 1.0,
-        "filing": {
-            "filing_number": "X", "filing_type": "initial",
-            "filing_date": "2024-01-01",
-            "debtor_name": "UNRELATED INC", "debtor_address": "",
-            "secured_party_name": "BANK", "secured_party_address": "",
-            "status_portal": "Active", "lapse_date": None, "source": "CA",
-        },
-    }) + "\n")
+    src.write_text(
+        json.dumps(
+            {
+                "cohort_company_name": "UNRELATED INC",
+                "match_confidence": "high",
+                "match_score": 1.0,
+                "filing": {
+                    "filing_number": "X",
+                    "filing_type": "initial",
+                    "filing_date": "2024-01-01",
+                    "debtor_name": "UNRELATED INC",
+                    "debtor_address": "",
+                    "secured_party_name": "BANK",
+                    "secured_party_address": "",
+                    "status_portal": "Active",
+                    "lapse_date": None,
+                    "source": "CA",
+                },
+            }
+        )
+        + "\n"
+    )
     assert list(build_ucc_events(cohort, src)) == []

--- a/tests/unit/scripts/capital_events/test_usaspending.py
+++ b/tests/unit/scripts/capital_events/test_usaspending.py
@@ -31,10 +31,16 @@ def _contract(recipient, award_id, start, amount, agency="Department of Defense"
 
 def test_emits_one_event_per_contract(cohort, tmp_path):
     src = tmp_path / "usaspending.jsonl"
-    src.write_text("\n".join(json.dumps(c) for c in [
-        _contract("ACME INC", "W56HZV-22-D-0001", "2022-06-01", 5_000_000.0),
-        _contract("ACME INC", "W56HZV-23-D-0002", "2023-09-15", 8_000_000.0),
-    ]) + "\n")
+    src.write_text(
+        "\n".join(
+            json.dumps(c)
+            for c in [
+                _contract("ACME INC", "W56HZV-22-D-0001", "2022-06-01", 5_000_000.0),
+                _contract("ACME INC", "W56HZV-23-D-0002", "2023-09-15", 8_000_000.0),
+            ]
+        )
+        + "\n"
+    )
 
     events = list(build_usaspending_events(cohort, src))
     assert len(events) == 2


### PR DESCRIPTION
## Summary

Pure ruff format pass on the 10 capital_events test files. No logic changes, 50 unit tests still pass.

## Why

The capital-events test files shipped in #307 weren't run through \`ruff format\` before merge. CI's Code Quality (Lint + Type Check) check has been failing on every PR that touches \`tests/\` since #307 landed, including #287 (phase-3-solicitation-alerts) which inherited the failure.

## Scope

10 files reformatted, 490 insertions / 191 deletions — mostly line wrapping for long string literals in test fixtures. Files:

- \`test_common.py\`
- \`test_form_d.py\`
- \`test_ma_events.py\`
- \`test_orchestrator.py\`
- \`test_patents.py\`
- \`test_sbir_awards.py\`
- \`test_schema.py\`
- \`test_summarize.py\`
- \`test_ucc.py\`
- \`test_usaspending.py\`

## Test plan

- [x] \`ruff format --check tests/unit/scripts/capital_events/\` — clean
- [x] \`ruff check tests/unit/scripts/capital_events/ scripts/data/capital_events/ scripts/data/build_capital_events.py\` — all checks passed
- [x] \`pytest tests/unit/scripts/capital_events/ -q\` — 50 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)