### PR TITLE
Add operational data caveats to docs

### DIFF
--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -7,6 +7,9 @@ Status: active
 
 # Data Sources Overview
 
+> **Operational data caveat.** No SBIR/STTR award data is committed to this repository. Commands and scripts referenced in this section can support local development once you provide `.env` values and small/local inputs, but full dataset reproduction requires downloading the source/bulk datasets yourself, supplying API credentials, and running supporting services such as Neo4j; reproducing the analyses end-to-end is non-trivial.
+
+
 This section provides comprehensive documentation for all data sources used in the SBIR Analytics pipeline.
 
 ## Primary Data Sources

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -7,6 +7,9 @@ Status: active
 
 # Deployment Documentation
 
+> **Operational data caveat.** No SBIR/STTR award data is committed to this repository. Local-development commands in these docs are intended to bring up services, run tests, or exercise pipeline components against small/local inputs after you provide `.env` values. Full dataset reproduction requires downloading the source/bulk datasets yourself, supplying the relevant API credentials, and running supporting services such as Neo4j; reproducing the analyses end-to-end is non-trivial setup, not a one-command deployment.
+
+
 This directory contains deployment documentation for the SBIR ETL project.
 
 ## Deployment Overview

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,5 +1,8 @@
 # Getting Started
 
+> **Operational data caveat.** No SBIR/STTR award data is committed to this repository. The setup commands below install dependencies and start local development services; they do not recreate the full research dataset by themselves. Full dataset reproduction requires downloading source/bulk data, adding your own API credentials to `.env`, and running supporting services such as Neo4j, so reproducing the analyses end-to-end is non-trivial.
+
+
 Quick setup guides for the SBIR ETL pipeline.
 
 ## Local Development

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,5 +1,8 @@
 # Testing Guide
 
+> **Operational data caveat.** No SBIR/STTR award data is committed to this repository. The quick-start and unit-test commands below are for local development and should run against fixtures, mocks, or small local inputs. Integration, E2E, and full dataset reproduction require your own source/bulk data downloads, API credentials, and local services such as Neo4j; reproducing the complete analyses end-to-end is non-trivial.
+
+
 Testing strategy and commands for the SBIR ETL pipeline.
 
 ## Quick Start


### PR DESCRIPTION
### Motivation
- Clarify repository expectations near the top of key operational docs so users understand that no award data is committed and full reproduction requires extra setup. 
- Distinguish commands that work for local development from those that are intended for full dataset reproduction which needs bulk downloads, API credentials, and supporting services.

### Description
- Inserted a short “Operational data caveat” paragraph near the top of `docs/deployment/README.md` that mirrors the root `README.md` guidance about no committed award data and non-trivial end-to-end reproduction. 
- Added the same caveat to `docs/testing/README.md` to explain that quick-start and unit-test commands are for local development and that integration/E2E runs need source data and services. 
- Added the same caveat to `docs/getting-started/README.md` to note that setup commands bring up local services but do not recreate the full research dataset. 
- Added the same caveat to `docs/data/index.md` to remind readers that scripts support local development but full dataset reproduction requires downloading bulk sources and API credentials.

### Testing
- Ran `git diff --check` to validate whitespace and formatting issues and it completed with no errors. 
- Ran `git status --short` to confirm the intended files were modified and it showed the four updated docs. 
- Inspected the top of each modified file to verify the caveat text appears as intended and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a85f420488322a293bb0e76a33186)