### PR TITLE
fix(ci): assert CET smoke relationship on Organization, not Company

### DIFF
--- a/scripts/ci/cet_smoke_test.py
+++ b/scripts/ci/cet_smoke_test.py
@@ -107,9 +107,9 @@ def main():
         ).single()["c"]
         assert rel_count == 1, f"Expected 1 APPLICABLE_TO, found {rel_count}"
 
-        # Company -> CET relationship exists
+        # Organization -> CET relationship exists
         comp_rel_count = session.run(
-            "MATCH (:Company {uei:$uei})-[:SPECIALIZES_IN]->(:CETArea {cet_id:$cid}) RETURN count(*) AS c",
+            "MATCH (:Organization {uei:$uei})-[:SPECIALIZES_IN]->(:CETArea {cet_id:$cid}) RETURN count(*) AS c",
             uei="UEI-SMOKE",
             cid="artificial_intelligence",
         ).single()["c"]


### PR DESCRIPTION
## Summary

The third and final layer of post-#325 staleness in `scripts/ci/cet_smoke_test.py`. With the import-path fix (#346) now letting the smoke test run end-to-end for the first time, it got all the way to its **last assertion** and failed:

```
File ".../cet_smoke_test.py", line 116, in main
    assert comp_rel_count == 1, f"Expected 1 SPECIALIZES_IN, found {comp_rel_count}"
AssertionError: Expected 1 SPECIALIZES_IN, found 0
```

### Root cause
The loader creates the relationship on an **`Organization`** node:
- `sbir_graph/loaders/neo4j/cet.py:437` → `(o:Organization)-[:SPECIALIZES_IN {…}]`
- migrations 002/003 establish `Organization` as the canonical company label ("Add Organization deduplication indexes", "Merge existing duplicate organizations")

…but the smoke test's verification query still used the old `:Company` label:

```diff
-"MATCH (:Company {uei:$uei})-[:SPECIALIZES_IN]->(:CETArea {cet_id:$cid}) RETURN count(*) AS c",
+"MATCH (:Organization {uei:$uei})-[:SPECIALIZES_IN]->(:CETArea {cet_id:$cid}) RETURN count(*) AS c",
```

The relationship *was* created (the loader logged "Organization → CETArea relationships (type=SPECIALIZES_IN) … 1 created, 0 errors"); the stale `:Company` query just couldn't see it. Fix the query to match the loader (and migrations). Everything upstream in the smoke test already passed (constraints, indexes, CETArea/Award/Organization upserts, APPLICABLE_TO relationship, Award assertion).

## Verification
- Loader + migrations confirm `Organization` is the canonical label (`grep` in `loaders/neo4j/cet.py`).
- This was the only remaining `:Company` reference in the script.
- `ruff check` + `ruff format --check` clean.
- The full CI run on #326 reached this exact assertion as the sole smoke-test failure — every prior step succeeded — so this one-line fix should carry it to "CET smoke completed successfully."

## Context
Completes the #337 → #346 → this chain that re-established the CET Smoke Test after the #325 source-layout migration:
1. #337 — install the workspace package (`install-dev-deps: true`)
2. #346 — fix stale module import paths (`neo4j.client` / `neo4j.cet`)
3. **this** — fix the stale node label in the verification query (`Company` → `Organization`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMakj3aBoK2yR5bth7qeza)_