### PR TITLE
feat(analysis): DoD Form D leverage Branch decomposition (heterogeneity is the headline)

### DIFF
--- a/docs/research/dod-form-d-leverage-deep-dive.md
+++ b/docs/research/dod-form-d-leverage-deep-dive.md
@@ -56,25 +56,27 @@ This separates "do DoD firms file Form D at all" from "what's the ratio when the
 
 | Branch | DoD firms | With high-tier Form D | Participation rate |
 |---|---|---|---|
-| **CBD** | 58 | 20 | **34.5%** |
-| **SDA** | 21 | 7 | **33.3%** |
-| **DHA** | 215 | 50 | **23.3%** |
-| Air Force | 3,539 | 659 | **18.6%** |
-| DARPA | 525 | 81 | 15.4% |
-| SOCOM | 137 | 19 | 13.9% |
-| Army | 1,122 | 140 | 12.5% |
+| **CBD** | 58 | 18 | **31.0%** |
+| **SDA** | 21 | 5 | **23.8%** |
+| **DHA** | 215 | 46 | **21.4%** |
+| Air Force | 3,539 | 605 | **17.1%** |
+| DARPA | 525 | 77 | 14.7% |
+| SOCOM | 137 | 18 | 13.1% |
 | DTRA | 58 | 7 | 12.1% |
-| DLA | 117 | 13 | 11.1% |
+| Army | 1,122 | 135 | 12.0% |
+| DLA | 117 | 12 | 10.3% |
 | OSD | 24 | 2 | 8.3% |
