### PR TITLE
Add suggested reading path to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ maintainable. They should not be read as a claim that this repository contains
 production-grade infrastructure, and they should not be deleted or restructured
 without explicit approval.
 
+## Suggested reading path
+
+If you want the fastest route to the domain insight without reading the whole
+repository, start with these documents in order:
+
+1. [Research questions](docs/research-questions.md) — the core policy and
+   evaluation questions the project is trying to answer.
+2. [SEC EDGAR SBIR learnings](docs/research/sec-edgar-sbir-learnings.md) —
+   practical findings from using EDGAR to detect SBIR-related exits and
+   financing signals.
+3. [SBIR Form D fundraising analysis](docs/research/sbir-form-d-fundraising-analysis.md) —
+   the private-capital lens on awardee commercialization.
+4. [Phase transition latency](docs/phase-transition-latency.md) — how the repo
+   thinks about timing from SBIR awards to follow-on federal contracts.
+5. [SBIR identification methodology](docs/sbir-identification-methodology.md) —
+   the methodology behind identifying and linking SBIR firms across datasets.
+
 ## Running it
 
 The project uses **Python 3.11** and [`uv`](https://github.com/astral-sh/uv) for


### PR DESCRIPTION
### Motivation
- Provide a concise onboarding path so readers can reach the core domain insights quickly without reading the entire repository.

### Description
- Inserted a `## Suggested reading path` section after the repository structure in `README.md` that links `docs/research-questions.md`, `docs/research/sec-edgar-sbir-learnings.md`, `docs/research/sbir-form-d-fundraising-analysis.md`, `docs/phase-transition-latency.md`, and `docs/sbir-identification-methodology.md` as the recommended reading order.

### Testing
- Ran `git diff --check` and `git status --short`, and committed the change; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370b42ab90832299177971eb79a90c)