### PR TITLE
docs(research-questions): add Last reviewed footer with audit guidance

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -301,7 +301,7 @@ Public studies the inventory draws from or benchmarks against.
 
 ## Maintenance
 
-**Last reviewed:** 2026-06-21 — staleness audit verified all PR refs, branch tags, spec/doc links, and architectural notes against current `main`. Three corrections shipped via PR #335 (F3 supersession by #321, E4 spec landed via #277, A4 M&A pipeline architecture note). One follow-on (PR #341) updated the published Form D fundraising doc with bootstrap CIs and PIF cross-link audit findings.
+**Last reviewed:** 2026-06-21 — staleness audit verified all PR refs, branch tags, spec/doc links, and architectural notes against current `main`. Three corrections shipped via PR #335 (F3 supersession by #321, E4 spec landed via #277, A4 M&A pipeline architecture note). A follow-on PR #341 (currently open) proposes updating the published Form D fundraising doc with bootstrap CIs and PIF cross-link audit findings.
 
 When this doc is reviewed next, the audit should cover:
 

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -297,3 +297,19 @@ Public studies the inventory draws from or benchmarks against.
 - **[L24]** Kortum, S. & Lerner, J. (2000). "Assessing the Contribution of Venture Capital to Innovation." *RAND Journal of Economics* 31(4), 674–692. Foundational study estimating VC's marginal contribution to patenting; reference point for SBIR-vs-VC innovation comparisons. <https://www.jstor.org/stable/2696354>
 - **[L25]** National Venture Capital Association. *NVCA Yearbook* (annual). Industry-standard benchmarks for VC fundraising, deployment, deal stage/size, and exit activity used as the non-SBIR cohort for capital-formation comparisons. <https://nvca.org/research/nvca-yearbook/>
 
+---
+
+## Maintenance
+
+**Last reviewed:** 2026-06-21 — staleness audit verified all PR refs, branch tags, spec/doc links, and architectural notes against current `main`. Three corrections shipped via PR #335 (F3 supersession by #321, E4 spec landed via #277, A4 M&A pipeline architecture note). One follow-on (PR #341) updated the published Form D fundraising doc with bootstrap CIs and PIF cross-link audit findings.
+
+When this doc is reviewed next, the audit should cover:
+
+- All `*(PR #...)*` references resolve to merged or otherwise tracked PRs (closed-without-merge PRs need explicit successor links — PR #311 → #321 was the prior failure mode)
+- All `*(branch: ...)*` tags point at branches that still exist on origin (`claude/sbir-data-imputation-strategy` was the prior failure mode — branch deleted, work landed under a different name)
+- Internal links to `../specs/` and `docs/` directories resolve
+- Each "deps:" tag accurately reflects current pipeline structure (M&A signals are script-driven, not orchestrated — flagged in the A4 implementation note)
+- Coverage gaps: cross-reference recent merged feature PRs against the question inventory to surface work not yet documented here
+
+Update this footer with the new review date when the audit completes.
+


### PR DESCRIPTION
## Summary

Adds a Maintenance section at the end of `docs/research-questions.md` that:

1. **Timestamps the last audit** ("Last reviewed: 2026-06-21") — closes the gap flagged in the recent staleness-audit findings where readers couldn't tell when the doc had been vetted last.

2. **Lists the specific failure modes the next audit should check**, with concrete prior examples:
   - PR refs that resolve to merged/tracked PRs (PR #311 → #321 supersession was the prior failure)
   - Branch tags pointing at branches that still exist (`claude/sbir-data-imputation-strategy` was the prior failure — branch deleted, work landed under a different name)
   - Internal `../specs/` and `docs/` link resolution
   - Architectural facts in deps tags (M&A is script-driven, not orchestrated — was a coverage gap fixed in #335)
   - Coverage gaps from recent merged feature PRs

The intent is that future audits inherit explicit context about what went wrong before, rather than rediscovering the same gaps from scratch. Net diff: +16 lines.

## Test plan

- [x] Diff applies cleanly against current main
- [ ] Spot-check: the cited PR numbers (#277, #311, #321, #335, #341) all resolve to real merged/closed PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)