### PR TITLE
docs: add audience-routing overlay to research-questions inventory

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -15,6 +15,17 @@ respected so foundational work appears before dependents.
 - [E. Program management & data infrastructure](#e-program-management--data-infrastructure)
 - [F. Capital formation & entrepreneurial finance](#f-capital-formation--entrepreneurial-finance)
 
+**Where to start, by audience:**
+
+- **Policymakers** (Congress, OMB, agency leadership, congressional defense committees): start with **A3** (DoD leverage ratio vs. NASEM's ~4:1 benchmark), **D2** (Treasury ROI / tax receipts from SBIR spending), and **F3** (private-to-SBIR leverage as the mirror to A3 on the private side).
+- **SBIR program managers** (NSF, NIH, DoD, DOE, SBA program offices): start with **B** (transitions, Phase II→III latency, company performance), **C1** (cross-agency CET portfolio composition), and **E6** (rolling quarterly snapshots / continuous monitoring).
+- **Investors** (VC, PE, angels, family offices, corporate VC): start with **F1** (Form D fundraising profile, M&A exit rate by funding agency, capital-event timeline) and **F2** (cohort outcomes vs. published VC/PE baselines, acquirer-type concentration).
+
+Each pointer above lands inside a section that mixes implemented and spec-only
+work — see status banners in the linked specs, and the inline *(PR #)* /
+*(branch: …)* tags on individual questions, to tell what's answerable today
+from what's a research target.
+
 **Dependency tags** used in parentheses after each question:
 
 - `ER` — entity resolution (UEI/CAGE/DUNS/fuzzy-name cascade)


### PR DESCRIPTION
## Summary

Adds a small **audience-routing overlay** to `docs/research-questions.md` so policymakers, SBIR program managers, and investors land on the questions most relevant to each — without restructuring the inventory itself.

This is the concrete recommendation from the high-level review I just did: the inventory is question-shaped but its three intended audiences arrive wanting answers. A 5-line "start here" block is the cheapest way to bridge that.

## Where each audience starts

| Audience | Routed to | Why |
|---|---|---|
| **Policymakers** (Congress, OMB, agency leadership) | A3 + D2 + F3 | A3 is the headline NASEM 4:1 DoD leverage benchmark; D2 is Treasury ROI / tax receipts; F3 is the private-side mirror of A3 |
| **SBIR program managers** (NSF, NIH, DoD, DOE, SBA program offices) | B + C1 + E6 | B covers transitions and Phase II→III latency (their core operational dashboard); C1 is the cross-agency CET portfolio view; E6 is rolling quarterly snapshots |
| **Investors** (VC, PE, angels, family offices, corporate VC) | F1 + F2 | F1 is Form D fundraising + M&A exit rate + capital-event timeline; F2 is cohort outcomes vs published VC/PE baselines (acquirer-type concentration) |

Plus a one-sentence footnote noting that pointers land in sections that mix implemented and spec-only work — status banners and inline *(PR #)* / *(branch: …)* tags remain the source of truth for what's actually answerable today vs. a research target.

## What this PR does NOT do

- No question rewording, no area reorganization, no spec edits.
- No new questions added.
- No changes to status banners, references, or dependency tags.

Net **+11 / -0 lines**, one file.

## Test plan

- [x] Markdown renders; intra-doc anchors (`#a-national-security--defense-industrial-base` etc.) work.
- [x] No code or tests touched.

🤖 Generated with [Claude Code](https://claude.ai/code/session_01Trur84H3UF6FXZNk9LQv3u)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Trur84H3UF6FXZNk9LQv3u)_