### PR TITLE
Clarify infrastructure and docs are experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ scripts/               One-off analysis and operational scripts
 infrastructure/        AWS CDK deployment (my personal cloud setup; optional)
 ```
 
+Directories such as `.github/`, `infrastructure/`, deployment docs, and E2E
+testing docs reflect experiments in making the project more runnable and
+maintainable. They should not be read as a claim that this repository contains
+production-grade infrastructure, and they should not be deleted or restructured
+without explicit approval.
+
 ## Running it
 
 The project uses **Python 3.11** and [`uv`](https://github.com/astral-sh/uv) for


### PR DESCRIPTION
### Motivation
- Make explicit in the README that directories such as `.github/`, `infrastructure/`, deployment docs, and E2E testing docs reflect experiments to make the project more runnable and maintainable and are not a claim of production-grade infrastructure.

### Description
- Added a short paragraph under "Repository structure" in `README.md` that names the relevant directories and states they are experimental and should not be deleted or restructured without explicit approval.

### Testing
- Ran `git diff --check` to validate the change and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370b2d6d4083229e8255ea8502c354)