### PR TITLE
chore(ci): install workspace packages for CET Smoke Test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -901,7 +901,9 @@ jobs:
         uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-          install-dev-deps: "false"
+          # stack-dev is required: smoke test imports sbir_graph.loaders.*,
+          # which only resolves after the workspace package is installed.
+          install-dev-deps: "true"
           cache-venv: "true"
           cache-pytest: "false"
           install-pyreadstat: "false"

--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ report.md
 infrastructure/**/.venv/
 results.csv
 
+# Git worktrees (project-local, ignored to keep git status clean)
+.worktrees/
+


### PR DESCRIPTION
## Summary

The CET Smoke Test step ran `uv sync --no-dev` via `install-dev-deps: "false"`,
which doesn't install the `sbir-graph` workspace package. Since #325 moved
sbir-graph to a real workspace package, `scripts/ci/cet_smoke_test.py` fails
with `ModuleNotFoundError: No module named 'sbir_graph'` on every PR that
touches CET paths.

Switch to `install-dev-deps: "true"` so the `stack-dev` extra (which pulls in
all three workspace packages) is installed.

Also adds `.worktrees/` to `.gitignore` so project-local worktree directories
don't show as untracked.

## Scope context

Most of what I originally diagnosed (Dagster test context, sbir-ml MyPy, ~85
sbir-analytics typing errors) is already on main via 4c385ee7. CET Smoke Test
was the one inherited failure that commit didn't touch — this PR closes that
gap.

## Known latent bug NOT addressed here

The E2E Tests job (`.github/workflows/ci.yml:1010`, push-only) has the same
`install-dev-deps: "false"` setting and the same need to import sbir_graph /
sbir_ml / sbir_analytics. Currently masked because that job only runs on
push to main/develop. Should be fixed separately.

## Test plan

- [ ] On this PR's CI run, CET Smoke Test step proceeds past `uv sync` and
      either passes or fails on test logic (not on `ModuleNotFoundError`)
- [ ] Other check jobs remain unaffected (this is a 4-line workflow change
      plus a gitignore line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)