### PR TITLE
fix(ci): correct CET smoke-test imports and format leverage CI test

### DIFF
--- a/scripts/ci/cet_smoke_test.py
+++ b/scripts/ci/cet_smoke_test.py
@@ -2,8 +2,8 @@
 """CET smoke test - validates constraints, nodes, enrichments, relationships, and assertions."""
 
 import os
-from sbir_graph.loaders.neo4j_client import Neo4jClient, Neo4jConfig
-from sbir_graph.loaders.cet_loader import CETLoader, CETLoaderConfig
+from sbir_graph.loaders.neo4j.client import Neo4jClient, Neo4jConfig
+from sbir_graph.loaders.neo4j.cet import CETLoader, CETLoaderConfig
 
 
 def main():

--- a/tests/unit/scripts/test_bootstrap_form_d_leverage_ci.py
+++ b/tests/unit/scripts/test_bootstrap_form_d_leverage_ci.py
@@ -114,7 +114,9 @@ class TestBootstrapTwoViews:
         raised = np.array([100.0, 200.0, 300.0])
         sbir = np.array([10.0, 20.0, 30.0])
         rng = np.random.default_rng(42)
-        result = _mod.bootstrap_two_views(raised, sbir, program_denominator=1000.0, n_iter=100, rng=rng)
+        result = _mod.bootstrap_two_views(
+            raised, sbir, program_denominator=1000.0, n_iter=100, rng=rng
+        )
         # 600 / 60 = 10.0
         assert result["per_matched_firm"]["point_estimate"] == pytest.approx(10.0)
 
@@ -162,7 +164,9 @@ class TestBootstrapTwoViews:
         raised = np.array([], dtype=float)
         sbir = np.array([], dtype=float)
         rng = np.random.default_rng(42)
-        result = _mod.bootstrap_two_views(raised, sbir, program_denominator=100.0, n_iter=10, rng=rng)
+        result = _mod.bootstrap_two_views(
+            raised, sbir, program_denominator=100.0, n_iter=10, rng=rng
+        )
         assert result["n_firms"] == 0
         assert result["program_level"]["point_estimate"] == 0.0
         assert result["per_matched_firm"]["point_estimate"] == 0.0
@@ -184,10 +188,34 @@ class TestBootstrapTwoViews:
 class TestCohortArrays:
     def _make_cohort(self):
         return [
-            {"name": "A", "tier": "high", "raised": 100.0, "award_total": 10.0, "has_sbir_in_window": True},
-            {"name": "B", "tier": "high", "raised": 200.0, "award_total": 0.0, "has_sbir_in_window": False},
-            {"name": "C", "tier": "medium", "raised": 300.0, "award_total": 30.0, "has_sbir_in_window": True},
-            {"name": "D", "tier": "low", "raised": 400.0, "award_total": 40.0, "has_sbir_in_window": True},
+            {
+                "name": "A",
+                "tier": "high",
+                "raised": 100.0,
+                "award_total": 10.0,
+                "has_sbir_in_window": True,
+            },
+            {
+                "name": "B",
+                "tier": "high",
+                "raised": 200.0,
+                "award_total": 0.0,
+                "has_sbir_in_window": False,
+            },
+            {
+                "name": "C",
+                "tier": "medium",
+                "raised": 300.0,
+                "award_total": 30.0,
+                "has_sbir_in_window": True,
+            },
+            {
+                "name": "D",
+                "tier": "low",
+                "raised": 400.0,
+                "award_total": 40.0,
+                "has_sbir_in_window": True,
+            },
         ]
 
     def test_tier_filter_high_only(self):
@@ -197,7 +225,9 @@ class TestCohortArrays:
         assert sorted(sbir.tolist()) == [0.0, 10.0]
 
     def test_tier_filter_high_plus_medium(self):
-        raised, sbir = _mod.cohort_arrays(self._make_cohort(), {"high", "medium"}, require_sbir=False)
+        raised, sbir = _mod.cohort_arrays(
+            self._make_cohort(), {"high", "medium"}, require_sbir=False
+        )
         # A, B, C. raised = [100, 200, 300]
         assert sorted(raised.tolist()) == [100.0, 200.0, 300.0]
 


### PR DESCRIPTION
## Summary

Two pre-existing, unrelated CI failures on `main`, fixed together because they were both surfaced by re-running CI on PR #326 (the tornado bump) against current main. Neither is caused by that dependency bump.

### 1. CET Smoke Test — stale imports (`scripts/ci/cet_smoke_test.py`)
The #325 source-layout migration moved the Neo4j loaders into a `neo4j/` subpackage, but the smoke test still imported the old paths:

```diff
-from sbir_graph.loaders.neo4j_client import Neo4jClient, Neo4jConfig
-from sbir_graph.loaders.cet_loader import CETLoader, CETLoaderConfig
+from sbir_graph.loaders.neo4j.client import Neo4jClient, Neo4jConfig
+from sbir_graph.loaders.neo4j.cet import CETLoader, CETLoaderConfig
```

This was masked until now: the job previously failed at `uv sync` (`No module named 'sbir_graph'`) before ever reaching these lines. #337 fixed the install (`install-dev-deps: true`), which advanced the job far enough to hit this second, deeper breakage. This PR is effectively the follow-on to #337.

### 2. Code Quality — unformatted test file
`tests/unit/scripts/test_bootstrap_form_d_leverage_ci.py` wasn't `ruff format`-clean, failing the Code Quality job. Reformatted — **line-wrapping only, no logic change**.

## Why bundle them
Both block the same goal (restoring green CI on main / unblocking #326), both are small, and both are out of scope for the Dependabot branch they surfaced on.

## Test plan
- [x] `ruff format --check` across all CI paths (`sbir_etl packages/.../{sbir_analytics,sbir_ml,sbir_graph} tests`) — clean (was "1 file would be reformatted")
- [x] `ruff check scripts/ci/cet_smoke_test.py` — clean
- [x] Corrected import path resolves to `sbir_graph/loaders/neo4j/client.py` (verified locally; only the optional `neo4j` runtime dep is absent locally — present in CI)
- [ ] CET Smoke Test job on a CET-touching run proceeds past imports into actual loader assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMakj3aBoK2yR5bth7qeza)_