### PR TITLE
docs: align getting-started with Makefile (prefer `make install` / `make dev`)

### DIFF
--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -4,15 +4,23 @@ Quick setup guides for the SBIR ETL pipeline.
 
 ## Local Development
 
+The project uses Python 3.11 and [`uv`](https://github.com/astral-sh/uv) for dependency management. The recommended local flow mirrors the repository README:
+
 ```bash
 # Clone and install
 git clone https://github.com/hollomancer/sbir-analytics
 cd sbir-analytics
-uv sync
+make install
 
 # Start Dagster UI
-uv run dagster dev
+make dev
 # Open http://localhost:3000
+```
+
+If you prefer to run the underlying commands directly, `make install` is equivalent to `uv sync`, and `make dev` runs:
+
+```bash
+uv run dagster dev -m sbir_analytics.definitions
 ```
 
 ## First Steps
@@ -39,6 +47,7 @@ NEO4J_PASSWORD=password
 
 ## Next Steps
 
+- [Local Development Setup](local-development.md) - Detailed local workflow
 - [Docker Setup](../development/docker.md) - Container-based development
 - [Deployment Guide](../deployment/README.md) - Production deployment
 - [Testing Guide](../testing/index.md) - Running tests

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -43,7 +43,7 @@ make dev
 # Materialize raw_sbir_awards asset
 ```
 
-`make dev` uses the same Dagster module path as the Makefile target:
+`make dev` uses the same Dagster module path as the Makefile’s `dev` target:
 
 ```bash
 uv run dagster dev -m sbir_analytics.definitions

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -16,11 +16,13 @@ git clone https://github.com/hollomancer/sbir-analytics
 cd sbir-analytics
 
 # Install dependencies
-uv sync
+make install
 
 # Copy environment template
 cp .env.example .env
 ```
+
+`make install` wraps the direct `uv sync` command used by the project.
 
 ## Neo4j Setup
 
@@ -35,10 +37,16 @@ docker compose --profile dev up neo4j -d
 
 ```bash
 # Start Dagster UI
-uv run dagster dev
+make dev
 
 # Open http://localhost:3000
 # Materialize raw_sbir_awards asset
+```
+
+`make dev` uses the same Dagster module path as the Makefile target:
+
+```bash
+uv run dagster dev -m sbir_analytics.definitions
 ```
 
 ## Development Workflow
@@ -58,7 +66,7 @@ uv run ruff format .
 ## Common Issues
 
 - **Neo4j connection failed**: Check `.env` credentials
-- **Import errors**: Run `uv sync` to update dependencies
+- **Import errors**: Run `make install` (or `uv sync`) to update dependencies
 - **Memory issues**: Reduce `SBIR_ETL__PIPELINE__CHUNK_SIZE`
 
 ## Next Steps


### PR DESCRIPTION
### Motivation

- Standardize the quick-start flow to use the repository Makefile as the primary developer entrypoint and avoid mismatches between docs and build targets.
- Ensure the Dagster startup command in docs is consistent with the `dev` Makefile target by documenting the module path `sbir_analytics.definitions`.

### Description

- Updated `docs/getting-started/README.md` to prefer `make install` and `make dev` and to document the equivalent direct commands `uv sync` and `uv run dagster dev -m sbir_analytics.definitions`.
- Updated `docs/getting-started/local-development.md` to use `make install` for dependency installation, to prefer `make dev` for starting Dagster, and to note that `make install` wraps `uv sync` while `make dev` runs the documented Dagster module path.
- Adjusted troubleshooting text to recommend `make install` (with `uv sync` as an alternative) and added a link from the getting-started index to the detailed local development page.

### Testing

- Ran `git diff --check` to verify no whitespace/errors in diffs and it passed.
- Ran `rg -n "uv sync|dagster dev|make install|make dev|sbir_analytics.definitions"` across relevant docs to validate the updates and it returned the expected matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a85e32420832296753b75ca4e56ca)