### PR TITLE
Migrate CI and automation to current source layout

### DIFF
--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -240,7 +240,10 @@ Detects which parts of the codebase changed using path filters.
   with:
     filters: |
       code-changed:
-        - 'src/**'
+        - 'sbir_etl/**'
+        - 'packages/sbir-analytics/sbir_analytics/**'
+        - 'packages/sbir-ml/sbir_ml/**'
+        - 'packages/sbir-graph/sbir_graph/**'
         - 'tests/**'
       docs-only:
         - '**/*.md'

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -94,7 +94,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: .pytest_cache
-        key: pytest-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('tests/**/*.py', 'src/**/*.py') }}
+        key: pytest-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('tests/**/*.py', 'sbir_etl/**/*.py', 'packages/sbir-analytics/sbir_analytics/**/*.py', 'packages/sbir-ml/sbir_ml/**/*.py', 'packages/sbir-graph/sbir_graph/**/*.py') }}
         restore-keys: |
           pytest-${{ runner.os }}-${{ inputs.python-version }}-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      production: ${{ steps.detect.outputs.production }}
       performance: ${{ steps.detect.outputs.performance }}
       cet: ${{ steps.detect.outputs.cet }}
       transition: ${{ steps.detect.outputs.transition }}
@@ -73,17 +74,24 @@ jobs:
               - '!Makefile'
               - '!.github/**'
           filters: |
+            production:
+              - 'sbir_etl/**'
+              - 'packages/sbir-analytics/sbir_analytics/**'
+              - 'packages/sbir-ml/sbir_ml/**'
+              - 'packages/sbir-graph/sbir_graph/**'
             performance:
-              - 'src/enrichers/**'
-              - 'src/assets/**'
-              - 'src/utils/performance_monitor.py'
-              - 'src/extractors/**'
+              - 'sbir_etl/enrichers/**'
+              - 'sbir_etl/extractors/**'
+              - 'sbir_etl/utils/performance_monitor.py'
+              - 'packages/sbir-analytics/sbir_analytics/assets/**'
+              - 'packages/sbir-graph/sbir_graph/**'
               - 'scripts/performance/benchmark_enrichment.py'
               - 'scripts/performance/detect_performance_regression.py'
               - 'config/base.yaml'
             cet:
-              - 'src/ml/config/**'
-              - 'src/assets/jobs/cet_*.py'
+              - 'packages/sbir-ml/sbir_ml/ml/config/**'
+              - 'packages/sbir-analytics/sbir_analytics/assets/cet/**'
+              - 'packages/sbir-analytics/sbir_analytics/assets/jobs/cet_*.py'
               - 'tests/unit/ml/**'
               - 'tests/integration/ml/**'
               - 'tests/e2e/ml/**'
@@ -129,13 +137,47 @@ jobs:
           cache-venv: "true"
 
       - name: Run Ruff lint
-        run: uv run python -m ruff check sbir_etl tests
+        run: uv run python -m ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests
 
       - name: Run Ruff format check
-        run: uv run python -m ruff format --check sbir_etl tests
+        run: uv run python -m ruff format --check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests
 
       - name: Run MyPy type checker
         run: uv run python -m mypy sbir_etl
