### PR TITLE
feat(analysis): bootstrap CIs for Form D leverage + DoD 1:1 finding

### DIFF
--- a/docs/research/form-d-leverage-bootstrap-findings.md
+++ b/docs/research/form-d-leverage-bootstrap-findings.md
@@ -8,7 +8,7 @@
 
 The published doc reports headline private-capital leverage ratios as point estimates: **1.82x** for the high-confidence cohort and **2.37x** for high+medium. This analysis adds **95% bootstrap confidence intervals at the firm level**, reproduces both headline numbers exactly, and surfaces two findings that change how readers should interpret the headline:
 
-1. **The denominator choice is doing a lot of work.** The doc's ratio uses *total federal SBIR program spending* ($50.98B) as the denominator. A complementary **per-matched-firm** ratio — Form D $ divided by SBIR $ for firms that actually match in Form D — comes out to **10.70x [9.39, 12.16]** for the same high-tier cohort. Neither number is wrong; they answer different policy questions. The doc doesn't currently flag this.
+1. **The denominator choice is doing a lot of work.** The doc's ratio uses *total federal SBIR program spending* ($50.98B) as the denominator. A complementary **per-matched-firm** ratio — Form D $ divided by SBIR $ for firms that actually match in Form D (restricted to firms with in-window SBIR awards) — comes out to **9.48x [8.26, 10.85]** for the high-tier cohort. Neither number is wrong; they answer different policy questions. The doc doesn't currently flag this.
 2. **DoD's leverage ratio is essentially 1:1 with a tight CI.** Among large-cohort agencies, **DoD is 1.011x [0.842, 1.214]** at the program level — statistically distinguishable from the cross-agency average and from NSF's 3.23x. This is a real finding worth understanding rather than a small-sample artifact.
 
 ## Method
@@ -63,11 +63,11 @@ The inner-join drops 404 firms (high-tier) whose SBIR awards fall outside 2009-2
 
 The 1.82x point estimate is tightly bracketed [1.650, 2.024]: under firm-level resampling, the headline is clearly distinguishable from 1.0x ("no leverage") and from 2.5x. The published number isn't a noisy estimate.
 
-But the headline interpretation depends on a methodological choice the doc doesn't flag. The denominator is *total program SBIR spending*, including the ~$42B going to SBIR firms with no Form D activity at all. From a "what's the per-firm leverage SBIR achieves when it leads to private capital" perspective, the relevant number is closer to **10.7x [9.39, 12.16]** — a different headline entirely.
+But the headline interpretation depends on a methodological choice the doc doesn't flag. The denominator is *total program SBIR spending*, including the ~$42B going to SBIR firms with no Form D activity at all. From a "what's the per-firm leverage SBIR achieves when it leads to private capital" perspective, the relevant number is closer to **9.48x [8.26, 10.85]** — a different headline entirely.
 
 Both numbers matter, but they answer different policy questions:
 - **1.82x ≈** "How much Form-D-detected private capital flows back to the SBIR-firm cohort per dollar of total program spending?" (Useful for: program-wide ROI framing, Congressional appropriations debates.)
-- **10.7x ≈** "For SBIR awardees who go on to attract private capital, what's their leverage?" (Useful for: investor/founder-track program design, Howell-style replication targets.)
+- **9.48x ≈** "For SBIR awardees who go on to attract private capital (filtered to firms with in-window SBIR awards), what's their leverage?" (Useful for: investor/founder-track program design, Howell-style replication targets.)
 
 The published doc should either (a) report both, or (b) make the methodological choice explicit so readers don't misread 1.82x as "the per-firm SBIR leverage."
 

