### PR TITLE
docs(specs): SBIR M&amp;A match rate by fiscal year (FY2015–2024)

### DIFF
--- a/specs/sbir_ma_match_rate_by_fy/design.md
+++ b/specs/sbir_ma_match_rate_by_fy/design.md
@@ -3,24 +3,29 @@
 ## Approach
 
 Read-only analysis on top of existing enrichment outputs. No new
-extraction, no schema changes. One script, one Dagster asset,
-two report files.
+extraction, no schema changes. One script, one Dagster asset, and
+three report files (per-FY CSV, narrative MD, firm-level detail CSV)
+matching the outputs enumerated in `requirements.md`.
 
-## Inputs (existing parquet)
+## Inputs (existing JSONL + Dagster asset)
 
-- `data/processed/sbir_awards.parquet` — award_recipient, award start
-  date, agency.
-- `data/processed/sec_edgar_mentions.parquet` — EFTS mentions with
-  classification and filing dates.
-- `data/processed/sec_edgar_ma_events.parquet` — `EdgarMAEvent` rows
-  (8-K Item 1.01/2.01 detections from `_detect_ma_events`).
-- `data/processed/form_d_filings.parquet` — Form D with
-  `is_business_combination` flag.
-- `data/processed/sbir_company_cik_map.parquet` — SBIR firm → CIK
-  mapping (existing entity resolution output).
+The implemented enrichment pipeline emits JSONL artifacts and one
+DataFrame asset, not per-filing parquet. The canonical inputs are:
 
-If any of these names differ in the actual repo, use the canonical
-asset names from `packages/sbir-analytics/sbir_analytics/assets/`.
+- `data/sbir_ma_events.jsonl` — curated M&A events output from PR #286
+  (`scripts/data/detect_sbir_ma_events.py`).
+- `data/sec_edgar_scan.jsonl` — resumable EFTS scan output.
+- `data/form_d_details.jsonl` — Form D filings with
+  `is_business_combination` flag and confidence tier.
+- Dagster asset `sec_edgar_enriched_companies` (DataFrame) — per-firm
+  enrichment surface including `mention_*` aggregates and CIK linkage;
+  use this rather than re-deriving from raw mentions.
+- SBIR awards: the canonical `enriched_sbir_awards` asset.
+
+If any later refactor introduces parquet equivalents, those become the
+preferred inputs; update this section accordingly. The acceptance
+criterion (AC1) is "reproducible from existing artifacts," not
+specifically parquet.
 
 ## Pipeline
 
@@ -77,11 +82,16 @@ Per firm, keep one row:
 
 Per FY:
 - Denominator: distinct firms with `primary_award_fy = FY`.
-- Numerator: distinct matched firms whose `match_fy` falls in any FY
-  ≥ their `primary_award_fy` and ≤ 2024.
+- Numerator (per requirements.md): distinct matched firms with at least
+  one qualifying M&A signal dated in FY2015–2024. A match is attributed
+  to the FY of its earliest qualifying signal.
+- Per AC6, firms whose `match_fy` precedes their `primary_award_fy`
+  are still counted in the numerator but flagged
+  `match_before_first_award = true` in the firm-level detail CSV and
+  surfaced as a caveat in the narrative.
 
-Two rate columns:
-- `match_rate_high` = high+medium tier matches / denom.
+Two rate columns (note the inclusive-tier semantics in the names):
+- `match_rate_high_medium` = (high + medium tier matches) / denom.
 - `match_rate_total` = all-tier matches / denom.
 
 Aggregate FY2015–2024 row reports Wilson 95% CI.

