### PR TITLE
fix(ci): docs-only filter no longer matches code-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,20 +59,20 @@ jobs:
         id: detect
         uses: ./.github/actions/detect-changes
         with:
-          # docs-only uses every-file semantics — true only when EVERY changed
-          # file is a doc. Otherwise a mixed PR (code + docs) would skip CI.
+          # docs-only uses every-file semantics (predicate-quantifier: every) —
+          # true only when EVERY changed file matches the allow-list below.
+          # Otherwise a mixed PR (code + docs) would skip CI.
+          #
+          # Allow-list only — do NOT add `!**/*.py` / `!**/*.yaml` etc. Under
+          # dorny/paths-filter's `every` quantifier a negation pattern like
+          # `!**/*.yaml` matches any non-yaml file (including .py files),
+          # which made docs-only=true even for code-only PRs. PRs #340, #342,
+          # and #343 hit exactly that and skipped Code Quality, dropping
+          # unformatted Python files onto main.
           every-file-filters: |
             docs-only:
               - '**/*.md'
               - 'docs/**'
-              - '!**/*.py'
-              - '!**/*.yaml'
-              - '!**/*.yml'
-              - '!**/*.json'
-              - '!**/*.toml'
-              - '!**/*.lock'
-              - '!Makefile'
-              - '!.github/**'
           filters: |
             production:
               - 'sbir_etl/**'


### PR DESCRIPTION
## Summary

Root cause of why PRs #340, #342, #343 bypassed Code Quality (Lint + Type Check) and dropped unformatted Python files onto main — which I had to clean up across two follow-up PRs (#337, #339).

## The bug

The `docs-only` filter in `detect-changes` runs with `predicate-quantifier: every` and these patterns:

```yaml
docs-only:
  - '**/*.md'
  - 'docs/**'
  - '!**/*.py'
  - '!**/*.yaml'
  - '!**/*.yml'
  - '!**/*.json'
  - '!**/*.toml'
  - '!**/*.lock'
  - '!Makefile'
  - '!.github/**'
```

Under `every` semantics, dorny/paths-filter treats `!**/*.yaml` as **"matches any non-yaml file"** — including `.py` files. So a PR adding only `tests/unit/scripts/test_audit_form_d_pif_cross_links.py` matches `!**/*.yaml` (it's not yaml), satisfies the `every` quantifier, and trips `docs-only = true`. Code Quality + 10 other gated jobs then skip.

Confirmed in the Detect File Changes log on PR #340:

```
[added] tests/unit/scripts/test_audit_form_d_pif_cross_links.py
##[group]Filter docs-only = true
```

## The fix

Remove all negation patterns. Pure allow-list — `**/*.md` and `docs/**` — so `docs-only` is true iff EVERY changed file is literally a markdown file or under `docs/`. Anything else (including `.py` files in `tests/`) keeps it false, so all 11 gated jobs run.

## Test plan

- [x] YAML validates locally.
- [ ] CI on this PR: Code Quality / Verify Setup Script / Tests etc. all RUN (this PR touches `.github/workflows/ci.yml` — a non-doc file — so docs-only should evaluate false and gated jobs should fire).
- [ ] After merge: a doc-only PR (e.g. `docs/...` change) should still get most jobs skipped.

## Bonus context: #3 (E2E Tests) self-resolved

The E2E Tests fix in #339 was push-only and couldn't be verified on the PR itself. The post-#339 merge to main triggered the E2E job and it **passed** (`gh run view 27920173257 --jq '.jobs[] | select(.name=="E2E Tests (Docker Neo4j)")'` → `success`). So my `install-dev-deps: "true"` fix worked end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)