--- a/docs/research/form-d-leverage-bootstrap-findings.md
+++ b/docs/research/form-d-leverage-bootstrap-findings.md
@@ -1,0 +1,132 @@
+# Form D leverage ratio — bootstrap confidence intervals
+
+**Date:** 2026-06-20
+**Companion to:** [sbir-form-d-fundraising-analysis.md](sbir-form-d-fundraising-analysis.md) (the published headline finding)
+**Script:** [`scripts/data/bootstrap_form_d_leverage_ci.py`](../../scripts/data/bootstrap_form_d_leverage_ci.py)
+
+## Summary
+
+The published doc reports headline private-capital leverage ratios as point estimates: **1.82x** for the high-confidence cohort and **2.37x** for high+medium. This analysis adds **95% bootstrap confidence intervals at the firm level**, reproduces both headline numbers exactly, and surfaces two findings that change how readers should interpret the headline:
+
+1. **The denominator choice is doing a lot of work.** The doc's ratio uses *total federal SBIR program spending* ($50.98B) as the denominator. A complementary **per-matched-firm** ratio — Form D $ divided by SBIR $ for firms that actually match in Form D — comes out to **10.70x [9.39, 12.16]** for the same high-tier cohort. Neither number is wrong; they answer different policy questions. The doc doesn't currently flag this.
+2. **DoD's leverage ratio is essentially 1:1 with a tight CI.** Among large-cohort agencies, **DoD is 1.011x [0.842, 1.214]** at the program level — statistically distinguishable from the cross-agency average and from NSF's 3.23x. This is a real finding worth understanding rather than a small-sample artifact.
+
+## Method
+
+Firm-level bootstrap with 1,000 iterations. Each iteration draws N firms with replacement from the cohort of size N, then recomputes the aggregate ratio sum(Form D $) / sum(SBIR $). RNG seed 42 for reproducibility.
+
+Resampling at the firm level (not the offering, not the year) is the right unit because the leverage ratio is fundamentally a per-firm quantity. Within-firm offering correlation is correctly handled (a firm contributes its total to numerator and denominator each iteration). Offering-level resampling would produce artificially narrow CIs.
+
+For the **program-level ratio**, the denominator is held fixed at the program total ($50.98B). The CI reflects only numerator variability — i.e., variability in which matched firms are in the cohort sample. For the **per-matched-firm ratio**, both numerator and denominator are recomputed from the resample.
+
+Filters match the published doc exactly: tier (`high` or `high+medium`), year window (2009-2024 by `filing_date` and `Award Year`), and `EXCLUDED_INDUSTRY_GROUPS` (Pooled Investment Fund, Insurance, Restaurants, etc.) applied at the offering level.
+
+## Headline results
+
+### Doc-cohort: all matched firms (reproduces published doc)
+
+| Cohort | Firms | Form D $B | Program SBIR $B | Program-level (95% CI) |
+|---|---|---|---|---|
+| High only | 3,640 | 92.96 | 50.98 | **1.824x** [1.650, 2.024] |
+| High + Medium | 4,760 | 120.61 | 50.98 | **2.366x** [2.100, 2.668] |
+
+Exact reproduction of the published 1.82x / 2.37x. The CIs are reasonably tight — high-only is statistically distinguishable from 1.5x and from 2.1x at the 95% level.
+
+### Per-matched-firm: inner-join with SBIR awards in window
+
+| Cohort | Firms | Form D $B | Matched SBIR $B | Program-level (95% CI) | Per-matched-firm (95% CI) |
+|---|---|---|---|---|---|
+| High only | 3,236 | 82.35 | 8.69 | 1.615x [1.447, 1.786] | **9.476x** [8.256, 10.845] |
+| High + Medium | 3,996 | 97.75 | 10.53 | 1.918x [1.735, 2.126] | **9.282x** [8.173, 10.533] |
+
+The inner-join drops 404 firms (high-tier) whose SBIR awards fall outside 2009-2024 but whose Form D filings are in window. Their Form D $ accounts for the gap between the doc cohort's $92.96B and the inner-join cohort's $82.35B.
+
+### Per-agency program-level leverage (high-only)
+
+| Agency | Firms (w/ Form D) | Program $B | Form D $B | Program-level (95% CI) | Per-firm (95% CI) |
+|---|---|---|---|---|---|
+| **DoD** | 931 (859) | 24.50 | 24.77 | **1.011x [0.842, 1.214]** | 7.095x [5.50, 9.20] |
+| HHS | 1,241 (1,190) | 16.03 | 37.84 | 2.360x [2.059, 2.674] | 9.738x [8.34, 11.32] |
+| DOE | 169 (154) | 4.01 | 5.98 | 1.492x [0.754, 2.755] | 11.128x [5.06, 23.92] |
+| NASA | 62 (57) | 2.68 | 3.01 | 1.126x [0.344, 2.466] | 26.494x [7.39, 65.18] |
+| **NSF** | 677 (631) | 2.46 | 7.93 | **3.230x [2.600, 4.016]** | 14.666x [11.68, 18.26] |
+| USDA | 73 (63) | 0.41 | 1.20 | 2.915x [1.630, 4.427] | 22.581x [12.36, 36.57] |
+| DHS | 20 (18) | 0.29 | 0.99 | 3.481x [0.639, 7.500] | 40.376x [6.25, 122.88] |
+| Commerce | 19 (19) | 0.19 | 0.45 | 2.322x [0.461, 5.023] | 44.958x [8.78, 102.09] |
+| **Education** | 22 (21) | 0.16 | 0.04 | **0.226x [0.127, 0.346]** | 1.559x [0.76, 2.92] |
+| **Transportation** | 4 (4) | 0.16 | 0.00 | **0.009x [0.008, 0.010]** | 0.460x [0.27, 1.14] |
+| EPA | 18 (17) | 0.08 | 0.12 | 1.467x [0.600, 2.568] | 23.549x [9.98, 44.18] |
+
+## What the CIs reveal
+
+### Headline 1.82x is statistically robust, but the headline framing hides a methodological choice
+
+The 1.82x point estimate is tightly bracketed [1.650, 2.024]: under firm-level resampling, the headline is clearly distinguishable from 1.0x ("no leverage") and from 2.5x. The published number isn't a noisy estimate.
+
+But the headline interpretation depends on a methodological choice the doc doesn't flag. The denominator is *total program SBIR spending*, including the ~$42B going to SBIR firms with no Form D activity at all. From a "what's the per-firm leverage SBIR achieves when it leads to private capital" perspective, the relevant number is closer to **10.7x [9.39, 12.16]** — a different headline entirely.
+
+Both numbers matter, but they answer different policy questions:
+- **1.82x ≈** "How much Form-D-detected private capital flows back to the SBIR-firm cohort per dollar of total program spending?" (Useful for: program-wide ROI framing, Congressional appropriations debates.)
+- **10.7x ≈** "For SBIR awardees who go on to attract private capital, what's their leverage?" (Useful for: investor/founder-track program design, Howell-style replication targets.)
+
+The published doc should either (a) report both, or (b) make the methodological choice explicit so readers don't misread 1.82x as "the per-firm SBIR leverage."
+
+### DoD's 1.011x is the most policy-significant finding
+
+DoD is the largest SBIR funder ($24.50B in window, 48% of total program) but its program-level leverage is **essentially 1:1** with a tight CI [0.842, 1.214]. The CI does NOT include 1.5x or higher. This is:
+
+- Statistically clean (859 DoD firms with Form D, narrow CI)
+- Distinguishable from HHS (2.360x [2.059, 2.674]) at the 95% level
+- Distinguishable from NSF (3.230x [2.600, 4.016]) at the 95% level
+- **Far below NASEM's 4:1 finding** (which measures non-SBIR DoD-federal follow-on, not private capital, but is the relevant benchmark for "DoD SBIR commercialization leverage")
+
+Several candidate explanations worth distinguishing in follow-up work:
+1. DoD SBIR firms are systematically less commercially-oriented (more government-services, more classified work, more SBIR-as-sole-revenue)
+2. DoD SBIR firms commercialize through *federal contracts* rather than *private capital* — they don't raise Form D because their downstream revenue comes from FPDS contracts, not VC
+3. Defense IP and classification restrictions discourage outside investment, making Form D filing less attractive
+4. Acquisition path is more common than capital-raising path (consistent with the M&A analysis in PR #286)
+
+Each of these has different policy implications. This is exactly the Path B item #3 deep-dive that needs to happen.
+
+### NSF leads at 3.23x with credible bounds
+
+NSF's program-level leverage [2.600, 4.016] is the highest among large-cohort agencies. The upper bound brushes against NASEM's 4:1 benchmark — suggesting that for NSF SBIR specifically, private-capital follow-on may approach the "leverage of 4× non-SBIR funding" benchmark that NASEM measures in a different channel. NSF's small SBIR award sizes combined with relatively high Form D participation rate (16% per the doc) are the mechanism.
+
+### Education and Transportation are essentially zero
+
+ED at 0.226x [0.127, 0.346] and DOT at 0.009x [0.008, 0.010] both have tight CIs around near-zero values. These agencies' SBIR programs produce essentially no Form D follow-on activity. Could be:
+- Mission-specific (educational research, transportation infrastructure) doesn't attract VC
+- Small cohort sizes (4 DOT firms, 21 ED firms) — but the CIs are narrow precisely because what little leverage exists is consistently low across the few firms
+
+### Small-cohort agency CIs are very wide and shouldn't be quoted
+
+Commerce, DHS, NASA, EPA, USDA all have wide CIs reflecting the small number of matched firms. Quoting "USDA's 2.92x leverage" as a point estimate without [1.630, 4.427] CI overstates precision by a large factor.
+
+## What this doesn't address
+
+CIs quantify **sampling uncertainty only**. They do NOT capture:
+
+- **Measurement error in `total_amount_sold`.** Form D filers self-report; SEC does not audit. Estimated 5-15% additional noise from this source alone.
+- **SBIR ↔ Form D matching error.** The confidence scoring is itself probabilistic; false positives (e.g., the ADVR-Inc Bozeman vs. ADVR-Inc Charleston SC collision flagged in prior work) are screened by the tier filter but not eliminated.
+- **The "in-window SBIR" filtering decision.** I've shown both lenses, but a more rigorous treatment would also account for firms whose SBIR-side activity straddles the window boundary.
+- **Selection effects in Form D filing.** Form D requires a securities offering exemption filing; firms that raise capital through other channels (bank debt, revenue, founder bootstrap, public offerings) are not represented. The "leverage" measured here is Form-D-mediated capital specifically, not total private capital.
+
+The realistic credibility margin around these CIs is wider than the 95% bootstrap bounds suggest.
+
+## Reproducibility
+
+```bash
+.venv/bin/python scripts/data/bootstrap_form_d_leverage_ci.py
+```
+
+Default config: 1,000 iterations, seed 42, window 2009-2024, inputs `data/form_d_details.jsonl` + `data/raw/sbir/award_data.csv`. Outputs to `reports/ml/form_d_leverage_ci.{json,md}` (gitignored under `/data/-adjacent reports/`).
+
+The script is self-contained, uses only numpy from the project's existing dependency set, and runs in ~5 seconds on a development laptop.
+
+## Follow-up work suggested
+
+1. **Update the published `sbir-form-d-fundraising-analysis.md`** to add CI bracketing to the headline tables (or reference this doc as the methodology supplement). The current doc presents point estimates without uncertainty quantification.
+
+2. **Drill into DoD's 1:1 finding** (Path B item #3). Decompose by firm type: classified vs. unclassified, service-only vs. product, single-agency vs. multi-agency. Compare to NASEM's 4:1 follow-on-federal-contract finding for the same DoD cohort and explain the channel difference.
+
+3. **Quantify the matching-error contribution** to CI width. Currently the bootstrap treats the cohort as fixed and only resamples *which* firms enter; it doesn't account for *whether* a given firm is correctly matched. A two-stage bootstrap (resample matches THEN resample firms) would give wider, more honest CIs.

--- a/scripts/data/bootstrap_form_d_leverage_ci.py
+++ b/scripts/data/bootstrap_form_d_leverage_ci.py
@@ -84,6 +84,27 @@ def _norm_name(s: str | None) -> str:
     return (s or "").strip().upper()
 
 
+def _parse_amount(s: str | None) -> float | None:
+    """Parse SBIR/Form D dollar amount strings defensively.
+
+    SBIR.gov bulk file historically uses plain numeric strings, but other
+    sources (and older bulk exports) include leading ``$`` and thousands-
+    separator commas. Match the convention in
+    ``sbir_etl/enrichers/award_history.py`` and ``inflation_adjuster.py``
+    by stripping both before float-converting. Returns None on parse
+    failure so the caller can decide whether to skip or zero-fill.
+    """
+    if s is None:
+        return None
+    cleaned = str(s).replace("$", "").replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
 def load_form_d_per_firm(
     path: Path, year_min: int, year_max: int
 ) -> dict[str, dict[str, Any]]:
@@ -134,11 +155,8 @@ def load_sbir_program_and_per_firm(
                 continue
             if year < year_min or year > year_max:
                 continue
-            try:
-                amt = float(row.get("Award Amount") or 0)
-            except ValueError:
-                continue
-            if amt <= 0:
+            amt = _parse_amount(row.get("Award Amount"))
+            if amt is None or amt <= 0:
                 continue
             agency = (row.get("Agency") or "Unknown").strip()
             program_total += amt
@@ -178,9 +196,13 @@ def build_cohort(
 
     Firms without SBIR awards in window get ``award_total = 0`` and
     ``dominant_agency = None``. They contribute to the program-level
-    numerator and to the all-matched cohort sizing, but are excluded
-    from the per-matched-firm ratio (denominator would be zero) and
-    from per-agency cohorts (no dominant agency).
+    numerator and to the all-matched cohort sizing. They are excluded
+    from per-agency cohorts (no dominant agency). The per-matched-firm
+    ratio is only computed on the inner-joined subset
+    (``has_sbir_in_window=True``) because mixing time-window semantics
+    in the per-firm ratio (Form D from all matched, SBIR from the
+    subset) would produce a hybrid number that doesn't cleanly answer
+    either of the framing questions in the published doc.
     """
     cohort = []
     for name, fd in form_d.items():
@@ -210,33 +232,54 @@ def bootstrap_two_views(
     program_denominator: float,
     n_iter: int,
     rng: np.random.Generator,
+    compute_per_firm: bool = True,
 ) -> dict[str, Any]:
-    """Bootstrap both program-level and per-matched-firm ratios in one pass."""
+    """Bootstrap program-level and (optionally) per-matched-firm ratios.
+
+    Args:
+      raised: Per-firm Form D dollars (cohort length N).
+      sbir_matched: Per-firm SBIR dollars from the same N firms. Used as
+        denominator for the per-matched-firm ratio. Should be sums of
+        ONLY in-window SBIR (otherwise per-firm ratio is undefined for
+        zero-SBIR firms).
+      program_denominator: Fixed total program SBIR $ in window.
+      n_iter: Bootstrap iterations.
+      rng: Seeded numpy Generator.
+      compute_per_firm: If False, the per-matched-firm ratio is omitted
+        (used for the all-matched cohort, where zero-SBIR firms would
+        make per-firm semantics a meaningless hybrid).
+    """
     n = len(raised)
     out: dict[str, Any] = {
         "n_firms": int(n),
         "raised_total_usd": float(raised.sum()),
         "matched_sbir_total_usd": float(sbir_matched.sum()),
         "program_sbir_total_usd": float(program_denominator),
+        "bootstrap_iterations": n_iter,
     }
     if n == 0:
-        return {**out, "program_level": _zero_result(), "per_matched_firm": _zero_result(), "bootstrap_iterations": n_iter}
+        out["program_level"] = _zero_result()
+        if compute_per_firm:
+            out["per_matched_firm"] = _zero_result()
+        return out
 
     out["program_level"] = {
         "point_estimate": float(raised.sum() / program_denominator) if program_denominator > 0 else 0.0
     }
-    out["per_matched_firm"] = {
-        "point_estimate": float(raised.sum() / sbir_matched.sum()) if sbir_matched.sum() > 0 else 0.0
-    }
+    if compute_per_firm:
+        out["per_matched_firm"] = {
+            "point_estimate": float(raised.sum() / sbir_matched.sum()) if sbir_matched.sum() > 0 else 0.0
+        }
 
     program_ratios = np.empty(n_iter)
-    perfirm_ratios = np.empty(n_iter)
+    perfirm_ratios = np.empty(n_iter) if compute_per_firm else None
     for i in range(n_iter):
         idx = rng.integers(0, n, size=n)
         raised_sum = raised[idx].sum()
-        sbir_sum = sbir_matched[idx].sum()
         program_ratios[i] = (raised_sum / program_denominator) if program_denominator > 0 else 0.0
-        perfirm_ratios[i] = (raised_sum / sbir_sum) if sbir_sum > 0 else 0.0
+        if compute_per_firm:
+            sbir_sum = sbir_matched[idx].sum()
+            perfirm_ratios[i] = (raised_sum / sbir_sum) if sbir_sum > 0 else 0.0
 
     out["program_level"].update(
         {
@@ -245,14 +288,14 @@ def bootstrap_two_views(
             "ci_hi": float(np.percentile(program_ratios, 97.5)),
         }
     )
-    out["per_matched_firm"].update(
-        {
-            "median": float(np.median(perfirm_ratios)),
-            "ci_lo": float(np.percentile(perfirm_ratios, 2.5)),
-            "ci_hi": float(np.percentile(perfirm_ratios, 97.5)),
-        }
-    )
-    out["bootstrap_iterations"] = n_iter
+    if compute_per_firm:
+        out["per_matched_firm"].update(
+            {
+                "median": float(np.median(perfirm_ratios)),
+                "ci_lo": float(np.percentile(perfirm_ratios, 2.5)),
+                "ci_hi": float(np.percentile(perfirm_ratios, 97.5)),
+            }
+        )
     return out
 
 
@@ -333,14 +376,15 @@ def write_markdown(snapshot: dict[str, Any], path: Path) -> None:
     L.append("")
     L.append("This reproduces the published doc's methodology: the cohort is all 3,640 high-tier (and 4,760 H+M) Form D matches, regardless of whether their SBIR awards fall in the 2009-2024 window.")
     L.append("")
-    L.append("| Cohort | Firms | Form D $ | Matched SBIR $ | Program-level ratio (95% CI) |")
-    L.append("|---|---|---|---|---|")
+    L.append("Only the program-level ratio is reported here. The per-matched-firm ratio is omitted because mixing time-window semantics (Form D from all 3,640 matched firms, SBIR from the 3,236 inner-join subset) would produce a hybrid number that doesn't cleanly answer either framing question. See the inner-joined table below for the per-firm leverage.")
+    L.append("")
+    L.append("| Cohort | Firms | Form D $ | Program-level ratio (95% CI) |")
+    L.append("|---|---|---|---|")
     for k, label in [("high_only_all_matched", "High only"), ("high_plus_medium_all_matched", "High + Medium")]:
         r = snapshot[k]
         pl = r["program_level"]
         L.append(
-            f"| {label} | {r['n_firms']:,} | "
-            f"${r['raised_total_usd']/1e9:.2f}B | ${r['matched_sbir_total_usd']/1e9:.2f}B | "
+            f"| {label} | {r['n_firms']:,} | ${r['raised_total_usd']/1e9:.2f}B | "
             f"**{pl['point_estimate']:.3f}x** [{pl['ci_lo']:.3f}, {pl['ci_hi']:.3f}] |"
         )
     L.append("")
@@ -432,14 +476,20 @@ def main() -> int:
 
     print(f"\nBootstrapping with {args.n_iter:,} iterations...", file=sys.stderr)
 
-    # Program-level cohort: ALL matched firms (reproduces doc)
+    # All-matched cohort: program-level only (reproduces doc; per-firm
+    # would be a hybrid that mixes time-window semantics — see build_cohort
+    # docstring for why)
     raised_h, sbir_h = cohort_arrays(cohort, {"high"}, require_sbir=False)
-    high_only_program = bootstrap_two_views(raised_h, sbir_h, program_total, args.n_iter, rng)
+    high_only_program = bootstrap_two_views(
+        raised_h, sbir_h, program_total, args.n_iter, rng, compute_per_firm=False
+    )
 
     raised_hm, sbir_hm = cohort_arrays(cohort, {"high", "medium"}, require_sbir=False)
-    h_plus_m_program = bootstrap_two_views(raised_hm, sbir_hm, program_total, args.n_iter, rng)
+    h_plus_m_program = bootstrap_two_views(
+        raised_hm, sbir_hm, program_total, args.n_iter, rng, compute_per_firm=False
+    )
 
-    # Per-firm cohort: only firms with SBIR in window (statistically cleaner)
+    # Inner-join cohort: program-level AND per-matched-firm
     raised_h_inner, sbir_h_inner = cohort_arrays(cohort, {"high"}, require_sbir=True)
     high_only_perfirm = bootstrap_two_views(raised_h_inner, sbir_h_inner, program_total, args.n_iter, rng)
 
@@ -477,10 +527,12 @@ def main() -> int:
         ("High + Medium (SBIR in window, per-firm)", "high_plus_medium_sbir_in_window"),
     ]:
         r = snapshot[key]
-        pl, pf = r["program_level"], r["per_matched_firm"]
+        pl = r["program_level"]
         print(f"\n  {label} (n={r['n_firms']:,}):", file=sys.stderr)
         print(f"    program-level: {pl['point_estimate']:.3f}x [{pl['ci_lo']:.3f}, {pl['ci_hi']:.3f}]", file=sys.stderr)
-        print(f"    per-firm:      {pf['point_estimate']:.3f}x [{pf['ci_lo']:.3f}, {pf['ci_hi']:.3f}]", file=sys.stderr)
+        if "per_matched_firm" in r:
+            pf = r["per_matched_firm"]
+            print(f"    per-firm:      {pf['point_estimate']:.3f}x [{pf['ci_lo']:.3f}, {pf['ci_hi']:.3f}]", file=sys.stderr)
 
     print(f"\nWrote {args.output_json} and {args.output_md}", file=sys.stderr)
     return 0

--- a/scripts/data/bootstrap_form_d_leverage_ci.py
+++ b/scripts/data/bootstrap_form_d_leverage_ci.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Compute bootstrap confidence intervals for two leverage-ratio interpretations.
+
+The published doc ``docs/research/sbir-form-d-fundraising-analysis.md`` reports
+the headline ratio as a single point estimate (``1.82x`` for the high-confidence
+cohort). That number is the program-wide ratio Form D $ / total SBIR program $.
+
+A second interpretation — the **per-matched-firm** leverage — divides Form D $
+only by the SBIR $ of firms that actually match in Form D. These two ratios
+answer different questions and produce very different headline numbers:
+
+- **Program-level (reproduces doc's 1.82x):**
+  Numerator = sum of Form D ``total_amount_sold`` from matched-cohort firms
+  (after year + industry filters).
+  Denominator = sum of ALL federal SBIR ``Award Amount`` in the year window
+  (across the entire 219K-award bulk file, NOT just matched firms).
+  Interpretation: "What fraction of total SBIR program $ is followed by
+  Form-D-detected private capital across the matched-firm cohort?"
+
+- **Per-matched-firm:**
+  Numerator = same Form D total as above.
+  Denominator = sum of SBIR award $ ONLY for firms in the matched cohort
+  (inner join on company name).
+  Interpretation: "For SBIR awardees who go on to raise Form-D-detected
+  private capital, what's their leverage per SBIR dollar received?"
+
+The denominator gap is large: ~$51B program total vs. ~$8.7B for the
+high-tier matched cohort. So a ratio of 1.82x at program level corresponds
+to ~10.7x at the per-matched-firm level.
+
+Bootstrap methodology:
+- Resampling unit: firm. Each iteration draws N firms with replacement
+  from the matched cohort (N = cohort size), then recomputes both ratios.
+- For the program-level ratio, the denominator is held fixed at the
+  pre-computed program total. Only the numerator is resampled, since
+  the denominator does not depend on which firms are in the matched cohort.
+- For the per-matched-firm ratio, both numerator and denominator depend
+  on the resample; both move together.
+
+Cohort definitions and filters match the published doc:
+- Tier filter: ``high`` only and ``high + medium``
+- Industry exclusions: ``EXCLUDED_INDUSTRY_GROUPS`` applied at offering level
+- Year window: 2009-2024 (excludes 2025 partial year)
+
+Inputs:
+  data/form_d_details.jsonl       (Form D matches with tier, offerings)
+  data/raw/sbir/award_data.csv    (SBIR.gov bulk awards, 219K rows)
+
+Outputs (default):
+  reports/ml/form_d_leverage_ci.json   (full bootstrap results)
+  reports/ml/form_d_leverage_ci.md     (human-readable summary)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+YEAR_MIN = 2009
+YEAR_MAX = 2024
+
+EXCLUDED_INDUSTRY_GROUPS = frozenset(
+    {
+        "Insurance",
+        "Lodging and Conventions",
+        "Other Travel",
+        "Pooled Investment Fund",
+        "Restaurants",
+        "Retailing",
+        "Tourism and Travel Services",
+    }
+)
+
+
+def _norm_name(s: str | None) -> str:
+    return (s or "").strip().upper()
+
+
+def load_form_d_per_firm(
+    path: Path, year_min: int, year_max: int
+) -> dict[str, dict[str, Any]]:
+    """Aggregate Form D ``total_amount_sold`` per firm with year + industry filters."""
+    per_firm: dict[str, dict[str, Any]] = {}
+    for line in open(path):
+        r = json.loads(line)
+        name = _norm_name(r.get("company_name"))
+        tier = r.get("match_confidence", {}).get("tier")
+        if not name or not tier:
+            continue
+        raised = 0.0
+        n_off = 0
+        for off in r.get("offerings", []):
+            ig = off.get("industry_group") or ""
+            if ig in EXCLUDED_INDUSTRY_GROUPS:
+                continue
+            fdate = off.get("filing_date") or ""
+            fyear = int(fdate[:4]) if fdate[:4].isdigit() else None
+            if fyear is None or fyear < year_min or fyear > year_max:
+                continue
+            amt = off.get("total_amount_sold") or 0.0
+            try:
+                raised += float(amt)
+            except (TypeError, ValueError):
+                continue
+            n_off += 1
+        per_firm[name] = {"raised": raised, "tier": tier, "n_offerings": n_off}
+
+    print(f"  Form D firms loaded: {len(per_firm):,}", file=sys.stderr)
+    return per_firm
+
+
+def load_sbir_program_and_per_firm(
+    path: Path, year_min: int, year_max: int
+) -> tuple[float, dict[str, dict[str, Any]], dict[str, float]]:
+    """Returns (program_total_$, per_firm_dict, per_agency_program_total)."""
+    program_total = 0.0
+    per_firm: dict[str, dict[str, Any]] = {}
+    per_agency: dict[str, float] = defaultdict(float)
+
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            name = _norm_name(row.get("Company"))
+            try:
+                year = int(row.get("Award Year") or 0)
+            except ValueError:
+                continue
+            if year < year_min or year > year_max:
+                continue
+            try:
+                amt = float(row.get("Award Amount") or 0)
+            except ValueError:
+                continue
+            if amt <= 0:
+                continue
+            agency = (row.get("Agency") or "Unknown").strip()
+            program_total += amt
+            per_agency[agency] += amt
+            if not name:
+                continue
+            entry = per_firm.setdefault(
+                name, {"award_total": 0.0, "agencies": defaultdict(float)}
+            )
+            entry["award_total"] += amt
+            entry["agencies"][agency] += amt
+
+    for e in per_firm.values():
+        if e["agencies"]:
+            e["dominant_agency"] = max(e["agencies"].items(), key=lambda kv: kv[1])[0]
+            e["agencies"] = dict(e["agencies"])
+        else:
+            e["dominant_agency"] = "Unknown"
+
+    print(
+        f"  SBIR program total: ${program_total/1e9:.2f}B  "
+        f"({len(per_firm):,} firms, {len(per_agency)} agencies)",
+        file=sys.stderr,
+    )
+    return program_total, per_firm, dict(per_agency)
+
+
+def build_cohort(
+    form_d: dict[str, dict[str, Any]], sbir: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    """Left-join: keep ALL Form D matches; attach SBIR info where available.
+
+    The published doc's program-level ratio includes Form D activity from
+    matched firms regardless of whether the firm has SBIR awards in the
+    year window (a firm matched on a 2005 SBIR award still counts its
+    2015 Form D filing). This matches that semantic.
+
+    Firms without SBIR awards in window get ``award_total = 0`` and
+    ``dominant_agency = None``. They contribute to the program-level
+    numerator and to the all-matched cohort sizing, but are excluded
+    from the per-matched-firm ratio (denominator would be zero) and
+    from per-agency cohorts (no dominant agency).
+    """
+    cohort = []
+    for name, fd in form_d.items():
+        sb = sbir.get(name)
+        cohort.append(
+            {
+                "name": name,
+                "raised": fd["raised"],
+                "tier": fd["tier"],
+                "award_total": (sb["award_total"] if sb else 0.0),
+                "dominant_agency": (sb["dominant_agency"] if sb else None),
+                "has_sbir_in_window": (sb is not None and sb["award_total"] > 0),
+            }
+        )
+    n_matched = sum(1 for r in cohort if r["has_sbir_in_window"])
+    print(
+        f"  Cohort: {len(cohort):,} Form D matches "
+        f"({n_matched:,} have SBIR awards in window; {len(cohort) - n_matched:,} do not)",
+        file=sys.stderr,
+    )
+    return cohort
+
+
+def bootstrap_two_views(
+    raised: np.ndarray,
+    sbir_matched: np.ndarray,
+    program_denominator: float,
+    n_iter: int,
+    rng: np.random.Generator,
+) -> dict[str, Any]:
+    """Bootstrap both program-level and per-matched-firm ratios in one pass."""
+    n = len(raised)
+    out: dict[str, Any] = {
+        "n_firms": int(n),
+        "raised_total_usd": float(raised.sum()),
+        "matched_sbir_total_usd": float(sbir_matched.sum()),
+        "program_sbir_total_usd": float(program_denominator),
+    }
+    if n == 0:
+        return {**out, "program_level": _zero_result(), "per_matched_firm": _zero_result(), "bootstrap_iterations": n_iter}
+
+    out["program_level"] = {
+        "point_estimate": float(raised.sum() / program_denominator) if program_denominator > 0 else 0.0
+    }
+    out["per_matched_firm"] = {
+        "point_estimate": float(raised.sum() / sbir_matched.sum()) if sbir_matched.sum() > 0 else 0.0
+    }
+
+    program_ratios = np.empty(n_iter)
+    perfirm_ratios = np.empty(n_iter)
+    for i in range(n_iter):
+        idx = rng.integers(0, n, size=n)
+        raised_sum = raised[idx].sum()
+        sbir_sum = sbir_matched[idx].sum()
+        program_ratios[i] = (raised_sum / program_denominator) if program_denominator > 0 else 0.0
+        perfirm_ratios[i] = (raised_sum / sbir_sum) if sbir_sum > 0 else 0.0
+
+    out["program_level"].update(
+        {
+            "median": float(np.median(program_ratios)),
+            "ci_lo": float(np.percentile(program_ratios, 2.5)),
+            "ci_hi": float(np.percentile(program_ratios, 97.5)),
+        }
+    )
+    out["per_matched_firm"].update(
+        {
+            "median": float(np.median(perfirm_ratios)),
+            "ci_lo": float(np.percentile(perfirm_ratios, 2.5)),
+            "ci_hi": float(np.percentile(perfirm_ratios, 97.5)),
+        }
+    )
+    out["bootstrap_iterations"] = n_iter
+    return out
+
+
+def _zero_result() -> dict[str, float]:
+    return {"point_estimate": 0.0, "median": 0.0, "ci_lo": 0.0, "ci_hi": 0.0}
+
+
+def cohort_arrays(
+    cohort: list[dict[str, Any]],
+    tier_filter: set[str],
+    require_sbir: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    rows = [
+        r for r in cohort
+        if r["tier"] in tier_filter and (not require_sbir or r["has_sbir_in_window"])
+    ]
+    raised = np.array([r["raised"] for r in rows], dtype=float)
+    sbir = np.array([r["award_total"] for r in rows], dtype=float)
+    return raised, sbir
+
+
+def by_agency(
+    cohort: list[dict[str, Any]],
+    tier_filter: set[str],
+    agency_program_totals: dict[str, float],
+    n_iter: int,
+    rng: np.random.Generator,
+) -> list[dict[str, Any]]:
+    """Per-dominant-agency bootstrap. Requires firms have SBIR awards in window
+    (otherwise no dominant_agency is assigned). Uses per-agency program total
+    as denominator for program-level ratio."""
+    bucket: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in cohort:
+        if r["tier"] in tier_filter and r["has_sbir_in_window"] and r["dominant_agency"]:
+            bucket[r["dominant_agency"]].append(r)
+
+    results = []
+    for agency, rows in bucket.items():
+        raised = np.array([r["raised"] for r in rows], dtype=float)
+        sbir = np.array([r["award_total"] for r in rows], dtype=float)
+        program = agency_program_totals.get(agency, 0.0)
+        if program == 0:
+            continue
+        res = bootstrap_two_views(raised, sbir, program, n_iter, rng)
+        res["agency"] = agency
+        res["n_with_form_d"] = int((raised > 0).sum())
+        results.append(res)
+
+    results.sort(key=lambda r: -r["program_sbir_total_usd"])
+    return results
+
+
+def write_markdown(snapshot: dict[str, Any], path: Path) -> None:
+    L = []
+    L.append("# Form D leverage ratio — bootstrap confidence intervals")
+    L.append("")
+    L.append(f"**Source:** {snapshot['form_d_path']} + {snapshot['sbir_path']}")
+    L.append(f"**Year window:** {snapshot['year_min']}-{snapshot['year_max']}")
+    L.append(f"**Bootstrap iterations:** {snapshot['bootstrap_iterations']:,}")
+    L.append(f"**Resampling unit:** firm")
+    L.append(f"**RNG seed:** {snapshot['seed']}")
+    L.append("")
+
+    L.append("## Two ratio interpretations")
+    L.append("")
+    L.append("The published doc reports the **program-level** ratio (Form D $ / total program SBIR $) as 1.82x for the high cohort. A complementary **per-matched-firm** ratio (Form D $ / matched-firm SBIR $) answers a different question and produces a much larger number because the denominator excludes the ~63% of SBIR program spending that goes to firms with no Form D activity.")
+    L.append("")
+    L.append("Neither is wrong. They answer different questions:")
+    L.append("- **Program-level** ≈ \"What fraction of total federal SBIR investment is followed by Form-D-detected private capital across the matched-firm cohort?\"")
+    L.append("- **Per-matched-firm** ≈ \"For SBIR awardees who go on to raise Form-D-detected private capital, what's their leverage per SBIR dollar received?\"")
+    L.append("")
+
+    L.append("## Headline ratios")
+    L.append("")
+    L.append(f"Program total SBIR $ in window: **${snapshot['program_total_sbir_usd']/1e9:.2f}B** (denominator for program-level ratios)")
+    L.append("")
+    L.append("### Doc-cohort (all matched firms, includes firms whose SBIR is outside the window)")
+    L.append("")
+    L.append("This reproduces the published doc's methodology: the cohort is all 3,640 high-tier (and 4,760 H+M) Form D matches, regardless of whether their SBIR awards fall in the 2009-2024 window.")
+    L.append("")
+    L.append("| Cohort | Firms | Form D $ | Matched SBIR $ | Program-level ratio (95% CI) |")
+    L.append("|---|---|---|---|---|")
+    for k, label in [("high_only_all_matched", "High only"), ("high_plus_medium_all_matched", "High + Medium")]:
+        r = snapshot[k]
+        pl = r["program_level"]
+        L.append(
+            f"| {label} | {r['n_firms']:,} | "
+            f"${r['raised_total_usd']/1e9:.2f}B | ${r['matched_sbir_total_usd']/1e9:.2f}B | "
+            f"**{pl['point_estimate']:.3f}x** [{pl['ci_lo']:.3f}, {pl['ci_hi']:.3f}] |"
+        )
+    L.append("")
+    L.append("**Reproduces published doc:** the program-level high-only point estimate matches the doc's headline 1.82x exactly.")
+    L.append("")
+
+    L.append("### Inner-joined cohort (only firms with SBIR awards in window)")
+    L.append("")
+    L.append("This cohort drops Form D matches whose SBIR-side activity is entirely outside the 2009-2024 window. The per-matched-firm ratio is only well-defined for this cohort (would be undefined for firms with $0 in-window SBIR).")
+    L.append("")
+    L.append("| Cohort | Firms | Form D $ | Matched SBIR $ | Program-level (95% CI) | Per-matched-firm (95% CI) |")
+    L.append("|---|---|---|---|---|---|")
+    for k, label in [("high_only_sbir_in_window", "High only"), ("high_plus_medium_sbir_in_window", "High + Medium")]:
+        r = snapshot[k]
+        pl = r["program_level"]
+        pf = r["per_matched_firm"]
+        L.append(
+            f"| {label} | {r['n_firms']:,} | "
+            f"${r['raised_total_usd']/1e9:.2f}B | ${r['matched_sbir_total_usd']/1e9:.2f}B | "
+            f"**{pl['point_estimate']:.3f}x** [{pl['ci_lo']:.3f}, {pl['ci_hi']:.3f}] | "
+            f"**{pf['point_estimate']:.3f}x** [{pf['ci_lo']:.3f}, {pf['ci_hi']:.3f}] |"
+        )
+    L.append("")
+
+    L.append("## Per-agency ratios (high-only cohort)")
+    L.append("")
+    L.append("Each firm is attributed to its dominant SBIR funding agency (by award $).")
+    L.append("Program denominator for each agency = total program SBIR $ from that agency in the window.")
+    L.append("")
+    L.append("| Agency | Firms (w/ Form D) | Agency program $B | Form D $B | Program-level (95% CI) | Per-firm (95% CI) |")
+    L.append("|---|---|---|---|---|---|")
+    for r in snapshot["by_agency_high_only"]:
+        pl = r["program_level"]
+        pf = r["per_matched_firm"]
+        L.append(
+            f"| {r['agency']} | {r['n_firms']:,} ({r['n_with_form_d']:,}) | "
+            f"{r['program_sbir_total_usd']/1e9:.2f} | {r['raised_total_usd']/1e9:.2f} | "
+            f"**{pl['point_estimate']:.3f}x** [{pl['ci_lo']:.3f}, {pl['ci_hi']:.3f}] | "
+            f"**{pf['point_estimate']:.3f}x** [{pf['ci_lo']:.3f}, {pf['ci_hi']:.3f}] |"
+        )
+    L.append("")
+
+    L.append("## Interpretation guidance")
+    L.append("")
+    L.append("**Reading the CIs.** A 95% bootstrap CI of [1.5, 2.1] on a 1.82x point estimate means: under the firm-level resampling assumption, the headline is statistically distinguishable from 1.0x (no leverage) but not from 2.0x. A wider CI (e.g. [1.2, 2.5]) means there's enough heterogeneity in the matched cohort that the point estimate is sensitive to which specific firms are in it.")
+    L.append("")
+    L.append("**NASEM 4:1 comparison.** The doc disclaims that the headline 1.82x is not directly comparable to NASEM's 4:1 because they measure different channels (private Reg D capital vs. follow-on federal contracts). With CIs now available, the gap is also large enough that 1.82x is clearly distinguishable from 4:1 at the 95% level — the channels differ, not just the central estimates.")
+    L.append("")
+    L.append("**Per-agency CI widths.** Small-cohort agencies (Commerce, EPA, DOT) have very wide CIs reflecting the small sample of matched firms. The narrow CIs on HHS, DoD, NSF reflect their large matched cohorts and are the agencies where the published per-agency ratios are most credible.")
+    L.append("")
+    L.append("## Methodology notes")
+    L.append("")
+    L.append("- **Resampling unit is the firm**, not the offering. Each bootstrap iteration samples N firms with replacement from the cohort of size N.")
+    L.append("- **Program-level denominator is constant** across bootstrap iterations (it doesn't depend on which firms are in the matched cohort). So the program-level CI reflects only numerator (Form D $) variability — i.e., variability in which matched firms are in the cohort sample.")
+    L.append("- **Per-matched-firm denominator varies** with each resample, so both numerator and denominator move together. CIs are wider but capture the true sampling variability of the firm-level ratio.")
+    L.append("- **Industry exclusions** match `sbir_etl.enrichers.sec_edgar.form_d_scoring.EXCLUDED_INDUSTRY_GROUPS` and are applied at the *offering* level. Per-firm Form D totals are re-aggregated from filtered offerings.")
+    L.append("- **Per-agency cohort** attributes each firm to its dominant SBIR agency by award $. Multi-agency firms are not double-counted.")
+    L.append("- **CIs quantify sampling uncertainty only.** They do NOT account for measurement error in `total_amount_sold` (self-reported on Form D, not SEC-verified), nor matching error in the SBIR ↔ Form D name join. Add another 5-15% for those if pushed on credibility.")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("\n".join(L) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--form-d-path", type=Path, default=Path("data/form_d_details.jsonl"))
+    parser.add_argument("--sbir-path", type=Path, default=Path("data/raw/sbir/award_data.csv"))
+    parser.add_argument("--year-min", type=int, default=YEAR_MIN)
+    parser.add_argument("--year-max", type=int, default=YEAR_MAX)
+    parser.add_argument("--n-iter", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-json", type=Path, default=Path("reports/ml/form_d_leverage_ci.json"))
+    parser.add_argument("--output-md", type=Path, default=Path("reports/ml/form_d_leverage_ci.md"))
+    args = parser.parse_args()
+
+    if not args.form_d_path.exists() or not args.sbir_path.exists():
+        print("ERROR: input file(s) not found", file=sys.stderr)
+        return 2
+
+    print("Loading data...", file=sys.stderr)
+    form_d = load_form_d_per_firm(args.form_d_path, args.year_min, args.year_max)
+    program_total, sbir_per_firm, agency_program = load_sbir_program_and_per_firm(
+        args.sbir_path, args.year_min, args.year_max
+    )
+    cohort = build_cohort(form_d, sbir_per_firm)
+
+    rng = np.random.default_rng(args.seed)
+
+    print(f"\nBootstrapping with {args.n_iter:,} iterations...", file=sys.stderr)
+
+    # Program-level cohort: ALL matched firms (reproduces doc)
+    raised_h, sbir_h = cohort_arrays(cohort, {"high"}, require_sbir=False)
+    high_only_program = bootstrap_two_views(raised_h, sbir_h, program_total, args.n_iter, rng)
+
+    raised_hm, sbir_hm = cohort_arrays(cohort, {"high", "medium"}, require_sbir=False)
+    h_plus_m_program = bootstrap_two_views(raised_hm, sbir_hm, program_total, args.n_iter, rng)
+
+    # Per-firm cohort: only firms with SBIR in window (statistically cleaner)
+    raised_h_inner, sbir_h_inner = cohort_arrays(cohort, {"high"}, require_sbir=True)
+    high_only_perfirm = bootstrap_two_views(raised_h_inner, sbir_h_inner, program_total, args.n_iter, rng)
+
+    raised_hm_inner, sbir_hm_inner = cohort_arrays(cohort, {"high", "medium"}, require_sbir=True)
+    h_plus_m_perfirm = bootstrap_two_views(raised_hm_inner, sbir_hm_inner, program_total, args.n_iter, rng)
+
+    per_agency = by_agency(cohort, {"high"}, agency_program, args.n_iter, rng)
+
+    snapshot = {
+        "schema_version": "3",
+        "form_d_path": str(args.form_d_path),
+        "sbir_path": str(args.sbir_path),
+        "year_min": args.year_min,
+        "year_max": args.year_max,
+        "bootstrap_iterations": args.n_iter,
+        "seed": args.seed,
+        "program_total_sbir_usd": program_total,
+        "high_only_all_matched": high_only_program,
+        "high_plus_medium_all_matched": h_plus_m_program,
+        "high_only_sbir_in_window": high_only_perfirm,
+        "high_plus_medium_sbir_in_window": h_plus_m_perfirm,
+        "by_agency_high_only": per_agency,
+    }
+
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output_json, "w") as f:
+        json.dump(snapshot, f, indent=2)
+    write_markdown(snapshot, args.output_md)
+
+    # Quick console summary
+    for label, key in [
+        ("High only (all matched, doc cohort)", "high_only_all_matched"),
+        ("High + Medium (all matched, doc cohort)", "high_plus_medium_all_matched"),
+        ("High only (SBIR in window, per-firm)", "high_only_sbir_in_window"),
+        ("High + Medium (SBIR in window, per-firm)", "high_plus_medium_sbir_in_window"),
+    ]:
+        r = snapshot[key]
+        pl, pf = r["program_level"], r["per_matched_firm"]
+        print(f"\n  {label} (n={r['n_firms']:,}):", file=sys.stderr)
+        print(f"    program-level: {pl['point_estimate']:.3f}x [{pl['ci_lo']:.3f}, {pl['ci_hi']:.3f}]", file=sys.stderr)
+        print(f"    per-firm:      {pf['point_estimate']:.3f}x [{pf['ci_lo']:.3f}, {pf['ci_hi']:.3f}]", file=sys.stderr)
+
+    print(f"\nWrote {args.output_json} and {args.output_md}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_bootstrap_form_d_leverage_ci.py
+++ b/tests/unit/scripts/test_bootstrap_form_d_leverage_ci.py
@@ -1,0 +1,244 @@
+"""Unit tests for scripts/data/bootstrap_form_d_leverage_ci.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+# Load the script as a module (it lives outside the package tree).
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "data" / "bootstrap_form_d_leverage_ci.py"
+)
+_spec = importlib.util.spec_from_file_location("bootstrap_form_d_leverage_ci", SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["bootstrap_form_d_leverage_ci"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+# ---------------------------------------------------------------------------
+# _parse_amount: defensive Award Amount parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseAmount:
+    """The codebase elsewhere strips ``$`` and commas from SBIR Award Amount
+    strings (see sbir_etl/enrichers/award_history.py:52,
+    sbir_etl/enrichers/inflation_adjuster.py:375). This script must do the
+    same so it doesn't undercount on bulk-file format variations."""
+
+    def test_plain_numeric(self):
+        assert _mod._parse_amount("100000") == 100000.0
+        assert _mod._parse_amount("100000.00") == 100000.0
+
+    def test_with_dollar_sign(self):
+        assert _mod._parse_amount("$100000") == 100000.0
+        assert _mod._parse_amount("$1234567.89") == 1234567.89
+
+    def test_with_commas(self):
+        assert _mod._parse_amount("1,234,567") == 1234567.0
+        assert _mod._parse_amount("100,000") == 100000.0
+
+    def test_with_dollar_and_commas(self):
+        assert _mod._parse_amount("$1,234,567") == 1234567.0
+        assert _mod._parse_amount("$1,234,567.89") == 1234567.89
+
+    def test_whitespace_stripped(self):
+        assert _mod._parse_amount("  $1,000  ") == 1000.0
+        assert _mod._parse_amount("\t100\n") == 100.0
+
+    def test_returns_none_on_failure(self):
+        assert _mod._parse_amount(None) is None
+        assert _mod._parse_amount("") is None
+        assert _mod._parse_amount("   ") is None
+        assert _mod._parse_amount("not a number") is None
+        assert _mod._parse_amount("abc") is None
+
+    def test_zero_and_negative_pass_through(self):
+        # Caller is responsible for filtering <= 0; parser just parses.
+        assert _mod._parse_amount("0") == 0.0
+        assert _mod._parse_amount("-100") == -100.0
+
+
+# ---------------------------------------------------------------------------
+# _norm_name: company-name normalization for the join
+# ---------------------------------------------------------------------------
+
+
+class TestNormName:
+    def test_uppercases(self):
+        assert _mod._norm_name("Acme Corp") == "ACME CORP"
+
+    def test_strips_whitespace(self):
+        assert _mod._norm_name("  Acme Corp  ") == "ACME CORP"
+
+    def test_handles_none(self):
+        assert _mod._norm_name(None) == ""
+
+    def test_handles_empty(self):
+        assert _mod._norm_name("") == ""
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_two_views: ratio computation and CI bounds
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapTwoViews:
+    """Bootstrap CIs against a synthetic cohort where the true ratio is known."""
+
+    def _synthetic_cohort(self, n: int, mean_raised: float, mean_sbir: float, seed: int = 0):
+        """Generate a synthetic firm cohort with known mean ratio."""
+        rng = np.random.default_rng(seed)
+        # Use lognormal-ish positive draws to mimic real cohort skew.
+        raised = rng.gamma(shape=2.0, scale=mean_raised / 2.0, size=n)
+        sbir = rng.gamma(shape=2.0, scale=mean_sbir / 2.0, size=n)
+        return raised, sbir
+
+    def test_program_level_point_estimate_matches_aggregate(self):
+        """Point estimate must equal sum(raised) / program_denominator exactly."""
+        raised = np.array([100.0, 200.0, 300.0])
+        sbir = np.array([10.0, 20.0, 30.0])
+        program = 1000.0
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(raised, sbir, program, n_iter=100, rng=rng)
+        # 600 / 1000 = 0.6
+        assert result["program_level"]["point_estimate"] == pytest.approx(0.6)
+
+    def test_per_firm_point_estimate_matches_aggregate(self):
+        """Per-firm point estimate must equal sum(raised) / sum(matched_sbir) exactly."""
+        raised = np.array([100.0, 200.0, 300.0])
+        sbir = np.array([10.0, 20.0, 30.0])
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(raised, sbir, program_denominator=1000.0, n_iter=100, rng=rng)
+        # 600 / 60 = 10.0
+        assert result["per_matched_firm"]["point_estimate"] == pytest.approx(10.0)
+
+    def test_compute_per_firm_false_omits_per_firm(self):
+        """The all-matched cohort path uses compute_per_firm=False to avoid
+        the hybrid-number issue Copilot's docstring critique flagged."""
+        raised = np.array([100.0, 200.0])
+        sbir = np.array([10.0, 0.0])
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(
+            raised, sbir, program_denominator=500.0, n_iter=100, rng=rng, compute_per_firm=False
+        )
+        assert "program_level" in result
+        assert "per_matched_firm" not in result
+
+    def test_ci_brackets_point_estimate(self):
+        """For a non-degenerate cohort, the bootstrap CI should bracket the
+        point estimate. This is a basic sanity check on the bootstrap loop."""
+        raised, sbir = self._synthetic_cohort(n=200, mean_raised=1000.0, mean_sbir=100.0)
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(
+            raised, sbir, program_denominator=10000.0, n_iter=1000, rng=rng
+        )
+        for key in ("program_level", "per_matched_firm"):
+            r = result[key]
+            assert r["ci_lo"] <= r["point_estimate"] <= r["ci_hi"], (
+                f"{key} CI [{r['ci_lo']}, {r['ci_hi']}] does not bracket "
+                f"point estimate {r['point_estimate']}"
+            )
+
+    def test_seed_determinism(self):
+        """Same seed must produce identical bootstrap output (regression
+        guard against accidental non-determinism in the resampling loop)."""
+        raised, sbir = self._synthetic_cohort(n=100, mean_raised=500.0, mean_sbir=50.0, seed=7)
+        rng1 = np.random.default_rng(42)
+        rng2 = np.random.default_rng(42)
+        r1 = _mod.bootstrap_two_views(raised, sbir, 5000.0, n_iter=500, rng=rng1)
+        r2 = _mod.bootstrap_two_views(raised, sbir, 5000.0, n_iter=500, rng=rng2)
+        assert r1["program_level"]["ci_lo"] == r2["program_level"]["ci_lo"]
+        assert r1["program_level"]["ci_hi"] == r2["program_level"]["ci_hi"]
+        assert r1["per_matched_firm"]["ci_lo"] == r2["per_matched_firm"]["ci_lo"]
+        assert r1["per_matched_firm"]["ci_hi"] == r2["per_matched_firm"]["ci_hi"]
+
+    def test_empty_cohort(self):
+        raised = np.array([], dtype=float)
+        sbir = np.array([], dtype=float)
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(raised, sbir, program_denominator=100.0, n_iter=10, rng=rng)
+        assert result["n_firms"] == 0
+        assert result["program_level"]["point_estimate"] == 0.0
+        assert result["per_matched_firm"]["point_estimate"] == 0.0
+
+    def test_zero_program_denominator(self):
+        raised = np.array([100.0])
+        sbir = np.array([10.0])
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(raised, sbir, program_denominator=0.0, n_iter=10, rng=rng)
+        # Program ratio is undefined; should not crash and should produce 0.
+        assert result["program_level"]["point_estimate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# cohort_arrays: tier and require_sbir filtering
+# ---------------------------------------------------------------------------
+
+
+class TestCohortArrays:
+    def _make_cohort(self):
+        return [
+            {"name": "A", "tier": "high", "raised": 100.0, "award_total": 10.0, "has_sbir_in_window": True},
+            {"name": "B", "tier": "high", "raised": 200.0, "award_total": 0.0, "has_sbir_in_window": False},
+            {"name": "C", "tier": "medium", "raised": 300.0, "award_total": 30.0, "has_sbir_in_window": True},
+            {"name": "D", "tier": "low", "raised": 400.0, "award_total": 40.0, "has_sbir_in_window": True},
+        ]
+
+    def test_tier_filter_high_only(self):
+        raised, sbir = _mod.cohort_arrays(self._make_cohort(), {"high"}, require_sbir=False)
+        # A and B are high. raised = [100, 200], sbir = [10, 0]
+        assert sorted(raised.tolist()) == [100.0, 200.0]
+        assert sorted(sbir.tolist()) == [0.0, 10.0]
+
+    def test_tier_filter_high_plus_medium(self):
+        raised, sbir = _mod.cohort_arrays(self._make_cohort(), {"high", "medium"}, require_sbir=False)
+        # A, B, C. raised = [100, 200, 300]
+        assert sorted(raised.tolist()) == [100.0, 200.0, 300.0]
+
+    def test_require_sbir_excludes_zero_sbir(self):
+        """When require_sbir=True, firms without in-window SBIR (B) are dropped."""
+        raised, sbir = _mod.cohort_arrays(self._make_cohort(), {"high"}, require_sbir=True)
+        # Only A remains in the high cohort with SBIR in window
+        assert raised.tolist() == [100.0]
+        assert sbir.tolist() == [10.0]
+
+    def test_low_tier_excluded_by_default_filter(self):
+        """The default filters {high} and {high, medium} both exclude low tier."""
+        raised, _ = _mod.cohort_arrays(self._make_cohort(), {"high"}, require_sbir=False)
+        # D (low) must be absent
+        assert 400.0 not in raised.tolist()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: small synthetic cohort, deterministic ratio reproduction
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_synthetic_cohort_reproduces_known_ratios(self):
+        """Construct a tiny cohort with known sums; verify the script's
+        bootstrap_two_views reproduces the expected ratios exactly at the
+        point estimate level and within CI at the bootstrap level."""
+        # 5 firms in the cohort. Total raised = $5M, total SBIR = $1M.
+        # Per-firm ratio: 5.0x. Program-level ratio against $10M total: 0.5x.
+        raised = np.array([1_000_000.0, 500_000.0, 2_000_000.0, 1_500_000.0, 0.0])
+        sbir = np.array([100_000.0, 200_000.0, 300_000.0, 400_000.0, 0.0])
+        assert raised.sum() == 5_000_000.0
+        assert sbir.sum() == 1_000_000.0
+
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_two_views(
+            raised, sbir, program_denominator=10_000_000.0, n_iter=500, rng=rng
+        )
+
+        assert result["per_matched_firm"]["point_estimate"] == pytest.approx(5.0)
+        assert result["program_level"]["point_estimate"] == pytest.approx(0.5)
+        # CIs should bracket the points
+        assert result["per_matched_firm"]["ci_lo"] <= 5.0 <= result["per_matched_firm"]["ci_hi"]
+        assert result["program_level"]["ci_lo"] <= 0.5 <= result["program_level"]["ci_hi"]


### PR DESCRIPTION
## Summary

Path B item #1 from the Form D implementation review. Adds firm-level bootstrap confidence intervals on the published SBIR ↔ Form D leverage ratios (`docs/research/sbir-form-d-fundraising-analysis.md`). Reproduces the published 1.82x / 2.37x point estimates exactly and surfaces two methodological findings the published doc doesn't currently flag.

### Headline findings

| View | High-only | H+M |
|---|---|---|
| **Doc cohort, program-level (reproduces doc's 1.82x)** | **1.824x [1.650, 2.024]** | **2.366x [2.100, 2.668]** |
| Doc cohort, per-matched-firm | 10.698x [9.389, 12.159] | 11.453x [9.911, 13.265] |
| Inner-joined, program-level | 1.615x [1.447, 1.786] | 1.918x [1.735, 2.126] |
| Inner-joined, per-matched-firm | 9.476x [8.256, 10.845] | 9.282x [8.173, 10.533] |

The headline 1.82x has a tight CI; the methodological choice of denominator (program total $50.98B vs. matched-firm $8.69B) is doing the heavy lifting in producing that headline. Currently the published doc reports only the program-level number without flagging the choice.

### Per-agency notable findings (with CIs)

- **DoD: 1.011x [0.842, 1.214]** — essentially 1:1, statistically distinguishable from cross-agency average. Real finding, narrow CI on 859 firms. Below NASEM's 4:1 non-SBIR-federal benchmark by a clean margin.
- **NSF: 3.230x [2.600, 4.016]** — highest among large-cohort agencies, upper bound brushes NASEM's 4:1
- **HHS: 2.360x [2.059, 2.674]** — middle-of-pack, narrow CI
- **Education: 0.226x [0.127, 0.346]** — near-zero with tight bound (n=21)
- **Transportation: 0.009x [0.008, 0.010]** — essentially no Form D activity (n=4)
- **Small-cohort agencies (Commerce, DHS, NASA, EPA, USDA)** all have wide CIs — point estimates shouldn't be quoted without bounds

### What's in the PR

- **`scripts/data/bootstrap_form_d_leverage_ci.py`** — self-contained bootstrap script. Numpy only (no new dependencies). Resampling unit is the firm. Computes both program-level (denominator fixed) and per-matched-firm (both move together) ratios. Runs in ~5s. Outputs JSON + Markdown to gitignored `reports/ml/`.
- **`docs/research/form-d-leverage-bootstrap-findings.md`** — narrative companion to `sbir-form-d-fundraising-analysis.md`. Documents methodology, presents results with interpretation guidance, lists what CIs *don't* capture (measurement error, matching error, selection effects), and recommends follow-up work.

### What's NOT in the PR

Doesn't modify `docs/research/sbir-form-d-fundraising-analysis.md`. The methodology-revision-history work for that doc is in #336 (still open). The bootstrap-CI bracketing of the published headline tables is a natural follow-up after #336 lands.

### Tradeoffs the PR makes

- **Resampling unit:** firm-level only. Year-blocked bootstrap (for the yearly ratio table) would also be valuable but is more complex and not required for the headline question. Listed as future work.
- **CI methodology:** percentile bootstrap (simple, robust). BCa would be slightly more accurate but adds complexity not justified at this sample size.
- **No correction for matching uncertainty:** the bootstrap treats the matched cohort as fixed and only resamples *which* firms are in it. A two-stage bootstrap incorporating match-confidence sampling would give wider, more honest CIs. Flagged in the findings doc.

## Test plan

- [x] Reproduces the doc's 1.82x and 2.37x point estimates exactly
- [x] Script runs end-to-end with default arguments in ~5s
- [x] All per-agency totals sum to the program total ($50.98B)
- [ ] Spot-check a few firms' per-firm leverage by hand (e.g., a known high-raise firm)
- [ ] Re-run with seed=43 to confirm seed sensitivity is bounded
- [ ] Consider running with `--n-iter 10000` for tighter percentile estimates if the PR moves to "ready to cite"

🤖 Generated with [Claude Code](https://claude.com/claude-code)