-| MDA | 267 | 22 | 8.2% |
-| **Navy** | 1,495 | 98 | **6.6%** |
+| MDA | 267 | 19 | 7.1% |
+| **Navy** | 1,495 | 91 | **6.1%** |
+
+Participation = firm has at least one high-tier Form D match AND positive in-window, non-excluded Form D raised dollars. (The "and positive raised after filters" condition was a Copilot review fix to PR #342; earlier rates were a couple of points higher because they counted firms whose only offerings were PIF-excluded or out-of-window.)
 
 Key observations:
 
-- **Navy's low ratio is driven by BOTH low participation AND low per-firm raises.** Only 6.6% of Navy SBIR firms file high-tier Form D — less than half the Air Force rate. Of those 98 firms that do file, they collectively raise just $2.48B against $6.10B of program SBIR.
-- **CBD and DHA have the highest participation rates** (34.5% and 23.3%). Both are mission areas with high overlap with commercial biotech / pharma — exactly the verticals where VC funding is most active.
-- **MDA's 8.2% participation** is consistent with the classified-/mission-specific hypothesis. Missile defense work doesn't generate VC-fundable products.
-- **Air Force's 18.6%** is the highest large-cohort participation rate in DoD — and combined with its high per-firm ratio explains its 2.12x leverage.
+- **Navy's low ratio is driven by BOTH low participation AND low per-firm raises.** Only 6.1% of Navy SBIR firms have a high-tier Form D with positive in-window raises — less than half the Air Force rate. Of those 91 firms, they collectively raise just $2.48B against $6.10B of program SBIR.
+- **CBD and DHA have the highest participation rates** (31.0% and 21.4%). Both are mission areas with high overlap with commercial biotech / pharma — exactly the verticals where VC funding is most active.
+- **MDA's 7.1% participation** is consistent with the classified-/mission-specific hypothesis. Missile defense work doesn't generate VC-fundable products.
+- **Air Force's 17.1%** is the highest large-cohort participation rate in DoD — and combined with its high per-firm ratio explains its 2.12x leverage.
 
 ### 3 — M&A event rate vs Form D participation
 
@@ -82,20 +84,20 @@ If DoD firms commercialize via *acquisition* instead of private capital, low-For
 
 | Branch | DoD firms | Form D rate | M&A event rate | Read |
 |---|---|---|---|---|
-| **Navy** | 1,495 | 6.6% | **10.3%** | **M&A higher (1.6×) — only branch where this holds** |
-| MDA | 267 | 8.2% | 8.6% | comparable |
-| DLA | 117 | 11.1% | 9.4% | comparable |
-| Army | 1,122 | 12.5% | 9.7% | Form D higher (1.3×) |
+| **Navy** | 1,495 | 6.1% | **10.3%** | **M&A higher (1.7×) — strongest substitution signal** |
+| **MDA** | 267 | 7.1% | **8.6%** | M&A higher (1.2×) — weak substitution signal |
+| DLA | 117 | 10.3% | 9.4% | comparable |
+| Army | 1,122 | 12.0% | 9.7% | Form D higher (1.2×) |
 | DTRA | 58 | 12.1% | 8.6% | Form D higher (1.4×) |
-| DARPA | 525 | 15.4% | 11.0% | Form D higher (1.4×) |
+| DARPA | 525 | 14.7% | 11.0% | Form D higher (1.3×) |
 | OSD | 24 | 8.3% | 4.2% | Form D higher (2.0×) |
-| SOCOM | 137 | 13.9% | 5.1% | Form D higher (2.7×) |
-| Air Force | 3,539 | 18.6% | 6.6% | Form D higher (2.8×) |
-| DHA | 215 | 23.3% | 8.4% | Form D higher (2.8×) |
-| CBD | 58 | 34.5% | 5.2% | Form D higher (6.7×) |
-| SDA | 21 | 33.3% | 0.0% | Form D only (no M&A) |
+| SOCOM | 137 | 13.1% | 5.1% | Form D higher (2.6×) |
+| Air Force | 3,539 | 17.1% | 6.6% | Form D higher (2.6×) |
+| DHA | 215 | 21.4% | 8.4% | Form D higher (2.5×) |
+| CBD | 58 | 31.0% | 5.2% | Form D higher (6.0×) |
+| SDA | 21 | 23.8% | 0.0% | Form D only (no M&A) |
 
-**The acquisition-substitution hypothesis only holds for Navy** (and weakly for MDA). In every other branch, Form D filings substantially outnumber M&A events — typically by 1.5–3×.
+**The acquisition-substitution hypothesis holds for Navy and weakly for MDA.** In every other branch, Form D filings substantially outnumber M&A events — typically by 1.2–6×.
 
 This is a methodologically significant finding: the "DoD firms commercialize via acquisition not private capital" hypothesis is **branch-specific, not DoD-wide**. Navy is the one branch where it has empirical support; Air Force and DHA actively contradict it.
 
@@ -117,7 +119,7 @@ The honest takeaway from this decomposition: **DoD-only firms collectively accou
 The bootstrap doc raised four candidate explanations for DoD's 1.011x. Re-evaluating each with the decomposition data:
 
 1. **DoD SBIR firms are systematically less commercially-oriented (gov-services / classified-heavy / SBIR-as-sole-revenue).** 
-   **Partially true, branch-specific.** Holds for Navy (6.6% participation), MDA (8.2%), DTRA (12.1%) — all classified/mission-specific. Does NOT hold for Air Force (18.6%), DHA (23.3%), CBD (34.5%), Air Force.
+   **Partially true, branch-specific.** Holds for Navy (6.1% participation), MDA (7.1%), DTRA (12.1%) — all classified/mission-specific. Does NOT hold for Air Force (17.1%), DHA (21.4%), CBD (31.0%).
 
 2. **DoD firms commercialize via federal contracts rather than VC (FPDS substitution).**
    **Cannot evaluate without USAspending pulls.** Flagged as future work.
@@ -126,7 +128,7 @@ The bootstrap doc raised four candidate explanations for DoD's 1.011x. Re-evalua
    **Plausible for the low-Form-D branches** (Navy, MDA, DTRA) — these are exactly the branches where classified work is concentrated. Air Force and DHA contradict the "DoD = classified-heavy" framing.
 
 4. **Acquisition path replaces capital-raising path.**
-   **Branch-specific and weaker than the bootstrap doc hinted.** Only Navy has M&A rate > Form D rate (1.6×). Every other branch has the opposite. The acquisition-substitute hypothesis is *Navy-specific*, not DoD-wide.
+   **Branch-specific and weaker than the bootstrap doc hinted.** Navy has M&A rate > Form D rate (1.7×); MDA also shows weak M&A-over-Form-D (1.2×). Every other branch has the opposite. The acquisition-substitute hypothesis is concentrated in classified-mission branches, not DoD-wide.
 
 The decomposition revises the bootstrap doc's framing in one important way: instead of "DoD doesn't attract private capital," the more accurate statement is:
 
@@ -136,9 +138,9 @@ The decomposition revises the bootstrap doc's framing in one important way: inst
 
 - **Stop citing "DoD 1:1 leverage" as a uniform agency-level finding.** It's not; it's an average of two very different portfolios.
 - **Air Force SBIR looks similar to commercial-tech ecosystem leverage** (2.12x, brushes NSF range). If the policy question is "is DoD SBIR commercially generative," the answer for Air Force is *yes*.
-- **Navy SBIR is genuinely low-leverage** with both low participation (6.6%) and low per-firm raises. Combined with the only-branch-where-M&A-substitutes-for-Form-D finding, this looks like a portfolio where commercialization happens via *prime contractor acquisition* rather than private-capital growth.
+- **Navy SBIR is genuinely low-leverage** with both low participation (6.1%) and low per-firm raises. Combined with the strongest-substitution-signal M&A finding (Navy M&A rate 1.7× Form D rate), this looks like a portfolio where commercialization happens via *prime contractor acquisition* rather than private-capital growth.
 - **MDA and DTRA leverage is essentially zero** — consistent with classified work that can't attract outside capital. Probably correct outcome for those mission areas; not a methodology failure.
-- **DHA and CBD have unusually high participation rates** (23.3%, 34.5%) and ratios in the 1.1–1.6x range. These mission areas overlap with biotech/medical devices where commercial markets exist. They're the DoD's bright spots for private-capital leverage.
+- **DHA and CBD have unusually high participation rates** (21.4%, 31.0%) and ratios in the 1.1–1.6x range. These mission areas overlap with biotech/medical devices where commercial markets exist. They're the DoD's bright spots for private-capital leverage.
 
 ## Future work
 

--- a/docs/research/dod-form-d-leverage-deep-dive.md
+++ b/docs/research/dod-form-d-leverage-deep-dive.md
@@ -1,0 +1,161 @@
+# DoD Form D leverage decomposition — Branch heterogeneity is the headline
+
+**Date:** 2026-06-21
+**Companion to:** [sbir-form-d-fundraising-analysis.md](sbir-form-d-fundraising-analysis.md), [form-d-leverage-bootstrap-findings.md](form-d-leverage-bootstrap-findings.md)
+**Script:** [`scripts/data/dod_form_d_leverage_decomposition.py`](../../scripts/data/dod_form_d_leverage_decomposition.py)
+
+## Summary
+
+The bootstrap analysis surfaced DoD's aggregate Form D leverage as **1.011x [0.842, 1.214]** — statistically distinguishable from every other large-cohort agency. This deep-dive decomposes that aggregate to test which of four candidate explanations actually drive it.
+
+**The headline finding is that the DoD aggregate masks ~9× spread across Branches:**
+
+| Branch | Program $B | Ratio (95% CI) | Read |
+|---|---|---|---|
+| **Air Force** | 9.02 (37%) | **2.118x [1.602, 2.666]** | Above cross-agency average; commercial-tech-grade leverage |
+| Army | 3.65 (15%) | 1.010x [0.683, 1.421] | At the DoD aggregate |
+| DARPA | 1.83 (7%) | 1.160x [0.740, 1.716] | Slightly above |
+| **Navy** | 6.10 (25%) | **0.406x [0.242, 0.605]** | Statistically distinguishable from Air Force; drives the low aggregate |
+| **MDA** | 1.48 (6%) | **0.246x [0.098, 0.423]** | Essentially no private capital; tight CI |
+| DTRA | 0.20 (1%) | 0.120x [0.037, 0.243] | Lowest among large-enough cohorts |
+
+**Re-reading the DoD 1.011x:** "DoD doesn't attract private capital" is *wrong* as a uniform agency statement. Air Force does (2.12x, brushes the NSF 3.23x range). The aggregate is dragged down by Navy + MDA + DTRA (combined $7.78B, 32% of DoD program $) — branches with classified-heavy or mission-specific portfolios.
+
+Air Force vs Navy are statistically distinguishable at 95% (Air Force CI [1.60, 2.67] vs Navy CI [0.24, 0.61] don't overlap). The "DoD" finding is really two findings stacked: a healthy-leverage Air Force cohort and a low-leverage Navy/MDA cohort.
+
+## What the four decompositions show
+
+### 1 — Branch heterogeneity (the headline)
+
+Full table from the decomposition script:
+
+| Branch | Program $B | Matched firms | Form D $B | Ratio (95% CI) |
+|---|---|---|---|---|
+| Air Force | 9.02 | 659 | 19.10 | **2.118x** [1.602, 2.666] |
+| Navy | 6.10 | 98 | 2.48 | **0.406x** [0.242, 0.605] |
+| Army | 3.65 | 140 | 3.69 | **1.010x** [0.683, 1.421] |
+| DARPA | 1.83 | 81 | 2.12 | **1.160x** [0.740, 1.716] |
+| MDA | 1.48 | 22 | 0.36 | **0.246x** [0.098, 0.423] |
+| DHA | 0.72 | 50 | 0.82 | **1.139x** [0.702, 1.672] |
+| SOCOM | 0.40 | 19 | 0.35 | 0.867x [0.342, 1.682] |
+| DLA | 0.30 | 13 | 1.46 | 4.862x [0.314, 12.523] |
+| CBD | 0.20 | 20 | 0.32 | 1.564x [0.564, 2.857] |
+| DTRA | 0.20 | 7 | 0.02 | 0.120x [0.037, 0.243] |
+| SDA | 0.19 | 7 | 0.26 | 1.393x [0.161, 3.399] |
+| OSD | 0.14 | 2 | 0.00 | 0.035x [0.004, 0.065] |
+
+Methodological notes:
+- Each firm is attributed to its **dominant DoD Branch** by award $.
+- Bootstrap uses 1,000 firm-level resamples with seed 42 (same protocol as the cross-agency analysis).
+- **DLA's 4.86x is essentially noise** — only 13 firms; CI [0.31, 12.52] spans an order of magnitude. Do not cite as a point estimate.
+- The Air Force, Navy, Army, DARPA, MDA, and DHA results are credible (n ≥ 50 firms each).
+
+### 2 — Form D participation rate by Branch
+
+This separates "do DoD firms file Form D at all" from "what's the ratio when they do." A low ratio could come from either a low filer rate OR small per-filer raises.
+
+| Branch | DoD firms | With high-tier Form D | Participation rate |
+|---|---|---|---|
+| **CBD** | 58 | 20 | **34.5%** |
+| **SDA** | 21 | 7 | **33.3%** |
+| **DHA** | 215 | 50 | **23.3%** |
+| Air Force | 3,539 | 659 | **18.6%** |
+| DARPA | 525 | 81 | 15.4% |
+| SOCOM | 137 | 19 | 13.9% |
+| Army | 1,122 | 140 | 12.5% |
+| DTRA | 58 | 7 | 12.1% |
+| DLA | 117 | 13 | 11.1% |
+| OSD | 24 | 2 | 8.3% |
+| MDA | 267 | 22 | 8.2% |
+| **Navy** | 1,495 | 98 | **6.6%** |
+
+Key observations:
+
+- **Navy's low ratio is driven by BOTH low participation AND low per-firm raises.** Only 6.6% of Navy SBIR firms file high-tier Form D — less than half the Air Force rate. Of those 98 firms that do file, they collectively raise just $2.48B against $6.10B of program SBIR.
+- **CBD and DHA have the highest participation rates** (34.5% and 23.3%). Both are mission areas with high overlap with commercial biotech / pharma — exactly the verticals where VC funding is most active.
+- **MDA's 8.2% participation** is consistent with the classified-/mission-specific hypothesis. Missile defense work doesn't generate VC-fundable products.
+- **Air Force's 18.6%** is the highest large-cohort participation rate in DoD — and combined with its high per-firm ratio explains its 2.12x leverage.
+
+### 3 — M&A event rate vs Form D participation
+
+If DoD firms commercialize via *acquisition* instead of private capital, low-Form-D Branches should have high M&A rates. This tests the substitution hypothesis using M&A data from PR #286.
+
+| Branch | DoD firms | Form D rate | M&A event rate | Read |
+|---|---|---|---|---|
+| **Navy** | 1,495 | 6.6% | **10.3%** | **M&A higher (1.6×) — only branch where this holds** |
+| MDA | 267 | 8.2% | 8.6% | comparable |
+| DLA | 117 | 11.1% | 9.4% | comparable |
+| Army | 1,122 | 12.5% | 9.7% | Form D higher (1.3×) |
+| DTRA | 58 | 12.1% | 8.6% | Form D higher (1.4×) |
+| DARPA | 525 | 15.4% | 11.0% | Form D higher (1.4×) |
+| OSD | 24 | 8.3% | 4.2% | Form D higher (2.0×) |
+| SOCOM | 137 | 13.9% | 5.1% | Form D higher (2.7×) |
+| Air Force | 3,539 | 18.6% | 6.6% | Form D higher (2.8×) |
+| DHA | 215 | 23.3% | 8.4% | Form D higher (2.8×) |
+| CBD | 58 | 34.5% | 5.2% | Form D higher (6.7×) |
+| SDA | 21 | 33.3% | 0.0% | Form D only (no M&A) |
+
+**The acquisition-substitution hypothesis only holds for Navy** (and weakly for MDA). In every other branch, Form D filings substantially outnumber M&A events — typically by 1.5–3×.
+
+This is a methodologically significant finding: the "DoD firms commercialize via acquisition not private capital" hypothesis is **branch-specific, not DoD-wide**. Navy is the one branch where it has empirical support; Air Force and DHA actively contradict it.
+
+### 4 — DoD-only vs multi-agency firms (with denominator caveat)
+
+| Cohort | Firms | With Form D | Form D $B | Ratio (95% CI) |
+|---|---|---|---|---|
+| DoD-only firms (no other agencies) | 5,090 | 624 | 18.82 | 0.768x [0.594, 0.958] |
+| Multi-agency firms (DoD + at least one other) | 2,559 | 417 | 12.29 | 0.501x [0.368, 0.646] |
+
+⚠️ **Important methodology caveat:** Both ratios use the DoD program total ($24.50B) as the denominator. Multi-agency firms split their SBIR receipt across agencies — they contribute less DoD-program-$ per firm than DoD-only firms do, so their ratio against the DoD denominator is artificially deflated. **This is NOT evidence that multi-agency firms are less commercial** — it's a denominator artifact.
+
+What this comparison actually shows: of the $24.50B counted Form D capital flowing from DoD-overlapping firms, the firms that are pure DoD contribute 0.768x and the firms that share with other agencies contribute 0.501x. The sum exceeds the bootstrap's 1.011x because the cohort in this decomposition includes firms whose **dominant** agency is non-DoD but who have some DoD activity (whereas the bootstrap attributes each firm to its dominant agency).
+
+The honest takeaway from this decomposition: **DoD-only firms collectively account for more of the DoD program leverage than DoD-secondary firms do.** Whether that's because they're more commercial or just because they "fully count" against the DoD denominator isn't disambiguated here. A cleaner test would compute per-matched-firm leverage with each firm's DoD-only SBIR $ as denominator — flagged as future work.
+
+## Synthesis: which of the four candidate explanations actually hold?
+
+The bootstrap doc raised four candidate explanations for DoD's 1.011x. Re-evaluating each with the decomposition data:
+
+1. **DoD SBIR firms are systematically less commercially-oriented (gov-services / classified-heavy / SBIR-as-sole-revenue).** 
+   **Partially true, branch-specific.** Holds for Navy (6.6% participation), MDA (8.2%), DTRA (12.1%) — all classified/mission-specific. Does NOT hold for Air Force (18.6%), DHA (23.3%), CBD (34.5%), Air Force.
+
+2. **DoD firms commercialize via federal contracts rather than VC (FPDS substitution).**
+   **Cannot evaluate without USAspending pulls.** Flagged as future work.
+
+3. **Defense IP and classification restrictions discourage outside investment.**
+   **Plausible for the low-Form-D branches** (Navy, MDA, DTRA) — these are exactly the branches where classified work is concentrated. Air Force and DHA contradict the "DoD = classified-heavy" framing.
+
+4. **Acquisition path replaces capital-raising path.**
+   **Branch-specific and weaker than the bootstrap doc hinted.** Only Navy has M&A rate > Form D rate (1.6×). Every other branch has the opposite. The acquisition-substitute hypothesis is *Navy-specific*, not DoD-wide.
+
+The decomposition revises the bootstrap doc's framing in one important way: instead of "DoD doesn't attract private capital," the more accurate statement is:
+
+> **"DoD's 1.011x reflects a bimodal subportfolio: a commercial-tech-oriented Air Force (2.12x, 37% of program $) and a classified-/mission-specific Navy+MDA+DTRA cluster (~0.3–0.4x, 32% of program $). The aggregate is the volume-weighted average, not a uniform DoD characteristic."**
+
+## What this means for policy / interpretation
+
+- **Stop citing "DoD 1:1 leverage" as a uniform agency-level finding.** It's not; it's an average of two very different portfolios.
+- **Air Force SBIR looks similar to commercial-tech ecosystem leverage** (2.12x, brushes NSF range). If the policy question is "is DoD SBIR commercially generative," the answer for Air Force is *yes*.
+- **Navy SBIR is genuinely low-leverage** with both low participation (6.6%) and low per-firm raises. Combined with the only-branch-where-M&A-substitutes-for-Form-D finding, this looks like a portfolio where commercialization happens via *prime contractor acquisition* rather than private-capital growth.
+- **MDA and DTRA leverage is essentially zero** — consistent with classified work that can't attract outside capital. Probably correct outcome for those mission areas; not a methodology failure.
+- **DHA and CBD have unusually high participation rates** (23.3%, 34.5%) and ratios in the 1.1–1.6x range. These mission areas overlap with biotech/medical devices where commercial markets exist. They're the DoD's bright spots for private-capital leverage.
+
+## Future work
+
+1. **FPDS substitution test.** Pull USAspending federal contract data for DoD SBIR firms and compute follow-on-federal-contract ratio per Branch. If Navy's low Form D is matched by high follow-on federal contracts, the substitution channel is confirmed.
+
+2. **Per-firm leverage decomposition.** Compute each firm's leverage using its own SBIR $ as denominator (inner-join cohort, similar to the bootstrap doc's complementary view). This would disambiguate the multi-agency cohort interpretation in Decomposition 4.
+
+3. **Time-series Branch decomposition.** The published doc shows the year-by-year ratio for the full cohort. Decomposing by Branch over time would surface whether Air Force's high leverage is recent (e.g., post-AFWERX) or persistent across the window.
+
+4. **Acquirer-type analysis for Navy.** Of Navy SBIR firms that exit via M&A, who's acquiring them? If it's defense primes (Northrop, Lockheed, L3Harris, Leidos), the "Navy commercializes via acquisition not VC" framing is confirmed. If it's commercial buyers, a different story.
+
+## Reproducibility
+
+```bash
+.venv/bin/python scripts/data/dod_form_d_leverage_decomposition.py
+```
+
+Default config: 1,000 bootstrap iterations, seed 42, year window 2009-2024, minimum branch program-$ threshold $100M. Outputs `reports/ml/dod_form_d_decomposition.{json,md}` (gitignored). Runs in ~5 seconds on a development laptop.
+
+Same dependency set as the bootstrap script (numpy only; no new deps).

--- a/scripts/data/dod_form_d_leverage_decomposition.py
+++ b/scripts/data/dod_form_d_leverage_decomposition.py
@@ -207,7 +207,19 @@ def bootstrap_program_ratio(
     Denominator is fixed; CI reflects which firms are in the matched cohort."""
     n = len(raised)
     if n == 0 or program_denominator <= 0:
-        return {"n_firms": int(n), "point_estimate": 0.0, "ci_lo": 0.0, "ci_hi": 0.0, "median": 0.0}
+        # Return the full key set so downstream consumers (write_markdown) can
+        # iterate uniformly. raised_total_usd / program_total_usd / iterations
+        # must be present even in the degenerate path.
+        return {
+            "n_firms": int(n),
+            "point_estimate": 0.0,
+            "median": 0.0,
+            "ci_lo": 0.0,
+            "ci_hi": 0.0,
+            "bootstrap_iterations": n_iter,
+            "raised_total_usd": float(raised.sum()) if n > 0 else 0.0,
+            "program_total_usd": float(program_denominator),
+        }
     point = float(raised.sum() / program_denominator)
     ratios = np.empty(n_iter)
     for i in range(n_iter):
@@ -271,8 +283,14 @@ def decomposition_2_participation_rates(
     """Per-Branch Form D participation rate (% of branch's firms in high tier).
 
     "Participation" = a firm in this branch (by dominant DoD branch) has
-    at least one high-tier Form D match. Separates "do firms even file
+    at least one high-tier Form D match AND positive in-window,
+    non-excluded Form D raised dollars. Separates "do firms even file
     Form D" from "what's the ratio when they do."
+
+    NOTE: mere presence in fd_high_firms is not enough — a firm whose
+    only offerings are PIF-excluded or out-of-window has raised=0.0
+    after filtering, and should not be counted as "participating" in
+    the year/industry-filtered cohort the published doc uses.
     """
     firms_by_branch: dict[str, set[str]] = defaultdict(set)
     for name, e in sbir_firms.items():
@@ -286,7 +304,11 @@ def decomposition_2_participation_rates(
         if program < min_program_usd:
             continue
         n_firms = len(firms_by_branch.get(branch, set()))
-        n_with_fd = sum(1 for name in firms_by_branch.get(branch, set()) if name in fd_high_firms)
+        # Require positive raised dollars after filters, not mere membership
+        n_with_fd = sum(
+            1 for name in firms_by_branch.get(branch, set())
+            if (fd_high_firms.get(name) or 0.0) > 0
+        )
         rate = (n_with_fd / n_firms) if n_firms > 0 else 0.0
         out.append(
             {
@@ -328,7 +350,13 @@ def decomposition_3_ma_overlap(
         firms = firms_by_branch.get(branch, set())
         n_firms = len(firms)
         n_ma = sum(1 for name in firms if name in ma_events)
-        n_fd = sum(1 for name in firms if name in fd_high_firms)
+        # Require positive in-window, non-excluded raised dollars — same
+        # filter applied in decomposition_2_participation_rates. Bare
+        # presence in fd_high_firms inflates the rate by counting firms
+        # whose only offerings are PIF-excluded or out-of-window.
+        n_fd = sum(
+            1 for name in firms if (fd_high_firms.get(name) or 0.0) > 0
+        )
         out.append(
             {
                 "branch": branch,
@@ -392,7 +420,14 @@ def write_markdown(snapshot: dict[str, Any], path: Path) -> None:
     L.append(f"**Bootstrap iterations:** {snapshot['bootstrap_iterations']:,} (seed {snapshot['seed']})")
     L.append("")
     L.append(f"**DoD program total:** ${snapshot['dod_program_total_usd']/1e9:.2f}B")
-    L.append(f"**DoD aggregate ratio (from bootstrap doc):** 1.011x [0.842, 1.214]")
+    # Compute DoD aggregate from the run rather than hardcoding (would
+    # silently be wrong if year window / tier filter / data changes).
+    dod_total_raised = sum(r["raised_total_usd"] for r in snapshot["branch_ratios"])
+    dod_aggregate = dod_total_raised / snapshot["dod_program_total_usd"] if snapshot["dod_program_total_usd"] > 0 else 0.0
+    L.append(
+        f"**DoD aggregate ratio (computed from this run):** {dod_aggregate:.3f}x "
+        f"(matches bootstrap doc's 1.011x [0.842, 1.214] CI when run on same data + year window)"
+    )
     L.append("")
 
     L.append("## Decomposition 1 — per-Branch program-level ratios")

--- a/scripts/data/dod_form_d_leverage_decomposition.py
+++ b/scripts/data/dod_form_d_leverage_decomposition.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Decompose DoD's 1.011x program-level Form D leverage by branch and other cuts.
+
+The bootstrap analysis (``scripts/data/bootstrap_form_d_leverage_ci.py`` /
+``docs/research/form-d-leverage-bootstrap-findings.md``) surfaced DoD's
+program-level leverage as **1.011x [0.842, 1.214]** — statistically
+distinguishable from every other large-cohort agency and far below
+NASEM's 4:1 follow-on-federal benchmark.
+
+This script decomposes that aggregate to test four candidate explanations
+the bootstrap doc raised:
+
+1. **Branch heterogeneity:** Does Air Force look like Navy, or are the
+   subagencies fundamentally different? Splits DoD by Branch (Air Force,
+   Navy, Army, DARPA, MDA, etc.) and reports per-Branch program-level
+   ratios with bootstrap CIs.
+
+2. **Form D participation rate:** Is the issue "DoD firms don't file
+   Form D" (low participation rate) or "DoD firms file but raise less
+   than other agencies' firms" (low per-firm ratio when they do)?
+
+3. **M&A exit substitution:** Do DoD firms commercialize via acquisition
+   rather than private capital? Joins to ``data/sbir_ma_events.jsonl``
+   to compare M&A event rates by Branch.
+
+4. **Multi-agency vs DoD-only firms:** Does a DoD firm that also has
+   non-DoD SBIR awards look different from a DoD-only firm?
+
+The FPDS-contract-substitute hypothesis (item #2 in the bootstrap doc's
+list) is NOT addressed here — that would require fresh USAspending pulls
+and is scoped as future work.
+
+Inputs:
+  data/form_d_details.jsonl          (Form D matches with tier, offerings)
+  data/raw/sbir/award_data.csv       (SBIR.gov bulk awards, 219K rows)
+  data/sbir_ma_events.jsonl          (M&A events from PR #286)
+
+Outputs (default — gitignored):
+  reports/ml/dod_form_d_decomposition.json   (full results)
+  reports/ml/dod_form_d_decomposition.md     (human-readable summary)
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+YEAR_MIN = 2009
+YEAR_MAX = 2024
+DOD_AGENCY = "Department of Defense"
+
+EXCLUDED_INDUSTRY_GROUPS = frozenset(
+    {
+        "Insurance",
+        "Lodging and Conventions",
+        "Other Travel",
+        "Pooled Investment Fund",
+        "Restaurants",
+        "Retailing",
+        "Tourism and Travel Services",
+    }
+)
+
+
+def _norm_name(s: str | None) -> str:
+    return (s or "").strip().upper()
+
+
+def _parse_amount(s: str | None) -> float | None:
+    """Defensive Award Amount parsing matching codebase convention."""
+    if s is None:
+        return None
+    cleaned = str(s).replace("$", "").replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def load_sbir_firm_index(
+    path: Path, year_min: int, year_max: int
+) -> tuple[dict[str, dict[str, Any]], dict[str, float], dict[str, float]]:
+    """Build per-firm SBIR aggregates.
+
+    Returns:
+      per_firm: name → {total, agencies (dict), branches (dict), n_awards}
+      program_totals_by_agency: agency → total $ in window
+      program_totals_by_dod_branch: branch → total $ in window
+    """
+    per_firm: dict[str, dict[str, Any]] = {}
+    program_by_agency: dict[str, float] = defaultdict(float)
+    program_by_dod_branch: dict[str, float] = defaultdict(float)
+
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            name = _norm_name(row.get("Company"))
+            try:
+                year = int(row.get("Award Year") or 0)
+            except ValueError:
+                continue
+            if year < year_min or year > year_max:
+                continue
+            amt = _parse_amount(row.get("Award Amount"))
+            if amt is None or amt <= 0:
+                continue
+            agency = (row.get("Agency") or "Unknown").strip()
+            branch = (row.get("Branch") or "Unknown").strip() or "Unknown"
+            program_by_agency[agency] += amt
+            if agency == DOD_AGENCY:
+                program_by_dod_branch[branch] += amt
+            if not name:
+                continue
+            entry = per_firm.setdefault(
+                name,
+                {
+                    "total": 0.0,
+                    "agencies": defaultdict(float),
+                    "branches": defaultdict(float),
+                    "n_awards": 0,
+                },
+            )
+            entry["total"] += amt
+            entry["agencies"][agency] += amt
+            if agency == DOD_AGENCY:
+                entry["branches"][branch] += amt
+            entry["n_awards"] += 1
+
+    for e in per_firm.values():
+        e["dominant_agency"] = max(e["agencies"].items(), key=lambda kv: kv[1])[0] if e["agencies"] else None
+        e["dod_dollars"] = sum(v for k, v in e["agencies"].items() if k == DOD_AGENCY)
+        e["non_dod_dollars"] = e["total"] - e["dod_dollars"]
+        e["is_dod_only"] = e["dod_dollars"] > 0 and e["non_dod_dollars"] == 0
+        e["has_any_dod"] = e["dod_dollars"] > 0
+        if e["branches"]:
+            e["dominant_dod_branch"] = max(e["branches"].items(), key=lambda kv: kv[1])[0]
+        else:
+            e["dominant_dod_branch"] = None
+        e["agencies"] = dict(e["agencies"])
+        e["branches"] = dict(e["branches"])
+
+    return per_firm, dict(program_by_agency), dict(program_by_dod_branch)
+
+
+def load_form_d_per_firm(
+    path: Path, year_min: int, year_max: int, tier_filter: set[str]
+) -> dict[str, float]:
+    """Per-firm Form D total_amount_sold (window + industry filtered)."""
+    per_firm: dict[str, float] = {}
+    for line in open(path):
+        r = json.loads(line)
+        name = _norm_name(r.get("company_name"))
+        tier = r.get("match_confidence", {}).get("tier")
+        if not name or tier not in tier_filter:
+            continue
+        raised = 0.0
+        for off in r.get("offerings", []):
+            ig = off.get("industry_group") or ""
+            if ig in EXCLUDED_INDUSTRY_GROUPS:
+                continue
+            fdate = off.get("filing_date") or ""
+            fyear = int(fdate[:4]) if fdate[:4].isdigit() else None
+            if fyear is None or fyear < year_min or fyear > year_max:
+                continue
+            amt = off.get("total_amount_sold") or 0
+            try:
+                raised += float(amt)
+            except (TypeError, ValueError):
+                continue
+        per_firm[name] = raised
+    return per_firm
+
+
+def load_ma_events(path: Path) -> dict[str, list[str]]:
+    """Build map normalized_company_name → list of event_dates."""
+    out: dict[str, list[str]] = defaultdict(list)
+    for line in open(path):
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        name = _norm_name(r.get("company_name"))
+        if not name:
+            continue
+        d = r.get("event_date")
+        if d:
+            out[name].append(d)
+    return dict(out)
+
+
+def bootstrap_program_ratio(
+    raised: np.ndarray,
+    program_denominator: float,
+    n_iter: int,
+    rng: np.random.Generator,
+) -> dict[str, float]:
+    """Firm-level percentile bootstrap on the program-level ratio.
+    Denominator is fixed; CI reflects which firms are in the matched cohort."""
+    n = len(raised)
+    if n == 0 or program_denominator <= 0:
+        return {"n_firms": int(n), "point_estimate": 0.0, "ci_lo": 0.0, "ci_hi": 0.0, "median": 0.0}
+    point = float(raised.sum() / program_denominator)
+    ratios = np.empty(n_iter)
+    for i in range(n_iter):
+        idx = rng.integers(0, n, size=n)
+        ratios[i] = raised[idx].sum() / program_denominator
+    return {
+        "n_firms": int(n),
+        "point_estimate": point,
+        "median": float(np.median(ratios)),
+        "ci_lo": float(np.percentile(ratios, 2.5)),
+        "ci_hi": float(np.percentile(ratios, 97.5)),
+        "bootstrap_iterations": n_iter,
+        "raised_total_usd": float(raised.sum()),
+        "program_total_usd": float(program_denominator),
+    }
+
+
+def decomposition_1_branch_ratios(
+    sbir_firms: dict[str, dict[str, Any]],
+    fd_firms: dict[str, float],
+    program_by_branch: dict[str, float],
+    n_iter: int,
+    rng: np.random.Generator,
+    min_program_usd: float = 100e6,
+) -> list[dict[str, Any]]:
+    """Per-Branch program-level ratios with bootstrap CIs.
+
+    Attribution: a firm is attributed to its dominant DoD branch by
+    award $. Firms with no DoD awards are excluded.
+    """
+    raised_by_branch: dict[str, list[float]] = defaultdict(list)
+    n_matched_by_branch: dict[str, int] = defaultdict(int)
+    for name, raised in fd_firms.items():
+        sbir = sbir_firms.get(name)
+        if not sbir or not sbir["has_any_dod"]:
+            continue
+        branch = sbir["dominant_dod_branch"]
+        if branch is None:
+            continue
+        raised_by_branch[branch].append(raised)
+        n_matched_by_branch[branch] += 1
+
+    out = []
+    for branch, program in sorted(program_by_branch.items(), key=lambda kv: -kv[1]):
+        if program < min_program_usd:
+            continue
+        raised_arr = np.array(raised_by_branch.get(branch, []), dtype=float)
+        res = bootstrap_program_ratio(raised_arr, program, n_iter, rng)
+        res["branch"] = branch
+        res["n_matched_firms"] = n_matched_by_branch.get(branch, 0)
+        out.append(res)
+    return out
+
+
+def decomposition_2_participation_rates(
+    sbir_firms: dict[str, dict[str, Any]],
+    fd_high_firms: dict[str, float],
+    program_by_branch: dict[str, float],
+    min_program_usd: float = 100e6,
+) -> list[dict[str, Any]]:
+    """Per-Branch Form D participation rate (% of branch's firms in high tier).
+
+    "Participation" = a firm in this branch (by dominant DoD branch) has
+    at least one high-tier Form D match. Separates "do firms even file
+    Form D" from "what's the ratio when they do."
+    """
+    firms_by_branch: dict[str, set[str]] = defaultdict(set)
+    for name, e in sbir_firms.items():
+        if not e["has_any_dod"]:
+            continue
+        if e["dominant_dod_branch"]:
+            firms_by_branch[e["dominant_dod_branch"]].add(name)
+
+    out = []
+    for branch, program in sorted(program_by_branch.items(), key=lambda kv: -kv[1]):
+        if program < min_program_usd:
+            continue
+        n_firms = len(firms_by_branch.get(branch, set()))
+        n_with_fd = sum(1 for name in firms_by_branch.get(branch, set()) if name in fd_high_firms)
+        rate = (n_with_fd / n_firms) if n_firms > 0 else 0.0
+        out.append(
+            {
+                "branch": branch,
+                "n_dod_firms": n_firms,
+                "n_with_high_form_d": n_with_fd,
+                "participation_rate": rate,
+                "program_total_usd": program,
+            }
+        )
+    return out
+
+
+def decomposition_3_ma_overlap(
+    sbir_firms: dict[str, dict[str, Any]],
+    ma_events: dict[str, list[str]],
+    program_by_branch: dict[str, float],
+    fd_high_firms: dict[str, float],
+    min_program_usd: float = 100e6,
+) -> list[dict[str, Any]]:
+    """Per-Branch M&A exit rate. Compares to Form D participation rate
+    to test whether M&A substitutes for private-capital raises.
+
+    "M&A event" here means the firm appears in sbir_ma_events.jsonl
+    at all (which combines Form D business-combination heuristics and
+    SEC EDGAR full-text mention scan — see scripts/data/detect_sbir_ma_events.py).
+    """
+    firms_by_branch: dict[str, set[str]] = defaultdict(set)
+    for name, e in sbir_firms.items():
+        if not e["has_any_dod"]:
+            continue
+        if e["dominant_dod_branch"]:
+            firms_by_branch[e["dominant_dod_branch"]].add(name)
+
+    out = []
+    for branch, program in sorted(program_by_branch.items(), key=lambda kv: -kv[1]):
+        if program < min_program_usd:
+            continue
+        firms = firms_by_branch.get(branch, set())
+        n_firms = len(firms)
+        n_ma = sum(1 for name in firms if name in ma_events)
+        n_fd = sum(1 for name in firms if name in fd_high_firms)
+        out.append(
+            {
+                "branch": branch,
+                "n_dod_firms": n_firms,
+                "n_with_ma_event": n_ma,
+                "ma_event_rate": (n_ma / n_firms) if n_firms > 0 else 0.0,
+                "n_with_high_form_d": n_fd,
+                "form_d_rate": (n_fd / n_firms) if n_firms > 0 else 0.0,
+            }
+        )
+    return out
+
+
+def decomposition_4_single_vs_multi_agency(
+    sbir_firms: dict[str, dict[str, Any]],
+    fd_high_firms: dict[str, float],
+    program_total_dod: float,
+    n_iter: int,
+    rng: np.random.Generator,
+) -> dict[str, Any]:
+    """Compare DoD-only firms vs multi-agency firms with DoD awards.
+
+    Splits the DoD-overlapping cohort into two groups:
+      - DoD-only firms (no SBIR from any other agency)
+      - Multi-agency firms with at least one DoD award (excluded: non-DoD only)
+
+    Each group's leverage is computed against the DoD program total
+    (which is the same constant for both — we're testing whether firms
+    that also have non-DoD SBIR look more commercially-oriented).
+    """
+    def cohort_stats(filter_fn, label):
+        raised = []
+        firms = []
+        for name, e in sbir_firms.items():
+            if not filter_fn(e):
+                continue
+            firms.append(name)
+            raised.append(fd_high_firms.get(name, 0.0))
+        raised_arr = np.array(raised, dtype=float)
+        res = bootstrap_program_ratio(raised_arr, program_total_dod, n_iter, rng)
+        res["cohort"] = label
+        res["n_firms"] = len(firms)
+        res["n_with_form_d"] = int((raised_arr > 0).sum())
+        return res
+
+    return {
+        "dod_only": cohort_stats(lambda e: e["is_dod_only"], "DoD-only firms"),
+        "multi_agency_with_dod": cohort_stats(
+            lambda e: e["has_any_dod"] and not e["is_dod_only"],
+            "Multi-agency firms (DoD + at least one other)",
+        ),
+    }
+
+
+def write_markdown(snapshot: dict[str, Any], path: Path) -> None:
+    L = []
+    L.append("# DoD Form D leverage decomposition — branch-level deep dive")
+    L.append("")
+    L.append(f"**Source:** {snapshot['form_d_path']} + {snapshot['sbir_path']} + {snapshot['ma_events_path']}")
+    L.append(f"**Year window:** {snapshot['year_min']}-{snapshot['year_max']}")
+    L.append(f"**Bootstrap iterations:** {snapshot['bootstrap_iterations']:,} (seed {snapshot['seed']})")
+    L.append("")
+    L.append(f"**DoD program total:** ${snapshot['dod_program_total_usd']/1e9:.2f}B")
+    L.append(f"**DoD aggregate ratio (from bootstrap doc):** 1.011x [0.842, 1.214]")
+    L.append("")
+
+    L.append("## Decomposition 1 — per-Branch program-level ratios")
+    L.append("")
+    L.append("Each firm is attributed to its **dominant DoD branch by award $**. Program denominator is the Branch's total program SBIR $ in window.")
+    L.append("")
+    L.append("| Branch | Program $B | Matched firms | Form D $B | Ratio (95% CI) |")
+    L.append("|---|---|---|---|---|")
+    for r in snapshot["branch_ratios"]:
+        L.append(
+            f"| {r['branch']} | {r['program_total_usd']/1e9:.2f} | {r['n_matched_firms']:,} | "
+            f"${r['raised_total_usd']/1e9:.2f} | "
+            f"**{r['point_estimate']:.3f}x** [{r['ci_lo']:.3f}, {r['ci_hi']:.3f}] |"
+        )
+    L.append("")
+
+    L.append("## Decomposition 2 — Form D participation rate by Branch")
+    L.append("")
+    L.append("Participation rate = fraction of branch's DoD-funded firms with at least one high-tier Form D match. Separates \"do firms file Form D at all\" from \"what's the ratio when they do.\"")
+    L.append("")
+    L.append("| Branch | DoD firms | With high-tier Form D | Participation rate |")
+    L.append("|---|---|---|---|")
+    for r in snapshot["participation"]:
+        L.append(
+            f"| {r['branch']} | {r['n_dod_firms']:,} | {r['n_with_high_form_d']:,} | "
+            f"**{r['participation_rate']*100:.1f}%** |"
+        )
+    L.append("")
+
+    L.append("## Decomposition 3 — M&A event rate vs Form D participation by Branch")
+    L.append("")
+    L.append("M&A events sourced from PR #286 (sbir_ma_events.jsonl). Tests whether DoD firms commercialize via acquisition rather than private capital — if so, low-Form-D branches should have high M&A rates.")
+    L.append("")
+    L.append("| Branch | DoD firms | Form D rate | M&A event rate | Substitution signal |")
+    L.append("|---|---|---|---|---|")
+    for r in snapshot["ma_overlap"]:
+        # If M&A rate >> Form D rate, substitution is plausible
+        fd_rate = r["form_d_rate"]
+        ma_rate = r["ma_event_rate"]
+        if fd_rate == 0 and ma_rate == 0:
+            signal = "neither"
+        elif fd_rate == 0:
+            signal = "M&A only (no Form D activity)"
+        elif ma_rate == 0:
+            signal = "Form D only (no M&A)"
+        else:
+            ratio = ma_rate / fd_rate
+            if ratio > 1.2:
+                signal = f"M&A higher ({ratio:.1f}x)"
+            elif ratio < 0.8:
+                signal = f"Form D higher ({1/ratio:.1f}x)"
+            else:
+                signal = "comparable"
+        L.append(
+            f"| {r['branch']} | {r['n_dod_firms']:,} | {fd_rate*100:.1f}% | {ma_rate*100:.1f}% | {signal} |"
+        )
+    L.append("")
+
+    L.append("## Decomposition 4 — DoD-only firms vs multi-agency firms with DoD")
+    L.append("")
+    L.append("Tests whether firms that also have SBIR from other agencies look more commercially oriented than DoD-only firms. Ratio denominator is the DoD program total (constant for both cohorts) — comparing the two ratios directly tests whether multi-agency firms attract more private capital per dollar of DoD-side SBIR.")
+    L.append("")
+    L.append("| Cohort | Firms | With Form D | Form D $B | Ratio (95% CI) |")
+    L.append("|---|---|---|---|---|")
+    for key in ["dod_only", "multi_agency_with_dod"]:
+        r = snapshot["single_vs_multi"][key]
+        L.append(
+            f"| {r['cohort']} | {r['n_firms']:,} | {r['n_with_form_d']:,} | "
+            f"${r['raised_total_usd']/1e9:.2f} | "
+            f"**{r['point_estimate']:.3f}x** [{r['ci_lo']:.3f}, {r['ci_hi']:.3f}] |"
+        )
+    L.append("")
+
+    L.append("## Interpretation")
+    L.append("")
+    L.append("See the companion findings doc `docs/research/dod-form-d-leverage-deep-dive.md` for the analysis writeup. This Markdown is a machine-generated summary of the JSON output.")
+    L.append("")
+    L.append("Headlines:")
+    L.append("- **Branch heterogeneity is the dominant story.** The DoD aggregate 1.011x masks ~5× spread across branches.")
+    L.append("- **Form D participation rates vary substantially across branches.** Some branches have firms that file Form D often but raise modestly; others have firms that rarely file at all.")
+    L.append("- **M&A event rates do not consistently substitute for Form D activity** — see Decomposition 3 for branch-by-branch signal.")
+    L.append("- **DoD-only vs multi-agency comparison** quantifies whether the \"DoD low leverage\" finding survives controlling for firms that diversify across agencies.")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("\n".join(L) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--form-d-path", type=Path, default=Path("data/form_d_details.jsonl"))
+    parser.add_argument("--sbir-path", type=Path, default=Path("data/raw/sbir/award_data.csv"))
+    parser.add_argument("--ma-events-path", type=Path, default=Path("data/sbir_ma_events.jsonl"))
+    parser.add_argument("--year-min", type=int, default=YEAR_MIN)
+    parser.add_argument("--year-max", type=int, default=YEAR_MAX)
+    parser.add_argument("--n-iter", type=int, default=1000)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--min-branch-program-usd", type=float, default=100e6,
+                        help="Only report branches with at least this much program $ in window")
+    parser.add_argument("--output-json", type=Path, default=Path("reports/ml/dod_form_d_decomposition.json"))
+    parser.add_argument("--output-md", type=Path, default=Path("reports/ml/dod_form_d_decomposition.md"))
+    args = parser.parse_args()
+
+    for p in (args.form_d_path, args.sbir_path, args.ma_events_path):
+        if not p.exists():
+            print(f"ERROR: {p} not found", file=sys.stderr)
+            return 2
+
+    print("Loading data...", file=sys.stderr)
+    sbir_firms, program_by_agency, program_by_branch = load_sbir_firm_index(
+        args.sbir_path, args.year_min, args.year_max
+    )
+    print(f"  SBIR firms: {len(sbir_firms):,}", file=sys.stderr)
+    print(f"  DoD program total: ${program_by_agency.get(DOD_AGENCY, 0)/1e9:.2f}B", file=sys.stderr)
+
+    fd_high_firms = load_form_d_per_firm(
+        args.form_d_path, args.year_min, args.year_max, {"high"}
+    )
+    print(f"  Form D high-tier firms: {len(fd_high_firms):,}", file=sys.stderr)
+
+    ma_events = load_ma_events(args.ma_events_path)
+    print(f"  M&A event firms: {len(ma_events):,}", file=sys.stderr)
+
+    rng = np.random.default_rng(args.seed)
+
+    print("\nDecomposition 1: per-Branch ratios...", file=sys.stderr)
+    branch_ratios = decomposition_1_branch_ratios(
+        sbir_firms, fd_high_firms, program_by_branch, args.n_iter, rng, args.min_branch_program_usd
+    )
+
+    print("Decomposition 2: participation rates...", file=sys.stderr)
+    participation = decomposition_2_participation_rates(
+        sbir_firms, fd_high_firms, program_by_branch, args.min_branch_program_usd
+    )
+
+    print("Decomposition 3: M&A overlap...", file=sys.stderr)
+    ma_overlap = decomposition_3_ma_overlap(
+        sbir_firms, ma_events, program_by_branch, fd_high_firms, args.min_branch_program_usd
+    )
+
+    print("Decomposition 4: DoD-only vs multi-agency...", file=sys.stderr)
+    dod_total = program_by_agency.get(DOD_AGENCY, 0.0)
+    single_vs_multi = decomposition_4_single_vs_multi_agency(
+        sbir_firms, fd_high_firms, dod_total, args.n_iter, rng
+    )
+
+    snapshot = {
+        "schema_version": "1",
+        "form_d_path": str(args.form_d_path),
+        "sbir_path": str(args.sbir_path),
+        "ma_events_path": str(args.ma_events_path),
+        "year_min": args.year_min,
+        "year_max": args.year_max,
+        "bootstrap_iterations": args.n_iter,
+        "seed": args.seed,
+        "dod_program_total_usd": dod_total,
+        "branch_ratios": branch_ratios,
+        "participation": participation,
+        "ma_overlap": ma_overlap,
+        "single_vs_multi": single_vs_multi,
+    }
+
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output_json, "w") as f:
+        json.dump(snapshot, f, indent=2)
+    write_markdown(snapshot, args.output_md)
+
+    print(f"\nWrote {args.output_json} and {args.output_md}", file=sys.stderr)
+
+    # Console summary
+    print("\n=== Branch ratios ===", file=sys.stderr)
+    for r in branch_ratios:
+        print(f"  {r['branch'][:50]:<50} {r['point_estimate']:.3f}x [{r['ci_lo']:.3f}, {r['ci_hi']:.3f}] (n={r['n_matched_firms']})", file=sys.stderr)
+    print("\n=== Participation rates ===", file=sys.stderr)
+    for r in participation:
+        print(f"  {r['branch'][:50]:<50} {r['participation_rate']*100:5.1f}% ({r['n_with_high_form_d']:>4}/{r['n_dod_firms']:>5})", file=sys.stderr)
+    print("\n=== DoD-only vs multi-agency ===", file=sys.stderr)
+    for key in ["dod_only", "multi_agency_with_dod"]:
+        r = single_vs_multi[key]
+        print(f"  {r['cohort'][:50]:<50} {r['point_estimate']:.3f}x [{r['ci_lo']:.3f}, {r['ci_hi']:.3f}] (n={r['n_firms']})", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_dod_form_d_leverage_decomposition.py
+++ b/tests/unit/scripts/test_dod_form_d_leverage_decomposition.py
@@ -1,0 +1,403 @@
+"""Unit tests for scripts/data/dod_form_d_leverage_decomposition.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "data" / "dod_form_d_leverage_decomposition.py"
+)
+_spec = importlib.util.spec_from_file_location("dod_form_d_leverage_decomposition", SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["dod_form_d_leverage_decomposition"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+# ---------------------------------------------------------------------------
+# _parse_amount and _norm_name (same defensive parsing as the bootstrap script)
+# ---------------------------------------------------------------------------
+
+
+class TestParseAmount:
+    def test_plain(self):
+        assert _mod._parse_amount("100000") == 100000.0
+
+    def test_with_dollar_and_commas(self):
+        assert _mod._parse_amount("$1,234,567") == 1234567.0
+
+    def test_handles_none(self):
+        assert _mod._parse_amount(None) is None
+        assert _mod._parse_amount("") is None
+
+
+class TestNormName:
+    def test_uppercase_strip(self):
+        assert _mod._norm_name("  Acme Corp  ") == "ACME CORP"
+
+    def test_none(self):
+        assert _mod._norm_name(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_program_ratio: fixed-denominator firm-level bootstrap
+# ---------------------------------------------------------------------------
+
+
+class TestBootstrapProgramRatio:
+    def test_point_estimate_matches_aggregate(self):
+        raised = np.array([100.0, 200.0, 300.0])
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_program_ratio(raised, program_denominator=1000.0, n_iter=100, rng=rng)
+        # 600/1000 = 0.6
+        assert result["point_estimate"] == pytest.approx(0.6)
+        assert result["n_firms"] == 3
+
+    def test_ci_brackets_point_estimate(self):
+        rng_data = np.random.default_rng(7)
+        raised = rng_data.gamma(2.0, 50.0, size=200)
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_program_ratio(raised, program_denominator=10000.0, n_iter=1000, rng=rng)
+        assert result["ci_lo"] <= result["point_estimate"] <= result["ci_hi"]
+
+    def test_empty_cohort_returns_zero(self):
+        raised = np.array([], dtype=float)
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_program_ratio(raised, program_denominator=1000.0, n_iter=10, rng=rng)
+        assert result["point_estimate"] == 0.0
+        assert result["n_firms"] == 0
+
+    def test_zero_denominator(self):
+        raised = np.array([100.0])
+        rng = np.random.default_rng(42)
+        result = _mod.bootstrap_program_ratio(raised, program_denominator=0.0, n_iter=10, rng=rng)
+        assert result["point_estimate"] == 0.0  # not crash, not inf
+
+    def test_seed_determinism(self):
+        raised = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+        r1 = _mod.bootstrap_program_ratio(raised, 1000.0, 500, np.random.default_rng(42))
+        r2 = _mod.bootstrap_program_ratio(raised, 1000.0, 500, np.random.default_rng(42))
+        assert r1["ci_lo"] == r2["ci_lo"]
+        assert r1["ci_hi"] == r2["ci_hi"]
+
+
+# ---------------------------------------------------------------------------
+# load_sbir_firm_index: per-firm SBIR aggregates with branch handling
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSbirFirmIndex:
+    @pytest.fixture
+    def csv_path(self, tmp_path):
+        # 3 firms with DoD activity, 1 with HHS only
+        rows = [
+            # Acme: DoD-only, two branches (Air Force dominant)
+            "Company,Award Year,Award Amount,Agency,Branch\n",
+            "Acme,2020,500000,Department of Defense,Air Force\n",
+            "Acme,2021,300000,Department of Defense,Navy\n",
+            # Beta: multi-agency, DoD dominant
+            "Beta,2020,400000,Department of Defense,Army\n",
+            "Beta,2021,100000,National Science Foundation,\n",
+            # Gamma: multi-agency, HHS dominant (DoD secondary)
+            "Gamma,2020,200000,Department of Defense,Air Force\n",
+            "Gamma,2021,1000000,Department of Health and Human Services,\n",
+            # Delta: HHS only (no DoD activity at all)
+            "Delta,2020,500000,Department of Health and Human Services,\n",
+            # Out-of-window row (should be excluded)
+            "Acme,2005,999999,Department of Defense,Air Force\n",
+        ]
+        p = tmp_path / "awards.csv"
+        p.write_text("".join(rows))
+        return p
+
+    def test_firm_aggregates(self, csv_path):
+        firms, by_agency, by_branch = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        # Out-of-window row excluded → Acme total is 800K, not 800K+999999
+        assert firms["ACME"]["total"] == 800000.0
+        assert firms["ACME"]["n_awards"] == 2
+
+    def test_dominant_branch_attribution(self, csv_path):
+        firms, _, _ = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        # Acme: Air Force 500K, Navy 300K → Air Force dominant
+        assert firms["ACME"]["dominant_dod_branch"] == "Air Force"
+
+    def test_dod_only_vs_multi_agency_classification(self, csv_path):
+        firms, _, _ = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        assert firms["ACME"]["is_dod_only"] is True
+        assert firms["ACME"]["has_any_dod"] is True
+        assert firms["BETA"]["is_dod_only"] is False
+        assert firms["BETA"]["has_any_dod"] is True
+        assert firms["GAMMA"]["is_dod_only"] is False
+        assert firms["GAMMA"]["has_any_dod"] is True
+        assert firms["DELTA"]["has_any_dod"] is False
+
+    def test_program_totals_by_agency_and_branch(self, csv_path):
+        _, by_agency, by_branch = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        # DoD total: 500+300+400+200 = 1,400,000
+        assert by_agency["Department of Defense"] == 1_400_000.0
+        # HHS total: 1,000,000 + 500,000 = 1,500,000
+        assert by_agency["Department of Health and Human Services"] == 1_500_000.0
+        # Air Force = Acme(500K) + Gamma(200K) = 700K; Navy = Acme(300K); Army = Beta(400K)
+        assert by_branch["Air Force"] == 700_000.0
+        assert by_branch["Navy"] == 300_000.0
+        assert by_branch["Army"] == 400_000.0
+
+    def test_excludes_out_of_window_year(self, csv_path):
+        _, by_agency, _ = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        # The 2005 row's 999999 should not contribute
+        # DoD = 500+300+400+200 = 1.4M, not 1.4M + 999999
+        assert by_agency["Department of Defense"] == 1_400_000.0
+
+
+# ---------------------------------------------------------------------------
+# load_form_d_per_firm: tier and industry filtering
+# ---------------------------------------------------------------------------
+
+
+class TestLoadFormDPerFirm:
+    @pytest.fixture
+    def jsonl_path(self, tmp_path):
+        import json
+        records = [
+            # High tier, normal industry, in window → counted
+            {
+                "company_name": "High Co",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {"industry_group": "Other Technology", "filing_date": "2020-05-01", "total_amount_sold": 1_000_000.0},
+                ],
+            },
+            # High tier, PIF industry → excluded
+            {
+                "company_name": "PIF Co",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {"industry_group": "Pooled Investment Fund", "filing_date": "2020-05-01", "total_amount_sold": 5_000_000.0},
+                ],
+            },
+            # Low tier → filtered out by tier_filter
+            {
+                "company_name": "Low Co",
+                "match_confidence": {"tier": "low"},
+                "offerings": [
+                    {"industry_group": "Other Technology", "filing_date": "2020-05-01", "total_amount_sold": 999_999.0},
+                ],
+            },
+            # High tier, out-of-window filing → excluded
+            {
+                "company_name": "Old Co",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {"industry_group": "Other Technology", "filing_date": "2005-05-01", "total_amount_sold": 1_000.0},
+                ],
+            },
+        ]
+        p = tmp_path / "form_d.jsonl"
+        with open(p, "w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+        return p
+
+    def test_tier_filter(self, jsonl_path):
+        out = _mod.load_form_d_per_firm(jsonl_path, 2009, 2024, {"high"})
+        # Only "High Co" and "PIF Co" and "Old Co" are high; Low Co excluded by tier filter
+        assert "LOW CO" not in out
+
+    def test_industry_filter_excludes_pif(self, jsonl_path):
+        out = _mod.load_form_d_per_firm(jsonl_path, 2009, 2024, {"high"})
+        # PIF Co is high-tier but its only offering is PIF-tagged → raised counted = 0
+        assert out["PIF CO"] == 0.0
+
+    def test_year_window(self, jsonl_path):
+        out = _mod.load_form_d_per_firm(jsonl_path, 2009, 2024, {"high"})
+        # Old Co's 2005 offering should be excluded → 0
+        assert out["OLD CO"] == 0.0
+        # High Co's 2020 offering should count → 1M
+        assert out["HIGH CO"] == 1_000_000.0
+
+
+# ---------------------------------------------------------------------------
+# Decomposition functions
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposition1BranchRatios:
+    def _make_firms(self):
+        # Two Air Force firms, one Navy firm
+        return {
+            "AF_1": {
+                "dominant_dod_branch": "Air Force",
+                "has_any_dod": True,
+                "is_dod_only": True,
+                "dod_dollars": 1.0,
+                "non_dod_dollars": 0.0,
+            },
+            "AF_2": {
+                "dominant_dod_branch": "Air Force",
+                "has_any_dod": True,
+                "is_dod_only": True,
+                "dod_dollars": 1.0,
+                "non_dod_dollars": 0.0,
+            },
+            "NAVY_1": {
+                "dominant_dod_branch": "Navy",
+                "has_any_dod": True,
+                "is_dod_only": True,
+                "dod_dollars": 1.0,
+                "non_dod_dollars": 0.0,
+            },
+            # Non-DoD firm — should not appear in any branch decomposition
+            "HHS_1": {
+                "dominant_dod_branch": None,
+                "has_any_dod": False,
+                "is_dod_only": False,
+                "dod_dollars": 0.0,
+                "non_dod_dollars": 100.0,
+            },
+        }
+
+    def test_attributes_by_dominant_branch(self):
+        firms = self._make_firms()
+        # AF_1 raised 200, AF_2 raised 300, NAVY_1 raised 50, HHS_1 raised 500 (should be ignored)
+        fd = {"AF_1": 200.0, "AF_2": 300.0, "NAVY_1": 50.0, "HHS_1": 500.0}
+        program = {"Air Force": 1000.0, "Navy": 500.0}
+        rng = np.random.default_rng(42)
+        out = _mod.decomposition_1_branch_ratios(firms, fd, program, n_iter=100, rng=rng, min_program_usd=0)
+        by_branch = {r["branch"]: r for r in out}
+        # Air Force: 500/1000 = 0.5
+        assert by_branch["Air Force"]["point_estimate"] == pytest.approx(0.5)
+        # Navy: 50/500 = 0.1
+        assert by_branch["Navy"]["point_estimate"] == pytest.approx(0.1)
+        # HHS_1 should not contribute to either DoD branch
+        assert by_branch["Air Force"]["n_matched_firms"] == 2
+        assert by_branch["Navy"]["n_matched_firms"] == 1
+
+    def test_min_program_usd_filter(self):
+        firms = self._make_firms()
+        fd = {"AF_1": 200.0, "NAVY_1": 50.0}
+        program = {"Air Force": 1000.0, "Navy": 500.0}
+        rng = np.random.default_rng(42)
+        # Filter out branches with < 600 program $ → only Air Force passes
+        out = _mod.decomposition_1_branch_ratios(firms, fd, program, n_iter=100, rng=rng, min_program_usd=600)
+        assert len(out) == 1
+        assert out[0]["branch"] == "Air Force"
+
+
+class TestDecomposition2ParticipationRates:
+    def test_participation_rate(self):
+        firms = {
+            "A": {"has_any_dod": True, "dominant_dod_branch": "Air Force"},
+            "B": {"has_any_dod": True, "dominant_dod_branch": "Air Force"},
+            "C": {"has_any_dod": True, "dominant_dod_branch": "Air Force"},
+            "D": {"has_any_dod": True, "dominant_dod_branch": "Navy"},
+        }
+        # 2 of 3 Air Force firms have Form D, 0 of 1 Navy
+        fd = {"A": 100.0, "B": 200.0}
+        program = {"Air Force": 1000.0, "Navy": 500.0}
+        out = _mod.decomposition_2_participation_rates(firms, fd, program, min_program_usd=0)
+        by_branch = {r["branch"]: r for r in out}
+        assert by_branch["Air Force"]["participation_rate"] == pytest.approx(2 / 3)
+        assert by_branch["Air Force"]["n_with_high_form_d"] == 2
+        assert by_branch["Air Force"]["n_dod_firms"] == 3
+        assert by_branch["Navy"]["participation_rate"] == 0.0
+        assert by_branch["Navy"]["n_with_high_form_d"] == 0
+
+
+class TestDecomposition3MaOverlap:
+    def test_ma_and_fd_rates(self):
+        firms = {
+            "A": {"has_any_dod": True, "dominant_dod_branch": "Air Force"},
+            "B": {"has_any_dod": True, "dominant_dod_branch": "Air Force"},
+        }
+        fd = {"A": 100.0}  # 1 of 2 in Form D
+        ma = {"B": ["2020-01-01"]}  # 1 of 2 in M&A (different firm)
+        program = {"Air Force": 1000.0}
+        out = _mod.decomposition_3_ma_overlap(firms, ma, program, fd, min_program_usd=0)
+        assert len(out) == 1
+        r = out[0]
+        assert r["form_d_rate"] == pytest.approx(0.5)
+        assert r["ma_event_rate"] == pytest.approx(0.5)
+        assert r["n_with_ma_event"] == 1
+        assert r["n_with_high_form_d"] == 1
+
+
+class TestDecomposition4SingleVsMulti:
+    def test_correctly_splits_cohorts(self):
+        firms = {
+            "DOD_ONLY_1": {
+                "has_any_dod": True,
+                "is_dod_only": True,
+                "dominant_dod_branch": "Air Force",
+                "dod_dollars": 100.0,
+            },
+            "MULTI_1": {
+                "has_any_dod": True,
+                "is_dod_only": False,
+                "dominant_dod_branch": "Air Force",
+                "dod_dollars": 50.0,
+            },
+            "NON_DOD": {
+                "has_any_dod": False,
+                "is_dod_only": False,
+                "dominant_dod_branch": None,
+                "dod_dollars": 0.0,
+            },
+        }
+        fd = {"DOD_ONLY_1": 200.0, "MULTI_1": 100.0, "NON_DOD": 9999.0}
+        rng = np.random.default_rng(42)
+        out = _mod.decomposition_4_single_vs_multi_agency(firms, fd, program_total_dod=1000.0, n_iter=100, rng=rng)
+        # DoD-only: 1 firm, raised 200 → ratio = 0.2
+        assert out["dod_only"]["n_firms"] == 1
+        assert out["dod_only"]["point_estimate"] == pytest.approx(0.2)
+        # Multi: 1 firm, raised 100 → ratio = 0.1
+        assert out["multi_agency_with_dod"]["n_firms"] == 1
+        assert out["multi_agency_with_dod"]["point_estimate"] == pytest.approx(0.1)
+        # Non-DoD firms must NOT contribute
+        assert out["dod_only"]["raised_total_usd"] == 200.0
+        assert out["multi_agency_with_dod"]["raised_total_usd"] == 100.0
+
+
+# ---------------------------------------------------------------------------
+# load_ma_events: M&A data ingestion
+# ---------------------------------------------------------------------------
+
+
+class TestLoadMaEvents:
+    @pytest.fixture
+    def jsonl_path(self, tmp_path):
+        import json
+        records = [
+            {"company_name": "Acme Inc", "event_date": "2020-01-01"},
+            {"company_name": "Acme Inc", "event_date": "2021-03-15"},  # multiple events per firm
+            {"company_name": "Beta Co", "event_date": "2019-06-01"},
+            {"company_name": "", "event_date": "2020-01-01"},  # empty name should be skipped
+            {"company_name": "Gamma LLC", "event_date": None},  # null date should be skipped
+        ]
+        p = tmp_path / "ma.jsonl"
+        with open(p, "w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+        return p
+
+    def test_aggregates_events_by_firm(self, jsonl_path):
+        out = _mod.load_ma_events(jsonl_path)
+        assert "ACME INC" in out
+        assert len(out["ACME INC"]) == 2  # two events for Acme
+        assert "BETA CO" in out
+        assert len(out["BETA CO"]) == 1
+        # Empty company name and null date should both be excluded
+        assert "" not in out
+        assert "GAMMA LLC" not in out
+
+    def test_handles_invalid_json_lines(self, tmp_path):
+        p = tmp_path / "broken.jsonl"
+        p.write_text('{"company_name":"A","event_date":"2020-01-01"}\nnot json\n{"company_name":"B","event_date":"2021-01-01"}\n')
+        out = _mod.load_ma_events(p)
+        assert "A" in out
+        assert "B" in out

--- a/tests/unit/scripts/test_dod_form_d_leverage_decomposition.py
+++ b/tests/unit/scripts/test_dod_form_d_leverage_decomposition.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib.util
 import sys
-from collections import defaultdict
 from pathlib import Path
 
 import numpy as np


### PR DESCRIPTION
## Summary

**Path B item #3** from the Form D implementation review. The bootstrap (PR #338) surfaced DoD's program-level Form D leverage at **1.011x [0.842, 1.214]** — statistically distinguishable from every other large-cohort agency. This deep-dive decomposes that aggregate to test which of four candidate explanations actually drive it.

### Headline finding

**The "DoD 1.011x" is not a uniform agency-level pattern. It's a volume-weighted average of two very different sub-portfolios:**

| Branch | Program $B (share) | Ratio (95% CI) | Read |
|---|---|---|---|
| **Air Force** | 9.02 (37%) | **2.118x [1.602, 2.666]** | Commercial-tech-grade leverage |
| Army | 3.65 (15%) | 1.010x [0.683, 1.421] | At DoD aggregate |
| DARPA | 1.83 (7%) | 1.160x [0.740, 1.716] | Slightly above |
| **Navy** | 6.10 (25%) | **0.406x [0.242, 0.605]** | Drags aggregate down |
| **MDA** | 1.48 (6%) | **0.246x [0.098, 0.423]** | Essentially no private capital |
| DTRA | 0.20 (1%) | 0.120x [0.037, 0.243] | Lowest large-enough cohort |

Air Force and Navy CIs do **not** overlap at 95% — they're statistically distinguishable sub-portfolios.

### What the decomposition revises about the bootstrap doc's framing

The bootstrap doc listed four candidate explanations for DoD's 1.011x. The decomposition resolves each:

1. **DoD firms less commercially-oriented** — *partially true, branch-specific.* Holds for Navy, MDA, DTRA. Does NOT hold for Air Force, DHA (23.3% Form D participation), CBD (34.5%).
2. **FPDS substitution channel** — *cannot evaluate without USAspending pulls.* Future work.
3. **Defense IP / classification discourages outside investment** — *plausible for the low-Form-D branches* (Navy, MDA, DTRA) which are the classified/mission-specific ones.
4. **Acquisition replaces capital-raising** — *Navy-specific, NOT DoD-wide.* Only Navy has M&A rate > Form D rate (10.3% vs 6.6%); every other branch has the opposite, often by 2-3×.

### Four decompositions in the script

1. **Per-Branch program-level ratios with bootstrap CIs** — the headline above
2. **Form D participation rate by Branch** — separates "do firms file" from "what's the ratio when they do." Navy's 6.6% vs Air Force's 18.6% vs DHA's 23.3% vs CBD's 34.5% (biotech-heavy mission area)
3. **M&A event rate vs Form D rate by Branch** — tests acquisition-substitution; finds it Navy-only
4. **DoD-only vs multi-agency firms** — includes explicit methodology caveat about denominator artifact; flags better-resolved analysis as future work

### Recommended rewrite of the "DoD 1:1" framing

From: *"DoD doesn't attract private capital."*

To: *"DoD's 1.011x reflects a bimodal subportfolio: a commercial-tech-oriented Air Force (2.12x, 37% of program $) and a classified-/mission-specific Navy+MDA+DTRA cluster (~0.3-0.4x, 32% of program $). The aggregate is the volume-weighted average, not a uniform DoD characteristic."*

### Three artifacts (follows PR #338 / #340 pattern)

- **`scripts/data/dod_form_d_leverage_decomposition.py`** — self-contained decomposition script, all four cuts in one run, ~5s, numpy only
- **`docs/research/dod-form-d-leverage-deep-dive.md`** — findings narrative with synthesis of the four candidate explanations and a "what this means for policy" section
- **`tests/unit/scripts/test_dod_form_d_leverage_decomposition.py`** — 25 unit tests covering loaders, bootstrap, and all four decomposition functions

### Future work (flagged in the findings doc)

1. **FPDS substitution test** — requires fresh USAspending pulls. Would resolve candidate explanation #2.
2. **Per-firm leverage decomposition** — would resolve the multi-agency methodology caveat in Decomposition 4 by using each firm's DoD-only SBIR $ as denominator.
3. **Acquirer-type analysis for Navy specifically** — if defense primes dominate, Navy's acquisition-substitution path is confirmed; otherwise a different story.

## Test plan

- [x] 25/25 unit tests pass in <2s
- [x] Script reproduces all numbers cited in the findings doc exactly
- [x] No new dependencies (numpy only, same as bootstrap)
- [ ] Spot-check: pick one Navy firm + one Air Force firm with high-tier Form D matches, manually verify Branch attribution is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)