--- a/specs/sbir_ma_match_rate_by_fy/design.md
+++ b/specs/sbir_ma_match_rate_by_fy/design.md
@@ -1,0 +1,133 @@
+# Design: SBIR M&A Match Rate by Fiscal Year
+
+## Approach
+
+Read-only analysis on top of existing enrichment outputs. No new
+extraction, no schema changes. One script, one Dagster asset,
+two report files.
+
+## Inputs (existing parquet)
+
+- `data/processed/sbir_awards.parquet` — award_recipient, award start
+  date, agency.
+- `data/processed/sec_edgar_mentions.parquet` — EFTS mentions with
+  classification and filing dates.
+- `data/processed/sec_edgar_ma_events.parquet` — `EdgarMAEvent` rows
+  (8-K Item 1.01/2.01 detections from `_detect_ma_events`).
+- `data/processed/form_d_filings.parquet` — Form D with
+  `is_business_combination` flag.
+- `data/processed/sbir_company_cik_map.parquet` — SBIR firm → CIK
+  mapping (existing entity resolution output).
+
+If any of these names differ in the actual repo, use the canonical
+asset names from `packages/sbir-analytics/sbir_analytics/assets/`.
+
+## Pipeline
+
+```
+awardees(FY2015-2024) ──┐
+                        ├─→ join on company_key ─→ matches ─→ tier-rank
+ma_signals(FY2015-2024)─┘                              │
+                                                       ↓
+                                            dedupe (one row per firm)
+                                                       ↓
+                                            group by match_fy → CSV + MD
+```
+
+### Step 1: Build awardee denominator
+
+```python
+awardees = (
+    awards
+    .filter(award_start_date >= 2014-10-01,
+            award_start_date <  2024-10-01)
+    .with_column(award_fy = fiscal_year(award_start_date))
+    .group_by(company_key)
+    .agg(primary_award_fy = min(award_fy))
+)
+```
+
+Federal FY: a date in [Oct 1 of year Y-1, Sep 30 of Y] is FY Y.
+
+### Step 2: Collect dated M&A signals
+
+Union the dated signal sources, tag each with tier and signal type:
+
+| Source | Filter | Tier | Date column |
+|---|---|---|---|
+| `ma_events` | all rows | Low (1.01/2.01) | `filing_date` |
+| `mentions` | `classification = 'subsidiary'` | High | `filing_date` (upper bound) |
+| `mentions` | `classification = 'acquisition'` | Medium | `filing_date` |
+| `mentions` | `classification = 'ma_definitive'`, form_type in (SC TO-T, SC 14D9) | Low | `filing_date` |
+| `mentions` | `classification = 'ma_proxy'` | Low | `filing_date` |
+| `mentions` | `classification = 'ownership_active'` | Low | `filing_date` |
+| `form_d` | `is_business_combination = True` | High | `filing_date` |
+
+Restrict to filings dated within FY2015–2024.
+
+### Step 3: Tier ranking and dedupe
+
+Per firm, keep one row:
+- Highest tier wins (High > Medium > Low).
+- Within tier, earliest filing_date wins.
+- Carry list of contributing signals for the detail CSV.
+- For Exhibit-21-only matches, set `date_upper_bound = true`.
+
+### Step 4: Compute rates
+
+Per FY:
+- Denominator: distinct firms with `primary_award_fy = FY`.
+- Numerator: distinct matched firms whose `match_fy` falls in any FY
+  ≥ their `primary_award_fy` and ≤ 2024.
+
+Two rate columns:
+- `match_rate_high` = high+medium tier matches / denom.
+- `match_rate_total` = all-tier matches / denom.
+
+Aggregate FY2015–2024 row reports Wilson 95% CI.
+
+### Step 5: Item 2.01 sub-rate (methodological footnote)
+
+Filter `ma_events` to rows where `'2.01' in items_reported`. Compute
+the same numerator/denominator. Report as a single number with the
+caveat that single-signal Item 2.01 has ~30–40% estimated precision.
+
+## File layout
+
+```
+scripts/analysis/sbir_ma_match_rate_by_fy.py    # script (one file)
+packages/sbir-analytics/sbir_analytics/assets/sbir_ma_match_rate.py
+                                                # thin Dagster wrapper
+reports/sbir_ma_match_rate_by_fy.csv            # generated
+reports/sbir_ma_match_rate_by_fy.md             # generated
+reports/sbir_ma_matched_firms_fy2015_2024.csv   # generated
+```
+
+The Dagster asset just calls the script and writes outputs to the
+`reports/` directory — no new IO managers, no new resources.
+
+## Open questions to resolve before implementation
+
+- **Q1: Company key.** Is `company_key` already canonical across
+  awards and SEC enrichment, or do we need to join through
+  `sbir_company_cik_map`? Verify before writing the join.
+- **Q2: Form D party.** Form D filings can be filed by the acquirer,
+  the target, or a holdco. Confirm the existing `form_d_filings`
+  parquet links the filing CIK back to the SBIR firm — and that
+  `is_business_combination = True` rows include both directions.
+- **Q3: Mentions parquet.** Confirm the column names for
+  `classification` and `form_type` in `sec_edgar_mentions.parquet`
+  match the model in `sbir_etl/models/sec_edgar.py`.
+- **Q4: Right-censoring.** A firm acquired in 2024 may not have its
+  10-K Exhibit 21 filed yet. Should the FY2024 row footnote this, or
+  exclude FY2024 from the headline aggregate?
+
+These are confirmable in <30 min by reading the asset definitions;
+not blocking the spec, but blocking implementation.
+
+## Non-goals
+
+- Form 15 (deregistration) extraction — separate spec if needed.
+- Re-running EFTS to attribute item codes per-mention — out of scope.
+- Linking to acquirer ticker / market cap — out of scope.
+- ML-based deduplication of signals — current rules are sufficient.

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -1,0 +1,78 @@
+# Requirements: SBIR M&A Match Rate by Fiscal Year
+
+## Question of record
+
+What is the SBIR-awardee → M&A-event match rate for FY2015–2024,
+attributable by fiscal year, using SEC filings as evidence?
+
+The user's literal question is "8-K Item 2.01 match rate." That cannot
+be answered in isolation: Item 2.01 has ~30–40% precision alone (per
+`docs/research/sbir-ma-exit-analysis.md:40-42`) and is bucketed with
+Item 1.01 in the existing pipeline. We answer the underlying question
+by combining the full signal stack.
+
+## Scope
+
+- **In:** SBIR awardees (any agency) with ≥1 award FY2015–2024,
+  matched against SEC filings indicating acquisition in the same window.
+- **In:** Per-FY breakdown of match counts and rates.
+- **In:** Signal-tier breakdown (high / medium / low confidence).
+- **Out:** New signal extraction — reuse existing `EdgarMAEvent`,
+  `EdgarMention`, and Form D enrichment outputs.
+- **Out:** Re-running EFTS or Form D fetches.
+- **Out:** Backfilling Form 15 (deregistration) — tracked separately.
+
+## Definitions
+
+- **Awardee universe (denominator):** distinct SBIR firms with award
+  start date in FY2015–2024 (federal FY: Oct 1 – Sep 30).
+- **Match (numerator):** awardee has ≥1 dated M&A signal where the
+  signal's filing date falls in FY2015–2024.
+- **Acquisition FY:** fiscal year of the earliest qualifying signal
+  per awardee (one match per firm).
+- **Confidence tier per match:** the highest tier among that firm's
+  qualifying signals, using the existing tier rules in
+  `scripts/data/detect_sbir_ma_events.py`.
+
+## Signals used and date attribution
+
+| Signal | Tier | Date used |
+|---|---|---|
+| `subsidiary` (Exhibit 21) | High | First 10-K filing date listing firm — **upper bound only** |
+| Form D `is_business_combination` | High | Form D filing date |
+| `acquisition` (10-K/10-Q text) | Medium | Filing date of the confirming 10-K/10-Q |
+| `ma_definitive` 8-K (Item 1.01/2.01) | Low | 8-K filing date |
+| `ma_definitive` tender (SC TO-T, SC 14D9) | Low | Tender filing date |
+| `ma_proxy` (DEFM14A/PREM14A) | Low | Proxy filing date |
+| `ownership_active` (SC 13D) | Low | 13D filing date (pre-event marker) |
+
+Exhibit 21 alone cannot date a transaction. When Exhibit 21 is the
+only signal, the match is attributed to the FY of the earliest 10-K
+in which the firm appears — flagged as `date_upper_bound = true`.
+
+## Outputs
+
+1. `reports/sbir_ma_match_rate_by_fy.csv` — one row per FY, columns:
+   `fiscal_year, awardees_in_fy, matched_high, matched_medium,
+   matched_low, matched_total, match_rate_high, match_rate_total`.
+2. `reports/sbir_ma_match_rate_by_fy.md` — narrative summary with
+   methodology, caveats, and the FY2015–2024 aggregate.
+3. `reports/sbir_ma_matched_firms_fy2015_2024.csv` — firm-level
+   detail: `award_recipient, primary_award_fy, match_fy,
+   tier, signals, acquirer (if known), date_upper_bound`.
+
+## Acceptance criteria
+
+- AC1: Numerator and denominator are reproducible from existing
+  parquet outputs (no new network calls required).
+- AC2: Per-FY denominator equals the count of distinct firms whose
+  earliest FY2015–2024 award is in that FY.
+- AC3: Each matched firm appears exactly once (deduped on firm key).
+- AC4: Aggregate FY2015–2024 high+medium match rate is reported with
+  a 95% Wilson confidence interval.
+- AC5: The Item-2.01-only sub-rate is reported as a methodological
+  footnote, not as the headline number.
+- AC6: Caveats section explicitly addresses: Exhibit-21 dating,
+  private acquirers (no SEC filings), SBIR firms acquired before any
+  award in the window, and right-censoring (recent acquisitions not
+  yet filed).

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -17,8 +17,9 @@ by combining the full signal stack.
   matched against SEC filings indicating acquisition in the same window.
 - **In:** Per-FY breakdown of match counts and rates.
 - **In:** Signal-tier breakdown (high / medium / low confidence).
