### PR TITLE
fix(ci): compute docs-only correctly so mixed PRs can't skip CI

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -8,22 +8,14 @@ inputs:
       Evaluated with default "some" semantics: a filter is true if at least
       one changed file matches the filter.
     required: true
-  every-file-filters:
-    description: |
-      YAML string of path filters evaluated with "every file matches" semantics
-      (dorny/paths-filter `predicate-quantifier: 'every'`). Currently only the
-      `docs-only` filter is wired through to a named output; add more outputs
-      below if you need to expose additional every-file filters.
-    required: false
-    default: ''
 
 outputs:
-  # Common outputs. `docs-only` is sourced from the every_filter step (run
-  # only when `every-file-filters` is non-empty) and falls back to 'false'
-  # so callers can always compare against a stable boolean string.
+  # `docs-only` is computed explicitly from the full changed-file list (see the
+  # "Compute docs-only" step) and falls back to 'false' so callers can always
+  # compare against a stable boolean string.
   docs-only:
-    description: Whether only documentation files changed (every-file semantics)
-    value: ${{ steps.every_filter.outputs.docs-only || 'false' }}
+    description: Whether only documentation files changed (every changed file is Markdown or under docs/)
+    value: ${{ steps.docs_only.outputs.docs-only || 'false' }}
   # CI-specific outputs (some-file semantics)
   performance:
     description: Whether performance-related files changed
@@ -58,11 +50,38 @@ runs:
       with:
         filters: ${{ inputs.filters }}
 
-    # Evaluate every-file-filters separately with predicate-quantifier='every'
-    # so e.g. `docs-only` is true only when EVERY changed file is a doc.
-    - if: inputs.every-file-filters != ''
-      uses: dorny/paths-filter@v4
-      id: every_filter
+    # Full list of changed files (JSON), used to compute docs-only.
+    - uses: dorny/paths-filter@v4
+      id: all_changes
       with:
-        filters: ${{ inputs.every-file-filters }}
-        predicate-quantifier: 'every'
+        list-files: json
+        filters: |
+          all:
+            - '**'
+
+    # Compute docs-only deterministically: true ONLY when every changed file is
+    # Markdown (anywhere) or lives under docs/. We deliberately do NOT use
+    # dorny's predicate-quantifier:'every' here — its semantics are "every
+    # pattern is matched by some file" (not "every file matches a pattern"), so
+    # a mixed PR like #350 (one doc + two .py files) was reported docs-only=true
+    # and skipped Code Quality, dropping unformatted Python onto main. An empty
+    # changed-file list yields false so CI is never skipped vacuously.
+    - name: Compute docs-only
+      id: docs_only
+      shell: bash
+      run: |
+        set -euo pipefail
+        files_json='${{ steps.all_changes.outputs.all_files }}'
+        [ -z "$files_json" ] && files_json='[]'
+        if [ "$(jq 'length' <<<"$files_json")" -eq 0 ]; then
+          echo "docs-only=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        docs_only=true
+        while IFS= read -r f; do
+          case "$f" in
+            docs/*|*.md) ;;             # under docs/, or Markdown anywhere
+            *) docs_only=false; break ;;
+          esac
+        done < <(jq -r '.[]' <<<"$files_json")
+        echo "docs-only=$docs_only" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,20 +58,11 @@ jobs:
         id: detect
         uses: ./.github/actions/detect-changes
         with:
-          # docs-only uses every-file semantics (predicate-quantifier: every) —
-          # true only when EVERY changed file matches the allow-list below.
-          # Otherwise a mixed PR (code + docs) would skip CI.
-          #
-          # Allow-list only — do NOT add `!**/*.py` / `!**/*.yaml` etc. Under
-          # dorny/paths-filter's `every` quantifier a negation pattern like
-          # `!**/*.yaml` matches any non-yaml file (including .py files),
-          # which made docs-only=true even for code-only PRs. PRs #340, #342,
-          # and #343 hit exactly that and skipped Code Quality, dropping
-          # unformatted Python files onto main.
-          every-file-filters: |
-            docs-only:
-              - '**/*.md'
-              - 'docs/**'
+          # docs-only (every changed file is Markdown or under docs/) is computed
+          # explicitly inside the action — see its "Compute docs-only" step. It
+          # intentionally does NOT use dorny's predicate-quantifier:'every',
+          # which is "every pattern matched by some file" rather than "every
+          # file is a doc" and silently let mixed code+docs PRs skip CI.
           filters: |
             production:
               - 'sbir_etl/**'


### PR DESCRIPTION
## The root cause behind the recurring "unformatted Python on main"

This fixes the systemic bug that produced #346, #354, and the breakage that was masked behind the entire #326 chase.

`detect-changes` derived `docs-only` from dorny/paths-filter with `predicate-quantifier: 'every'` over an allow-list (`['**/*.md', 'docs/**']`). That quantifier **does not** mean "every changed file is a doc." Per [dorny's docs](https://github.com/dorny/paths-filter), `every` makes a *file* match only if it matches *all* patterns — but the filter's boolean output is still "**some** file matched." So `docs-only` was true whenever *any* Markdown-under-`docs/` file changed, **regardless of how many `.py` files changed alongside it.**

### Proof (PR #350's detect-changes log)
```
Received 3 items
[added] docs/research/dod-fpds-substitution-test-findings.md
[added] scripts/data/dod_fpds_substitution_test.py
[added] tests/unit/scripts/test_dod_fpds_substitution_test.py
...
Filter docs-only = true
Matching files:
  docs/research/dod-fpds-substitution-test-findings.md [added]
```
→ `docs-only=true` ⇒ every code job (Code Quality, Tests, MyPy, …) `skipped` via `docs-only != 'true'` ⇒ an unformatted test file landed on `main` ⇒ it then failed Code Quality on the next unrelated PR (#354). The prior allow-list was itself a failed attempt to fix the same class of bug (the maintainer's earlier negation-under-`every` attempt, noted in the old config comment re: #340/#342/#343).

## The fix
Compute `docs-only` **deterministically** from the full changed-file list (`dorny/paths-filter` with `list-files: json` + a small bash step), instead of relying on dorny's confusing quantifier:
- `docs-only=true` **only** when *every* changed file is Markdown (anywhere) or under `docs/`
- empty changed-file list ⇒ `false` (never skip CI vacuously)
- removes the now-unused `every-file-filters` action input and its ci.yml block

The `docs-only` output name is unchanged, so all 9 `docs-only != 'true'` gates keep working.

## Verification
Logic tested locally against representative inputs (all pass):

| changed files | docs-only |
|---|---|
| `#350`: 1 `.md` + 2 `.py` | **false** ✅ (was wrongly true) |
| pure docs (`docs/*.md`, `README.md`) | true ✅ |
| Markdown anywhere (`packages/foo/CHANGELOG.md`) | true ✅ |
| code only (`sbir_etl/foo.py`) | false ✅ |
| `docs/a.md` + `.github/workflows/ci.yml` | false ✅ |
| empty list | false ✅ |

Both files are valid YAML; the `Validate GitHub Actions Workflows` CI job will lint further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RMakj3aBoK2yR5bth7qeza)_