### PR TITLE
docs(research): Form D methodology revision history + replace stale branch ref

### DIFF
--- a/docs/research/sbir-form-d-fundraising-analysis.md
+++ b/docs/research/sbir-form-d-fundraising-analysis.md
@@ -1,7 +1,17 @@
 # SBIR Federal Spending vs Form D Private Capital (2009-2024)
 
 **Date:** 2026-04-23
-**Branch:** `claude/integrate-sec-edgar-sbir-6Krd1`
+**Methodology commit:** `f65abb89` (rule-based two-signal tiering + ZIP address matching)
+
+## Methodology revision history
+
+**2026-04-23 — commit [`f65abb89`](https://github.com/hollomancer/sbir-analytics/commit/f65abb89):**
+
+- **What changed:** Replaced the weighted-composite confidence score with **rule-based two-signal tiering** (high = person ≥ 0.7 OR ZIP match; medium = state match; low = neither). Added ZIP-address matching as a parallel confirmation signal (motivation in the "HHS/NIH and Address Matching" section below). Added `EXCLUDED_INDUSTRY_GROUPS` (Pooled Investment Fund, Insurance, Restaurants, etc.) for false-positive prevention.
+- **Net cohort impact (v1 → current):** High **2,212 → 3,640 (+65%)** · Medium 3,310 → 1,120 (−66%) · Low 4,883 → 5,645 (+16%). 2,844 records (27% of 10,405) changed tier under the new rule.
+- **Address-signal-specific contribution:** 1,620 of the current high-tier records have ZIP as the deciding signal — i.e., they would have been medium or low under the new rule without the ZIP component. Detailed breakdown in the "HHS/NIH and Address Matching" section below.
+- **Reproducibility:** The pre-change snapshot is preserved locally as `data/form_d_details_v1.jsonl` for verifying the methodology change. The file is gitignored under `/data/` (raw analysis output) and is regenerable by reverting `form_d_scoring.py` to its pre-`f65abb89` state and re-running `scripts/data/fetch_form_d_details.py`.
+- **Findings below are computed against the post-change (current) cohort.**
 
 ## Summary
 

--- a/docs/research/sbir-form-d-fundraising-analysis.md
+++ b/docs/research/sbir-form-d-fundraising-analysis.md
@@ -10,7 +10,7 @@
 - **What changed:** Replaced the weighted-composite confidence score with **rule-based two-signal tiering** (high = person ≥ 0.7 OR ZIP match; medium = state match; low = neither). Added ZIP-address matching as a parallel confirmation signal (motivation in the "HHS/NIH and Address Matching" section below). Added `EXCLUDED_INDUSTRY_GROUPS` (Pooled Investment Fund, Insurance, Restaurants, etc.) for false-positive prevention.
 - **Net cohort impact (v1 → current):** High **2,212 → 3,640 (+65%)** · Medium 3,310 → 1,120 (−66%) · Low 4,883 → 5,645 (+16%). 2,844 records (27% of 10,405) changed tier under the new rule.
 - **Address-signal-specific contribution:** 1,620 of the current high-tier records have ZIP as the deciding signal — i.e., they would have been medium or low under the new rule without the ZIP component. Detailed breakdown in the "HHS/NIH and Address Matching" section below.
-- **Reproducibility:** The pre-change snapshot is preserved locally as `data/form_d_details_v1.jsonl` for verifying the methodology change. The file is gitignored under `/data/` (raw analysis output) and is regenerable by reverting `form_d_scoring.py` to its pre-`f65abb89` state and re-running `scripts/data/fetch_form_d_details.py`.
+- **Reproducibility:** The pre-change snapshot is preserved locally as `data/form_d_details_v1.jsonl` for verifying the methodology change. The file is gitignored under `/data/` (raw analysis output) and is regenerable by reverting `sbir_etl/enrichers/sec_edgar/form_d_scoring.py` to its pre-`f65abb89` state and re-running `scripts/data/fetch_form_d_details.py`.
 - **Findings below are computed against the post-change (current) cohort.**
 
 ## Summary


### PR DESCRIPTION
## Summary

Two small staleness fixes to `docs/research/sbir-form-d-fundraising-analysis.md` — the published doc reporting the **1.82x private-capital leverage** headline finding. Same fix-shape as PR #335 (research-questions.md staleness), continuing the project-wide pattern of replacing PR/branch references with durable commit SHAs.

### What's in the PR

1. **Header staleness fix.** Replaced `**Branch:** claude/integrate-sec-edgar-sbir-6Krd1` (long-merged branch, no longer locatable) with `**Methodology commit:** f65abb89` (durable SHA pointing at the scoring-methodology change that produced the published numbers).

2. **New "Methodology revision history" subsection.** Documents the 2026-04-23 atomic change that:
   - Replaced weighted-composite scoring with rule-based two-signal tiering (high = person ≥ 0.7 OR ZIP match; medium = state match; low = neither)
   - Added ZIP-address matching as a parallel confirmation signal
   - Added `EXCLUDED_INDUSTRY_GROUPS` for false-positive prevention
   - Net cohort impact: high tier grew **+65% (2,212 → 3,640)**; 27% of records (2,844 of 10,405) changed tier
   - Distinguishes the address-signal-specific contribution (1,620 high-tier records where ZIP is deciding) from net cohort movement (which bundles rule change + address addition)
   - Documents that the pre-change `form_d_details_v1.jsonl` is preserved locally for reproducibility but gitignored
   - Provides a regeneration recipe

### Why this matters

A reader looking at the published 1.82x leverage finding needs to know:
- Which methodology produced it
- What the cohort size is and where it came from
- How to verify the methodology change if they want to reproduce it

The previous header didn't make any of that traceable — pointing at a merged branch instead of a durable commit.

### How I verified

- Reverse-engineered the doc's "1,617 medium → high (3 low → high)" promotion count from the actual data: it's computed as "tier under the new rule WITHOUT address signal" vs "tier WITH address signal" — confirmed it matches the doc exactly.
- Independently computed v1 → current tier flips for the cohort-impact numbers (medium → high: 1,446; low → high: 154; etc.) — these are net cohort movements, complementary to the doc's address-isolated 1,620.
- Both numbers are correct; they measure different things. The new revision-history subsection explains both lenses.

## Test plan

- [ ] Confirm the f65abb89 commit URL resolves
- [ ] Spot-check that the cohort numbers (2,212, 3,640, etc.) and percentages match the raw data (they were independently computed from `data/form_d_details*.jsonl` against `tier` field)
- [ ] Confirm the "HHS/NIH and Address Matching" section that the new text references is still present at the same logical location (it is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)