-- **Out:** New signal extraction — reuse existing `EdgarMAEvent`,
-  `EdgarMention`, and Form D enrichment outputs.
+- **Out:** New signal extraction — reuse existing `EdgarMAEvent` rows,
+  the `mention_*` aggregates on `CompanyEdgarProfile`, and Form D
+  enrichment outputs.
 - **Out:** Re-running EFTS or Form D fetches.
 - **Out:** Backfilling Form 15 (deregistration) — tracked separately.
 
@@ -54,7 +55,10 @@ in which the firm appears — flagged as `date_upper_bound = true`.
 
 1. `reports/sbir_ma_match_rate_by_fy.csv` — one row per FY, columns:
    `fiscal_year, awardees_in_fy, matched_high, matched_medium,
-   matched_low, matched_total, match_rate_high, match_rate_total`.
+   matched_low, matched_total, match_rate_high_medium,
+   match_rate_total`. The `match_rate_high_medium` column is named
+   for what it contains (high + medium tier numerator) so it cannot
+   be misread as "high tier only."
 2. `reports/sbir_ma_match_rate_by_fy.md` — narrative summary with
    methodology, caveats, and the FY2015–2024 aggregate.
 3. `reports/sbir_ma_matched_firms_fy2015_2024.csv` — firm-level

--- a/specs/sbir_ma_match_rate_by_fy/tasks.md
+++ b/specs/sbir_ma_match_rate_by_fy/tasks.md
@@ -1,0 +1,65 @@
+# Tasks: SBIR M&A Match Rate by Fiscal Year
+
+Estimated total: 1–1.5 days. No new extraction; analysis only.
+
+## T0. Resolve open questions (design.md §"Open questions")
+
+- [ ] Confirm canonical join key between awards and SEC enrichment.
+- [ ] Confirm `form_d_filings` parquet schema and SBIR-firm linkage.
+- [ ] Confirm `sec_edgar_mentions` parquet column names.
+- [ ] Decide FY2024 right-censoring policy (footnote vs. exclude).
+  → verify: each question answered in design.md before T1.
+
+## T1. Implement match-rate script
+
+- [ ] Create `scripts/analysis/sbir_ma_match_rate_by_fy.py`.
+- [ ] Build awardee denominator (FY2015–2024, distinct firms).
+- [ ] Union dated signal sources with tier + signal-type labels.
+- [ ] Tier-rank dedupe (one row per firm).
+- [ ] Compute per-FY counts and rates; Wilson CI on aggregate.
+- [ ] Compute Item-2.01-only sub-rate.
+- [ ] Write three output files to `reports/`.
+  → verify: run end-to-end on local parquets; rows match
+  `awardees_in_fy ≥ matched_total`; aggregate rate is in
+  plausible range (5–15% based on prior 8.1% all-time figure).
+
+## T2. Unit tests
+
+- [ ] `tests/unit/scripts/test_ma_match_rate_by_fy.py`:
+  - Tier-rank dedupe with synthetic firm having High + Low signals.
+  - FY boundary cases (Sep 30 vs. Oct 1).
+  - Exhibit-21-only match flagged `date_upper_bound = true`.
+  - Wilson CI matches a known reference value.
+  - Item 2.01 sub-rate filters correctly when 1.01 also present.
+  → verify: `pytest tests/unit/scripts/test_ma_match_rate_by_fy.py -v`.
+
+## T3. Dagster asset
+
+- [ ] `packages/sbir-analytics/sbir_analytics/assets/sbir_ma_match_rate.py`.
+- [ ] Thin wrapper that invokes the script and registers
+  outputs as Dagster assets for the `reports/` files.
+- [ ] No new resources; reuse existing parquet IO managers.
+  → verify: `dagster asset materialize --select sbir_ma_match_rate_by_fy`
+  produces all three reports.
+
+## T4. Report and write-up
+
+- [ ] Populate `reports/sbir_ma_match_rate_by_fy.md` with: methodology,
+  per-FY table, aggregate FY2015–2024 row with CI, Item 2.01 footnote,
+  caveats (Exhibit-21 dating, private acquirers, right-censoring,
+  pre-window acquisitions).
+- [ ] Cross-link from `docs/research-questions.md` A4.
+  → verify: numbers in MD match the CSV exactly; markdown lints clean.
+
+## T5. Quality sweep
+
+- [ ] Run `quality-sweep` agent on changed files.
+- [ ] Run full test suite: `pytest tests/unit -v`.
+  → verify: zero ruff / mypy errors; all tests pass.
+
+## Out of scope (not in this spec)
+
+- Form 15 (deregistration) extraction.
+- Per-item-code attribution from EFTS (would require re-fetching).
+- Acquirer market-cap / sector enrichment.
+- Backfill of acquisitions before FY2015.

--- a/specs/sbir_ma_match_rate_by_fy/tasks.md
+++ b/specs/sbir_ma_match_rate_by_fy/tasks.md
@@ -4,9 +4,13 @@ Estimated total: 1–1.5 days. No new extraction; analysis only.
 
 ## T0. Resolve open questions (design.md §"Open questions")
 
-- [ ] Confirm canonical join key between awards and SEC enrichment.
-- [ ] Confirm `form_d_filings` parquet schema and SBIR-firm linkage.
-- [ ] Confirm `sec_edgar_mentions` parquet column names.
+- [ ] Confirm canonical join key between awards and SEC enrichment
+  (UEI/DUNS vs. normalized company name) for both `sbir_ma_events.jsonl`
+  and the `sec_edgar_enriched_companies` asset.
+- [ ] Confirm `data/form_d_details.jsonl` schema and SBIR-firm linkage
+  (CIK and/or normalized name).
+- [ ] Confirm `data/sec_edgar_scan.jsonl` mention columns and
+  classification labels.
 - [ ] Decide FY2024 right-censoring policy (footnote vs. exclude).
   → verify: each question answered in design.md before T1.
 


### PR DESCRIPTION
## Summary

Spec-only PR. Adds `specs/sbir_ma_match_rate_by_fy/` — design + requirements + tasks for measuring the SBIR ↔ M&A-event match rate across FY2015–2024.

## What this answers

Research-question anchor: **A4 (M&A & monitoring) / D3 (Reconciliation)**.

> What fraction of SBIR awardees can be matched to a detected M&A event (Form D high-confidence + 8-K), broken down by fiscal year, and how does the match rate trend over time?

This is the audit-quality companion to PR #286 — once the M&A pipeline is producing events, this spec asks "how confident are we that the coverage is stable and trending the right way?"

## Files

- `specs/sbir_ma_match_rate_by_fy/{design,requirements,tasks}.md`

Clean merge with current `main`.

🤖 Triaged via Claude Code session_01Trur84H3UF6FXZNk9LQv3u

---
_Generated by [Claude Code](https://claude.ai/code/session_01Trur84H3UF6FXZNk9LQv3u)_