### PR TITLE
Clarify exploratory fiscal impact fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ record to other public datasets. A few of the questions it explores:
   and how does that vary by agency and technology area?
 - **Technology classification & patent linkage.** Which awards map to
   Critical & Emerging Technology (CET) areas, and which awards produced patents?
-- **Economic & fiscal impact.** Rough estimates of tax receipts and economic
-  activity attributable to award spending, using BEA input-output tables.
+- **Economic & fiscal impact.** Rough exploratory estimates of tax receipts and
+  economic activity attributable to award spending, using BEA input-output tables
+  where available and fallback assumptions when live BEA inputs are unavailable.
 
 The full, sourced inventory — organized by policy area and complexity tier — is
 in [docs/research-questions.md](docs/research-questions.md).

--- a/sbir_etl/transformers/bea_io_adapter.py
+++ b/sbir_etl/transformers/bea_io_adapter.py
@@ -448,6 +448,7 @@ class BEAIOAdapter:
     def _compute_placeholder_impacts(
         self, shocks_df: pd.DataFrame, model_version: str
     ) -> pd.DataFrame:
+        """Fallback for exploratory/local use, not a validated fiscal-impact model."""
         result_df = shocks_df.copy()
         multiplier = Decimal("2.0")
 


### PR DESCRIPTION
### Motivation
- Make it explicit that the placeholder BEA computation is a lightweight fallback for exploratory/local use when BEA API data is unavailable and is not a validated fiscal-impact model, and ensure the README describes fiscal-impact outputs as rough exploratory estimates that may rely on fallback assumptions.

### Description
- Add a short docstring to `BEAIOAdapter._compute_placeholder_impacts` clarifying it is a fallback for exploratory/local use and not a validated fiscal-impact model, and update the README bullet under "Economic & fiscal impact" to note these are rough exploratory estimates that use BEA tables where available and fallback assumptions when live BEA inputs are unavailable (files changed: `sbir_etl/transformers/bea_io_adapter.py`, `README.md`).

### Testing
- Ran `python -m py_compile sbir_etl/transformers/bea_io_adapter.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370b3faa3c832284b3accd73086648)