### PR TITLE
feat(analysis): DoD Form D leverage — deferred follow-ups from PR #342

### DIFF
--- a/docs/research/dod-form-d-followup-findings.md
+++ b/docs/research/dod-form-d-followup-findings.md
@@ -1,0 +1,208 @@
+# DoD Form D leverage — deferred follow-ups from PR #342
+
+**Date:** 2026-06-21
+**Companion to:** [dod-form-d-leverage-deep-dive.md](dod-form-d-leverage-deep-dive.md) (PR #342)
+**Script:** [`scripts/data/dod_form_d_followups.py`](../../scripts/data/dod_form_d_followups.py)
+
+## Summary
+
+PR #342 surfaced **DoD's 1.011x [0.842, 1.214]** as a bimodal subportfolio — Air Force at 2.12x, Navy at 0.41x, MDA at 0.25x — and flagged four follow-up items. The FPDS substitution test (item 1) requires fresh USAspending pulls and is left for a separate PR. This document resolves the other three.
+
+**Three findings, two of them revising PR #342's framing:**
+
+1. **Per-firm leverage is far MORE uniform across branches than program-level ratios.** Air Force median 6.79x vs Navy median 4.12x vs Army median 7.34x. The dramatic Branch heterogeneity in program-level ratios (2.12x vs 0.41x) is dominated by **participation rate differences**, not per-firm raise size. MDA (1.24x median) is the only large-cohort branch where per-firm leverage is genuinely low.
+
+2. **Air Force's high leverage is RECENT, not structural.** Time-series decomposition shows Air Force averaged ~0.4x in 2009-2014 and ~2.5x in 2018-2024 — a 6× jump that corresponds to the AFWERX program launch (March 2017). Navy and MDA show no comparable trend; their low ratios are structural across the entire window.
+
+3. **The "Navy commercializes via defense-prime acquisition" hypothesis from PR #342 is WRONG.** Only **6.9% of named Navy SBIR firm acquirers are defense primes**. The dominant pattern is **commercial acquisition (88.5%)**. Air Force shows a near-identical mix (5.7% / 83.9%). Whatever distinguishes Navy from Air Force in PR #342's M&A-vs-Form-D finding, it isn't the *type* of acquirer.
+
+## Item 2 — Per-firm leverage by Branch (resolves Decomposition 4 methodology caveat)
+
+The DoD decomposition in PR #342 attributed each firm to its dominant Branch but used the Branch's program total as the denominator. The multi-agency comparison in Decomposition 4 had a flagged methodology caveat: multi-agency firms' ratios were artificially deflated against the DoD denominator because they split SBIR receipt across agencies.
+
+This decomposition computes per-firm leverage (Form D $ / firm's own DoD SBIR $) and aggregates by dominant Branch with median + interquartile range. Per-firm ratios are heavily right-skewed (a handful of large-raise outliers per Branch), so median is the more representative central tendency.
+
+| Branch | Firms | Median | Mean | P25 | P75 |
+|---|---|---|---|---|---|
+| Air Force | 659 | **6.79x** | 167.73x | 0.80x | 43.34x |
+| Army | 140 | **7.34x** | 47.73x | 1.34x | 28.85x |
+| Navy | 98 | **4.12x** | 77.25x | 0.38x | 27.37x |
+| DARPA | 81 | **6.55x** | 28.56x | 0.68x | 17.21x |
+| DHA | 50 | 4.70x | 37.23x | 1.07x | 29.10x |
+| MDA | 22 | **1.24x** | 47.67x | 0.11x | 11.56x |
+| CBD | 20 | 2.55x | 44.07x | 0.18x | 16.05x |
+| SOCOM | 19 | 9.23x | 25.61x | 2.22x | 23.15x |
+| DLA | 13 | 15.00x | 867.29x | 1.55x | 114.48x |
+
+**What this revises about PR #342:**
+
+- The "Air Force is commercial-tech-grade, Navy is defense-services-pipeline" framing **overstates the per-firm story**. Air Force firms that DO file Form D raise about 1.6× more per SBIR dollar than Navy firms that do (6.79x vs 4.12x medians), but they're in the same order of magnitude.
+- **The dramatic 5× program-level spread (Air Force 2.12x vs Navy 0.41x) is mostly about how many firms participate, not how much they raise when they do.** Air Force has 659 matched firms against $9.02B program; Navy has 98 against $6.10B.
+- **MDA's 1.24x per-firm median is genuinely low** — even MDA firms that DO file Form D raise relatively little. Consistent with the classified-work hypothesis: missile defense products don't have commercial markets even for firms that try.
+
+The decomposition is fully consistent with PR #342's Decomposition 2 (participation rates) but adjusts the interpretation of Decomposition 1 (program-level ratios). The "DoD has different commercial DNAs by Branch" framing should be:
+
+> **"DoD branches differ mainly in how many of their SBIR firms participate in private capital markets, less in how much those firms raise. Per-firm leverage is in the 4-7x range across most major branches; only MDA is genuinely outside that range."**
+
+## Item 3 — Time-series Branch ratios (Air Force's leverage is recent, AFWERX-aligned)
+
+Per-(Branch, Year) program-level ratios for all major DoD branches, 2009-2024. The headline finding is **Air Force's clear post-2017 inflection**.
+
+### Air Force
+
+| Year | Program $M | Form D $M | Ratio |
+|---|---|---|---|
+| 2009 | 335 | 67 | 0.20x |
+| 2010 | 363 | 42 | 0.12x |
+| 2011 | 257 | 179 | 0.70x |
+| 2012 | 311 | 131 | 0.42x |
+| 2013 | 347 | 225 | 0.65x |
+| 2014 | 276 | 397 | 1.44x |
+| 2015 | 385 | 413 | 1.07x |
+| 2016 | 344 | 622 | 1.81x |
+| 2017 | 328 | 618 | 1.88x |
+| 2018 | 280 | 1,104 | **3.94x** |
+| 2019 | 826 | 1,199 | 1.45x |
+| 2020 | 708 | 1,810 | 2.56x |
+| 2021 | 633 | 4,911 | **7.76x** |
+| 2022 | 1,020 | 2,253 | 2.21x |
+| 2023 | 1,224 | 2,140 | 1.75x |
+| 2024 | 1,382 | 2,985 | 2.16x |
+
+**5-year early average (2009-2013): 0.42x. 5-year late average (2020-2024): 3.29x. 8× jump.**
+
+The inflection lines up with **AFWERX**, the Air Force's commercial-engagement program launched in March 2017. AFWERX restructured Air Force SBIR around dual-use commercial-defense technology and explicitly courted VC-backed startups. The Form D leverage ratio's rise from sub-1x to consistently 2x+ post-2018 is consistent with AFWERX's stated goal of attracting commercial-tech firms whose downstream funding comes from VC, not federal contracts.
+
+The 2021 peak at 7.76x corresponds to the VC boom year — same pattern visible in the cross-agency yearly table from the published doc.
+
+**Air Force pre-AFWERX (2009-2016) averaged 0.78x — actually below the DoD aggregate.** The headline 2.118x is almost entirely a post-2017 phenomenon.
+
+### Navy (no comparable trend)
+
+| Year | Ratio | Year | Ratio |
+|---|---|---|---|
+| 2009 | 0.21x | 2017 | 0.17x |
+| 2010 | 0.18x | 2018 | 0.16x |
+| 2011 | 0.38x | 2019 | 0.21x |
+| 2012 | 0.53x | 2020 | 0.53x |
+| 2013 | 0.32x | 2021 | 0.35x |
+| 2014 | 0.65x | 2022 | 1.07x |
+| 2015 | 0.57x | 2023 | 0.43x |
+| 2016 | 0.45x | 2024 | 0.25x |
+
+**5-year early average: 0.40x. 5-year late average: 0.41x. Essentially flat.**
+
+Recent years (2017-2024) average 0.40x — *lower* than the 2014-2016 peak. Navy doesn't show the post-AFWERX-style commercial engagement. The Navy SBIR program is structurally low-leverage, not in a transition.
+
+### MDA (consistently low across whole window)
+
+| Year | Ratio | Year | Ratio |
+|---|---|---|---|
+| 2009 | 0.18x | 2017 | 0.43x |
+| 2010 | 0.33x | 2018 | 0.48x |
+| 2011 | 0.59x | 2019 | 0.07x |
+| 2012 | 0.16x | 2020 | 0.03x |
+| 2013 | 0.12x | 2021 | 0.12x |
+| 2014 | 0.12x | 2022 | 0.21x |
+| 2015 | 0.47x | 2023 | 0.49x |
+| 2016 | 0.09x | 2024 | 0.00x |
+
+**5-year early average: 0.26x. 5-year late average: 0.17x.**
+
+Recent years if anything are *worse* than the early window. Missile defense SBIR is structurally not commercialization-attracting. The classified-/mission-specific hypothesis is supported across the full time window.
+
+### DHA (clear upward trend)
+
+5-year early avg: ~0.4x → 5-year late avg: ~1.4x. Defense health follow-on private capital has roughly tripled over the window, possibly reflecting the broader biotech-VC cycle. The 23.3% Form D participation rate (highest in DoD) plus the rising trend makes DHA the second clear "commercial engagement" story alongside Air Force.
+
+### Army, DARPA, others
+
+Generally volatile year-over-year (high variance from small annual cohorts), no clear directional trend. Army 5-yr early (~0.81x) vs 5-yr late (~1.70x) shows some uplift but not the dramatic Air Force pattern.
+
+**What this revises about PR #342:**
+
+The Air Force 2.118x finding shouldn't be cited as a stable structural characteristic of Air Force SBIR. **It's a measurement against the 2009-2024 window that's dominated by 2018-2024 post-AFWERX activity.** If the analysis was rerun on 2009-2016 data, Air Force would show a 0.78x program-level ratio — *lower* than the DoD aggregate.
+
+This has implications for policy framing:
+- "Air Force SBIR is commercial-tech-grade" is true *for the post-AFWERX era*. It's not a permanent characteristic.
+- AFWERX appears causally relevant. If the policy question is "what made Air Force private-capital-leverage rise," AFWERX is the right thing to study.
+- Navy has not had an equivalent transformation. Whether that's because no Navy-equivalent program exists, or because Navy's underlying tech mix is harder to commercialize, is a separate question.
+
+## Item 4 — Navy acquirer-type analysis (the defense-prime hypothesis fails)
+
+PR #342 hypothesized that Navy's "M&A rate > Form D rate" pattern reflects *defense-prime consolidation* — Navy SBIR firms commercialize by getting acquired by Lockheed / Northrop / L3Harris / Leidos / Kratos / Mercury / Teledyne rather than by raising VC. This decomposition tests that hypothesis by classifying M&A acquirers.
+
+Classifier categories:
+- **defense_prime**: substring match against canonical DoD-prime / defense-services contractor names (Lockheed, Northrop, Raytheon, Boeing, BAE, L3, Leidos, CACI, Kratos, Mercury Systems, Teledyne, KBR, etc.). Uses word-boundary regex for short acronyms to avoid false matches.
+- **financial_sponsor**: investment-vehicle markers (Capital, Partners, BDC, SPAC, Acquisition Corp, Merger Sub, Hercules Capital, Golub Capital, Churchill Capital, etc.). Tightened from initial version to exclude "Holdings" alone (too many false positives on real operating companies).
+- **commercial**: everything else.
+
+### Navy
+
+- Navy SBIR firms (dominant Navy): 2,510
+- M&A events for Navy firms: 250
+- Events with named acquirer: 203
+
+| Acquirer type | Count | Share |
+|---|---|---|
+| **defense_prime** | 14 | **6.9%** |
+| **commercial** | 180 | **88.5%** |
+| financial_sponsor | 9 | 4.6% |
+| unknown | 0 | 0.0% |
+
+Top defense-prime Navy acquirers: L3 Technologies (3), Teledyne (2), CACI (1), TransDigm (1), KBR (1), Northrop Grumman, Lockheed Martin, Mercury Systems, etc.
+
+### Air Force (control)
+
+- Air Force SBIR firms (dominant Air Force): 3,539
+- M&A events for AF firms: 297
+- Events with named acquirer: 244
+
+| Acquirer type | Count | Share |
+|---|---|---|
+| **defense_prime** | 14 | **5.7%** |
+| **commercial** | 205 | **83.9%** |
+| financial_sponsor | 25 | 10.4% |
+| unknown | 0 | 0.0% |
+
+Top defense-prime AF acquirers: Kratos (3), L3 Technologies (2), KBR (1), Raytheon, Parsons, CACI, etc.
+
+### What this revises about PR #342
+
+**The "Navy commercializes via defense-prime acquisition" hypothesis is not supported by the acquirer-type data.** Navy's defense-prime share (6.9%) is essentially the same as Air Force's (5.7%), and both are dominated by **commercial acquisition (~85-90% of named acquirers)**.
+
+If Navy SBIR firms are exiting via commercial acquisition rather than via private-capital raises, the relevant mechanism is **acquisition-by-commercial-companies** (probably tech consolidators, instruments/semiconductor companies, medical-device buyers), not by-defense-primes.
+
+This actually deepens the Navy story rather than resolving it:
+- Navy SBIR firms file Form D less (6.6% participation vs Air Force 18.6%)
+- Navy SBIR firms ARE more likely to have M&A events (10.3% vs 6.6%)
+- But Navy SBIR firms that get acquired are not predominantly acquired by defense primes — they get acquired by commercial buyers, same as Air Force firms
+
+Possible mechanisms still on the table for Navy's distinct profile:
+1. **Smaller commercial-tech footprint per firm** — Navy SBIR firms may build products that get rolled up into larger commercial companies' portfolios as one-time acquisitions, rather than as ongoing VC-funded scale-ups. The Navy firm structure may not support standalone scaling.
+2. **Earlier exits** — Navy SBIR firms may exit before they'd need to file Form D. Median time-to-exit comparison would test this.
+3. **Different industry mix** — Navy SBIR may concentrate in industries where exits are more common than VC scale-ups (e.g., sensor manufacturing, marine systems, specialized hardware).
+
+The acquirer-type analysis closes one specific hypothesis from PR #342 and opens a few more. The honest reframing:
+
+> **"Navy SBIR firms exit via commercial acquisition at higher rates than Air Force firms, but not via defense-prime consolidation. The mechanism behind Navy's M&A-over-Form-D pattern requires different evidence than PR #342 suggested."**
+
+## What's still deferred (Item 1 — FPDS substitution)
+
+The substitution-via-federal-contracts hypothesis from the bootstrap doc's candidate explanation #2 still cannot be evaluated without USAspending pulls. Three followup items would close it:
+
+1. **DoD non-SBIR federal contract activity for matched firms**, by Branch. If Navy firms have high follow-on FPDS activity (relative to Air Force / NSF firms), the "Navy commercializes via federal contracts not VC" hypothesis is confirmed.
+2. **Repeat this per-Branch**, since Air Force may show a different substitution profile.
+3. **Compare against NASEM's 4:1 non-SBIR-federal benchmark** for DoD specifically, decomposed by Branch.
+
+Each requires USAspending API pulls and per-firm contract matching — bigger scope than the computational follow-ups above.
+
+## Reproducibility
+
+```bash
+.venv/bin/python scripts/data/dod_form_d_followups.py
+```
+
+Default config: year window 2009-2024, inputs `data/form_d_details.jsonl` + `data/raw/sbir/award_data.csv` + `data/sbir_ma_events.jsonl`. Outputs `reports/ml/dod_form_d_followups.{json,md}` (gitignored). Runs in ~3 seconds on a development laptop.
+
+Same dependency set as the other Form D scripts (numpy only; no new deps).

--- a/scripts/data/dod_form_d_followups.py
+++ b/scripts/data/dod_form_d_followups.py
@@ -155,7 +155,7 @@ def _parse_amount(s: str | None) -> float | None:
 
 def load_sbir_firm_index(
     path: Path, year_min: int, year_max: int
-) -> tuple[dict[str, dict[str, Any]], dict[str, float]]:
+) -> tuple[dict[str, dict[str, Any]], dict[tuple[str, int], float]]:
     """Per-firm SBIR aggregates (DoD only) + per-(branch, year) totals.
 
     Returns:
@@ -219,13 +219,21 @@ def load_sbir_firm_index(
 def load_form_d_per_firm(
     path: Path, year_min: int, year_max: int
 ) -> tuple[dict[str, float], dict[str, dict[int, float]]]:
-    """Per-firm Form D total + per-firm-per-year breakdown (high tier only)."""
+    """Per-firm Form D total + per-firm-per-year breakdown (high tier only).
+
+    Defensive: skips malformed JSON lines and records missing
+    company_name / match_confidence.tier, matching the convention in
+    bootstrap_form_d_leverage_ci.py.
+    """
     per_firm: dict[str, float] = {}
     per_firm_year: dict[str, dict[int, float]] = defaultdict(lambda: defaultdict(float))
     for line in open(path):
-        r = json.loads(line)
+        try:
+            r = json.loads(line)
+        except json.JSONDecodeError:
+            continue
         name = _norm_name(r.get("company_name"))
-        tier = r.get("match_confidence", {}).get("tier")
+        tier = (r.get("match_confidence") or {}).get("tier")
         if not name or tier != "high":
             continue
         raised = 0.0
@@ -349,7 +357,7 @@ def item_3_time_series_branch_ratios(
 def item_4_navy_acquirer_analysis(
     sbir_firms: dict[str, dict[str, Any]],
     ma_events_path: Path,
-    target_branches: list[str] = None,
+    target_branches: list[str] | None = None,
 ) -> dict[str, Any]:
     """Classify acquirers of SBIR firms with the given dominant DoD Branch.
 
@@ -468,7 +476,7 @@ def write_markdown(snapshot: dict[str, Any], path: Path) -> None:
 
     L.append("## Item 4 — Navy acquirer-type analysis (Air Force as control)")
     L.append("")
-    L.append("Classifies acquirers of M&A-event SBIR firms into three types using substring matching against canonical name patterns: **defense_prime** (Lockheed, Northrop, L3Harris, Leidos, CACI, Kratos, etc.), **financial_sponsor** (Capital, Partners, BDC, Fund, Holdings, etc.), and **commercial** (everything else). Tests whether Navy's higher M&A-than-Form-D pattern is driven by defense-prime acquisition specifically.")
+    L.append("Classifies acquirers of M&A-event SBIR firms into three types using substring matching against canonical name patterns: **defense_prime** (Lockheed, Northrop, L3Harris, Leidos, CACI, Kratos, KBR, BAE, etc. — short acronyms use word-boundary regex), **financial_sponsor** (narrow markers only: Capital, Partners, BDC, Acquisition Corp, plus specific named investment vehicles like Hercules Capital, Golub Capital, Churchill Capital — \"Holdings\" alone is NOT matched because too many real operating companies use it), and **commercial** (everything else). Tests whether Navy's higher M&A-than-Form-D pattern is driven by defense-prime acquisition specifically.")
     L.append("")
     for branch, r in snapshot["item_4_navy_acquirers"].items():
         L.append(f"### {branch}")

--- a/scripts/data/dod_form_d_followups.py
+++ b/scripts/data/dod_form_d_followups.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""DoD Form D leverage — follow-ups from PR #342 deferred items.
+
+The Branch decomposition in
+``docs/research/dod-form-d-leverage-deep-dive.md`` flagged four
+follow-up items. The FPDS substitution test (item 1) requires fresh
+USAspending pulls and is left as separate-PR work. This script
+implements the three computational items:
+
+**Item 2 — Per-firm leverage decomposition.** The DoD decomposition
+attributed each firm to its dominant Branch but used the Branch's
+program total as the denominator. That produced a methodology caveat
+in Decomposition 4 about multi-agency firms being artificially deflated
+against the DoD denominator. This script resolves it by computing per-
+firm leverage (Form D $ / firm's own DoD SBIR $) and aggregating by
+Branch with median/mean across firms. This is comparable across firms
+and removes the multi-agency denominator artifact.
+
+**Item 3 — Time-series Branch decomposition.** Was Air Force's high
+2.12x leverage always there, or is it a recent post-AFWERX phenomenon?
+This script computes per-(Branch, Year) program-level ratios from
+2009 to 2024 and surfaces whether leverage trends are stable or
+emerging.
+
+**Item 4 — Navy acquirer-type analysis.** PR #342 found that Navy is
+the only DoD branch where M&A rate exceeds Form D rate, suggesting
+acquisition substitutes for private capital. If Navy firms are
+predominantly acquired by *defense primes* (Lockheed, Northrop,
+L3Harris, Leidos, CACI, Kratos, Mercury, Teledyne), that's the
+"Navy commercializes via FPDS-adjacent acquisition" pattern. If
+they're acquired by commercial buyers, it's a different story. This
+script classifies Navy SBIR firm acquirers by type and compares
+against Air Force as a control.
+
+Inputs:
+  data/form_d_details.jsonl
+  data/raw/sbir/award_data.csv
+  data/sbir_ma_events.jsonl
+
+Outputs (default — gitignored):
+  reports/ml/dod_form_d_followups.json
+  reports/ml/dod_form_d_followups.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+YEAR_MIN = 2009
+YEAR_MAX = 2024
+DOD_AGENCY = "Department of Defense"
+
+EXCLUDED_INDUSTRY_GROUPS = frozenset(
+    {
+        "Insurance",
+        "Lodging and Conventions",
+        "Other Travel",
+        "Pooled Investment Fund",
+        "Restaurants",
+        "Retailing",
+        "Tourism and Travel Services",
+    }
+)
+
+
+# Acquirer-type lexicon for Item 4. Patterns drawn from the observed
+# Navy + Air Force acquirer lists in sbir_ma_events.jsonl plus the
+# canonical DoD-prime / financial-sponsor name catalogs.
+#
+# Defense primes split into two groups:
+# - PREFIX patterns: matched against the start of the acquirer name OR
+#   immediately after a non-alpha character (handles "KBR," "KBR-Wyle"
+#   etc. without false-positive matches against "Sebkbright" or similar)
+# - SUBSTRING patterns: matched anywhere (multi-word brand names that
+#   don't have substring collisions)
+import re
+
+_DEFENSE_PRIME_PREFIXES = frozenset(
+    {"KBR", "HII", "SAIC", "BAE", "L3", "L-3", "CACI"}
+)
+_DEFENSE_PRIME_SUBSTRINGS = frozenset(
+    {
+        "LOCKHEED MARTIN", "NORTHROP GRUMMAN", "RAYTHEON", "BOEING",
+        "GENERAL DYNAMICS", "BAE SYSTEMS", "L3HARRIS",
+        "L3 TECHNOLOGIES", "LEIDOS", "KRATOS", "MERCURY SYSTEMS",
+        "TELEDYNE", "BOOZ ALLEN", "PARSONS CORP",
+        "MAXAR", "ENGILITY", "PERSPECTA", "SCIENCE APPLICATIONS",
+        "ELBIT", "RAFAEL ", "TEXTRON", "HUNTINGTON INGALLS",
+        "CURTISS-WRIGHT", "MANTECH", "AECOM", "AMENTUM", "DXC TECHNOLOGY",
+        "PEROT SYSTEMS", "MOOG INC", "TRANSDIGM", "HONEYWELL",
+    }
+)
+# Compiled once for speed: word-boundary match for the prefix-style names.
+_DEFENSE_PRIME_PREFIX_RE = re.compile(
+    r"(?:^|[^A-Z])(" + "|".join(re.escape(p) for p in _DEFENSE_PRIME_PREFIXES) + r")(?:[^A-Z]|$)"
+)
+
+# Financial-sponsor patterns. Avoid "HOLDINGS" alone because many real
+# operating companies use it ("Ortho Clinical Diagnostics Holdings",
+# "Alarm.com Holdings"). Keep narrow markers that genuinely indicate
+# investment vehicles or SPACs.
+FINANCIAL_SPONSOR_PATTERNS = frozenset(
+    {
+        " CAPITAL ", " CAPITAL,", " PARTNERS", "BDC",
+        "PRIVATE EQUITY", "VENTURES",
+        "MERGER SUB", "ACQUISITION CORP", "SPAC ", "FINANCE CORP",
+        "HORIZON TECHNOLOGY FINANCE", "HERCULES CAPITAL",
+        "GOLUB CAPITAL", "CHURCHILL CAPITAL",
+    }
+)
+
+
+def classify_acquirer(name: str | None) -> str:
+    """Classify an acquirer string into one of:
+    'defense_prime' | 'financial_sponsor' | 'commercial' | 'unknown'.
+    """
+    if not name:
+        return "unknown"
+    n = name.upper()
+    # Defense primes take priority (most informative)
+    if any(p in n for p in _DEFENSE_PRIME_SUBSTRINGS):
+        return "defense_prime"
+    if _DEFENSE_PRIME_PREFIX_RE.search(n):
+        return "defense_prime"
+    # Financial sponsor markers
+    if any(p in n for p in FINANCIAL_SPONSOR_PATTERNS):
+        return "financial_sponsor"
+    return "commercial"
+
+
+def _norm_name(s: str | None) -> str:
+    return (s or "").strip().upper()
+
+
+def _parse_amount(s: str | None) -> float | None:
+    if s is None:
+        return None
+    cleaned = str(s).replace("$", "").replace(",", "").strip()
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def load_sbir_firm_index(
+    path: Path, year_min: int, year_max: int
+) -> tuple[dict[str, dict[str, Any]], dict[str, float]]:
+    """Per-firm SBIR aggregates (DoD only) + per-(branch, year) totals.
+
+    Returns:
+      per_firm: name → {total, dod_dollars, dod_dollars_by_year, branches,
+                        dominant_dod_branch, dominant_branch_dollars}
+      program_by_branch_year: (branch, year) → $ total
+    """
+    per_firm: dict[str, dict[str, Any]] = {}
+    program_by_branch_year: dict[tuple[str, int], float] = defaultdict(float)
+
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            try:
+                year = int(row.get("Award Year") or 0)
+            except ValueError:
+                continue
+            if year < year_min or year > year_max:
+                continue
+            amt = _parse_amount(row.get("Award Amount"))
+            if amt is None or amt <= 0:
+                continue
+            agency = (row.get("Agency") or "Unknown").strip()
+            branch = (row.get("Branch") or "Unknown").strip() or "Unknown"
+            name = _norm_name(row.get("Company"))
+            if agency == DOD_AGENCY:
+                program_by_branch_year[(branch, year)] += amt
+            if not name:
+                continue
+            entry = per_firm.setdefault(
+                name,
+                {
+                    "total": 0.0,
+                    "dod_dollars": 0.0,
+                    "dod_dollars_by_year": defaultdict(float),
+                    "branches": defaultdict(float),
+                    "branches_by_year": defaultdict(lambda: defaultdict(float)),
+                },
+            )
+            entry["total"] += amt
+            if agency == DOD_AGENCY:
+                entry["dod_dollars"] += amt
+                entry["dod_dollars_by_year"][year] += amt
+                entry["branches"][branch] += amt
+                entry["branches_by_year"][branch][year] += amt
+
+    for e in per_firm.values():
+        if e["branches"]:
+            e["dominant_dod_branch"] = max(e["branches"].items(), key=lambda kv: kv[1])[0]
+            e["dominant_branch_dollars"] = e["branches"][e["dominant_dod_branch"]]
+        else:
+            e["dominant_dod_branch"] = None
+            e["dominant_branch_dollars"] = 0.0
+        # Convert defaultdicts so the snapshot serializes cleanly
+        e["branches"] = dict(e["branches"])
+        e["dod_dollars_by_year"] = dict(e["dod_dollars_by_year"])
+        e["branches_by_year"] = {b: dict(yy) for b, yy in e["branches_by_year"].items()}
+
+    return per_firm, dict(program_by_branch_year)
+
+
+def load_form_d_per_firm(
+    path: Path, year_min: int, year_max: int
+) -> tuple[dict[str, float], dict[str, dict[int, float]]]:
+    """Per-firm Form D total + per-firm-per-year breakdown (high tier only)."""
+    per_firm: dict[str, float] = {}
+    per_firm_year: dict[str, dict[int, float]] = defaultdict(lambda: defaultdict(float))
+    for line in open(path):
+        r = json.loads(line)
+        name = _norm_name(r.get("company_name"))
+        tier = r.get("match_confidence", {}).get("tier")
+        if not name or tier != "high":
+            continue
+        raised = 0.0
+        for off in r.get("offerings", []):
+            ig = off.get("industry_group") or ""
+            if ig in EXCLUDED_INDUSTRY_GROUPS:
+                continue
+            fdate = off.get("filing_date") or ""
+            fyear = int(fdate[:4]) if fdate[:4].isdigit() else None
+            if fyear is None or fyear < year_min or fyear > year_max:
+                continue
+            amt = off.get("total_amount_sold") or 0
+            try:
+                amt_f = float(amt)
+                raised += amt_f
+                per_firm_year[name][fyear] += amt_f
+            except (TypeError, ValueError):
+                continue
+        per_firm[name] = raised
+    return per_firm, {k: dict(v) for k, v in per_firm_year.items()}
+
+
+def item_2_per_firm_leverage_by_branch(
+    sbir_firms: dict[str, dict[str, Any]],
+    fd_firms: dict[str, float],
+    min_n_firms: int = 10,
+) -> list[dict[str, Any]]:
+    """Per-firm leverage (Form D $ / firm DoD SBIR $) aggregated by Branch.
+
+    For each firm matched in Form D with at least some DoD SBIR in
+    window, compute the firm's per-firm leverage ratio using its OWN
+    DoD-side SBIR $ as denominator. Aggregate by dominant Branch with
+    count, mean, median, and 25th/75th percentiles.
+    """
+    firm_ratios_by_branch: dict[str, list[float]] = defaultdict(list)
+    firm_count_with_fd_by_branch: dict[str, int] = defaultdict(int)
+
+    for name, raised in fd_firms.items():
+        sbir = sbir_firms.get(name)
+        if not sbir or sbir["dod_dollars"] <= 0:
+            continue
+        branch = sbir["dominant_dod_branch"]
+        if branch is None:
+            continue
+        # Per-firm leverage uses the firm's TOTAL DoD SBIR (across branches),
+        # since the Form D total isn't branch-attributed.
+        ratio = raised / sbir["dod_dollars"]
+        firm_ratios_by_branch[branch].append(ratio)
+        if raised > 0:
+            firm_count_with_fd_by_branch[branch] += 1
+
+    out = []
+    for branch, ratios in firm_ratios_by_branch.items():
+        if len(ratios) < min_n_firms:
+            continue
+        arr = np.array(ratios)
+        out.append(
+            {
+                "branch": branch,
+                "n_firms": len(ratios),
+                "n_with_form_d_raise": firm_count_with_fd_by_branch[branch],
+                "mean_per_firm_leverage": float(arr.mean()),
+                "median_per_firm_leverage": float(np.median(arr)),
+                "p25_per_firm_leverage": float(np.percentile(arr, 25)),
+                "p75_per_firm_leverage": float(np.percentile(arr, 75)),
+            }
+        )
+    out.sort(key=lambda r: -r["n_firms"])
+    return out
+
+
+def item_3_time_series_branch_ratios(
+    sbir_firms: dict[str, dict[str, Any]],
+    fd_per_firm_year: dict[str, dict[int, float]],
+    program_by_branch_year: dict[tuple[str, int], float],
+    year_min: int,
+    year_max: int,
+    min_program_usd: float = 100e6,
+) -> dict[str, list[dict[str, Any]]]:
+    """Per-(Branch, Year) program-level ratios for major branches.
+
+    Numerator: sum across firms whose dominant DoD Branch is X, of their
+    Form D raises in year Y.
+    Denominator: total DoD SBIR program $ in Branch X in year Y.
+    """
+    # Total program $ per branch across all years — for filtering
+    branch_totals: dict[str, float] = defaultdict(float)
+    for (b, y), v in program_by_branch_year.items():
+        branch_totals[b] += v
+    major_branches = {b for b, t in branch_totals.items() if t >= min_program_usd}
+
+    # Build per-(branch, year) numerator from Form D
+    fd_by_branch_year: dict[tuple[str, int], float] = defaultdict(float)
+    for name, year_dict in fd_per_firm_year.items():
+        sbir = sbir_firms.get(name)
+        if not sbir or sbir["dominant_dod_branch"] not in major_branches:
+            continue
+        branch = sbir["dominant_dod_branch"]
+        for year, amt in year_dict.items():
+            fd_by_branch_year[(branch, year)] += amt
+
+    out: dict[str, list[dict[str, Any]]] = {}
+    for branch in sorted(major_branches, key=lambda b: -branch_totals[b]):
+        rows = []
+        for year in range(year_min, year_max + 1):
+            program = program_by_branch_year.get((branch, year), 0.0)
+            fd = fd_by_branch_year.get((branch, year), 0.0)
+            ratio = (fd / program) if program > 0 else 0.0
+            rows.append(
+                {
+                    "year": year,
+                    "program_usd": program,
+                    "form_d_usd": fd,
+                    "ratio": ratio,
+                }
+            )
+        out[branch] = rows
+    return out
+
+
+def item_4_navy_acquirer_analysis(
+    sbir_firms: dict[str, dict[str, Any]],
+    ma_events_path: Path,
+    target_branches: list[str] = None,
+) -> dict[str, Any]:
+    """Classify acquirers of SBIR firms with the given dominant DoD Branch.
+
+    Default: ['Navy', 'Air Force'] for Navy-vs-Air-Force comparison
+    (Air Force as a control, since it has very different Form D /
+    leverage characteristics).
+    """
+    if target_branches is None:
+        target_branches = ["Navy", "Air Force"]
+    firms_by_branch: dict[str, set[str]] = {
+        b: {name for name, e in sbir_firms.items() if e.get("dominant_dod_branch") == b}
+        for b in target_branches
+    }
+
+    results: dict[str, Any] = {}
+    for branch in target_branches:
+        branch_firms = firms_by_branch[branch]
+        type_counts: Counter[str] = Counter()
+        type_acquirers: dict[str, list[str]] = defaultdict(list)
+        n_events = 0
+        n_unique_firms_with_acquirer = set()
+
+        for line in open(ma_events_path):
+            try:
+                r = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = _norm_name(r.get("company_name"))
+            if name not in branch_firms:
+                continue
+            n_events += 1
+            acq = r.get("acquirer")
+            if not acq:
+                continue
+            n_unique_firms_with_acquirer.add(name)
+            kind = classify_acquirer(acq)
+            type_counts[kind] += 1
+            type_acquirers[kind].append(acq)
+
+        # Most common acquirers per type (for spot-checking the classification)
+        top_acquirers = {
+            kind: Counter(acqs).most_common(5) for kind, acqs in type_acquirers.items()
+        }
+
+        total_classified = sum(type_counts.values())
+        results[branch] = {
+            "n_branch_firms": len(branch_firms),
+            "n_ma_events": n_events,
+            "n_unique_firms_with_named_acquirer": len(n_unique_firms_with_acquirer),
+            "type_counts": dict(type_counts),
+            "type_pct": {
+                k: (v / total_classified * 100) if total_classified > 0 else 0.0
+                for k, v in type_counts.items()
+            },
+            "top_acquirers_by_type": {
+                k: [{"acquirer": a, "n": n} for a, n in v]
+                for k, v in top_acquirers.items()
+            },
+        }
+    return results
+
+
+def write_markdown(snapshot: dict[str, Any], path: Path) -> None:
+    L = []
+    L.append("# DoD Form D leverage — deferred follow-ups from PR #342")
+    L.append("")
+    L.append(f"Year window: {snapshot['year_min']}-{snapshot['year_max']}")
+    L.append("")
+
+    L.append("## Item 2 — Per-firm leverage by Branch")
+    L.append("")
+    L.append("Per-firm leverage = each high-tier matched firm's Form D $ divided by its OWN DoD SBIR $. Aggregates by dominant Branch. Resolves the multi-agency methodology caveat in Decomposition 4 of PR #342.")
+    L.append("")
+    L.append("| Branch | Firms | With Form D | Mean | Median | P25 | P75 |")
+    L.append("|---|---|---|---|---|---|---|")
+    for r in snapshot["item_2_per_firm_leverage"]:
+        L.append(
+            f"| {r['branch']} | {r['n_firms']} | {r['n_with_form_d_raise']} | "
+            f"{r['mean_per_firm_leverage']:.2f}x | {r['median_per_firm_leverage']:.2f}x | "
+            f"{r['p25_per_firm_leverage']:.2f}x | {r['p75_per_firm_leverage']:.2f}x |"
+        )
+    L.append("")
+    L.append("**Note on median vs mean.** Per-firm leverage distributions are heavily right-skewed (a handful of large-raise outliers per Branch). Median is the more representative central tendency; mean is sensitive to the top few firms.")
+    L.append("")
+
+    L.append("## Item 3 — Time-series Branch ratios")
+    L.append("")
+    L.append("Per-(Branch, Year) program-level ratio = sum of Form D $ from firms whose dominant Branch is X in year Y, divided by total DoD SBIR program $ in Branch X in year Y. Tests whether Branch-level leverage trends are stable or emerging.")
+    L.append("")
+    for branch in snapshot["item_3_time_series"]:
+        L.append(f"### {branch}")
+        L.append("")
+        L.append("| Year | Program $M | Form D $M | Ratio |")
+        L.append("|---|---|---|---|")
+        rows = snapshot["item_3_time_series"][branch]
+        for r in rows:
+            if r["program_usd"] > 0:
+                L.append(
+                    f"| {r['year']} | {r['program_usd']/1e6:.0f} | {r['form_d_usd']/1e6:.0f} | "
+                    f"{r['ratio']:.3f}x |"
+                )
+        # Compute trend
+        ratios = [r["ratio"] for r in rows if r["program_usd"] > 0]
+        if len(ratios) >= 5:
+            early = sum(ratios[:5]) / 5
+            late = sum(ratios[-5:]) / 5
+            if late > early * 1.5:
+                trend = f"**Increasing**: 5-yr early avg {early:.2f}x → 5-yr late avg {late:.2f}x"
+            elif late < early * 0.67:
+                trend = f"**Decreasing**: 5-yr early avg {early:.2f}x → 5-yr late avg {late:.2f}x"
+            else:
+                trend = f"Stable: 5-yr early avg {early:.2f}x, 5-yr late avg {late:.2f}x"
+            L.append("")
+            L.append(trend)
+        L.append("")
+
+    L.append("## Item 4 — Navy acquirer-type analysis (Air Force as control)")
+    L.append("")
+    L.append("Classifies acquirers of M&A-event SBIR firms into three types using substring matching against canonical name patterns: **defense_prime** (Lockheed, Northrop, L3Harris, Leidos, CACI, Kratos, etc.), **financial_sponsor** (Capital, Partners, BDC, Fund, Holdings, etc.), and **commercial** (everything else). Tests whether Navy's higher M&A-than-Form-D pattern is driven by defense-prime acquisition specifically.")
+    L.append("")
+    for branch, r in snapshot["item_4_navy_acquirers"].items():
+        L.append(f"### {branch}")
+        L.append(f"- Branch firms (dominant {branch}): {r['n_branch_firms']:,}")
+        L.append(f"- M&A events for these firms: {r['n_ma_events']:,}")
+        L.append(f"- Events with named acquirer: {r['n_unique_firms_with_named_acquirer']:,}")
+        L.append("")
+        L.append("| Acquirer type | Count | Share |")
+        L.append("|---|---|---|")
+        for kind in ("defense_prime", "commercial", "financial_sponsor", "unknown"):
+            n = r["type_counts"].get(kind, 0)
+            pct = r["type_pct"].get(kind, 0.0)
+            L.append(f"| {kind} | {n} | {pct:.1f}% |")
+        L.append("")
+        for kind in ("defense_prime", "commercial", "financial_sponsor"):
+            top = r["top_acquirers_by_type"].get(kind, [])
+            if top:
+                L.append(f"**Top {kind} acquirers:**")
+                for entry in top:
+                    L.append(f"- {entry['n']} × {entry['acquirer']}")
+                L.append("")
+
+    # Interpretation
+    L.append("## Interpretation")
+    L.append("")
+    L.append("See companion findings doc `docs/research/dod-form-d-followup-findings.md` for the narrative analysis tying these three items back to PR #342's deferred items.")
+    L.append("")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        f.write("\n".join(L) + "\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--form-d-path", type=Path, default=Path("data/form_d_details.jsonl"))
+    parser.add_argument("--sbir-path", type=Path, default=Path("data/raw/sbir/award_data.csv"))
+    parser.add_argument("--ma-events-path", type=Path, default=Path("data/sbir_ma_events.jsonl"))
+    parser.add_argument("--year-min", type=int, default=YEAR_MIN)
+    parser.add_argument("--year-max", type=int, default=YEAR_MAX)
+    parser.add_argument("--output-json", type=Path, default=Path("reports/ml/dod_form_d_followups.json"))
+    parser.add_argument("--output-md", type=Path, default=Path("reports/ml/dod_form_d_followups.md"))
+    args = parser.parse_args()
+
+    for p in (args.form_d_path, args.sbir_path, args.ma_events_path):
+        if not p.exists():
+            print(f"ERROR: {p} not found", file=sys.stderr)
+            return 2
+
+    print("Loading data...", file=sys.stderr)
+    sbir_firms, program_by_branch_year = load_sbir_firm_index(
+        args.sbir_path, args.year_min, args.year_max
+    )
+    fd_per_firm, fd_per_firm_year = load_form_d_per_firm(
+        args.form_d_path, args.year_min, args.year_max
+    )
+
+    print("Item 2: per-firm leverage by Branch...", file=sys.stderr)
+    item_2 = item_2_per_firm_leverage_by_branch(sbir_firms, fd_per_firm)
+
+    print("Item 3: time-series Branch ratios...", file=sys.stderr)
+    item_3 = item_3_time_series_branch_ratios(
+        sbir_firms, fd_per_firm_year, program_by_branch_year, args.year_min, args.year_max
+    )
+
+    print("Item 4: Navy acquirer analysis...", file=sys.stderr)
+    item_4 = item_4_navy_acquirer_analysis(sbir_firms, args.ma_events_path)
+
+    snapshot = {
+        "schema_version": "1",
+        "year_min": args.year_min,
+        "year_max": args.year_max,
+        "item_2_per_firm_leverage": item_2,
+        "item_3_time_series": item_3,
+        "item_4_navy_acquirers": item_4,
+    }
+
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.output_json, "w") as f:
+        json.dump(snapshot, f, indent=2)
+    write_markdown(snapshot, args.output_md)
+
+    # Console summary
+    print("\n=== Item 2: Per-firm leverage by Branch (median) ===", file=sys.stderr)
+    for r in item_2:
+        print(f"  {r['branch'][:40]:<40} n={r['n_firms']:>4} median={r['median_per_firm_leverage']:6.2f}x  mean={r['mean_per_firm_leverage']:6.2f}x  P25-P75=[{r['p25_per_firm_leverage']:.2f}, {r['p75_per_firm_leverage']:.2f}]", file=sys.stderr)
+
+    print("\n=== Item 4: Navy vs Air Force acquirer mix ===", file=sys.stderr)
+    for b, r in item_4.items():
+        print(f"  {b}: defense_prime={r['type_pct'].get('defense_prime', 0):.1f}%  commercial={r['type_pct'].get('commercial', 0):.1f}%  financial={r['type_pct'].get('financial_sponsor', 0):.1f}%", file=sys.stderr)
+
+    print(f"\nWrote {args.output_json} and {args.output_md}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_dod_form_d_followups.py
+++ b/tests/unit/scripts/test_dod_form_d_followups.py
@@ -1,0 +1,326 @@
+"""Unit tests for scripts/data/dod_form_d_followups.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[3] / "scripts" / "data" / "dod_form_d_followups.py"
+)
+_spec = importlib.util.spec_from_file_location("dod_form_d_followups", SCRIPT_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["dod_form_d_followups"] = _mod
+_spec.loader.exec_module(_mod)
+
+
+# ---------------------------------------------------------------------------
+# classify_acquirer: the new function compared to other scripts
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyAcquirer:
+    """Classification heuristic for M&A acquirers — the function whose
+    accuracy directly determines whether PR #342's "Navy commercializes
+    via defense-prime acquisition" hypothesis is confirmed or refuted."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "LOCKHEED MARTIN CORP",
+            "Northrop Grumman Corporation",
+            "RAYTHEON TECHNOLOGIES CORP",
+            "L3 TECHNOLOGIES, INC.",
+            "L3Harris Technologies, Inc.",
+            "KRATOS DEFENSE & SECURITY SOLUTIONS, INC.",
+            "Mercury Systems Inc.",
+            "TELEDYNE TECHNOLOGIES INC",
+            "Leidos Holdings, Inc.",
+            "CACI INTERNATIONAL INC /DE/",
+            "KBR, INC.",  # was previously misclassified due to "KBR " trailing space
+            "Booz Allen Hamilton",
+            "BAE Systems plc",
+            "Boeing Company",
+            "Huntington Ingalls Industries",
+        ],
+    )
+    def test_classifies_known_defense_primes(self, name):
+        assert _mod.classify_acquirer(name) == "defense_prime"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Golub Capital BDC 3, Inc.",
+            "Hercules Capital, Inc.",
+            "Horizon Technology Finance Corp",
+            "Churchill Capital Corp X/Cayman",
+            "HCM II Acquisition Corp.",
+            "Shell Midstream Partners, L.P.",
+            "PennantPark Floating Rate Capital Ltd.",
+        ],
+    )
+    def test_classifies_known_financial_sponsors(self, name):
+        assert _mod.classify_acquirer(name) == "financial_sponsor"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Arrayit Corp",
+            "Riot Blockchain, Inc.",
+            "Continental Cement Company, L.L.C.",
+            "META MATERIALS INC.",
+            "BRUKER CORP",
+            "Redwire Corp",
+            "WiderThan Co., Ltd.",
+            "Wayside Technology Group, Inc.",
+            "Ortho Clinical Diagnostics Holdings plc",  # WAS misclassified as financial in v1
+            "Alarm.com Holdings, Inc.",  # WAS misclassified as financial in v1
+            "SUPERIOR CONSULTANT HOLDINGS CORP",  # WAS misclassified as financial in v1
+        ],
+    )
+    def test_classifies_commercial(self, name):
+        """These are real commercial operating companies; some have
+        'Holdings' in their name which the v1 classifier wrongly
+        caught as financial_sponsor."""
+        assert _mod.classify_acquirer(name) == "commercial"
+
+    def test_none_returns_unknown(self):
+        assert _mod.classify_acquirer(None) == "unknown"
+        assert _mod.classify_acquirer("") == "unknown"
+
+    def test_kbr_word_boundary(self):
+        """KBR must match in real-world variants but not in spurious
+        substrings."""
+        assert _mod.classify_acquirer("KBR Inc.") == "defense_prime"
+        assert _mod.classify_acquirer("KBR, INC.") == "defense_prime"
+        assert _mod.classify_acquirer("KBR-Wyle") == "defense_prime"
+        # No false-positive on substrings that happen to contain "KBR"
+        assert _mod.classify_acquirer("SOMEKBRCO") != "defense_prime"
+
+
+# ---------------------------------------------------------------------------
+# load_sbir_firm_index — DoD-specific aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSbirFirmIndex:
+    @pytest.fixture
+    def csv_path(self, tmp_path):
+        rows = [
+            "Company,Award Year,Award Amount,Agency,Branch\n",
+            # AcmeAF: Air Force-dominant, $1M
+            "AcmeAF,2020,500000,Department of Defense,Air Force\n",
+            "AcmeAF,2021,500000,Department of Defense,Air Force\n",
+            # MultiAF: Multi-agency, AF dominant by $
+            "MultiAF,2020,500000,Department of Defense,Air Force\n",
+            "MultiAF,2021,200000,National Science Foundation,\n",
+            # NonDoD: HHS only
+            "NonDoD,2020,1000000,Department of Health and Human Services,\n",
+            # Out-of-window (excluded)
+            "AcmeAF,2005,999999,Department of Defense,Air Force\n",
+        ]
+        p = tmp_path / "awards.csv"
+        p.write_text("".join(rows))
+        return p
+
+    def test_dod_dollars_excludes_non_dod(self, csv_path):
+        firms, _ = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        # MultiAF: 500K DoD + 200K NSF → total 700K, dod_dollars 500K
+        assert firms["MULTIAF"]["total"] == 700000.0
+        assert firms["MULTIAF"]["dod_dollars"] == 500000.0
+
+    def test_non_dod_firm_has_no_branch(self, csv_path):
+        firms, _ = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        assert firms["NONDOD"]["dominant_dod_branch"] is None
+        assert firms["NONDOD"]["dod_dollars"] == 0.0
+
+    def test_program_by_branch_year(self, csv_path):
+        _, by_by = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        # 2020 Air Force: AcmeAF 500K + MultiAF 500K = 1M
+        assert by_by[("Air Force", 2020)] == 1_000_000.0
+        # 2021 Air Force: AcmeAF 500K = 500K
+        assert by_by[("Air Force", 2021)] == 500_000.0
+
+    def test_dollars_by_year_per_firm(self, csv_path):
+        firms, _ = _mod.load_sbir_firm_index(csv_path, 2009, 2024)
+        assert firms["ACMEAF"]["dod_dollars_by_year"][2020] == 500_000.0
+        assert firms["ACMEAF"]["dod_dollars_by_year"][2021] == 500_000.0
+
+
+# ---------------------------------------------------------------------------
+# item_2_per_firm_leverage_by_branch
+# ---------------------------------------------------------------------------
+
+
+class TestItem2PerFirmLeverage:
+    def _firms(self):
+        return {
+            "AF_1": {"dod_dollars": 100.0, "dominant_dod_branch": "Air Force"},
+            "AF_2": {"dod_dollars": 200.0, "dominant_dod_branch": "Air Force"},
+            "NAVY_1": {"dod_dollars": 50.0, "dominant_dod_branch": "Navy"},
+            "NON_DOD": {"dod_dollars": 0.0, "dominant_dod_branch": None},
+        }
+
+    def test_per_firm_ratios_aggregated_by_branch(self):
+        firms = self._firms()
+        # AF_1 raised 200 → 200/100 = 2.0x; AF_2 raised 1000 → 1000/200 = 5.0x
+        fd = {"AF_1": 200.0, "AF_2": 1000.0, "NAVY_1": 100.0, "NON_DOD": 9999.0}
+        out = _mod.item_2_per_firm_leverage_by_branch(firms, fd, min_n_firms=1)
+        by_branch = {r["branch"]: r for r in out}
+        # Air Force: 2.0 and 5.0 → median 3.5, mean 3.5
+        assert by_branch["Air Force"]["n_firms"] == 2
+        assert by_branch["Air Force"]["median_per_firm_leverage"] == pytest.approx(3.5)
+        assert by_branch["Air Force"]["mean_per_firm_leverage"] == pytest.approx(3.5)
+        # Navy: 100/50 = 2.0x
+        assert by_branch["Navy"]["median_per_firm_leverage"] == pytest.approx(2.0)
+
+    def test_skips_non_dod_firms(self):
+        firms = self._firms()
+        fd = {"AF_1": 100.0, "NON_DOD": 99999.0}
+        out = _mod.item_2_per_firm_leverage_by_branch(firms, fd, min_n_firms=1)
+        # NON_DOD has no DoD branch → must not contribute
+        assert sum(r["n_firms"] for r in out) == 1
+
+    def test_skips_firms_with_zero_dod_dollars(self):
+        firms = {"X": {"dod_dollars": 0.0, "dominant_dod_branch": "Air Force"}}
+        fd = {"X": 1000.0}
+        out = _mod.item_2_per_firm_leverage_by_branch(firms, fd, min_n_firms=1)
+        assert out == []  # would be div-by-zero, must be skipped
+
+    def test_min_n_firms_filter(self):
+        firms = self._firms()
+        fd = {"AF_1": 200.0, "AF_2": 1000.0, "NAVY_1": 100.0}
+        # min_n_firms=2 → Navy (n=1) should be excluded
+        out = _mod.item_2_per_firm_leverage_by_branch(firms, fd, min_n_firms=2)
+        branches = [r["branch"] for r in out]
+        assert "Navy" not in branches
+        assert "Air Force" in branches
+
+
+# ---------------------------------------------------------------------------
+# item_3_time_series_branch_ratios
+# ---------------------------------------------------------------------------
+
+
+class TestItem3TimeSeries:
+    def test_basic_time_series_aggregation(self):
+        firms = {
+            "F1": {"dominant_dod_branch": "Air Force"},
+            "F2": {"dominant_dod_branch": "Air Force"},
+        }
+        fd_per_firm_year = {
+            "F1": {2020: 100.0, 2021: 200.0},
+            "F2": {2020: 50.0},
+        }
+        program_by_branch_year = {
+            ("Air Force", 2020): 1000.0,
+            ("Air Force", 2021): 500.0,
+        }
+        out = _mod.item_3_time_series_branch_ratios(
+            firms, fd_per_firm_year, program_by_branch_year, 2019, 2022, min_program_usd=0
+        )
+        assert "Air Force" in out
+        rows = {r["year"]: r for r in out["Air Force"]}
+        # 2020: 150 FD / 1000 program = 0.15
+        assert rows[2020]["ratio"] == pytest.approx(0.15)
+        # 2021: 200 FD / 500 program = 0.40
+        assert rows[2021]["ratio"] == pytest.approx(0.40)
+        # 2019: no data → 0
+        assert rows[2019]["ratio"] == 0.0
+
+    def test_excludes_minor_branches_via_threshold(self):
+        firms = {"F1": {"dominant_dod_branch": "Tiny Branch"}}
+        fd_per_firm_year = {"F1": {2020: 100.0}}
+        program_by_branch_year = {("Tiny Branch", 2020): 50_000.0}  # only $50K
+        out = _mod.item_3_time_series_branch_ratios(
+            firms, fd_per_firm_year, program_by_branch_year, 2020, 2020, min_program_usd=100_000.0
+        )
+        assert out == {}
+
+
+# ---------------------------------------------------------------------------
+# item_4_navy_acquirer_analysis
+# ---------------------------------------------------------------------------
+
+
+class TestItem4NavyAcquirers:
+    @pytest.fixture
+    def ma_events_path(self, tmp_path):
+        records = [
+            # Navy firms
+            {"company_name": "NavyFirm1", "acquirer": "LOCKHEED MARTIN CORP", "event_date": "2020-01-01"},
+            {"company_name": "NavyFirm2", "acquirer": "Acme Commercial Inc.", "event_date": "2021-01-01"},
+            {"company_name": "NavyFirm3", "acquirer": "Golub Capital BDC", "event_date": "2022-01-01"},
+            # Air Force firms
+            {"company_name": "AfFirm1", "acquirer": "RAYTHEON TECHNOLOGIES CORP", "event_date": "2020-01-01"},
+            {"company_name": "AfFirm2", "acquirer": "Megacorp Industries", "event_date": "2021-01-01"},
+            # Firm not in any branch — should be ignored
+            {"company_name": "Stranger", "acquirer": "Whoever", "event_date": "2023-01-01"},
+            # Event with no acquirer — should not affect classified counts
+            {"company_name": "NavyFirm4", "acquirer": None, "event_date": "2020-01-01"},
+        ]
+        p = tmp_path / "ma.jsonl"
+        with open(p, "w") as f:
+            for r in records:
+                f.write(json.dumps(r) + "\n")
+        return p
+
+    def test_classifies_by_branch(self, ma_events_path):
+        firms = {
+            "NAVYFIRM1": {"dominant_dod_branch": "Navy"},
+            "NAVYFIRM2": {"dominant_dod_branch": "Navy"},
+            "NAVYFIRM3": {"dominant_dod_branch": "Navy"},
+            "NAVYFIRM4": {"dominant_dod_branch": "Navy"},
+            "AFFIRM1": {"dominant_dod_branch": "Air Force"},
+            "AFFIRM2": {"dominant_dod_branch": "Air Force"},
+        }
+        out = _mod.item_4_navy_acquirer_analysis(firms, ma_events_path)
+        # Navy: 4 events total, 3 with named acquirer (LM=defense, Acme=commercial, Golub=financial)
+        navy = out["Navy"]
+        assert navy["n_branch_firms"] == 4
+        assert navy["n_ma_events"] == 4
+        assert navy["n_unique_firms_with_named_acquirer"] == 3
+        assert navy["type_counts"]["defense_prime"] == 1
+        assert navy["type_counts"]["commercial"] == 1
+        assert navy["type_counts"]["financial_sponsor"] == 1
+        # Air Force: 2 events, both named (1 defense, 1 commercial)
+        af = out["Air Force"]
+        assert af["type_counts"]["defense_prime"] == 1
+        assert af["type_counts"]["commercial"] == 1
+
+    def test_handles_invalid_json_lines(self, tmp_path):
+        p = tmp_path / "broken.jsonl"
+        p.write_text(
+            '{"company_name":"NavyFirm","acquirer":"LOCKHEED MARTIN","event_date":"2020-01-01"}\n'
+            'not json\n'
+        )
+        firms = {"NAVYFIRM": {"dominant_dod_branch": "Navy"}}
+        out = _mod.item_4_navy_acquirer_analysis(firms, p)
+        # Should not crash; valid line should still be processed
+        assert out["Navy"]["type_counts"]["defense_prime"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Top-level helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseAmount:
+    def test_dollar_and_comma_stripped(self):
+        assert _mod._parse_amount("$1,234,567") == 1234567.0
+
+    def test_none(self):
+        assert _mod._parse_amount(None) is None
+
+
+class TestNormName:
+    def test_uppercase_strip(self):
+        assert _mod._norm_name("  Acme Corp  ") == "ACME CORP"
+
+    def test_none(self):
+        assert _mod._norm_name(None) == ""


### PR DESCRIPTION
## Summary

Resolves three of four computational follow-ups deferred by **PR #342** (DoD Branch decomposition). The FPDS substitution test (item 1) requires fresh USAspending pulls and remains separate-PR scope.

### Three findings, two of them revising PR #342's framing

**Item 2 — Per-firm leverage is far MORE uniform across branches than program-level ratios.**

| Branch | Firms | Median per-firm leverage | Mean |
|---|---|---|---|
| Army | 140 | 7.34x | 47.7x |
| Air Force | 659 | 6.79x | 167.7x |
| DARPA | 81 | 6.55x | 28.6x |
| DHA | 50 | 4.70x | 37.2x |
| Navy | 98 | 4.12x | 77.3x |
| MDA | 22 | **1.24x** | 47.7x |

The dramatic Branch heterogeneity in PR #342's program-level ratios (Air Force 2.12x vs Navy 0.41x) is dominated by **participation rate** differences, not per-firm raise size. MDA is the only large-cohort branch where per-firm leverage is genuinely low. **Resolves the multi-agency methodology caveat in PR #342's Decomposition 4.**

**Item 3 — Air Force's high leverage is RECENT, not structural.**

- Air Force 5-yr early avg (2009-2013): **0.42x**
- Air Force 5-yr late avg (2020-2024): **3.29x** — an 8× jump
- The inflection lines up with **AFWERX** launch (March 2017)
- Pre-AFWERX (2009-2016) Air Force ratio: 0.78x — actually *below* the DoD aggregate
- Navy: flat across the window (5-yr early 0.40x, 5-yr late 0.41x)
- MDA: structurally low; recent years even lower than early years

The Air Force 2.118x headline in PR #342 is heavily weighted by post-2017 activity. It's not a stable Air Force characteristic — it's an AFWERX-era phenomenon.

**Item 4 — The "Navy commercializes via defense-prime acquisition" hypothesis is WRONG.**

| Branch | defense_prime | commercial | financial_sponsor |
|---|---|---|---|
| Navy | **6.9%** | **88.5%** | 4.6% |
| Air Force (control) | 5.7% | 83.9% | 10.4% |

Navy SBIR firms that exit via M&A are predominantly acquired by **commercial buyers**, not by defense primes (Lockheed/Northrop/L3Harris/Leidos/Kratos/Mercury/Teledyne). Air Force shows a near-identical mix. **The acquirer-type composition does NOT distinguish Navy from Air Force.** Whatever drives Navy's higher M&A-than-Form-D pattern from PR #342, it isn't the type of acquirer.

### Open Navy questions (the deeper finding)

The PR #342 mechanism hypothesis fails, which actually deepens the Navy puzzle rather than resolving it. Three candidate explanations remain on the table:

1. **Earlier exits** — Navy SBIR firms may exit before reaching Form D filing scale
2. **Different industry mix** — Navy SBIR may concentrate in industries where exits dominate over VC scaling
3. **Smaller commercial-tech footprint per firm** — Navy firm structure may not support standalone scaling, so acquisition is the default exit

Each requires different follow-up evidence to test.

### What's in the PR

- **`scripts/data/dod_form_d_followups.py`** — self-contained script with all three decompositions, ~3s runtime, numpy only
- **`docs/research/dod-form-d-followup-findings.md`** — findings narrative with the three revised framings, time-series interpretation, and discussion of remaining Navy questions
- **`tests/unit/scripts/test_dod_form_d_followups.py`** — **51 unit tests** including 33 parametrized acquirer-classifier cases that lock in the v2 classifier's correct handling of "Holdings" false positives (Ortho Clinical Diagnostics Holdings, Alarm.com Holdings) and KBR word-boundary matching

### Acquirer classifier improvements (v1 → v2)

The classifier was iterated during development:

- **Defense-prime short acronyms** (KBR, HII, SAIC, BAE, L3, CACI) now use **word-boundary regex** matching. Catches "KBR, INC." and "KBR-Wyle" which the v1 substring "KBR " (trailing space) missed
- Removed **"HOLDINGS"** alone from financial_sponsor patterns — too many false positives on real operating companies. Now only narrow markers (Capital, Partners, BDC, SPAC, Acquisition Corp, etc.) plus specific named investment vehicles (Hercules Capital, Golub Capital, etc.)

Tests lock in both fixes so future maintenance can't regress them.

### Reads after PR #342 lands

This PR's findings doc references PR #342's findings doc and the bootstrap doc (PR #338). For a reader landing here cold, the read order is:
1. `docs/research/sbir-form-d-fundraising-analysis.md` (published headline)
2. `docs/research/form-d-leverage-bootstrap-findings.md` (PR #338 — bootstrap CIs)
3. `docs/research/dod-form-d-leverage-deep-dive.md` (PR #342 — Branch decomposition)
4. This PR's `dod-form-d-followup-findings.md` (closes 3 of 4 PR #342 deferred items)

## Test plan

- [x] 51/51 unit tests pass in <3s
- [x] Acquirer classifier validated against the actual Navy + Air Force top-acquirer lists (no false positives in the sampled top names)
- [x] Script reproduces all findings in the doc exactly
- [x] No new dependencies (numpy only)
- [ ] Spot-check: pick one defense_prime classification (e.g. KBR) + one commercial classification (e.g. Ortho Clinical) and confirm against the underlying SEC filings

🤖 Generated with [Claude Code](https://claude.com/claude-code)