### PR TITLE
Clarify README reproducibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,9 @@ brings one up along with the supporting services. See
 > **Note on data and reproducibility.** No award data is committed to this repo
 > (only a small NAICS→BEA reference table). Reproducing the analyses end-to-end
 > means downloading the source datasets yourself and supplying your own API
-> credentials, which is a non-trivial amount of setup. The pipeline runs; it is
-> not a one-command turnkey reproduction.
+> credentials, which is a non-trivial amount of setup. Core components are
+> designed to run locally, but full end-to-end reproduction requires source-data
+> downloads, API credentials, and local services such as Neo4j.
 
 ## Honest limitations
 


### PR DESCRIPTION
### Motivation
- Replace an overly broad claim that the pipeline simply "runs" with a more cautious, accurate statement that preserves confidence in the analytical design while acknowledging operational requirements for full reproduction.

### Description
- Updated the `README.md` note on data and reproducibility to replace the sentence claiming "The pipeline runs" with: "Core components are designed to run locally, but full end-to-end reproduction requires source-data downloads, API credentials, and local services such as Neo4j." 

### Testing
- Ran `git diff --check` after the change and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370b2b6f088322b1ab0af0d8f72c0b)