+
+      - name: Reject removed source-root references
+        run: uv run python scripts/ci/check_removed_src_references.py
+
+  package-type-checks:
+    name: Package MyPy - ${{ matrix.package.name }}
+    needs: [detect-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: needs.detect-changes.outputs.docs-only != 'true'
+    continue-on-error: ${{ matrix.package.non_blocking }}
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - name: sbir-analytics
+            path: packages/sbir-analytics/sbir_analytics
+            non_blocking: true
+          - name: sbir-ml
+            path: packages/sbir-ml/sbir_ml
+            non_blocking: true
+          - name: sbir-graph
+            path: packages/sbir-graph/sbir_graph
+            non_blocking: false
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Python and UV
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          install-dev-deps: "true"
+          cache-venv: "true"
+      - name: Run package MyPy
+        run: uv run python -m mypy ${{ matrix.package.path }}
 
   verify-setup-script:
     name: Verify Setup Script
@@ -318,7 +360,7 @@ jobs:
           REQUIRE_NEO4J: ${{ matrix.suite.needs_neo4j && '1' || '' }}
         run: |
           uv run pytest ${{ matrix.suite.path }} ${{ matrix.suite.args }} \
-            --cov=src --cov-report=xml --cov-report=term \
+            --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-report=xml --cov-report=term \
             --junitxml=test-results-${{ matrix.suite.name }}.xml -v
 
       - name: Stop Neo4j service

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -250,7 +250,7 @@ jobs:
         run: |
           uv run pytest \
             -m "e2e or real_data or weekly" \
-            --cov=src \
+            --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph \
             --cov-report=html \
             --cov-report=xml \
             --cov-report=term \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,26 +8,26 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  # Python linting and formatting (matches CI scope: src and tests)
-  # CI equivalent: ruff check src tests && ruff format --check src tests
+  # Python linting and formatting (matches CI scope: production packages and tests)
+  # CI equivalent: ruff check <production-roots> tests && ruff format --check <production-roots> tests
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.4
     hooks:
       - id: ruff
-        files: ^(src|tests)/
+        files: ^(sbir_etl|packages/sbir-(analytics/sbir_analytics|ml/sbir_ml|graph/sbir_graph)|tests)/
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
-        files: ^(src|tests)/
+        files: ^(sbir_etl|packages/sbir-(analytics/sbir_analytics|ml/sbir_ml|graph/sbir_graph)|tests)/
 
-  # Type checking (matches CI scope: src only)
-  # CI equivalent: mypy src
+  # Type checking (matches blocking CI scope: sbir_etl only)
+  # CI equivalent: mypy sbir_etl
   # Note: mypy is configured in pyproject.toml with exclude patterns for
   # scripts/, tests/, examples/, and migrations/ to match this scope
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.2
     hooks:
       - id: mypy
-        files: ^src/
+        files: ^sbir_etl/
         args: [--config-file=pyproject.toml]
         additional_dependencies:
           [
@@ -40,8 +40,18 @@ repos:
             pydantic,
           ]
 
+  # Source-layout regression guard (matches CI)
+  - repo: local
+    hooks:
+      - id: removed-src-root
+        name: Reject removed src source-root references
+        entry: python scripts/ci/check_removed_src_references.py
+        language: system
+        pass_filenames: false
+        always_run: true
+
 # Security scanning (bandit and detect-secrets) moved to nightly CI only
-# Run manually with: uv run bandit -r src -c pyproject.toml
+# Run manually with: uv run bandit -r sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph -c pyproject.toml
 # Run manually with: uv run detect-secrets scan --baseline .secrets.baseline
 
 # Configuration notes for maintainers:
@@ -52,9 +62,9 @@ repos:
 #   the same paths to ensure consistency between local and CI environments.
 #
 #   Tool Scope Mapping:
-#   - Ruff (lint/format): src/ tests/     [matches CI: ruff check src tests]
-#   - MyPy (type check):  src/            [matches CI: mypy src]
-#   - Bandit (security):  src/            [matches CI: bandit -r src]
+#   - Ruff (lint/format): all production package roots and tests
+#   - MyPy (type check):  sbir_etl/      [matches blocking CI check]
+#   - Bandit (security):  all production package roots
 #   - Standard hooks:     all files       [good practice, not in CI]
 #   - Detect-secrets:     all files       [best practice, not in CI]
 #

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ install: ## Install dependencies with uv
 .PHONY: test
 test: ## Run all tests
 	@$(call info,Running tests)
-	$(call run,uv run pytest -v --cov=src)
+	$(call run,uv run pytest -v --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph)
 
 .PHONY: test-unit
 test-unit: ## Run unit tests only
@@ -214,7 +214,7 @@ format: ## Format code
 .PHONY: dev
 dev: ## Run Dagster dev server locally
 	@$(call info,Starting Dagster dev server)
-	$(call run,uv run dagster dev -m src.definitions)
+	$(call run,uv run dagster dev -m sbir_analytics.definitions)
 
 .PHONY: install-ml
 install-ml: ## Install ML dependencies (jupyter, paecter)
@@ -488,25 +488,25 @@ neo4j-check: env-check ## Run the Neo4j health check
 .PHONY: transition-run
 transition-run: ## Run transition detection pipeline
 	@$(call info,Running transition detection)
-	$(call run,uv run dagster job execute -m src.definitions -j transition_job)
+	$(call run,uv run dagster job execute -m sbir_analytics.definitions -j transition_job)
 	@$(call success,Transition detection completed)
 
 .PHONY: cet-run
 cet-run: ## Run CET classification pipeline
 	@$(call info,Running CET classification)
-	$(call run,uv run dagster job execute -m src.definitions_ml -j cet_full_pipeline_job)
+	$(call run,uv run dagster job execute -m sbir_analytics.definitions_ml -j cet_full_pipeline_job)
 	@$(call success,CET classification completed)
 
 .PHONY: fiscal-run
 fiscal-run: ## Run fiscal returns analysis (BEA API)
 	@$(call info,Running fiscal returns analysis)
-	$(call run,uv run dagster job execute -m src.definitions_ml -j fiscal_returns_mvp_job)
+	$(call run,uv run dagster job execute -m sbir_analytics.definitions_ml -j fiscal_returns_mvp_job)
 	@$(call success,Fiscal returns analysis completed)
 
 .PHONY: paecter-run
 paecter-run: ## Run PaECTER embeddings and similarity
 	@$(call info,Running PaECTER analysis)
-	$(call run,uv run dagster job execute -m src.definitions_ml -j paecter_job)
+	$(call run,uv run dagster job execute -m sbir_analytics.definitions_ml -j paecter_job)
 	@$(call success,PaECTER analysis completed)
 
 # -----------------------------------------------------------------------------

--- a/config/README.md
+++ b/config/README.md
@@ -75,7 +75,7 @@ export SBIR_ETL__LOGGING__LEVEL="DEBUG"
 
 ## Type Safety
 
-Configuration is validated using Pydantic models in `src/config/schemas.py`. This ensures:
+Configuration is validated using Pydantic models in `sbir_etl/config/schemas/`. This ensures:
 
 - Type safety at runtime
 - Automatic validation of configuration values
@@ -149,7 +149,7 @@ Configuration is automatically validated when loaded. Invalid configuration will
 
 ## Adding New Configuration
 
-1. Add the new fields to the appropriate Pydantic model in `src/config/schemas.py`
+1. Add the new fields to the appropriate Pydantic model in `sbir_etl/config/schemas/`
 2. Add default values to `base.yaml`
 3. Add environment-specific overrides to `dev.yaml`/`test.yaml`/`prod.yaml` as needed
 4. Update this documentation

--- a/docs/architecture/shared-tech-stack.md
+++ b/docs/architecture/shared-tech-stack.md
@@ -340,7 +340,7 @@ def my_asset_quality_check(my_asset: pd.DataFrame) -> AssetCheckResult:
 ## packages/sbir-analytics/sbir_analytics/assets/__init__.py
 
 from dagster import load_assets_from_modules
-from src import assets
+from sbir_analytics import assets
 
 asset_modules = assets.iter_asset_modules()
 all_assets = load_assets_from_modules(asset_modules)

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -677,7 +677,7 @@ services:
       - NEO4J_PASSWORD=${NEO4J_PASSWORD}
       - DAGSTER_HOME=/opt/dagster/dagster_home
     volumes:
-      - ./src:/app/src  # Dev profile only
+      - ./sbir_etl:/app/sbir_etl  # Dev profile only
       - ./config:/app/config
       - dagster-home:/opt/dagster/dagster_home
     depends_on:
@@ -717,7 +717,7 @@ services:
   app:
     command: dagster-webserver -h 0.0.0.0 -p 3000
     volumes:
-      - ./src:/app/src:ro  # Read-only bind mount
+      - ./sbir_etl:/app/sbir_etl:ro  # Read-only bind mount
       - ./config:/app/config:ro
     environment:
       - DAGSTER_RELOAD=true
@@ -769,7 +769,7 @@ services:
           memory: 4G
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import src"]
+      test: ["CMD", "python", "-c", "import sbir_etl"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -844,7 +844,7 @@ See [Configuration Patterns](../steering/configuration-patterns.md) for complete
 | `neo4j-data` | Named | Neo4j database | Required |
 | `dagster-home` | Named | Dagster metadata | Recommended |
 | `app-data` | Named | Application data | Optional |
-| `./src` | Bind | Source code (dev) | N/A |
+| `./sbir_etl` | Bind | Source code (dev) | N/A |
 | `./config` | Bind | Configuration | N/A |
 
 ### Backup Strategy
@@ -1002,7 +1002,7 @@ services:
 
 ```dockerfile
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-  CMD python -c "import importlib; importlib.import_module('src')" || exit 1
+  CMD python -c "import importlib; importlib.import_module('sbir_etl')" || exit 1
 ```
 
 ### Neo4j Health Check

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -96,7 +96,7 @@ S3_BUCKET=sbir-etl-production-data
 DAGSTER_HOME=/app/.dagster
 
 # Python environment
-PYTHONPATH=/app/src
+PYTHONPATH=/app
 ```
 
 ## Docker Compose Configuration
@@ -117,7 +117,7 @@ Development profile mounts local directories for live editing:
 
 | Local | Container | Purpose |
 |-------|-----------|---------|
-| `./src` | `/app/src` | Source code |
+| `./sbir_etl` | `/app/sbir_etl` | ETL source code |
 | `./tests` | `/app/tests` | Test files |
 | `./config` | `/app/config` | Configuration |
 

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -149,7 +149,7 @@ Some rule failed
 
 **Common issues:**
 
-- **Ruff errors:** Run `ruff check src tests --fix` to auto-fix many issues
+- **Ruff errors:** Run `ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests --fix` to auto-fix many issues
 - **MyPy errors:** Read the error message and add type hints or `# type: ignore` comments
 - **Bandit alerts:** Review and fix security issues, or add `# nosec` if false positive
 - **Detect-secrets alerts:** Review the secret, or add to `.secrets.baseline` if approved
@@ -174,17 +174,17 @@ This workflow runs on:
    - Time: ~5-10 minutes
 
 2. **lint** (Ruff)
-   - Runs: `ruff check src tests` + `ruff format --check src tests`
+   - Runs: `ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests` + `ruff format --check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests`
    - Purpose: Visibility into linting results
    - Time: ~1-2 minutes
 
 3. **types** (MyPy)
-   - Runs: `mypy src`
+   - Runs: `mypy sbir_etl`
    - Purpose: Type checking visibility
    - Time: ~1-2 minutes
 
 4. **security** (Bandit)
-   - Runs: `bandit -r src -c pyproject.toml`
+   - Runs: `bandit -r sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph -c pyproject.toml`
    - Purpose: Security scanning visibility
    - Time: ~1 minute
 
@@ -253,11 +253,11 @@ Tool versions are pinned in:
 | Item | Local | CI | Notes |
 |------|-------|----|----|
 | Tool versions | `.pre-commit-config.yaml` | `.pre-commit-config.yaml` | Identical |
-| Ruff scope | `.pre-commit-config.yaml` | `static-analysis.yml` | Both: `src tests` |
+| Ruff scope | `.pre-commit-config.yaml` | `static-analysis.yml` | Both: all production roots plus `tests` |
 | Ruff config | `pyproject.toml` | `pyproject.toml` | Identical |
-| MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `static-analysis.yml` | Both: `src` only |
+| MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `static-analysis.yml` | Both: `sbir_etl` only |
 | MyPy config | `pyproject.toml` | `pyproject.toml` | Identical |
-| Bandit scope | `.pre-commit-config.yaml` | `static-analysis.yml` | Both: `-r src` |
+| Bandit scope | `.pre-commit-config.yaml` | `static-analysis.yml` | Both: all production roots |
 | Bandit config | `pyproject.toml` | `pyproject.toml` | Identical |
 
 ---

--- a/docs/development/source-layout-migration.md
+++ b/docs/development/source-layout-migration.md
@@ -1,0 +1,30 @@
+# Source-layout migration inventory
+
+The former `src/` source root has been replaced by four production source roots:
+
+- `sbir_etl/`
+- `packages/sbir-analytics/sbir_analytics/`
+- `packages/sbir-ml/sbir_ml/`
+- `packages/sbir-graph/sbir_graph/`
+
+## Reference inventory
+
+| Classification | Locations reviewed | Migration action |
+| --- | --- | --- |
+| Executable automation | `.github/workflows/ci.yml`, `.github/workflows/weekly.yml`, `.github/actions/setup-python-uv/action.yml`, `.pre-commit-config.yaml`, `Makefile`, and `scripts/` | Updated coverage, change detection, quality checks, Dagster modules, import paths, and command examples to current package roots. |
+| Active documentation | `.github/` documentation, `config/README.md`, and active documents under `docs/` | Updated commands and package-path examples to current roots. |
+| Historical documentation | `docs/decisions/ADR-002-etl-library-extraction.md` | Preserved because its references explain the prior layout and migration decision. |
+
+CI and pre-commit run `scripts/ci/check_removed_src_references.py` to reject executable automation that reintroduces the removed source root. The historical ADR is explicitly excluded from that policy.
+
+## Quality-check scope
+
+Before this migration, CI Ruff checked only `sbir_etl/` and `tests/`, MyPy checked `sbir_etl/`, and coverage targeted the removed source root. After this migration:
+
+- Ruff checks all four production roots plus `tests/`.
+- Blocking MyPy remains scoped to `sbir_etl/`.
+- Each package under `packages/` has a separate MyPy matrix job. `sbir-analytics` and `sbir-ml` are non-blocking while their existing typing debt is resolved; `sbir-graph` is blocking because it currently passes.
+- Coverage measures all four current production roots.
+- Change detection exposes a `production` result covering every production root and updates domain-specific filters to current paths.
+
+Follow-up work should resolve MyPy findings in `sbir-analytics` and `sbir-ml` one package at a time, then make those matrix entries blocking.

--- a/docs/steering/configuration-patterns.md
+++ b/docs/steering/configuration-patterns.md
@@ -18,7 +18,7 @@ This document centralizes all configuration examples and patterns used throughou
 ```text
 Layer 1: YAML Files (config/)
     ↓
-Layer 2: Pydantic Validation (src/config/schemas.py)
+Layer 2: Pydantic Validation (sbir_etl/config/schemas/)
     ↓
 Layer 3: Runtime Configuration with Environment Overrides
 ```

--- a/docs/steering/pipeline-orchestration.md
+++ b/docs/steering/pipeline-orchestration.md
@@ -206,7 +206,7 @@ def enrichment_success_rate_check(enriched_sbir_awards: pd.DataFrame) -> AssetCh
 
 ### How to Add a New Quality Gate
 
-1. Co-locate the check with the target asset in `src/assets/...`.
+1. Co-locate the check with the target asset in `packages/sbir-analytics/sbir_analytics/assets/...`.
 2. Name the function `<asset_name>_<check_purpose>_check`.
 3. Read thresholds from loaded config (e.g., `config.data_quality.thresholds`).
 4. Compute metrics and return `AssetCheckResult(passed=..., metadata=...)`.

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -6,7 +6,7 @@ The project has undergone major consolidation to eliminate code duplication and 
 
 ### Key Consolidation Achievements
 
-- ✅ **Asset Consolidation**: USPTO assets unified into single file (`src/assets/uspto_assets.py`)
+- ✅ **Asset Consolidation**: USPTO assets unified into single file (`packages/sbir-analytics/sbir_analytics/assets/uspto/`)
 - ✅ **Configuration Consolidation**: Hierarchical PipelineConfig with 16+ consolidated schemas
 - ✅ **Model Consolidation**: Unified Award model replaces separate implementations
 - ✅ **Docker Consolidation**: Single profile-based docker-compose.yml
@@ -17,19 +17,11 @@ The project has undergone major consolidation to eliminate code duplication and 
 The project follows a consolidated modular ETL architecture with clear separation of concerns:
 
 ```text
-src/
-├── assets/                 # Dagster asset definitions (pipeline orchestration)
-├── config/                 # Configuration management and schemas
-├── extractors/             # Stage 1: Data extraction from various sources
-├── validators/             # Stage 2: Schema validation and data quality checks
-├── enrichers/              # Stage 3: External enrichment and fuzzy matching (includes fiscal enrichers)
-├── transformers/           # Stage 4: Business logic and graph preparation (includes fiscal transformers)
-├── loaders/                # Stage 5: Neo4j loading and relationship creation
-├── models/                 # Pydantic data models and type definitions
-├── utils/                  # Shared utilities (logging, metrics, performance)
-├── quality/                # Data quality validation modules
-├── ml/                     # Machine learning models (CET classification)
-└── transition/             # Technology transition detection logic
+sbir_etl/                                  # Core extraction, validation, and loading library
+packages/
+├── sbir-analytics/sbir_analytics/         # Dagster definitions, assets, and analytics tools
+├── sbir-ml/sbir_ml/                       # Machine-learning and transition models
+└── sbir-graph/sbir_graph/                 # Graph loaders and queries
 ```
 
 ## Key Architectural Patterns
@@ -44,15 +36,15 @@ src/
 
 ### Consolidated Dagster Asset Organization
 
-- **Unified Assets**: Major consolidation completed - USPTO assets in single file (`src/assets/uspto_assets.py`)
+- **Unified Assets**: Major consolidation completed - USPTO assets in single file (`packages/sbir-analytics/sbir_analytics/assets/uspto/`)
 - **Consistent Naming**: Standardized prefixes (raw_, validated_, enriched_, transformed_, loaded_)
-- **Jobs**: Defined in `src/assets/jobs/` for pipeline orchestration
+- **Jobs**: Defined in `packages/sbir-analytics/sbir_analytics/assets/jobs/` for pipeline orchestration
 - **Asset Checks**: Co-located with assets for quality validation
 - **Groups**: Assets organized by functional area (sbir_ingestion, cet_pipeline, etc.)
 
 ### Consolidated Configuration Management
 
-- **Hierarchical Schema**: Single PipelineConfig with 16+ consolidated schemas in `src/config/schemas.py`
+- **Hierarchical Schema**: Single PipelineConfig with 16+ consolidated schemas in `sbir_etl/config/schemas/`
 - **Type Safety**: Complete Pydantic validation with custom validators
 - **YAML Files**: Environment-specific configs in `config/` directory
 - **Environment Overrides**: Standardized `SBIR_ETL__SECTION__KEY` format for runtime configuration

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -69,7 +69,7 @@ mypy sbir_etl/
 
 ## Security scan
 
-bandit -r src/
+bandit -r sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph
 
 ## Run all quality checks
 
@@ -107,10 +107,10 @@ uv run dagster dev
 
 ## Run specific jobs via CLI
 
-dagster job execute -f src/definitions.py -j sbir_weekly_refresh_job
-dagster job execute -f src/definitions.py -j cet_full_pipeline_job
-dagster job execute -f src/definitions.py -j fiscal_returns_mvp_job
-dagster job execute -f src/definitions.py -j fiscal_returns_full_job
+dagster job execute -m sbir_analytics.definitions -j sbir_weekly_refresh_job
+dagster job execute -m sbir_analytics.definitions -j cet_full_pipeline_job
+dagster job execute -m sbir_analytics.definitions -j fiscal_returns_mvp_job
+dagster job execute -m sbir_analytics.definitions -j fiscal_returns_full_job
 
 ## Container-based development
 

--- a/packages/sbir-analytics/sbir_analytics/assets/jobs/cet_pipeline_job.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/jobs/cet_pipeline_job.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/assets/jobs/cet_pipeline_job.py
+# packages/sbir-analytics/sbir_analytics/assets/jobs/cet_pipeline_job.py
 """
 Dagster job that orchestrates the full CET flow end-to-end:
 

--- a/packages/sbir-analytics/sbir_analytics/assets/jobs/uspto_ai_job.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/jobs/uspto_ai_job.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/assets/jobs/uspto_ai_job.py
+# packages/sbir-analytics/sbir_analytics/assets/jobs/uspto_ai_job.py
 """
 Dagster job that composes USPTO AI extraction assets into a single run.
 

--- a/packages/sbir-analytics/sbir_analytics/assets/jobs/uspto_job.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/jobs/uspto_job.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/assets/jobs/uspto_job.py
+# packages/sbir-analytics/sbir_analytics/assets/jobs/uspto_job.py
 """
 Dagster job that composes the USPTO assets into a single materialization job.
 

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/pairs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/pairs.py
@@ -87,7 +87,17 @@ def _join_on(
     # avoid pandas' merge-suffix gymnastics.
     ii = (
         phase_ii.loc[phase_ii[key].notna()]
-        .loc[:, ["award_id", "source", "agency", "period_of_performance_end", "recipient_uei", "recipient_duns"]]
+        .loc[
+            :,
+            [
+                "award_id",
+                "source",
+                "agency",
+                "period_of_performance_end",
+                "recipient_uei",
+                "recipient_duns",
+            ],
+        ]
         .rename(
             columns={
                 "award_id": "phase_ii_award_id",
@@ -269,9 +279,7 @@ def transformed_phase_ii_iii_pairs(
     validated_phase_iii_contracts: pd.DataFrame | None = None,
 ) -> Output[pd.DataFrame]:
     phase_ii = (
-        validated_phase_ii_awards
-        if validated_phase_ii_awards is not None
-        else pd.DataFrame()
+        validated_phase_ii_awards if validated_phase_ii_awards is not None else pd.DataFrame()
     )
     phase_iii = (
         validated_phase_iii_contracts
@@ -290,9 +298,7 @@ def transformed_phase_ii_iii_pairs(
         pairs.to_parquet(output_path, index=False)
 
     summary = _latency_summary(pairs)
-    basis_counts = (
-        pairs["identifier_basis"].value_counts().to_dict() if not pairs.empty else {}
-    )
+    basis_counts = pairs["identifier_basis"].value_counts().to_dict() if not pairs.empty else {}
 
     checks = {
         "ok": True,
@@ -338,9 +344,7 @@ def transformed_phase_transition_survival(
     transformed_phase_ii_iii_pairs: pd.DataFrame | None = None,
 ) -> Output[pd.DataFrame]:
     phase_ii = (
-        validated_phase_ii_awards
-        if validated_phase_ii_awards is not None
-        else pd.DataFrame()
+        validated_phase_ii_awards if validated_phase_ii_awards is not None else pd.DataFrame()
     )
     pairs = (
         transformed_phase_ii_iii_pairs

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_ii.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_ii.py
@@ -172,7 +172,9 @@ def _prepare_contract_rows(contracts: pd.DataFrame) -> pd.DataFrame:
                 _pick("federal_action_obligation", "obligation_amount", "obligated_amount"),
                 errors="coerce",
             ),
-            "award_date": coerce_date_series(_pick("action_date", "award_date", "start_date")).dt.date,
+            "award_date": coerce_date_series(
+                _pick("action_date", "award_date", "start_date")
+            ).dt.date,
             "period_of_performance_start": coerce_date_series(
                 _pick("period_of_performance_start_date", "start_date", "pop_start_date")
             ).dt.date,
@@ -212,7 +214,9 @@ def _prepare_sbir_gov_rows(sbir_awards: pd.DataFrame) -> pd.DataFrame:
             "sub_agency": df.get("branch"),
             "award_amount": pd.to_numeric(df.get("award_amount"), errors="coerce"),
             "award_date": coerce_date_series(df.get("award_date")).dt.date,
-            "period_of_performance_start": coerce_date_series(df.get("contract_start_date")).dt.date,
+            "period_of_performance_start": coerce_date_series(
+                df.get("contract_start_date")
+            ).dt.date,
             "period_of_performance_end": coerce_date_series(df.get("contract_end_date")).dt.date,
             "source": "sbir_gov",
             "phase_coding_reconciled": True,
@@ -260,12 +264,17 @@ def _agency_coverage(df: pd.DataFrame) -> dict[str, int]:
 def validated_phase_ii_awards(context=None) -> Output[pd.DataFrame]:
     """Materialize the unified Phase II frame."""
 
-    contracts_path = Path(env_str("SBIR_ETL__PHASE_TRANSITION__CONTRACTS_PATH", DEFAULT_CONTRACTS_PATH) or DEFAULT_CONTRACTS_PATH)
+    contracts_path = Path(
+        env_str("SBIR_ETL__PHASE_TRANSITION__CONTRACTS_PATH", DEFAULT_CONTRACTS_PATH)
+        or DEFAULT_CONTRACTS_PATH
+    )
     sbir_awards_path = Path(
-        env_str("SBIR_ETL__PHASE_TRANSITION__SBIR_AWARDS_PATH", DEFAULT_SBIR_AWARDS_PATH) or DEFAULT_SBIR_AWARDS_PATH
+        env_str("SBIR_ETL__PHASE_TRANSITION__SBIR_AWARDS_PATH", DEFAULT_SBIR_AWARDS_PATH)
+        or DEFAULT_SBIR_AWARDS_PATH
     )
     output_path = Path(
-        env_str("SBIR_ETL__PHASE_TRANSITION__PHASE_II_OUTPUT_PATH", DEFAULT_OUTPUT_PATH) or DEFAULT_OUTPUT_PATH
+        env_str("SBIR_ETL__PHASE_TRANSITION__PHASE_II_OUTPUT_PATH", DEFAULT_OUTPUT_PATH)
+        or DEFAULT_OUTPUT_PATH
     )
 
     contracts = load_parquet_if_exists(contracts_path)
@@ -283,16 +292,10 @@ def validated_phase_ii_awards(context=None) -> Output[pd.DataFrame]:
     if not unified.empty:
         unified.to_parquet(output_path, index=False)
 
-    uei_cov = (
-        float(unified["recipient_uei"].notna().mean()) if not unified.empty else 0.0
-    )
-    duns_cov = (
-        float(unified["recipient_duns"].notna().mean()) if not unified.empty else 0.0
-    )
+    uei_cov = float(unified["recipient_uei"].notna().mean()) if not unified.empty else 0.0
+    duns_cov = float(unified["recipient_duns"].notna().mean()) if not unified.empty else 0.0
     pop_end_cov = (
-        float(unified["period_of_performance_end"].notna().mean())
-        if not unified.empty
-        else 0.0
+        float(unified["period_of_performance_end"].notna().mean()) if not unified.empty else 0.0
     )
     source_counts = unified["source"].value_counts().to_dict() if not unified.empty else {}
 

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_iii.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_iii.py
@@ -92,7 +92,9 @@ def _prepare_phase_iii_rows(contracts: pd.DataFrame) -> pd.DataFrame:
     return out
 
 
-def _agency_coverage_table(all_contracts: pd.DataFrame, phase_iii: pd.DataFrame) -> dict[str, dict[str, int]]:
+def _agency_coverage_table(
+    all_contracts: pd.DataFrame, phase_iii: pd.DataFrame
+) -> dict[str, dict[str, int]]:
     """Row counts by agency for both the full contract frame and Phase III.
 
     This is the "Phase III flag as known undercount" audit: total contract

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_ingestion.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
@@ -56,11 +56,13 @@ def _apply_quality_filters(
         sample_indices = df.index[empty_mask].tolist()[:_SAMPLE_LIMIT]
         df = df[~empty_mask].copy()
         after = len(df)
-        audit["steps"].append({
-            "name": "empty_award_id",
-            "dropped_count": dropped_count,
-            "sample_indices": sample_indices,
-        })
+        audit["steps"].append(
+            {
+                "name": "empty_award_id",
+                "dropped_count": dropped_count,
+                "sample_indices": sample_indices,
+            }
+        )
         if before != after:
             context.log.info(f"Empty award_id filter: {before} -> {after} ({after / before:.1%})")
 
@@ -73,10 +75,12 @@ def _apply_quality_filters(
         became_null = before_numeric.isna()
         amount_coerced_count = int((was_non_null & became_null).sum())
         df["award_amount"] = before_numeric
-        audit["steps"].append({
-            "name": "award_amount_coercion",
-            "coerced_to_nan_count": amount_coerced_count,
-        })
+        audit["steps"].append(
+            {
+                "name": "award_amount_coercion",
+                "coerced_to_nan_count": amount_coerced_count,
+            }
+        )
 
     # 3. Coerce award_date to datetime (records modified, not dropped)
     date_coerced_count = 0
@@ -86,10 +90,12 @@ def _apply_quality_filters(
         became_null = before_dates.isna()
         date_coerced_count = int((was_non_null & became_null).sum())
         df["award_date"] = before_dates
-        audit["steps"].append({
-            "name": "award_date_coercion",
-            "coerced_to_nat_count": date_coerced_count,
-        })
+        audit["steps"].append(
+            {
+                "name": "award_date_coercion",
+                "coerced_to_nat_count": date_coerced_count,
+            }
+        )
 
     # 4. Remove exact duplicates (award_id + phase or award_id only)
     if "award_id" in df.columns and "phase" in df.columns:
@@ -99,11 +105,13 @@ def _apply_quality_filters(
         sample_indices = df.index[dup_mask].tolist()[:_SAMPLE_LIMIT]
         df = df[~dup_mask].copy()
         after = len(df)
-        audit["steps"].append({
-            "name": "dedup_award_id_phase",
-            "dropped_count": dropped_count,
-            "sample_indices": sample_indices,
-        })
+        audit["steps"].append(
+            {
+                "name": "dedup_award_id_phase",
+                "dropped_count": dropped_count,
+                "sample_indices": sample_indices,
+            }
+        )
         if before != after:
             context.log.info(
                 f"Duplicate filter (award_id + phase): {before} -> {after} ({after / before:.1%})"
@@ -115,11 +123,13 @@ def _apply_quality_filters(
         sample_indices = df.index[dup_mask].tolist()[:_SAMPLE_LIMIT]
         df = df[~dup_mask].copy()
         after = len(df)
-        audit["steps"].append({
-            "name": "dedup_award_id",
-            "dropped_count": dropped_count,
-            "sample_indices": sample_indices,
-        })
+        audit["steps"].append(
+            {
+                "name": "dedup_award_id",
+                "dropped_count": dropped_count,
+                "sample_indices": sample_indices,
+            }
+        )
         if before != after:
             context.log.info(
                 f"Duplicate filter (award_id only): {before} -> {after} ({after / before:.1%})"
@@ -304,7 +314,7 @@ def raw_sbir_awards(context: AssetExecutionContext) -> Output[pd.DataFrame]:
 
     # Stamp data source provenance on every record
     # Prefer the original S3 URL over the resolved temp/cache path
-    ingested_at = datetime.now(timezone.utc)
+    ingested_at = datetime.now(UTC)
     source_url = sbir_config.csv_path_s3 or str(extractor.csv_path)
     df["data_source"] = "sbir.gov"
     df["data_source_url"] = str(source_url)
@@ -352,9 +362,7 @@ def validated_sbir_awards(
     filtered_df, filter_audit = _apply_quality_filters(raw_sbir_awards, context)
 
     # Run validation on the filtered data
-    quality_report = validate_sbir_awards(
-        df=filtered_df, pass_rate_threshold=pass_rate_threshold
-    )
+    quality_report = validate_sbir_awards(df=filtered_df, pass_rate_threshold=pass_rate_threshold)
 
     # Filter to passing records using failing_row_indices (fast path) or
     # fall back to issue-based filtering for backward compatibility
@@ -388,9 +396,7 @@ def validated_sbir_awards(
     # Build audit summary for metadata (strip sample indices for serialization —
     # keep counts and step names so Dagster UI shows a concise trail)
     audit_summary = {
-        step["name"]: {
-            k: v for k, v in step.items() if k != "sample_indices"
-        }
+        step["name"]: {k: v for k, v in step.items() if k != "sample_indices"}
         for step in filter_audit.get("steps", [])
     }
     audit_summary["totals"] = {

--- a/packages/sbir-analytics/sbir_analytics/assets/usaspending_database_enrichment.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/usaspending_database_enrichment.py
@@ -5,7 +5,7 @@ to extract and enrich SBIR award data with transaction-level details.
 """
 
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import pandas as pd
 from dagster import AssetExecutionContext, MetadataValue, Output, asset
@@ -15,7 +15,11 @@ from sbir_etl.config.loader import get_config
 from sbir_etl.exceptions import ExtractionError
 from sbir_etl.extractors.sbir_gov_api import SbirGovClient, SbirGovLookupIndex
 from sbir_etl.extractors.usaspending import DuckDBUSAspendingExtractor
-from sbir_etl.models.sbir_identification import ALL_SBIR_ALNS, EXCLUSIVE_SBIR_ALNS, SBIR_RESEARCH_CODES
+from sbir_etl.models.sbir_identification import (
+    ALL_SBIR_ALNS,
+    EXCLUSIVE_SBIR_ALNS,
+    SBIR_RESEARCH_CODES,
+)
 from sbir_etl.utils.cloud_storage import find_latest_usaspending_dump, get_s3_bucket_from_env
 
 
@@ -40,9 +44,9 @@ def _table_has_column(
 def _build_sbir_gov_index(
     context: AssetExecutionContext,
     *,
-    agencies: Optional[list[str]] = None,
-    year_range: Optional[tuple[int, int]] = None,
-) -> Optional[SbirGovLookupIndex]:
+    agencies: list[str] | None = None,
+    year_range: tuple[int, int] | None = None,
+) -> SbirGovLookupIndex | None:
     """Build a SBIR.gov cross-reference index, trying API first then bulk file.
 
     Args:
@@ -59,11 +63,7 @@ def _build_sbir_gov_index(
     try:
         with SbirGovClient() as client:
             target_agencies = agencies or ["HHS", "DOE", "ED", "DOT"]
-            years = (
-                list(range(year_range[0], year_range[1] + 1))
-                if year_range
-                else [None]
-            )
+            years = list(range(year_range[0], year_range[1] + 1)) if year_range else [None]
 
             for agency in target_agencies:
                 for year in years:
@@ -108,7 +108,7 @@ def _build_sbir_gov_index(
     return None
 
 
-def _find_sbir_gov_bulk_file() -> Optional[Path]:
+def _find_sbir_gov_bulk_file() -> Path | None:
     """Locate a SBIR.gov bulk awards JSON file.
 
     Checks:
@@ -165,8 +165,14 @@ def _crossref_dataframe_with_sbir_gov(
     """
     if df.empty:
         df = df.copy()
-        for col in ["sbir_gov_confirmed", "sbir_gov_match_key", "sbir_gov_program",
-                     "sbir_gov_phase", "sbir_gov_topic_code", "sbir_gov_firm"]:
+        for col in [
+            "sbir_gov_confirmed",
+            "sbir_gov_match_key",
+            "sbir_gov_program",
+            "sbir_gov_phase",
+            "sbir_gov_topic_code",
+            "sbir_gov_firm",
+        ]:
             df[col] = pd.Series(dtype="object")
         df["sbir_gov_confirmed"] = df["sbir_gov_confirmed"].astype(bool)
         return df
@@ -207,9 +213,15 @@ def _crossref_dataframe_with_sbir_gov(
     df = df.copy()
     df["sbir_gov_confirmed"] = hits.apply(lambda h: isinstance(h, dict))
     df["sbir_gov_match_key"] = match_keys
-    df["sbir_gov_program"] = hits.apply(lambda h: h.get("program", "") if isinstance(h, dict) else "")
-    df["sbir_gov_phase"] = hits.apply(lambda h: str(h.get("phase", "")) if isinstance(h, dict) else "")
-    df["sbir_gov_topic_code"] = hits.apply(lambda h: h.get("topic_code", "") if isinstance(h, dict) else "")
+    df["sbir_gov_program"] = hits.apply(
+        lambda h: h.get("program", "") if isinstance(h, dict) else ""
+    )
+    df["sbir_gov_phase"] = hits.apply(
+        lambda h: str(h.get("phase", "")) if isinstance(h, dict) else ""
+    )
+    df["sbir_gov_topic_code"] = hits.apply(
+        lambda h: h.get("topic_code", "") if isinstance(h, dict) else ""
+    )
     df["sbir_gov_firm"] = hits.apply(lambda h: h.get("firm", "") if isinstance(h, dict) else "")
 
     return df
@@ -331,18 +343,31 @@ def sbir_relevant_usaspending_transactions(
     else:
         # FALLBACK: Heuristic filter (agency + NAICS + dollar cap)
         sbir_agencies = [
-            "Department of Defense", "DOD",
-            "Department of Energy", "DOE",
-            "National Aeronautics and Space Administration", "NASA",
-            "National Science Foundation", "NSF",
-            "Department of Health and Human Services", "HHS",
-            "NIH", "National Institutes of Health",
-            "Department of Agriculture", "USDA",
-            "Department of Commerce", "DOC", "NOAA",
-            "Department of Homeland Security", "DHS",
-            "Department of Transportation", "DOT",
-            "Environmental Protection Agency", "EPA",
-            "Department of Education", "ED",
+            "Department of Defense",
+            "DOD",
+            "Department of Energy",
+            "DOE",
+            "National Aeronautics and Space Administration",
+            "NASA",
+            "National Science Foundation",
+            "NSF",
+            "Department of Health and Human Services",
+            "HHS",
+            "NIH",
+            "National Institutes of Health",
+            "Department of Agriculture",
+            "USDA",
+            "Department of Commerce",
+            "DOC",
+            "NOAA",
+            "Department of Homeland Security",
+            "DHS",
+            "Department of Transportation",
+            "DOT",
+            "Environmental Protection Agency",
+            "EPA",
+            "Department of Education",
+            "ED",
         ]
         agencies_sql = ",".join(f"'{a}'" for a in sbir_agencies)
 
@@ -418,9 +443,7 @@ def sbir_relevant_usaspending_transactions(
     # ones are real SBIR awards.
     sbir_gov_stats: dict[str, Any] = {}
     if not has_research_col and not df.empty:
-        context.log.info(
-            "Heuristic filter used — cross-referencing with SBIR.gov to validate"
-        )
+        context.log.info("Heuristic filter used — cross-referencing with SBIR.gov to validate")
         sbir_gov_index = _build_sbir_gov_index(context)
         if sbir_gov_index:
             df = _crossref_dataframe_with_sbir_gov(df, sbir_gov_index)
@@ -430,9 +453,7 @@ def sbir_relevant_usaspending_transactions(
                 "sbir_gov_confirmed": confirmed,
                 "sbir_gov_unconfirmed": len(df) - confirmed,
             }
-            context.log.info(
-                f"SBIR.gov cross-reference: {confirmed}/{len(df)} confirmed"
-            )
+            context.log.info(f"SBIR.gov cross-reference: {confirmed}/{len(df)} confirmed")
         else:
             sbir_gov_stats = {"sbir_gov_status": "unavailable"}
 
@@ -719,9 +740,7 @@ def sbir_grant_transactions(
     # enrichment fields (topic_code, PI); for shared ALNs it confirms or denies.
     sbir_gov_stats: dict[str, Any] = {}
     if shared_count > 0:
-        context.log.info(
-            f"Cross-referencing {shared_count} shared-ALN grants with SBIR.gov"
-        )
+        context.log.info(f"Cross-referencing {shared_count} shared-ALN grants with SBIR.gov")
 
         # Determine which agencies have shared ALNs to limit API queries
         shared_agencies = []
@@ -765,12 +784,12 @@ def sbir_grant_transactions(
 
             # Upgrade shared-ALN records that are confirmed by SBIR.gov
             if "sbir_gov_confirmed" in df.columns and "sbir_aln_confidence" in df.columns:
-                upgrade_mask = (
-                    (df["sbir_aln_confidence"] == "shared") & df["sbir_gov_confirmed"]
-                )
+                upgrade_mask = (df["sbir_aln_confidence"] == "shared") & df["sbir_gov_confirmed"]
                 df.loc[upgrade_mask, "sbir_aln_confidence"] = "shared_confirmed"
 
-            confirmed_total = int(df["sbir_gov_confirmed"].sum()) if "sbir_gov_confirmed" in df.columns else 0
+            confirmed_total = (
+                int(df["sbir_gov_confirmed"].sum()) if "sbir_gov_confirmed" in df.columns else 0
+            )
             shared_confirmed = int(
                 (df["sbir_aln_confidence"] == "shared_confirmed").sum()
                 if "sbir_aln_confidence" in df.columns

--- a/packages/sbir-analytics/sbir_analytics/assets/usaspending_ingestion.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/usaspending_ingestion.py
@@ -7,7 +7,7 @@ Data Source Priority:
 """
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any
 
@@ -154,7 +154,7 @@ def _import_usaspending_table(
     # Stamp data source provenance on the returned DataFrame
     # Note: _import_usaspending_table returns a sample (limit=100) per the existing
     # query_awards call above. Provenance is stamped on whatever this function returns.
-    ingested_at = datetime.now(timezone.utc)
+    ingested_at = datetime.now(UTC)
     source_url = str(dump_path) if dump_path else "usaspending_api"
     sample_df["data_source"] = "usaspending"
     sample_df["data_source_url"] = source_url
@@ -234,7 +234,7 @@ def raw_usaspending_recipients(context: AssetExecutionContext) -> Output[pd.Data
 
     # Stamp data source provenance (if not already stamped by _import_usaspending_table)
     if "data_source" not in df.columns:
-        ingested_at = datetime.now(timezone.utc)
+        ingested_at = datetime.now(UTC)
         source_url = parquet_url if parquet_url else "usaspending_dump"
         df["data_source"] = "usaspending"
         df["data_source_url"] = str(source_url)

--- a/packages/sbir-analytics/sbir_analytics/assets/uspto/ai_extraction.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/uspto/ai_extraction.py
@@ -405,9 +405,7 @@ def raw_uspto_ai_human_sample_extraction(context, uspto_ai_deduplicate) -> str:
     try:
         con = duckdb.connect(database=str(duckdb_path), read_only=True)
         try:
-            df = con.execute(
-                f"SELECT * FROM {table} ORDER BY RANDOM() LIMIT {sample_n}"
-            ).fetchdf()
+            df = con.execute(f"SELECT * FROM {table} ORDER BY RANDOM() LIMIT {sample_n}").fetchdf()
         except Exception:
             context.log.warning("Failed to query DuckDB table %s for sampling", table)
             df = None

--- a/packages/sbir-analytics/sbir_analytics/assets/uspto/transformation.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/uspto/transformation.py
@@ -47,7 +47,9 @@ TRANSFORM_SUCCESS_THRESHOLD = 0.9
 LINKAGE_TARGET = 0.8
 DEFAULT_NEO4J_URI = "bolt://localhost:7687"
 DEFAULT_NEO4J_USER = "neo4j"
-DEFAULT_NEO4J_PASSWORD = "password"  # pragma: allowlist secret  # nosec B105 - dev/local default; override via env
+DEFAULT_NEO4J_PASSWORD = (
+    "password"  # pragma: allowlist secret  # nosec B105 - dev/local default; override via env
+)
 DEFAULT_NEO4J_DATABASE = "neo4j"
 
 

--- a/packages/sbir-analytics/sbir_analytics/lambda/weekly_refresh_handler.py
+++ b/packages/sbir-analytics/sbir_analytics/lambda/weekly_refresh_handler.py
@@ -221,7 +221,7 @@ def run_validation_scripts(
     # Try multiple possible locations for schema files
     schema_paths = [
         Path("/var/task/docs/data/sbir_awards_columns.json"),
-        Path("/var/task/src/docs/data/sbir_awards_columns.json"),
+        Path("/var/task/docs/data/sbir_awards_columns.json"),
     ]
     schema_path = next((p for p in schema_paths if p.exists()), None)
     if not schema_path:
@@ -229,7 +229,7 @@ def run_validation_scripts(
 
     company_schema_paths = [
         Path("/var/task/docs/data/sbir_company_columns.json"),
-        Path("/var/task/src/docs/data/sbir_company_columns.json"),
+        Path("/var/task/docs/data/sbir_company_columns.json"),
     ]
     company_schema_path = next((p for p in company_schema_paths if p.exists()), None)
     if not company_schema_path:

--- a/packages/sbir-analytics/sbir_analytics/tools/base.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/base.py
@@ -141,11 +141,15 @@ class ToolResult:
         return downstream_metadata
 
     def to_dict(self) -> dict[str, Any]:
-        data_repr = self.data if isinstance(self.data, dict) else {
-            "type": "DataFrame",
-            "shape": list(self.data.shape),
-            "columns": list(self.data.columns),
-        }
+        data_repr = (
+            self.data
+            if isinstance(self.data, dict)
+            else {
+                "type": "DataFrame",
+                "shape": list(self.data.shape),
+                "columns": list(self.data.columns),
+            }
+        )
         return {
             "data": data_repr,
             "metadata": self.metadata.to_dict(),
@@ -198,8 +202,7 @@ class BaseTool(ABC):
             metadata.execution_end = datetime.utcnow()
             elapsed = time.monotonic() - start
             logger.info(
-                f"Tool '{self.name}' completed in {elapsed:.2f}s "
-                f"({metadata.record_count} records)"
+                f"Tool '{self.name}' completed in {elapsed:.2f}s ({metadata.record_count} records)"
             )
             return result
         except Exception:
@@ -236,7 +239,10 @@ class BaseTool(ABC):
             elif isinstance(v, (str, int, float, bool, type(None))):
                 sanitized[k] = v
             elif isinstance(v, (list, tuple)):
-                sanitized[k] = [str(item) if not isinstance(item, (str, int, float, bool, type(None))) else item for item in v]
+                sanitized[k] = [
+                    str(item) if not isinstance(item, (str, int, float, bool, type(None))) else item
+                    for item in v
+                ]
             elif isinstance(v, dict):
                 sanitized[k] = str(v)[:200]
             else:

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_a/cluster_topics.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_a/cluster_topics.py
@@ -76,9 +76,7 @@ class ClusterTopicsTool(BaseTool):
             sim_matrix = normalized @ normalized.T
         else:
             # Fallback: generate embeddings on-the-fly with ModernBERT-Embed
-            metadata.warnings.append(
-                "No embeddings provided; generating via ModernBERT-Embed"
-            )
+            metadata.warnings.append("No embeddings provided; generating via ModernBERT-Embed")
             try:
                 from sbir_ml.ml.config import PaECTERClientConfig
                 from sbir_ml.ml.paecter_client import PaECTERClient
@@ -109,8 +107,14 @@ class ClusterTopicsTool(BaseTool):
         assigned = set()
         cluster_id = 0
 
-        agencies = topics_df["agency"].tolist() if "agency" in topics_df.columns else [None] * n_topics
-        topic_ids = topics_df["topic_id"].tolist() if "topic_id" in topics_df.columns else list(range(n_topics))
+        agencies = (
+            topics_df["agency"].tolist() if "agency" in topics_df.columns else [None] * n_topics
+        )
+        topic_ids = (
+            topics_df["topic_id"].tolist()
+            if "topic_id" in topics_df.columns
+            else list(range(n_topics))
+        )
 
         for i in range(n_topics):
             if i in assigned:
@@ -141,32 +145,44 @@ class ClusterTopicsTool(BaseTool):
 
             # Calculate cluster statistics
             cluster_agencies = {agencies[idx] for idx in candidate if agencies[idx] is not None}
-            pairwise_sims = [
-                sim_matrix[a, b] for a in candidate for b in candidate if a < b
-            ]
+            pairwise_sims = [sim_matrix[a, b] for a in candidate for b in candidate if a < b]
             avg_sim = float(np.mean(pairwise_sims)) if pairwise_sims else 0.0
 
             cluster_topics = [topic_ids[idx] for idx in candidate]
-            clusters.append({
-                "cluster_id": f"cluster-{cluster_id:04d}",
-                "topic_ids": cluster_topics,
-                "agencies_involved": sorted(a for a in cluster_agencies if a is not None),
-                "num_agencies": len(cluster_agencies),
-                "num_topics": len(candidate),
-                "avg_similarity": round(avg_sim, 4),
-                "max_similarity": round(float(max(pairwise_sims)) if pairwise_sims else 0.0, 4),
-                "classification": "ambiguous",  # LLM judgment point — not resolved here
-                "classification_reasoning": None,
-            })
+            clusters.append(
+                {
+                    "cluster_id": f"cluster-{cluster_id:04d}",
+                    "topic_ids": cluster_topics,
+                    "agencies_involved": sorted(a for a in cluster_agencies if a is not None),
+                    "num_agencies": len(cluster_agencies),
+                    "num_topics": len(candidate),
+                    "avg_similarity": round(avg_sim, 4),
+                    "max_similarity": round(float(max(pairwise_sims)) if pairwise_sims else 0.0, 4),
+                    "classification": "ambiguous",  # LLM judgment point — not resolved here
+                    "classification_reasoning": None,
+                }
+            )
 
             assigned.update(candidate)
             cluster_id += 1
 
-        clusters_df = pd.DataFrame(clusters) if clusters else pd.DataFrame(columns=[
-            "cluster_id", "topic_ids", "agencies_involved", "num_agencies",
-            "num_topics", "avg_similarity", "max_similarity",
-            "classification", "classification_reasoning",
-        ])
+        clusters_df = (
+            pd.DataFrame(clusters)
+            if clusters
+            else pd.DataFrame(
+                columns=[
+                    "cluster_id",
+                    "topic_ids",
+                    "agencies_involved",
+                    "num_agencies",
+                    "num_topics",
+                    "avg_similarity",
+                    "max_similarity",
+                    "classification",
+                    "classification_reasoning",
+                ]
+            )
+        )
 
         metadata.record_count = len(clusters_df)
         metadata.data_sources.append(

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_a/compute_portfolio_metrics.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_a/compute_portfolio_metrics.py
@@ -79,25 +79,36 @@ class ComputePortfolioMetricsTool(BaseTool):
         # Map company names to canonical IDs using entity table for deduplication
         if entity_table is not None and not entity_table.empty:
             canonical_col = next(
-                (c for c in ["canonical_id"] if c in entity_table.columns), None,
+                (c for c in ["canonical_id"] if c in entity_table.columns),
+                None,
             )
             name_col = next(
-                (c for c in ["canonical_name"] if c in entity_table.columns), None,
+                (c for c in ["canonical_name"] if c in entity_table.columns),
+                None,
             )
             company_src = next(
-                (c for c in ["company", "company_name"] if c in df.columns), None,
+                (c for c in ["company", "company_name"] if c in df.columns),
+                None,
             )
             if canonical_col and name_col and company_src:
-                name_to_id = dict(zip(entity_table[name_col], entity_table[canonical_col], strict=False))
+                name_to_id = dict(
+                    zip(entity_table[name_col], entity_table[canonical_col], strict=False)
+                )
                 df["canonical_id"] = df[company_src].map(name_to_id).fillna(df[company_src])
 
         # Identify columns
-        cet_col = next((c for c in ["cet_primary", "cet_area", "cet_classification"] if c in df.columns), None)
+        cet_col = next(
+            (c for c in ["cet_primary", "cet_area", "cet_classification"] if c in df.columns), None
+        )
         agency_col = next((c for c in ["agency", "awarding_agency"] if c in df.columns), None)
-        company_col = next((c for c in ["canonical_id", "company", "company_name"] if c in df.columns), None)
+        company_col = next(
+            (c for c in ["canonical_id", "company", "company_name"] if c in df.columns), None
+        )
         state_col = next((c for c in ["state", "company_state"] if c in df.columns), None)
         fy_col = next((c for c in ["fiscal_year", "award_year", "fy"] if c in df.columns), None)
-        phase_col = next((c for c in ["phase", "award_phase", "program_phase"] if c in df.columns), None)
+        phase_col = next(
+            (c for c in ["phase", "award_phase", "program_phase"] if c in df.columns), None
+        )
         # Apply fiscal year filter
         if fiscal_years and fy_col:
             df = df[df[fy_col].isin(fiscal_years)]
@@ -108,7 +119,9 @@ class ComputePortfolioMetricsTool(BaseTool):
             for area, group in df.groupby(cet_col):
                 agency_counts = group[agency_col].value_counts().tolist()
                 hhi = _compute_hhi(agency_counts)
-                dominant = group[agency_col].value_counts().index[0] if len(agency_counts) > 0 else None
+                dominant = (
+                    group[agency_col].value_counts().index[0] if len(agency_counts) > 0 else None
+                )
                 agency_hhi[area] = {
                     "hhi": round(hhi, 4),
                     "dominant_agency": dominant,
@@ -164,9 +177,21 @@ class ComputePortfolioMetricsTool(BaseTool):
         if cet_col and phase_col and company_col:
             for area, group in df.groupby(cet_col):
                 phase_counts = group[phase_col].value_counts().to_dict()
-                p1 = sum(v for k, v in phase_counts.items() if str(k).strip().upper() in ("I", "1", "PHASE I"))
-                p2 = sum(v for k, v in phase_counts.items() if str(k).strip().upper() in ("II", "2", "PHASE II"))
-                p3 = sum(v for k, v in phase_counts.items() if str(k).strip().upper() in ("III", "3", "PHASE III"))
+                p1 = sum(
+                    v
+                    for k, v in phase_counts.items()
+                    if str(k).strip().upper() in ("I", "1", "PHASE I")
+                )
+                p2 = sum(
+                    v
+                    for k, v in phase_counts.items()
+                    if str(k).strip().upper() in ("II", "2", "PHASE II")
+                )
+                p3 = sum(
+                    v
+                    for k, v in phase_counts.items()
+                    if str(k).strip().upper() in ("III", "3", "PHASE III")
+                )
                 progression_rates[area] = {
                     "phase_1_count": p1,
                     "phase_2_count": p2,
@@ -188,7 +213,9 @@ class ComputePortfolioMetricsTool(BaseTool):
                 "cross_agency_companies": cross_agency_companies,
                 "avg_agency_hhi": round(
                     sum(v["hhi"] for v in agency_hhi.values()) / len(agency_hhi), 4
-                ) if agency_hhi else None,
+                )
+                if agency_hhi
+                else None,
             },
         }
 

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_a/detect_gaps.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_a/detect_gaps.py
@@ -133,18 +133,22 @@ class DetectGapsTool(BaseTool):
                     area_awards = df[df[cet_col] == area]
                     if not area_awards.empty:
                         last_funded = int(area_awards[fy_col].max())
-                unfunded_areas.append({
-                    "area": area,
-                    "award_count": 0,
-                    "last_funded_fy": last_funded,
-                    "nstc_priority": True,
-                })
+                unfunded_areas.append(
+                    {
+                        "area": area,
+                        "award_count": 0,
+                        "last_funded_fy": last_funded,
+                        "nstc_priority": True,
+                    }
+                )
             elif count < min_awards_threshold:
-                minimal_areas.append({
-                    "area": area,
-                    "award_count": count,
-                    "threshold": min_awards_threshold,
-                })
+                minimal_areas.append(
+                    {
+                        "area": area,
+                        "award_count": count,
+                        "threshold": min_awards_threshold,
+                    }
+                )
 
         # b. Single-agency concentration
         single_agency_deps = []
@@ -156,12 +160,16 @@ class DetectGapsTool(BaseTool):
                 agencies = area_df[agency_col].nunique()
                 if agencies == 1:
                     sole_agency = area_df[agency_col].iloc[0]
-                    single_agency_deps.append({
-                        "area": area,
-                        "sole_agency": sole_agency,
-                        "award_count": len(area_df),
-                        "total_amount": float(area_df[amount_col].sum()) if amount_col else None,
-                    })
+                    single_agency_deps.append(
+                        {
+                            "area": area,
+                            "sole_agency": sole_agency,
+                            "award_count": len(area_df),
+                            "total_amount": float(area_df[amount_col].sum())
+                            if amount_col
+                            else None,
+                        }
+                    )
 
         # c. Declining investment
         declining = []
@@ -180,18 +188,20 @@ class DetectGapsTool(BaseTool):
                 counts = yearly.values.astype(float)
                 if len(years) >= 2:
                     slope = float(
-                        (len(years) * (years * counts).sum() - years.sum() * counts.sum()) /
-                        (len(years) * (years ** 2).sum() - years.sum() ** 2 + 1e-10)
+                        (len(years) * (years * counts).sum() - years.sum() * counts.sum())
+                        / (len(years) * (years**2).sum() - years.sum() ** 2 + 1e-10)
                     )
                     if slope < -0.5:  # Meaningful decline
                         peak_fy = int(years[counts.argmax()])
-                        declining.append({
-                            "area": area,
-                            "trend_slope": round(slope, 3),
-                            "peak_fy": peak_fy,
-                            "current_count": int(counts[-1]) if len(counts) > 0 else 0,
-                            "peak_count": int(counts.max()),
-                        })
+                        declining.append(
+                            {
+                                "area": area,
+                                "trend_slope": round(slope, 3),
+                                "peak_fy": peak_fy,
+                                "current_count": int(counts[-1]) if len(counts) > 0 else 0,
+                                "peak_count": int(counts.max()),
+                            }
+                        )
 
         # d. Mission misalignment — placeholder for LLM judgment
         # This is a genuine decision point requiring interpretation of
@@ -233,7 +243,10 @@ class DetectGapsTool(BaseTool):
     @staticmethod
     def _empty_gap_result(taxonomy: list[str]) -> dict[str, Any]:
         return {
-            "unfunded_cet_areas": [{"area": a, "award_count": 0, "last_funded_fy": None, "nstc_priority": True} for a in taxonomy],
+            "unfunded_cet_areas": [
+                {"area": a, "award_count": 0, "last_funded_fy": None, "nstc_priority": True}
+                for a in taxonomy
+            ],
             "minimal_investment_areas": [],
             "single_agency_dependencies": [],
             "declining_investment": [],

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_a/extract_topics.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_a/extract_topics.py
@@ -85,15 +85,22 @@ class ExtractTopicsTool(BaseTool):
 
             # Group awards by solicitation topic to extract topic-level data
             topic_col = next(
-                (c for c in ["solicitation_topic", "topic_code", "topic_number", "solicitation_id"]
-                 if c in df.columns),
+                (
+                    c
+                    for c in ["solicitation_topic", "topic_code", "topic_number", "solicitation_id"]
+                    if c in df.columns
+                ),
                 None,
             )
 
             if topic_col:
                 for topic_key, group in df.groupby(topic_col):
                     abstract_col = next(
-                        (c for c in ["abstract", "award_abstract", "description"] if c in group.columns),
+                        (
+                            c
+                            for c in ["abstract", "award_abstract", "description"]
+                            if c in group.columns
+                        ),
                         None,
                     )
                     agency_col = next(
@@ -101,7 +108,11 @@ class ExtractTopicsTool(BaseTool):
                         None,
                     )
                     title_col = next(
-                        (c for c in ["solicitation_title", "topic_title", "title"] if c in group.columns),
+                        (
+                            c
+                            for c in ["solicitation_title", "topic_title", "title"]
+                            if c in group.columns
+                        ),
                         None,
                     )
 
@@ -110,16 +121,47 @@ class ExtractTopicsTool(BaseTool):
                     if abstract_col:
                         abstracts = group[abstract_col].dropna().tolist()
 
-                    topics.append({
-                        "topic_id": str(topic_key),
-                        "agency": group[agency_col].iloc[0] if agency_col and agency_col in group.columns else None,
-                        "title": group[title_col].iloc[0] if title_col and title_col in group.columns else str(topic_key),
-                        "description": " ".join(abstracts[:5]) if abstracts else None,
-                        "award_count": len(group),
-                        "total_amount": group["award_amount"].sum() if "award_amount" in group.columns else None,
-                        "fiscal_years": sorted(group[next((c for c in ["fiscal_year", "award_year", "fy"] if c in group.columns), "fiscal_year")].dropna().unique().tolist()) if any(c in group.columns for c in ["fiscal_year", "award_year", "fy"]) else [],
-                        "companies": group[next((c for c in ["company", "company_name"] if c in group.columns), "company")].nunique() if any(c in group.columns for c in ["company", "company_name"]) else 0,
-                    })
+                    topics.append(
+                        {
+                            "topic_id": str(topic_key),
+                            "agency": group[agency_col].iloc[0]
+                            if agency_col and agency_col in group.columns
+                            else None,
+                            "title": group[title_col].iloc[0]
+                            if title_col and title_col in group.columns
+                            else str(topic_key),
+                            "description": " ".join(abstracts[:5]) if abstracts else None,
+                            "award_count": len(group),
+                            "total_amount": group["award_amount"].sum()
+                            if "award_amount" in group.columns
+                            else None,
+                            "fiscal_years": sorted(
+                                group[
+                                    next(
+                                        (
+                                            c
+                                            for c in ["fiscal_year", "award_year", "fy"]
+                                            if c in group.columns
+                                        ),
+                                        "fiscal_year",
+                                    )
+                                ]
+                                .dropna()
+                                .unique()
+                                .tolist()
+                            )
+                            if any(c in group.columns for c in ["fiscal_year", "award_year", "fy"])
+                            else [],
+                            "companies": group[
+                                next(
+                                    (c for c in ["company", "company_name"] if c in group.columns),
+                                    "company",
+                                )
+                            ].nunique()
+                            if any(c in group.columns for c in ["company", "company_name"])
+                            else 0,
+                        }
+                    )
             else:
                 # No topic column — create pseudo-topics from agency + abstract clustering
                 metadata.warnings.append(
@@ -132,22 +174,28 @@ class ExtractTopicsTool(BaseTool):
                 )
                 if agency_col:
                     for agency, group in df.groupby(agency_col):
-                        topics.append({
-                            "topic_id": f"agency-{agency}",
-                            "agency": agency,
-                            "title": f"All {agency} topics",
-                            "description": None,
-                            "award_count": len(group),
-                            "total_amount": group["award_amount"].sum() if "award_amount" in group.columns else None,
-                            "fiscal_years": [],
-                            "companies": 0,
-                        })
+                        topics.append(
+                            {
+                                "topic_id": f"agency-{agency}",
+                                "agency": agency,
+                                "title": f"All {agency} topics",
+                                "description": None,
+                                "award_count": len(group),
+                                "total_amount": group["award_amount"].sum()
+                                if "award_amount" in group.columns
+                                else None,
+                                "fiscal_years": [],
+                                "companies": 0,
+                            }
+                        )
 
         # Load solicitation data file if provided
         if solicitation_data_path:
             try:
                 sol_df = pd.read_csv(solicitation_data_path)
-                logger.info(f"Loaded {len(sol_df)} solicitation records from {solicitation_data_path}")
+                logger.info(
+                    f"Loaded {len(sol_df)} solicitation records from {solicitation_data_path}"
+                )
                 metadata.data_sources.append(
                     DataSourceRef(
                         name="SBIR.gov Solicitations (file)",
@@ -160,10 +208,22 @@ class ExtractTopicsTool(BaseTool):
                 logger.warning(f"Could not load solicitation data: {e}")
                 metadata.warnings.append(f"Solicitation file load failed: {e}")
 
-        topics_df = pd.DataFrame(topics) if topics else pd.DataFrame(columns=[
-            "topic_id", "agency", "title", "description", "award_count",
-            "total_amount", "fiscal_years", "companies",
-        ])
+        topics_df = (
+            pd.DataFrame(topics)
+            if topics
+            else pd.DataFrame(
+                columns=[
+                    "topic_id",
+                    "agency",
+                    "title",
+                    "description",
+                    "award_count",
+                    "total_amount",
+                    "fiscal_years",
+                    "companies",
+                ]
+            )
+        )
 
         metadata.data_sources.append(
             DataSourceRef(

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_b/compute_observable_commercialization.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_b/compute_observable_commercialization.py
@@ -82,10 +82,14 @@ class ComputeObservableCommercializationTool(BaseTool):
         Returns:
             ToolResult with per-company three-prong scores and profiles
         """
-        metadata.upstream_tools.extend([
-            "extract_awards", "extract_fpds_contracts",
-            "extract_sam_entities", "resolve_entities",
-        ])
+        metadata.upstream_tools.extend(
+            [
+                "extract_awards",
+                "extract_fpds_contracts",
+                "extract_sam_entities",
+                "resolve_entities",
+            ]
+        )
 
         if awards_df is None or awards_df.empty:
             metadata.warnings.append("No awards data provided")
@@ -99,10 +103,12 @@ class ComputeObservableCommercializationTool(BaseTool):
             None,
         )
         phase_col = next(
-            (c for c in ["phase", "award_phase"] if c in df.columns), None,
+            (c for c in ["phase", "award_phase"] if c in df.columns),
+            None,
         )
         fy_col = next(
-            (c for c in ["fiscal_year", "award_year", "fy"] if c in df.columns), None,
+            (c for c in ["fiscal_year", "award_year", "fy"] if c in df.columns),
+            None,
         )
 
         if not all([company_col, phase_col, fy_col]):
@@ -133,20 +139,23 @@ class ComputeObservableCommercializationTool(BaseTool):
         fpds_revenue: dict[str, float] = {}
         if fpds_contracts is not None and not fpds_contracts.empty:
             fpds_co_col = next(
-                (c for c in ["canonical_id", "vendor_uei", "vendor_name"] if c in fpds_contracts.columns),
+                (
+                    c
+                    for c in ["canonical_id", "vendor_uei", "vendor_name"]
+                    if c in fpds_contracts.columns
+                ),
                 None,
             )
             amount_col = next(
-                (c for c in ["obligation_amount", "amount", "federal_action_obligation"]
-                 if c in fpds_contracts.columns),
+                (
+                    c
+                    for c in ["obligation_amount", "amount", "federal_action_obligation"]
+                    if c in fpds_contracts.columns
+                ),
                 None,
             )
             if fpds_co_col and amount_col:
-                fpds_revenue = (
-                    fpds_contracts.groupby(fpds_co_col)[amount_col]
-                    .sum()
-                    .to_dict()
-                )
+                fpds_revenue = fpds_contracts.groupby(fpds_co_col)[amount_col].sum().to_dict()
             metadata.data_sources.append(
                 DataSourceRef(
                     name="FPDS-NG (via USAspending.gov)",
@@ -160,7 +169,11 @@ class ComputeObservableCommercializationTool(BaseTool):
         patent_counts: dict[str, int] = {}
         if patent_data is not None and not patent_data.empty:
             pat_co_col = next(
-                (c for c in ["canonical_id", "assignee_name", "company"] if c in patent_data.columns),
+                (
+                    c
+                    for c in ["canonical_id", "assignee_name", "company"]
+                    if c in patent_data.columns
+                ),
                 None,
             )
             if pat_co_col:
@@ -179,7 +192,11 @@ class ComputeObservableCommercializationTool(BaseTool):
         sam_growth: dict[str, bool] = {}
         if sam_entities is not None and not sam_entities.empty:
             sam_co_col = next(
-                (c for c in ["canonical_id", "unique_entity_id", "uei"] if c in sam_entities.columns),
+                (
+                    c
+                    for c in ["canonical_id", "unique_entity_id", "uei"]
+                    if c in sam_entities.columns
+                ),
                 None,
             )
             status_col = next(
@@ -206,13 +223,19 @@ class ComputeObservableCommercializationTool(BaseTool):
             # Prong 1: Federal revenue
             total_revenue = fpds_revenue.get(company, 0.0)
             avg_revenue_per_p2 = total_revenue / p2_count if p2_count > 0 else 0.0
-            revenue_prong = min(avg_revenue_per_p2 / revenue_threshold, 1.0) if revenue_threshold > 0 else 0.0
+            revenue_prong = (
+                min(avg_revenue_per_p2 / revenue_threshold, 1.0) if revenue_threshold > 0 else 0.0
+            )
             revenue_pass = avg_revenue_per_p2 >= revenue_threshold
 
             # Prong 2: Patent portfolio
             patents = patent_counts.get(company, 0)
             patent_ratio = patents / p2_count if p2_count > 0 else 0.0
-            patent_prong = min(patent_ratio / PATENT_PRONG_THRESHOLD, 1.0) if PATENT_PRONG_THRESHOLD > 0 else 0.0
+            patent_prong = (
+                min(patent_ratio / PATENT_PRONG_THRESHOLD, 1.0)
+                if PATENT_PRONG_THRESHOLD > 0
+                else 0.0
+            )
             patent_pass = patent_ratio >= PATENT_PRONG_THRESHOLD
 
             # Prong 3: Entity survival
@@ -223,44 +246,46 @@ class ComputeObservableCommercializationTool(BaseTool):
 
             # Composite score (weighted)
             composite = (
-                weight_revenue * revenue_prong +
-                weight_patent * patent_prong +
-                weight_survival * survival_prong
+                weight_revenue * revenue_prong
+                + weight_patent * patent_prong
+                + weight_survival * survival_prong
             )
 
             # Overall pass: at least 2 of 3 prongs passing
             prongs_passing = sum([revenue_pass, patent_pass, survival_pass])
             overall_status = "passing" if prongs_passing >= 2 else "failing"
 
-            results.append({
-                "company_id": company,
-                "phase_2_count": p2_count,
-                "measurement_window": f"FY{start_fy}-FY{end_fy}",
-                # Revenue prong
-                "fpds_total_revenue": round(total_revenue, 2),
-                "avg_revenue_per_p2": round(avg_revenue_per_p2, 2),
-                "revenue_prong_score": round(revenue_prong, 4),
-                "revenue_prong_pass": revenue_pass,
-                # Patent prong
-                "patent_count": patents,
-                "patent_ratio": round(patent_ratio, 4),
-                "patent_prong_score": round(patent_prong, 4),
-                "patent_prong_pass": patent_pass,
-                # Survival prong
-                "sam_active": is_active,
-                "survival_prong_score": round(survival_prong, 4),
-                "survival_prong_pass": survival_pass,
-                # Composite
-                "composite_score": round(composite, 4),
-                "prongs_passing": prongs_passing,
-                "overall_status": overall_status,
-                # Weights used
-                "weights": {
-                    "revenue": weight_revenue,
-                    "patent": weight_patent,
-                    "survival": weight_survival,
-                },
-            })
+            results.append(
+                {
+                    "company_id": company,
+                    "phase_2_count": p2_count,
+                    "measurement_window": f"FY{start_fy}-FY{end_fy}",
+                    # Revenue prong
+                    "fpds_total_revenue": round(total_revenue, 2),
+                    "avg_revenue_per_p2": round(avg_revenue_per_p2, 2),
+                    "revenue_prong_score": round(revenue_prong, 4),
+                    "revenue_prong_pass": revenue_pass,
+                    # Patent prong
+                    "patent_count": patents,
+                    "patent_ratio": round(patent_ratio, 4),
+                    "patent_prong_score": round(patent_prong, 4),
+                    "patent_prong_pass": patent_pass,
+                    # Survival prong
+                    "sam_active": is_active,
+                    "survival_prong_score": round(survival_prong, 4),
+                    "survival_prong_pass": survival_pass,
+                    # Composite
+                    "composite_score": round(composite, 4),
+                    "prongs_passing": prongs_passing,
+                    "overall_status": overall_status,
+                    # Weights used
+                    "weights": {
+                        "revenue": weight_revenue,
+                        "patent": weight_patent,
+                        "survival": weight_survival,
+                    },
+                }
+            )
 
         results_df = pd.DataFrame(results) if results else pd.DataFrame()
 
@@ -274,10 +299,20 @@ class ComputeObservableCommercializationTool(BaseTool):
             "failing": len(qualifying) - len(passing),
             "avg_composite_score": round(
                 sum(r["composite_score"] for r in results) / len(results), 4
-            ) if results else None,
-            "revenue_data_coverage": len([c for c in qualifying if c in fpds_revenue]) / len(qualifying) if qualifying else 0,
-            "patent_data_coverage": len([c for c in qualifying if c in patent_counts]) / len(qualifying) if qualifying else 0,
-            "sam_data_coverage": len([c for c in qualifying if c in sam_active]) / len(qualifying) if qualifying else 0,
+            )
+            if results
+            else None,
+            "revenue_data_coverage": len([c for c in qualifying if c in fpds_revenue])
+            / len(qualifying)
+            if qualifying
+            else 0,
+            "patent_data_coverage": len([c for c in qualifying if c in patent_counts])
+            / len(qualifying)
+            if qualifying
+            else 0,
+            "sam_data_coverage": len([c for c in qualifying if c in sam_active]) / len(qualifying)
+            if qualifying
+            else 0,
             "limitation_note": (
                 "Observable benchmark cannot see private-market-only commercialization. "
                 "FPDS captures federal pathway only. Patent prong preserves statutory 15% threshold."

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_b/compute_transition_rate.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_b/compute_transition_rate.py
@@ -22,7 +22,7 @@ from ..base import BaseTool, DataSourceRef, ToolMetadata, ToolResult
 
 
 # Statutory thresholds
-STANDARD_THRESHOLD = 21   # Phase I awards to trigger benchmark
+STANDARD_THRESHOLD = 21  # Phase I awards to trigger benchmark
 INCREASED_THRESHOLD = 51  # Phase I awards for stricter standard
 
 
@@ -76,16 +76,21 @@ class ComputeTransitionRateTool(BaseTool):
         # Map company names to canonical IDs using entity table for deduplication
         if entity_table is not None and not entity_table.empty:
             canonical_col = next(
-                (c for c in ["canonical_id"] if c in entity_table.columns), None,
+                (c for c in ["canonical_id"] if c in entity_table.columns),
+                None,
             )
             name_col = next(
-                (c for c in ["canonical_name"] if c in entity_table.columns), None,
+                (c for c in ["canonical_name"] if c in entity_table.columns),
+                None,
             )
             company_src = next(
-                (c for c in ["company", "company_name"] if c in df.columns), None,
+                (c for c in ["company", "company_name"] if c in df.columns),
+                None,
             )
             if canonical_col and name_col and company_src:
-                name_to_id = dict(zip(entity_table[name_col], entity_table[canonical_col], strict=False))
+                name_to_id = dict(
+                    zip(entity_table[name_col], entity_table[canonical_col], strict=False)
+                )
                 df["canonical_id"] = df[company_src].map(name_to_id).fillna(df[company_src])
 
         # Identify columns
@@ -159,17 +164,23 @@ class ComputeTransitionRateTool(BaseTool):
             else:
                 status = "failing"
 
-            results.append({
-                "company_id": company,
-                "phase_1_count": p1,
-                "phase_2_count": p2,
-                "transition_rate": round(transition_rate, 4),
-                "threshold_tier": threshold_tier,
-                "minimum_rate": min_rate,
-                "status": status,
-                "awards_to_next_threshold": max(0, STANDARD_THRESHOLD - p1) if p1 < STANDARD_THRESHOLD else max(0, INCREASED_THRESHOLD - p1) if p1 < INCREASED_THRESHOLD else 0,
-                "measurement_window": f"FY{start_fy}-FY{end_fy}",
-            })
+            results.append(
+                {
+                    "company_id": company,
+                    "phase_1_count": p1,
+                    "phase_2_count": p2,
+                    "transition_rate": round(transition_rate, 4),
+                    "threshold_tier": threshold_tier,
+                    "minimum_rate": min_rate,
+                    "status": status,
+                    "awards_to_next_threshold": max(0, STANDARD_THRESHOLD - p1)
+                    if p1 < STANDARD_THRESHOLD
+                    else max(0, INCREASED_THRESHOLD - p1)
+                    if p1 < INCREASED_THRESHOLD
+                    else 0,
+                    "measurement_window": f"FY{start_fy}-FY{end_fy}",
+                }
+            )
 
         results_df = pd.DataFrame(results) if results else pd.DataFrame()
 
@@ -186,7 +197,9 @@ class ComputeTransitionRateTool(BaseTool):
             "failing": len(failing),
             "standard_tier_count": len([r for r in results if r["threshold_tier"] == "standard"]),
             "increased_tier_count": len([r for r in results if r["threshold_tier"] == "increased"]),
-            "below_threshold_count": len([r for r in results if r["threshold_tier"] == "below_threshold"]),
+            "below_threshold_count": len(
+                [r for r in results if r["threshold_tier"] == "below_threshold"]
+            ),
         }
 
         metadata.record_count = len(results_df)

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_c/stateio_multipliers.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_c/stateio_multipliers.py
@@ -92,12 +92,14 @@ class StateIOMultipliersTool(BaseTool):
                     from decimal import Decimal
 
                     unit_shock = Decimal("1000000")
-                    shocks_df = pd.DataFrame({
-                        "state": [s for s, _ in pairs],
-                        "bea_sector": [b for _, b in pairs],
-                        "fiscal_year": [2020] * len(pairs),
-                        "shock_amount": [unit_shock] * len(pairs),
-                    })
+                    shocks_df = pd.DataFrame(
+                        {
+                            "state": [s for s, _ in pairs],
+                            "bea_sector": [b for _, b in pairs],
+                            "fiscal_year": [2020] * len(pairs),
+                            "shock_amount": [unit_shock] * len(pairs),
+                        }
+                    )
                     impacts_df = adapter.compute_impacts(shocks_df)
 
                     for _, row in impacts_df.iterrows():
@@ -112,18 +114,22 @@ class StateIOMultipliersTool(BaseTool):
                         else:
                             emp_multiplier = None
 
-                        multipliers.append({
-                            "state": row["state"],
-                            "bea_sector": row["bea_sector"],
-                            "output_multiplier": float(row.get("production_impact", shock)) / shock,
-                            "employment_multiplier": emp_multiplier,
-                            "value_added_multiplier": (
-                                float(row.get("wage_impact", 0))
-                                + float(row.get("gross_operating_surplus", 0))
-                                + float(row.get("tax_impact", 0))
-                            ) / shock,
-                            "source": "bea_api",
-                        })
+                        multipliers.append(
+                            {
+                                "state": row["state"],
+                                "bea_sector": row["bea_sector"],
+                                "output_multiplier": float(row.get("production_impact", shock))
+                                / shock,
+                                "employment_multiplier": emp_multiplier,
+                                "value_added_multiplier": (
+                                    float(row.get("wage_impact", 0))
+                                    + float(row.get("gross_operating_surplus", 0))
+                                    + float(row.get("tax_impact", 0))
+                                )
+                                / shock,
+                                "source": "bea_api",
+                            }
+                        )
                     if multipliers:
                         access_method = "bea_api"
                 except Exception as e:
@@ -136,19 +142,23 @@ class StateIOMultipliersTool(BaseTool):
             try:
                 csv_df = pd.read_csv(csv_fallback_path)
                 for state, sector in pairs:
-                    match = csv_df[
-                        (csv_df["state"] == state) & (csv_df["bea_sector"] == sector)
-                    ]
+                    match = csv_df[(csv_df["state"] == state) & (csv_df["bea_sector"] == sector)]
                     if not match.empty:
                         row = match.iloc[0]
-                        multipliers.append({
-                            "state": state,
-                            "bea_sector": sector,
-                            "output_multiplier": float(row.get("output_multiplier", 1.0)),
-                            "employment_multiplier": float(row.get("employment_multiplier", 1.0)),
-                            "value_added_multiplier": float(row.get("value_added_multiplier", 1.0)),
-                            "source": "csv_precomputed",
-                        })
+                        multipliers.append(
+                            {
+                                "state": state,
+                                "bea_sector": sector,
+                                "output_multiplier": float(row.get("output_multiplier", 1.0)),
+                                "employment_multiplier": float(
+                                    row.get("employment_multiplier", 1.0)
+                                ),
+                                "value_added_multiplier": float(
+                                    row.get("value_added_multiplier", 1.0)
+                                ),
+                                "source": "csv_precomputed",
+                            }
+                        )
                 access_method = "csv_precomputed"
             except Exception as e:
                 logger.warning(f"CSV fallback failed: {e}")
@@ -160,14 +170,16 @@ class StateIOMultipliersTool(BaseTool):
                 "No multiplier source available (R or CSV). Using default multiplier of 1.0"
             )
             for state, sector in pairs:
-                multipliers.append({
-                    "state": state,
-                    "bea_sector": sector,
-                    "output_multiplier": 1.0,
-                    "employment_multiplier": 1.0,
-                    "value_added_multiplier": 1.0,
-                    "source": "default",
-                })
+                multipliers.append(
+                    {
+                        "state": state,
+                        "bea_sector": sector,
+                        "output_multiplier": 1.0,
+                        "employment_multiplier": 1.0,
+                        "value_added_multiplier": 1.0,
+                        "source": "default",
+                    }
+                )
             access_method = "default_fallback"
 
         multipliers_df = pd.DataFrame(multipliers)

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py
@@ -90,10 +90,13 @@ class TaxEstimationTool(BaseTool):
         Returns:
             ToolResult with Track A estimates, Track B observations, calibration
         """
-        metadata.upstream_tools.extend([
-            "naics_to_bea_crosswalk", "stateio_multipliers",
-            "compute_observable_commercialization",
-        ])
+        metadata.upstream_tools.extend(
+            [
+                "naics_to_bea_crosswalk",
+                "stateio_multipliers",
+                "compute_observable_commercialization",
+            ]
+        )
 
         tax_rates = effective_tax_rates or DEFAULT_EFFECTIVE_TAX_RATES
 
@@ -107,19 +110,24 @@ class TaxEstimationTool(BaseTool):
 
             # Required columns
             sector_col = next(
-                (c for c in ["bea_sector", "sector"] if c in df.columns), None,
+                (c for c in ["bea_sector", "sector"] if c in df.columns),
+                None,
             )
             state_col = next(
-                (c for c in ["state", "company_state"] if c in df.columns), None,
+                (c for c in ["state", "company_state"] if c in df.columns),
+                None,
             )
             amount_col = next(
-                (c for c in ["award_amount", "amount"] if c in df.columns), None,
+                (c for c in ["award_amount", "amount"] if c in df.columns),
+                None,
             )
             fy_col = next(
-                (c for c in ["fiscal_year", "award_year", "fy"] if c in df.columns), None,
+                (c for c in ["fiscal_year", "award_year", "fy"] if c in df.columns),
+                None,
             )
             company_col = next(
-                (c for c in ["canonical_id", "company"] if c in df.columns), None,
+                (c for c in ["canonical_id", "company"] if c in df.columns),
+                None,
             )
 
             # Build multiplier lookup
@@ -142,7 +150,9 @@ class TaxEstimationTool(BaseTool):
                 company = row.get(company_col) if company_col else None
 
                 # Get multiplier
-                mult = mult_lookup.get((state, sector), {"output": 1.0, "employment": 1.0, "value_added": 1.0})
+                mult = mult_lookup.get(
+                    (state, sector), {"output": 1.0, "employment": 1.0, "value_added": 1.0}
+                )
                 output_impact = award_amount * mult["output"]
                 value_added = award_amount * mult["value_added"]
 
@@ -167,24 +177,26 @@ class TaxEstimationTool(BaseTool):
                 discount_factor = 1.0 / ((1.0 + discount_rate) ** years_from_present)
                 discounted_tax = total_tax * discount_factor
 
-                track_a_results.append({
-                    "company_id": company,
-                    "fiscal_year": fy,
-                    "state": state,
-                    "bea_sector": sector,
-                    "award_amount": round(award_amount, 2),
-                    "output_multiplier": round(mult["output"], 4),
-                    "output_impact": round(output_impact, 2),
-                    "value_added": round(value_added, 2),
-                    "estimated_wages": round(wages, 2),
-                    "individual_income_tax": round(individual_income_tax, 2),
-                    "payroll_tax": round(payroll_tax, 2),
-                    "corporate_income_tax": round(corporate_income_tax, 2),
-                    "total_estimated_tax": round(total_tax, 2),
-                    "discounted_tax": round(discounted_tax, 2),
-                    "discount_factor": round(discount_factor, 6),
-                    "effective_tax_rate_used": corp_tax_rate,
-                })
+                track_a_results.append(
+                    {
+                        "company_id": company,
+                        "fiscal_year": fy,
+                        "state": state,
+                        "bea_sector": sector,
+                        "award_amount": round(award_amount, 2),
+                        "output_multiplier": round(mult["output"], 4),
+                        "output_impact": round(output_impact, 2),
+                        "value_added": round(value_added, 2),
+                        "estimated_wages": round(wages, 2),
+                        "individual_income_tax": round(individual_income_tax, 2),
+                        "payroll_tax": round(payroll_tax, 2),
+                        "corporate_income_tax": round(corporate_income_tax, 2),
+                        "total_estimated_tax": round(total_tax, 2),
+                        "discounted_tax": round(discounted_tax, 2),
+                        "discount_factor": round(discount_factor, 6),
+                        "effective_tax_rate_used": corp_tax_rate,
+                    }
+                )
 
         track_a_df = pd.DataFrame(track_a_results) if track_a_results else pd.DataFrame()
 
@@ -194,8 +206,11 @@ class TaxEstimationTool(BaseTool):
         track_b_summary: dict[str, Any] = {}
         if fpds_revenue is not None and not fpds_revenue.empty:
             amount_col_b = next(
-                (c for c in ["fpds_total_revenue", "obligation_amount", "amount"]
-                 if c in fpds_revenue.columns),
+                (
+                    c
+                    for c in ["fpds_total_revenue", "obligation_amount", "amount"]
+                    if c in fpds_revenue.columns
+                ),
                 None,
             )
             if amount_col_b:
@@ -227,7 +242,11 @@ class TaxEstimationTool(BaseTool):
             if company_col_b:
                 a_by_company = track_a_df.groupby(company_col_a)["total_estimated_tax"].sum()
                 b_col = next(
-                    (c for c in ["fpds_total_revenue", "obligation_amount"] if c in fpds_revenue.columns),
+                    (
+                        c
+                        for c in ["fpds_total_revenue", "obligation_amount"]
+                        if c in fpds_revenue.columns
+                    ),
                     None,
                 )
                 if b_col:
@@ -241,7 +260,11 @@ class TaxEstimationTool(BaseTool):
                             "overlapping_companies": len(overlap),
                             "track_a_total": float(a_vals.sum()),
                             "track_b_total": float(b_vals.sum()),
-                            "median_ratio": float((a_vals / b_vals.replace(0, float("nan"))).median()) if len(overlap) > 0 else None,
+                            "median_ratio": float(
+                                (a_vals / b_vals.replace(0, float("nan"))).median()
+                            )
+                            if len(overlap) > 0
+                            else None,
                         }
 
         # =====================================================================
@@ -249,17 +272,31 @@ class TaxEstimationTool(BaseTool):
         # =====================================================================
         summary: dict[str, Any] = {
             "track_a": {
-                "total_estimated_tax_receipts": float(track_a_df["total_estimated_tax"].sum()) if not track_a_df.empty else 0.0,
-                "total_discounted_tax_receipts": float(track_a_df["discounted_tax"].sum()) if not track_a_df.empty and "discounted_tax" in track_a_df.columns else 0.0,
-                "total_sbir_investment": float(track_a_df["award_amount"].sum()) if not track_a_df.empty else 0.0,
+                "total_estimated_tax_receipts": float(track_a_df["total_estimated_tax"].sum())
+                if not track_a_df.empty
+                else 0.0,
+                "total_discounted_tax_receipts": float(track_a_df["discounted_tax"].sum())
+                if not track_a_df.empty and "discounted_tax" in track_a_df.columns
+                else 0.0,
+                "total_sbir_investment": float(track_a_df["award_amount"].sum())
+                if not track_a_df.empty
+                else 0.0,
                 "implied_roi": round(
-                    float(track_a_df["total_estimated_tax"].sum()) /
-                    float(track_a_df["award_amount"].sum()), 4
-                ) if not track_a_df.empty and track_a_df["award_amount"].sum() > 0 else None,
+                    float(track_a_df["total_estimated_tax"].sum())
+                    / float(track_a_df["award_amount"].sum()),
+                    4,
+                )
+                if not track_a_df.empty and track_a_df["award_amount"].sum() > 0
+                else None,
                 "npv_roi": round(
-                    float(track_a_df["discounted_tax"].sum()) /
-                    float(track_a_df["award_amount"].sum()), 4
-                ) if not track_a_df.empty and "discounted_tax" in track_a_df.columns and track_a_df["award_amount"].sum() > 0 else None,
+                    float(track_a_df["discounted_tax"].sum())
+                    / float(track_a_df["award_amount"].sum()),
+                    4,
+                )
+                if not track_a_df.empty
+                and "discounted_tax" in track_a_df.columns
+                and track_a_df["award_amount"].sum() > 0
+                else None,
                 "discount_rate": discount_rate,
                 "awards_estimated": len(track_a_df),
             },

--- a/packages/sbir-analytics/sbir_analytics/tools/phase0/extract_fpds_contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/phase0/extract_fpds_contracts.py
@@ -78,7 +78,9 @@ class ExtractFPDSContractsTool(BaseTool):
             )
 
             dump_path = Path(dump_dir)
-            out_path = Path(output_path) if output_path else dump_path / "extracted_contracts.parquet"
+            out_path = (
+                Path(output_path) if output_path else dump_path / "extracted_contracts.parquet"
+            )
 
             count = extractor.extract_from_dump(
                 dump_dir=dump_path,

--- a/packages/sbir-analytics/sbir_analytics/tools/phase0/resolve_entities.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/phase0/resolve_entities.py
@@ -106,7 +106,9 @@ class ResolveEntitiesTool(BaseTool):
             try:
                 gold_df = pd.read_csv(gold_set_path)
                 src_col = next((c for c in ["source_name", "name"] if c in gold_df.columns), None)
-                can_col = next((c for c in ["canonical_id", "canonical"] if c in gold_df.columns), None)
+                can_col = next(
+                    (c for c in ["canonical_id", "canonical"] if c in gold_df.columns), None
+                )
                 if src_col and can_col:
                     gold_set = dict(zip(gold_df[src_col], gold_df[can_col], strict=False))
                     logger.info(f"Loaded {len(gold_set)} gold set linkages from {gold_set_path}")
@@ -215,17 +217,24 @@ class ResolveEntitiesTool(BaseTool):
                     matched["source_ids"]["sbir_gov"] = uei or duns or name
                     if name not in matched["name_variants"]:
                         matched["name_variants"].append(name)
-                    match_log.append({
-                        "source": "sbir_gov",
-                        "source_name": name,
-                        "canonical_id": matched["canonical_id"],
-                        "method": method,
-                        "confidence": 1.0 if method in ("uei_exact", "duns_exact") else 0.95,
-                    })
+                    match_log.append(
+                        {
+                            "source": "sbir_gov",
+                            "source_name": name,
+                            "canonical_id": matched["canonical_id"],
+                            "method": method,
+                            "confidence": 1.0 if method in ("uei_exact", "duns_exact") else 0.95,
+                        }
+                    )
                 else:
-                    unmatched_sbir.append({
-                        "name": name, "state": state, "uei": uei, "duns": duns,
-                    })
+                    unmatched_sbir.append(
+                        {
+                            "name": name,
+                            "state": state,
+                            "uei": uei,
+                            "duns": duns,
+                        }
+                    )
 
             logger.info(
                 f"SBIR deterministic: {deterministic_matches}/{len(sbir_companies)} matched, "
@@ -259,27 +268,35 @@ class ResolveEntitiesTool(BaseTool):
                     if best_score >= fuzzy_auto_threshold and best_idx >= 0:
                         # Auto-merge
                         matched = entities[canonical_names[best_idx][1]]
-                        matched["source_ids"]["sbir_gov"] = company["uei"] or company["duns"] or company["name"]
+                        matched["source_ids"]["sbir_gov"] = (
+                            company["uei"] or company["duns"] or company["name"]
+                        )
                         if company["name"] not in matched["name_variants"]:
                             matched["name_variants"].append(company["name"])
                         fuzzy_matches += 1
-                        match_log.append({
-                            "source": "sbir_gov",
-                            "source_name": company["name"],
-                            "canonical_id": matched["canonical_id"],
-                            "method": "fuzzy_auto",
-                            "confidence": best_score / 100.0,
-                        })
+                        match_log.append(
+                            {
+                                "source": "sbir_gov",
+                                "source_name": company["name"],
+                                "canonical_id": matched["canonical_id"],
+                                "method": "fuzzy_auto",
+                                "confidence": best_score / 100.0,
+                            }
+                        )
                     elif best_score >= fuzzy_review_threshold and best_idx >= 0:
                         # Flag for review
                         flagged_for_review += 1
-                        match_log.append({
-                            "source": "sbir_gov",
-                            "source_name": company["name"],
-                            "canonical_id": entities[canonical_names[best_idx][1]]["canonical_id"],
-                            "method": "fuzzy_review_needed",
-                            "confidence": best_score / 100.0,
-                        })
+                        match_log.append(
+                            {
+                                "source": "sbir_gov",
+                                "source_name": company["name"],
+                                "canonical_id": entities[canonical_names[best_idx][1]][
+                                    "canonical_id"
+                                ],
+                                "method": "fuzzy_review_needed",
+                                "confidence": best_score / 100.0,
+                            }
+                        )
                     else:
                         # Create new entity
                         canonical_id = _generate_canonical_id(company["name"], company["uei"])
@@ -292,18 +309,22 @@ class ResolveEntitiesTool(BaseTool):
                             "state": company["state"],
                             "naics": None,
                             "name_variants": [company["name"]],
-                            "source_ids": {"sbir_gov": company["uei"] or company["duns"] or company["name"]},
+                            "source_ids": {
+                                "sbir_gov": company["uei"] or company["duns"] or company["name"]
+                            },
                             "confidence": 0.5,
                             "match_method": "new_entity",
                         }
                         entities.append(new_entity)
-                        match_log.append({
-                            "source": "sbir_gov",
-                            "source_name": company["name"],
-                            "canonical_id": canonical_id,
-                            "method": "new_entity",
-                            "confidence": 0.5,
-                        })
+                        match_log.append(
+                            {
+                                "source": "sbir_gov",
+                                "source_name": company["name"],
+                                "canonical_id": canonical_id,
+                                "method": "new_entity",
+                                "confidence": 0.5,
+                            }
+                        )
 
                 logger.info(
                     f"Fuzzy matching: {fuzzy_matches} auto-merged, "
@@ -347,11 +368,21 @@ class ResolveEntitiesTool(BaseTool):
         if entities:
             entity_df = pd.DataFrame(entities)
         else:
-            entity_df = pd.DataFrame(columns=[
-                "canonical_id", "canonical_name", "uei", "duns", "cage",
-                "state", "naics", "name_variants", "source_ids",
-                "confidence", "match_method",
-            ])
+            entity_df = pd.DataFrame(
+                columns=[
+                    "canonical_id",
+                    "canonical_name",
+                    "uei",
+                    "duns",
+                    "cage",
+                    "state",
+                    "naics",
+                    "name_variants",
+                    "source_ids",
+                    "confidence",
+                    "match_method",
+                ]
+            )
 
         match_log_df = pd.DataFrame(match_log) if match_log else pd.DataFrame()
 
@@ -367,10 +398,14 @@ class ResolveEntitiesTool(BaseTool):
             "match_log": match_log_df,
             "stats": {
                 "total_canonical_entities": len(entity_df),
-                "deterministic_matches": len([m for m in match_log if m.get("method", "").endswith("exact")]),
+                "deterministic_matches": len(
+                    [m for m in match_log if m.get("method", "").endswith("exact")]
+                ),
                 "fuzzy_auto_merges": fuzzy_matches,
                 "flagged_for_review": flagged_for_review,
-                "new_entities_created": len([e for e in entities if e.get("match_method") == "new_entity"]),
+                "new_entities_created": len(
+                    [e for e in entities if e.get("match_method") == "new_entity"]
+                ),
             },
         }
 

--- a/packages/sbir-graph/sbir_graph/loaders/__init__.py
+++ b/packages/sbir-graph/sbir_graph/loaders/__init__.py
@@ -13,7 +13,11 @@ from typing import Any
 __all__ = ["Neo4jClient", "Neo4jConfig", "LoadMetrics", "PatentLoader", "PatentLoaderConfig"]
 
 _NEO4J_NAMES = {
-    "LoadMetrics", "Neo4jClient", "Neo4jConfig", "PatentLoader", "PatentLoaderConfig",
+    "LoadMetrics",
+    "Neo4jClient",
+    "Neo4jConfig",
+    "PatentLoader",
+    "PatentLoaderConfig",
 }
 
 

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/client.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/client.py
@@ -14,8 +14,7 @@ try:
     from neo4j import Driver, GraphDatabase, Session, Transaction  # type: ignore[attr-defined]
 except ImportError as _neo4j_err:
     raise ImportError(
-        "The neo4j package is required for Neo4j loaders. "
-        "Install it with: pip install sbir-graph"
+        "The neo4j package is required for Neo4j loaders. Install it with: pip install sbir-graph"
     ) from _neo4j_err
 
 
@@ -799,8 +798,7 @@ class Neo4jClient:
 
                 if record and record["test"] == 1:
                     version_result = session.run(
-                        "CALL dbms.components() YIELD name, versions "
-                        "RETURN versions[0] as version"
+                        "CALL dbms.components() YIELD name, versions RETURN versions[0] as version"
                     )
                     version_record = version_result.single()
                     version = version_record["version"] if version_record else None
@@ -836,9 +834,7 @@ class Neo4jClient:
                 """
                 node_result = session.run(node_query)
                 node_counts = {
-                    record["label"]: record["count"]
-                    for record in node_result
-                    if record["label"]
+                    record["label"]: record["count"] for record in node_result if record["label"]
                 }
 
                 rel_query = """
@@ -847,9 +843,7 @@ class Neo4jClient:
                 ORDER BY count DESC
                 """
                 rel_result = session.run(rel_query)
-                relationship_counts = {
-                    record["rel_type"]: record["count"] for record in rel_result
-                }
+                relationship_counts = {record["rel_type"]: record["count"] for record in rel_result}
 
                 return Neo4jStatistics(
                     node_counts=node_counts,

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/patent_cet.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/patent_cet.py
@@ -1,5 +1,5 @@
 """
-sbir-analytics/src/loaders/neo4j_patent_loader.py
+packages/sbir-graph/sbir_graph/loaders/neo4j/patent_cet.py
 
 Neo4j loader for patent CET classifications with idempotent MERGE operations.
 

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/sec_edgar.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/sec_edgar.py
@@ -65,8 +65,7 @@ class SecEdgarLoader(BaseNeo4jLoader):
         """Create indexes for SEC EDGAR properties on Company nodes."""
         if indexes is None:
             indexes = [
-                "CREATE INDEX company_sec_cik_idx IF NOT EXISTS "
-                "FOR (c:Company) ON (c.sec_cik)",
+                "CREATE INDEX company_sec_cik_idx IF NOT EXISTS FOR (c:Company) ON (c.sec_cik)",
                 "CREATE INDEX company_sec_publicly_traded_idx IF NOT EXISTS "
                 "FOR (c:Company) ON (c.sec_is_publicly_traded)",
                 "CREATE INDEX company_sec_ticker_idx IF NOT EXISTS "

--- a/packages/sbir-ml/sbir_ml/ml/config/__init__.py
+++ b/packages/sbir-ml/sbir_ml/ml/config/__init__.py
@@ -8,7 +8,9 @@ from .taxonomy_loader import ClassificationConfig, TaxonomyConfig, TaxonomyLoade
 class PaECTERClientConfig(BaseModel):
     """Configuration for the PaECTERClient."""
 
-    model_name: str = Field("nomic-ai/modernbert-embed-base", description="HuggingFace model identifier")
+    model_name: str = Field(
+        "nomic-ai/modernbert-embed-base", description="HuggingFace model identifier"
+    )
     use_local: bool = Field(
         False, description="If True, use local sentence-transformers. If False, use API."
     )

--- a/packages/sbir-ml/sbir_ml/ml/config/taxonomy_checks.py
+++ b/packages/sbir-ml/sbir_ml/ml/config/taxonomy_checks.py
@@ -25,7 +25,7 @@ from typing import Any
 
 from loguru import logger
 
-# Import the project's TaxonomyLoader. This module lives under src/ml/config and
+# Import the project's TaxonomyLoader. This module lives under packages/sbir-ml/sbir_ml/ml/config and
 # depends on the project's models (Pydantic) to validate the taxonomy.
 from sbir_ml.ml.config.taxonomy_loader import TaxonomyConfig, TaxonomyLoader
 

--- a/packages/sbir-ml/sbir_ml/ml/models/dummy_pipeline.py
+++ b/packages/sbir-ml/sbir_ml/ml/models/dummy_pipeline.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/ml/models/dummy_pipeline.py
+# packages/sbir-ml/sbir_ml/ml/models/dummy_pipeline.py
 """
 DummyPipeline
 

--- a/packages/sbir-ml/sbir_ml/ml/models/patent_classifier.py
+++ b/packages/sbir-ml/sbir_ml/ml/models/patent_classifier.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/ml/models/patent_classifier.py
+# packages/sbir-ml/sbir_ml/ml/models/patent_classifier.py
 """
 PatentCETClassifier
 
@@ -42,7 +42,12 @@ except Exception:  # pragma: no cover - defensive import
 
 import pickle  # nosec B403 - Used for loading internally-generated ML model files
 
-from sbir_etl.exceptions import CETClassificationError, DependencyError, FileSystemError, ValidationError
+from sbir_etl.exceptions import (
+    CETClassificationError,
+    DependencyError,
+    FileSystemError,
+    ValidationError,
+)
 
 
 # Define optional placeholders so static analysis doesn't flag undefined names before lazy import

--- a/packages/sbir-ml/sbir_ml/ml/train/patent_training.py
+++ b/packages/sbir-ml/sbir_ml/ml/train/patent_training.py
@@ -1,5 +1,5 @@
 """
-sbir-analytics/src/ml/train/patent_training.py
+packages/sbir-ml/sbir_ml/ml/train/patent_training.py
 
 Helper routines to train and persist a PatentCETClassifier from a labeled
 DataFrame. Keeps Dagster assets thin and enables unit tests to call training

--- a/packages/sbir-ml/sbir_ml/transition/analysis/benchmark_evaluator.py
+++ b/packages/sbir-ml/sbir_ml/transition/analysis/benchmark_evaluator.py
@@ -216,12 +216,8 @@ class BenchmarkEligibilityEvaluator:
         comm_p2_counts = df[comm_p2_mask].groupby("_company_id").size().to_dict()
 
         # Phase I FYs per company (for detail)
-        p1_fys = (
-            df[p1_mask].groupby("_company_id")["_fy"].apply(sorted).apply(list).to_dict()
-        )
-        p2_fys = (
-            df[p2_mask].groupby("_company_id")["_fy"].apply(sorted).apply(list).to_dict()
-        )
+        p1_fys = df[p1_mask].groupby("_company_id")["_fy"].apply(sorted).apply(list).to_dict()
+        p2_fys = df[p2_mask].groupby("_company_id")["_fy"].apply(sorted).apply(list).to_dict()
 
         # Company names
         if name_col:
@@ -268,9 +264,7 @@ class BenchmarkEligibilityEvaluator:
 
     # ─── Transition rate evaluation ──────────────────────────────────
 
-    def _evaluate_transition_rate(
-        self, counts: CompanyAwardCounts
-    ) -> TransitionRateResult:
+    def _evaluate_transition_rate(self, counts: CompanyAwardCounts) -> TransitionRateResult:
         """Evaluate the Phase I→II transition rate benchmark for one company."""
         t = self.transition_thresholds
         p1 = counts.phase1_count
@@ -360,9 +354,7 @@ class BenchmarkEligibilityEvaluator:
         required_patent_rate = c.standard_min_patent_rate if patents_path else None
 
         # Compute metrics
-        avg_sales = (
-            counts.total_sales_and_investment / p2 if p2 > 0 else None
-        )
+        avg_sales = counts.total_sales_and_investment / p2 if p2 > 0 else None
         patent_rate = counts.patent_count / p2 if p2 > 0 else None
 
         # Determine status
@@ -469,7 +461,12 @@ class BenchmarkEligibilityEvaluator:
         # Already subject and close to failing
         if commercialization_result.margin_from_sales_threshold is not None:
             margin = commercialization_result.margin_from_sales_threshold
-            if commercialization_result.required_avg_sales is not None and 0 <= margin <= self.sensitivity_margin_ratio * commercialization_result.required_avg_sales:
+            if (
+                commercialization_result.required_avg_sales is not None
+                and 0
+                <= margin
+                <= self.sensitivity_margin_ratio * commercialization_result.required_avg_sales
+            ):
                 at_risk_commercialization = True
 
         return SensitivityResult(
@@ -565,9 +562,7 @@ class BenchmarkEligibilityEvaluator:
                 sensitivity_results.append(sr)
 
         # Sort: companies subject to benchmarks first, then by company_id
-        transition_results.sort(
-            key=lambda r: (r.tier == BenchmarkTier.NOT_SUBJECT, r.company_id)
-        )
+        transition_results.sort(key=lambda r: (r.tier == BenchmarkTier.NOT_SUBJECT, r.company_id))
         commercialization_results.sort(
             key=lambda r: (r.tier == BenchmarkTier.NOT_SUBJECT, r.company_id)
         )
@@ -626,9 +621,7 @@ class BenchmarkEligibilityEvaluator:
             name_col = _first_col(df, ["Company", "company", "company_name"])
             if name_col:
                 company_df = df[
-                    df[name_col].astype(str).str.lower().str.contains(
-                        company_id.lower(), na=False
-                    )
+                    df[name_col].astype(str).str.lower().str.contains(company_id.lower(), na=False)
                 ]
 
         if company_df.empty:
@@ -710,7 +703,8 @@ class BenchmarkEligibilityEvaluator:
         ]
         for label, status in [("Failing", BenchmarkStatus.FAIL), ("Passing", BenchmarkStatus.PASS)]:
             rows = [
-                r for r in summary.transition_results
+                r
+                for r in summary.transition_results
                 if r.status == status and r.tier != BenchmarkTier.NOT_SUBJECT
             ]
             if rows:
@@ -720,7 +714,9 @@ class BenchmarkEligibilityEvaluator:
 
         # Commercialization rate details — failures first
         def _cr_row(r: CommercializationRateResult) -> str:
-            sales_str = f"${r.avg_sales_per_phase2:,.0f}" if r.avg_sales_per_phase2 is not None else "N/A"
+            sales_str = (
+                f"${r.avg_sales_per_phase2:,.0f}" if r.avg_sales_per_phase2 is not None else "N/A"
+            )
             pat_str = f"{r.patent_rate:.1%}" if r.patent_rate is not None else "N/A"
             name = r.company_name or r.company_id
             return (
@@ -734,7 +730,8 @@ class BenchmarkEligibilityEvaluator:
         ]
         for label, status in [("Failing", BenchmarkStatus.FAIL), ("Passing", BenchmarkStatus.PASS)]:
             rows = [
-                r for r in summary.commercialization_results
+                r
+                for r in summary.commercialization_results
                 if r.status == status and r.tier != BenchmarkTier.NOT_SUBJECT
             ]
             if rows:
@@ -744,16 +741,19 @@ class BenchmarkEligibilityEvaluator:
 
         # Sensitivity analysis
         at_risk = [
-            sr for sr in summary.sensitivity_results
+            sr
+            for sr in summary.sensitivity_results
             if sr.at_risk_transition or sr.at_risk_commercialization
         ]
         if at_risk:
-            lines.extend([
-                "## Sensitivity Analysis: Companies Near Thresholds",
-                "",
-                "| Company | Phase I | To Std Trans | To Inc Trans | Phase II (Comm) | To Std Comm | Risk |",
-                "|---------|---------|-------------|-------------|-----------------|-------------|------|",
-            ])
+            lines.extend(
+                [
+                    "## Sensitivity Analysis: Companies Near Thresholds",
+                    "",
+                    "| Company | Phase I | To Std Trans | To Inc Trans | Phase II (Comm) | To Std Comm | Risk |",
+                    "|---------|---------|-------------|-------------|-----------------|-------------|------|",
+                ]
+            )
             for sr in at_risk:
                 name = sr.company_name or sr.company_id
                 risks = []
@@ -772,22 +772,24 @@ class BenchmarkEligibilityEvaluator:
                 )
             lines.append("")
 
-        lines.extend([
-            "## Benchmark Rules Reference",
-            "",
-            "### Phase I to Phase II Transition Rate",
-            "- **Standard:** >=21 Phase I awards -> ratio must be >= 0.25",
-            "- **Increased (experienced):** >=51 Phase I awards -> ratio must be >= 0.50",
-            "- **Consequence (standard fail):** Ineligible for Phase I awards for 1 year",
-            "- **Consequence (increased fail):** Capped at 20 Phase I awards per agency",
-            "",
-            "### Commercialization Rate",
-            "- **Standard:** >=16 Phase II awards -> avg $100K+ sales/investment per Phase II, "
-            "OR >= 15% patents per Phase II",
-            "- **Increased Tier 1:** >=51 Phase II awards -> avg $250K+ (no patent path)",
-            "- **Increased Tier 2:** >=101 Phase II awards -> avg $450K+ (no patent path)",
-            "",
-        ])
+        lines.extend(
+            [
+                "## Benchmark Rules Reference",
+                "",
+                "### Phase I to Phase II Transition Rate",
+                "- **Standard:** >=21 Phase I awards -> ratio must be >= 0.25",
+                "- **Increased (experienced):** >=51 Phase I awards -> ratio must be >= 0.50",
+                "- **Consequence (standard fail):** Ineligible for Phase I awards for 1 year",
+                "- **Consequence (increased fail):** Capped at 20 Phase I awards per agency",
+                "",
+                "### Commercialization Rate",
+                "- **Standard:** >=16 Phase II awards -> avg $100K+ sales/investment per Phase II, "
+                "OR >= 15% patents per Phase II",
+                "- **Increased Tier 1:** >=51 Phase II awards -> avg $250K+ (no patent path)",
+                "- **Increased Tier 2:** >=101 Phase II awards -> avg $450K+ (no patent path)",
+                "",
+            ]
+        )
 
         return "\n".join(lines)
 

--- a/packages/sbir-ml/sbir_ml/transition/analysis/usaspending_commercialization.py
+++ b/packages/sbir-ml/sbir_ml/transition/analysis/usaspending_commercialization.py
@@ -54,6 +54,7 @@ _CACHE_SAVE_INTERVAL = 500  # save cache every N completed queries
 # Parquet-based path
 # ═══════════════════════════════════════════════════════════════════════
 
+
 def build_commercialization_from_usaspending(
     transaction_path: str | Path,
     evaluation_fy: int = 2026,
@@ -95,9 +96,7 @@ def build_commercialization_from_usaspending(
         df["action_date"] = pd.to_datetime(df["action_date"], errors="coerce")
         df["_fy"] = df["action_date"].dt.year + (df["action_date"].dt.month >= 10).astype(int)
     else:
-        raise ValueError(
-            "Transaction data must contain 'start_date' or 'action_date' column"
-        )
+        raise ValueError("Transaction data must contain 'start_date' or 'action_date' column")
 
     end_fy = evaluation_fy - exclude_recent_years
     start_fy = end_fy - lookback_years + 1
@@ -108,7 +107,9 @@ def build_commercialization_from_usaspending(
         if uei_col:
             before = len(df)
             df = df[df[uei_col].astype(str).str.strip().isin(uei_filter)]
-            print(f"  Filtered Parquet to {len(df):,} rows (from {before:,}) for {len(uei_filter)} candidate UEIs")
+            print(
+                f"  Filtered Parquet to {len(df):,} rows (from {before:,}) for {len(uei_filter)} candidate UEIs"
+            )
 
     if df.empty:
         return _empty_commercialization_df()
@@ -136,6 +137,7 @@ def build_commercialization_from_usaspending(
 # ═══════════════════════════════════════════════════════════════════════
 # API-based path
 # ═══════════════════════════════════════════════════════════════════════
+
 
 def fetch_commercialization_from_api(
     awards_df: pd.DataFrame,
@@ -278,10 +280,7 @@ def fetch_commercialization_from_api(
         print(f"  Fetching with {workers} concurrent workers...")
 
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            futures = {
-                pool.submit(_rate_limited_fetch, uei): uei
-                for uei in to_fetch
-            }
+            futures = {pool.submit(_rate_limited_fetch, uei): uei for uei in to_fetch}
             for future in as_completed(futures):
                 uei, total = future.result()
                 if total is not None:
@@ -453,6 +452,7 @@ def _api_post(endpoint: str, payload: dict, *, retries: int = 3) -> dict:
 # Shared helpers
 # ═══════════════════════════════════════════════════════════════════════
 
+
 def _extract_unique_ueis(df: pd.DataFrame) -> list[str]:
     """Extract unique non-empty UEI values from an awards DataFrame."""
     uei_col = _first_present(df, ["UEI", "uei", "company_uei", "vendor_uei"])
@@ -460,16 +460,12 @@ def _extract_unique_ueis(df: pd.DataFrame) -> list[str]:
         return []
 
     ueis = df[uei_col].dropna().astype(str).str.strip()
-    ueis = ueis[
-        (ueis != "") & (~ueis.isin(["None", "nan", "NaN"])) & (ueis.str.len() == 12)
-    ]
+    ueis = ueis[(ueis != "") & (~ueis.isin(["None", "nan", "NaN"])) & (ueis.str.len() == 12)]
     return sorted(ueis.unique().tolist())
 
 
 def _empty_commercialization_df() -> pd.DataFrame:
-    return pd.DataFrame(
-        columns=["company_id", "total_sales_and_investment", "patent_count"]
-    )
+    return pd.DataFrame(columns=["company_id", "total_sales_and_investment", "patent_count"])
 
 
 def _resolve_company_id(df: pd.DataFrame) -> pd.Series:

--- a/packages/sbir-ml/sbir_ml/transition/detection/detector.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/detector.py
@@ -25,7 +25,12 @@ from uuid import uuid4
 from loguru import logger
 from tqdm import tqdm
 
-from sbir_etl.models.transition_models import ConfidenceLevel, FederalContract, Transition, VendorMatch
+from sbir_etl.models.transition_models import (
+    ConfidenceLevel,
+    FederalContract,
+    Transition,
+    VendorMatch,
+)
 from sbir_ml.transition.detection.evidence import EvidenceGenerator
 from sbir_ml.transition.detection.scoring import TransitionScorer
 from sbir_ml.transition.features.vendor_resolver import ResolverMatch, VendorResolver
@@ -219,7 +224,9 @@ class TransitionDetector:
                 if resolver_match.record:
                     self.metrics["vendor_matches"] += 1
                     return self._resolver_to_domain_match(
-                        resolver_match, method, fallback_id,
+                        resolver_match,
+                        method,
+                        fallback_id,
                         extra_metadata={method: identifier},
                     )
 
@@ -231,7 +238,8 @@ class TransitionDetector:
             ):
                 self.metrics["vendor_matches"] += 1
                 return self._resolver_to_domain_match(
-                    resolver_match, resolver_match.method,
+                    resolver_match,
+                    resolver_match.method,
                     resolver_match.record.metadata.get("vendor_id", "unknown"),
                     extra_metadata={
                         "input_name": contract.vendor_name,

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/transition/features/vendor_crosswalk.py
+# packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
 """
 Vendor cross-walk and alias management.
 

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/transition/features/vendor_resolver.py
+# packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
 """
 Vendor resolution utilities for transition detection.
 
@@ -232,7 +232,12 @@ class VendorResolver:
                 score = fuzz.token_sort_ratio(s1, s2) / 100.0
                 return float(score)
             except (TypeError, ValueError) as exc:
-                logger.debug("rapidfuzz scoring failed for {!r} vs {!r}: {}; falling back to difflib", s1, s2, exc)
+                logger.debug(
+                    "rapidfuzz scoring failed for {!r} vs {!r}: {}; falling back to difflib",
+                    s1,
+                    s2,
+                    exc,
+                )
         # difflib fallback
         sm = SequenceMatcher(None, s1, s2)
         return float(sm.ratio())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ ignore = [
     "C901", # too complex
     "E402", # module level import not at top - OK for conditional imports after version checks
     "I001", # import sorting - OK for optional imports in try blocks
+    "UP042", # preserve str/Enum behavior until a dedicated StrEnum migration
 ]
 
 [tool.ruff.lint.isort]

--- a/sbir_etl/enrichers/usaspending/enricher.py
+++ b/sbir_etl/enrichers/usaspending/enricher.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/enrichers/usaspending_enricher.py
+# sbir_etl/enrichers/usaspending/enricher.py
 """
 USAspending enricher for SBIR awards using identifier-first matching strategy.
 

--- a/sbir_etl/extractors/uspto_ai_extractor.py
+++ b/sbir_etl/extractors/uspto_ai_extractor.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/extractors/uspto_ai_extractor.py
+# sbir_etl/extractors/uspto_ai_extractor.py
 """
 USPTOAIExtractor - streaming, chunked extractor for the USPTO AI predictions dataset.
 

--- a/sbir_etl/extractors/uspto_extractor.py
+++ b/sbir_etl/extractors/uspto_extractor.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/extractors/uspto_extractor.py
+# sbir_etl/extractors/uspto_extractor.py
 """
 USPTOExtractor - chunked and streaming extractor for USPTO datasets.
 

--- a/sbir_etl/transformers/company_cet_aggregator.py
+++ b/sbir_etl/transformers/company_cet_aggregator.py
@@ -308,7 +308,7 @@ class CompanyCETAggregator:
 
         # Build dominant CET and specialization
         rows: list[dict[str, Any]] = []
-        company_ids = sorted(stats.index.tolist(), key=lambda x: (str(x) if x is not None else ""))
+        company_ids = sorted(stats.index.tolist(), key=lambda x: str(x) if x is not None else "")
         for cid in company_ids:
             company_row = stats.loc[cid]
             c_name = self.df.loc[self.df["company_id"] == cid, "company_name"]

--- a/sbir_etl/transformers/patent_transformer.py
+++ b/sbir_etl/transformers/patent_transformer.py
@@ -1,4 +1,4 @@
-# sbir-analytics/src/transformers/patent_transformer.py
+# sbir_etl/transformers/patent_transformer.py
 """
 PatentAssignmentTransformer
 

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Reject executable automation references to the removed ``src/`` source root."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SCANNED_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/")
+SCANNED_FILES = {"Makefile", ".pre-commit-config.yaml"}
+EXCLUDED_HISTORICAL_DOCUMENTS = {"docs/decisions/ADR-002-etl-library-extraction.md"}
+PATTERNS = (
+    re.compile(r"--cov=src(?:\b|/)"),
+    re.compile(r"\bsrc\.definitions(?:_ml)?\b"),
+    re.compile(r"(?:^|[\s'\"(=:/])src/[A-Za-z0-9_.*?/-]+"),
+)
+
+
+def tracked_automation_files() -> list[Path]:
+    """Return tracked automation files covered by the source-root policy."""
+    result = subprocess.run(
+        ["git", "ls-files"],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    paths = []
+    for relative in result.stdout.splitlines():
+        if relative in EXCLUDED_HISTORICAL_DOCUMENTS or relative == __file_relative__():
+            continue
+        if relative in SCANNED_FILES or relative.startswith(SCANNED_PREFIXES):
+            paths.append(REPOSITORY_ROOT / relative)
+    return paths
+
+
+def __file_relative__() -> str:
+    return str(Path(__file__).resolve().relative_to(REPOSITORY_ROOT))
+
+
+def main() -> int:
+    """Report removed source-root references and return a failing status when found."""
+    violations: list[str] = []
+    for path in tracked_automation_files():
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for line_number, line in enumerate(lines, 1):
+            if any(pattern.search(line) for pattern in PATTERNS):
+                violations.append(
+                    f"{path.relative_to(REPOSITORY_ROOT)}:{line_number}: {line.strip()}"
+                )
+
+    if violations:
+        print("Executable references to the removed src/ source root were found:")
+        print("\n".join(violations))
+        return 1
+
+    print("No executable references to the removed src/ source root found.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docker/dagster-daemon.sh
+++ b/scripts/docker/dagster-daemon.sh
@@ -12,7 +12,7 @@
 #
 # Usage:
 #   sh dagster-daemon.sh start
-#   sh dagster-daemon.sh etl-runner -- python -m src.scripts.job
+#   sh dagster-daemon.sh etl-runner -- python -m scripts.job
 #   sh dagster-daemon.sh healthcheck
 #
 # Notes:
@@ -234,7 +234,7 @@ start_daemon() {
 etl_runner() {
   # Expect the user to pass the command to run after the 'etl-runner' arg
   if [ "$#" -eq 0 ]; then
-    err "etl-runner requires a command to execute. Example: etl-runner -- python -m src.scripts.job"
+    err "etl-runner requires a command to execute. Example: etl-runner -- python -m scripts.job"
     exit 2
   fi
 
@@ -271,7 +271,7 @@ Modes:
   help              Show this usage
 Examples:
   $0 start
-  $0 etl-runner -- python -m src.scripts.materialize
+  $0 etl-runner -- python -m scripts.materialize
   $0 healthcheck
 EOF
 }

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -203,7 +203,7 @@ If invoked with no service or with '-- <cmd>', the provided command will be exec
 Examples:
   entrypoint.sh dagster-webserver
   entrypoint.sh dagster-daemon
-  entrypoint.sh etl-runner -- python -m src.scripts.my_job
+  entrypoint.sh etl-runner -- python -m scripts.my_job
   entrypoint.sh -- python -c 'print(\"hello\")'
 EOF
 }

--- a/scripts/docker/etl-runner.sh
+++ b/scripts/docker/etl-runner.sh
@@ -11,8 +11,8 @@
 #  - executes the provided command
 #
 # Usage:
-#   sh etl-runner.sh -- python -m src.scripts.materialize
-#   sh etl-runner.sh python -m src.scripts.materialize
+#   sh etl-runner.sh -- python -m scripts.materialize
+#   sh etl-runner.sh python -m scripts.materialize
 #
 # Exit codes:
 #   0  - command executed successfully
@@ -177,7 +177,7 @@ usage() {
 Usage: $0 -- <cmd>
 Run an ad-hoc ETL command inside the container after ensuring dependencies.
 Examples:
-  $0 -- python -m src.scripts.materialize
+  $0 -- python -m scripts.materialize
   $0 -- dbt run
 Notes:
   - Ensure you have a local .env file (copy from .env.example) or the environment

--- a/scripts/docker/healthcheck.sh
+++ b/scripts/docker/healthcheck.sh
@@ -123,18 +123,18 @@ tcp_probe() {
 
 # Mode implementations
 check_app() {
-  # Try importing the project package. Common module names include 'sbir_etl' or 'src'.
-  # Try in order: sbir_etl, src
+  # Try importing the project package. Current module names include 'sbir_etl' and 'sbir_analytics'.
+  # Try the current top-level application packages
   # Exit 0 on first success, otherwise non-zero.
   log "Running app import check (timeout ${TIMEOUT}s)"
   # Use python -c in a separate process; respect TIMEOUT if available
   if command -v timeout >/dev/null 2>&1; then
-    timeout "$TIMEOUT" sh -c "python - <<'PY'\nimport sys\nok=False\nfor mod in ('sbir_etl','src'):\n  try:\n    __import__(mod)\n    ok=True\n    break\n  except Exception as e:\n    pass\nsys.exit(0 if ok else 2)\nPY" >/dev/null 2>&1 || rc=$? ; rc=${rc:-$?}
+    timeout "$TIMEOUT" sh -c "python - <<'PY'\nimport sys\nok=False\nfor mod in ('sbir_etl','sbir_analytics'):\n  try:\n    __import__(mod)\n    ok=True\n    break\n  except Exception as e:\n    pass\nsys.exit(0 if ok else 2)\nPY" >/dev/null 2>&1 || rc=$? ; rc=${rc:-$?}
   else
     python - <<'PY' >/dev/null 2>&1 || rc=$? ; rc=${rc:-$?}
 import sys
 ok=False
-for mod in ('sbir_etl','src'):
+for mod in ('sbir_etl','sbir_analytics'):
   try:
     __import__(mod)
     ok=True

--- a/scripts/e2e_health_check.py
+++ b/scripts/e2e_health_check.py
@@ -11,8 +11,8 @@ import sys
 from pathlib import Path
 
 
-# Add src to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Add the repository root to the import path
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def check_neo4j_connection() -> tuple[bool, str]:

--- a/scripts/performance/profile_cet_performance.py
+++ b/scripts/performance/profile_cet_performance.py
@@ -15,7 +15,7 @@ Behavior:
   - If a real trained model artifact exists at `artifacts/models/cet_classifier_v1.pkl`
     this script will attempt to load it (best-effort). If loading fails, a
     deterministic keyword-based fallback classifier is used for profiling.
-- Uses the performance monitoring utilities (`src.utils.monitoring`)
+- Uses the performance monitoring utilities (`sbir_etl.utils.monitoring`)
   to capture timing/memory metrics where available.
 - Writes outputs:
   - JSON summary: --output-json (default: /tmp/cet_performance.json)

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -24,8 +24,8 @@ from pathlib import Path
 from typing import Any
 
 
-# Add src to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Add the repository root to the import path
+sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 def get_test_config(scenario: str) -> dict[str, Any]:
@@ -166,7 +166,10 @@ def run_e2e_tests(scenario: str, timeout: int) -> int:
     if scenario != "minimal":
         pytest_args.extend(
             [
-                "--cov=src",
+                "--cov=sbir_etl",
+                "--cov=packages/sbir-analytics/sbir_analytics",
+                "--cov=packages/sbir-ml/sbir_ml",
+                "--cov=packages/sbir-graph/sbir_graph",
                 "--cov-report=term-missing",
                 "--cov-report=html:/app/artifacts/htmlcov",
             ]

--- a/scripts/validation/manual_psc_check.py
+++ b/scripts/validation/manual_psc_check.py
@@ -13,8 +13,8 @@ import sys
 from pathlib import Path
 
 
-# Add src to path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
+# Add the repository root to the import path
+sys.path.insert(0, str(Path(__file__).parents[2]))
 
 from loguru import logger
 

--- a/scripts/validation/validate_dagster.py
+++ b/scripts/validation/validate_dagster.py
@@ -34,9 +34,9 @@ try:
 
     print("\n✓ Dagster setup is valid and ready to use!")
     print("\nTo launch the Dagster UI, run:")
-    print("  dagster dev -f src/definitions.py")
+    print("  dagster dev -m sbir_analytics.definitions")
     print("\nOr if using the module:")
-    print("  DAGSTER_HOME=. dagster dev -m src.definitions")
+    print("  DAGSTER_HOME=. dagster dev -m sbir_analytics.definitions")
 
 except ImportError as e:
     print(f"✗ Failed to import Dagster definitions: {e}")

--- a/tests/functional/test_pipelines.py
+++ b/tests/functional/test_pipelines.py
@@ -88,8 +88,9 @@ class TestPaECTERPipeline:
             "transitions",
             ["award_id", "contract_id", "transition_score", "confidence"],
             {
-                "transition_score": lambda df: df["transition_score"].dtype
-                in ["float64", "float32"],
+                "transition_score": lambda df: (
+                    df["transition_score"].dtype in ["float64", "float32"]
+                ),
                 "confidence": lambda df: df["confidence"].dtype in ["float64", "float32"],
             },
         ),
@@ -97,17 +98,18 @@ class TestPaECTERPipeline:
             "cet_classifications",
             ["award_id", "cet_id", "score", "classification"],
             {
-                "classification": lambda df: df["classification"]
-                .isin(["High", "Medium", "Low"])
-                .all(),
+                "classification": lambda df: (
+                    df["classification"].isin(["High", "Medium", "Low"]).all()
+                ),
             },
         ),
         (
             "fiscal_returns",
             ["award_id", "roi", "federal_tax_receipts", "economic_impact"],
             {
-                "roi": lambda df: df["roi"].dtype in ["float64", "float32"]
-                and (df["roi"] >= 0).all(),
+                "roi": lambda df: (
+                    df["roi"].dtype in ["float64", "float32"] and (df["roi"] >= 0).all()
+                ),
             },
         ),
         (

--- a/tests/unit/assets/cet/test_classifications.py
+++ b/tests/unit/assets/cet/test_classifications.py
@@ -580,8 +580,8 @@ class TestEdgeCases:
         mock_checks_path = Mock()
         mock_checks_path.parent = Mock()
         mock_checks_path.parent.mkdir = Mock()
-        mock_path.with_suffix.side_effect = (
-            lambda suffix: mock_json_path if suffix == ".json" else mock_checks_path
+        mock_path.with_suffix.side_effect = lambda suffix: (
+            mock_json_path if suffix == ".json" else mock_checks_path
         )
         mock_path_class.return_value = mock_path
 

--- a/tests/unit/enrichers/test_geographic_resolver.py
+++ b/tests/unit/enrichers/test_geographic_resolver.py
@@ -1,5 +1,5 @@
 """
-Tests for src/enrichers/geographic_resolver.py
+Tests for the current package module: enrichers/geographic_resolver.py
 
 Tests the GeographicResolver for normalizing company locations to state-level
 codes using multiple resolution strategies.

--- a/tests/unit/transition/analysis/test_analytics.py
+++ b/tests/unit/transition/analysis/test_analytics.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/analysis/analytics.py
+Tests for the current package module: transition/analysis/analytics.py
 
 Tests the TransitionAnalytics module for computing KPIs and breakdowns
 from transition detection outputs (award-level, company-level, by agency).

--- a/tests/unit/transition/detection/test_detector.py
+++ b/tests/unit/transition/detection/test_detector.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/detection/detector.py
+Tests for the current package module: transition/detection/detector.py
 
 Tests the TransitionDetector orchestration class that coordinates
 vendor matching, scoring, evidence generation, and metrics tracking

--- a/tests/unit/transition/evaluation/test_evaluator.py
+++ b/tests/unit/transition/evaluation/test_evaluator.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/evaluation/evaluator.py
+Tests for the current package module: transition/evaluation/evaluator.py
 
 Tests the TransitionEvaluator for measuring transition detection quality
 against ground truth using precision, recall, F1, and confusion matrices.

--- a/tests/unit/transition/features/test_cet_analyzer.py
+++ b/tests/unit/transition/features/test_cet_analyzer.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/features/cet_analyzer.py
+Tests for the current package module: transition/features/cet_analyzer.py
 
 Tests the CETSignalExtractor for extracting CET (Critical and Emerging
 Technologies) area alignment signals between SBIR awards and contracts.

--- a/tests/unit/transition/features/test_patent_analyzer.py
+++ b/tests/unit/transition/features/test_patent_analyzer.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/features/patent_analyzer.py
+Tests for the current package module: transition/features/patent_analyzer.py
 
 Tests the PatentSignalExtractor for extracting patent-related signals
 that indicate SBIR Phase III commercialization through federal contracts.

--- a/tests/unit/transition/features/test_vendor_crosswalk.py
+++ b/tests/unit/transition/features/test_vendor_crosswalk.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/features/vendor_crosswalk.py
+Tests for the current package module: transition/features/vendor_crosswalk.py
 
 Tests the VendorCrosswalk manager for vendor identity resolution,
 alias management, and acquisition tracking with optional persistence.

--- a/tests/unit/transition/features/test_vendor_resolver.py
+++ b/tests/unit/transition/features/test_vendor_resolver.py
@@ -1,5 +1,5 @@
 """
-Tests for src/transition/features/vendor_resolver.py
+Tests for the current package module: transition/features/vendor_resolver.py
 
 Tests the VendorResolver for vendor identity resolution across
 multiple identifier spaces (UEI, CAGE, DUNS) with fuzzy name matching.


### PR DESCRIPTION
### Motivation

- Remove lingering references to the old `src/` source root and align CI, automation, and docs with the current package layout (`sbir_etl/`, `packages/sbir-analytics/sbir_analytics/`, `packages/sbir-ml/sbir_ml/`, `packages/sbir-graph/sbir_graph/`).
- Ensure change-detection, linting, typing, coverage, and Dagster invocations operate on the real production roots while keeping historical ADR text intact.
- Add a lightweight guard to prevent new executable automation from reintroducing `src/` references.

### Description

- Updated CI and scheduling: replaced `--cov=src` and `src/...` path filters with coverage and detect-change filters that target `sbir_etl` and the three `packages/*` production roots in `.github/workflows/ci.yml` and `.github/workflows/weekly.yml` and added a `production` detect-changes output.  (coverage now collects from `sbir_etl`, `packages/sbir-analytics/sbir_analytics`, `packages/sbir-ml/sbir_ml`, `packages/sbir-graph/sbir_graph`).
- Expanded lint/type scopes: extended Ruff lint/format runs to all production roots + `tests/` and kept blocking MyPy on `sbir_etl/` while adding a package MyPy matrix job for each package, marking `sbir-analytics` and `sbir-ml` non-blocking until typing debt is resolved and keeping `sbir-graph` blocking.
- Added a static regression guard: `scripts/ci/check_removed_src_references.py` and wired it into CI and pre-commit to reject executable references to `src/` while excluding `docs/decisions/ADR-002-etl-library-extraction.md` (historical documentation).
- Updated related automation and examples: `.pre-commit-config.yaml`, `.github/actions/setup-python-uv/action.yml` (cache keys), `Makefile` (coverage, Dagster module flags, and test targets), Docker healthchecks/entrypoints, and `scripts/*` (E2E runner, validate scripts) to use the current package import paths and coverage flags.
- Updated active docs and added an inventory `docs/development/source-layout-migration.md` describing the migration, before/after quality-check scope, and follow-up work.
- Minor code/style adjustments to satisfy Ruff (pyupgrade / formatting) and to use standardized names (e.g., `datetime.UTC`, short-form unions) and formatting fixes across newly-covered files.

### Testing

- Ran the removed-root static guard: `python scripts/ci/check_removed_src_references.py` — passed (no executable `src/` references found in scanned automation roots).
- Ran linter/formatter: `ruff check ...` and `ruff format --check ...` across `sbir_etl` and all three `packages/*` plus `tests/` — passed after applying automatic fixes and formatting.
- Ran type checks: `mypy sbir_etl` and `mypy packages/sbir-graph/sbir_graph` — passed; package-level MyPy for `sbir-analytics` and `sbir-ml` produced existing typing findings (56 and 8 errors respectively) and are intentionally configured as non-blocking in the new CI matrix.
- Validated workflow and action YAML with `yaml.safe_load(...)` on modified files — passed.
- Attempted environment dependency sync and unit tests (`uv sync --extra dev`, `pytest ...`) but they could not complete in this environment because PyPI access / dependency resolution was blocked (missing runtime test dependencies such as `pytest-cov`, `pytest-xdist`, `dagster`, `neo4j`, etc.), so full test execution/coverage collection could not be run here; CI will run these with proper workspace installation.

Follow-up: resolve MyPy findings in `packages/sbir-analytics` and `packages/sbir-ml` package-by-package and remove the non-blocking `continue-on-error` flags once typing debt is cleared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c108649208322a105e8429ecff755)