### PR TITLE
docs: repair stale internal references

### DIFF
--- a/docs/SAM_GOV_INTEGRATION.md
+++ b/docs/SAM_GOV_INTEGRATION.md
@@ -54,7 +54,7 @@ sbir_etl/
 │   └── cloud_storage.py            # S3 utilities (find_latest_sam_gov_parquet)
 └── config/
     └── schemas/
-        └── data_pipeline.py         # SamGovConfig schema
+        └── data.py         # SamGovConfig schema
 
 packages/sbir-analytics/sbir_analytics/
 └── assets/
@@ -96,7 +96,7 @@ extraction:
 
 ### Schema Definition
 
-Located in `sbir_etl/config/schemas/data_pipeline.py`:
+Located in `sbir_etl/config/schemas/data.py`:
 
 ```python
 class SamGovConfig(BaseModel):
@@ -357,7 +357,7 @@ MemoryError: Unable to allocate array
 
 - [SAM.gov Entity Information API](https://open.gsa.gov/api/entity-api/)
 - [Cloud Storage Utilities](../sbir_etl/utils/cloud_storage.py)
-- [Configuration Schema](../sbir_etl/config/schemas/data_pipeline.py)
+- [Configuration Schema](../sbir_etl/config/schemas/data.py)
 
 ## Changelog
 

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -133,17 +133,17 @@ sbir-analytics/
 │
 ├── specs/                        # Feature specifications
 │   ├── statistical_reporting/
-│   ├── weekly-award-data-refresh/
+│   ├── data-refresh/
 │   ├── merger_acquisition_detection/
 │   └── archive/                  # Completed specs
 │
 ├── .github/workflows/            # CI/CD pipelines
 │   ├── ci.yml                    # Standard lint/test
-│   ├── container-ci.yml          # Docker build & test
-│   ├── neo4j-smoke.yml           # Integration tests
-│   ├── performance-regression-check.yml
-│   ├── cet-pipeline-ci.yml
-│   └── secret-scan.yml
+│   ├── build-images.yml          # Docker build & test
+│   ├── data-refresh.yml          # Scheduled source refreshes
+│   ├── etl-pipeline.yml          # ETL orchestration
+│   ├── monthly-analysis.yml      # Scheduled analysis
+│   └── weekly.yml                # Scheduled tests and quality
 │
 └── docker-compose.yml            # Local dev/test environment
 ```

--- a/docs/data/awards-refresh.md
+++ b/docs/data/awards-refresh.md
@@ -4,8 +4,8 @@ Weekly automation keeps the canonical SBIR.gov CSV (`data/raw/sbir/award_data.cs
 
 ## Workflow summary
 
-- **Workflow:** `.github/workflows/weekly-award-data-refresh.yml` (runs Mondays at 09:00 UTC)
-- **Triggers:** scheduled cron + `workflow_dispatch` with `force_refresh` (bool) and `source_url` (string) inputs
+- **Workflow:** `.github/workflows/data-refresh.yml` (runs Mondays at 09:00 UTC)
+- **Triggers:** scheduled cron + `workflow_dispatch` with `source`, `environment`, and `force_refresh` inputs
 - **Branch / commit:** `data-refresh/<YYYY-MM-DD>` with commit `chore(data): refresh sbir awards <YYYY-MM-DD>`
 - **Owners:** `@sbir-analytics/data-stewards` (see `.github/CODEOWNERS`)
 - **Neo4j:** Optionally loads to Neo4j (Docker locally, EC2 in production)
@@ -35,10 +35,10 @@ Weekly automation keeps the canonical SBIR.gov CSV (`data/raw/sbir/award_data.cs
 
 ### Trigger a manual refresh
 
-1. Navigate to **Actions → Weekly SBIR Awards Refresh → Run workflow**.
+1. Navigate to **Actions → Data Refresh → Run workflow**.
 2. Optionally set:
    - `force_refresh` = `true` to capture metadata even if the CSV is unchanged.
-   - `source_url` to point at an alternate mirror or local test server.
+   - `source` = `sbir` and the target `environment` for an awards-only refresh.
 3. Monitor the run for validation logs and artifact uploads.
 
 ### Run validation locally

--- a/docs/deployment/deployment-comparison.md
+++ b/docs/deployment/deployment-comparison.md
@@ -234,7 +234,7 @@ Example monthly costs:
 You currently have **EC2 configuration ready**:
 
 - ✅ `scripts/setup-ec2-agent.sh` - one-command setup
-- ✅ `docs/deployment/multi-location-setup.md` - full guide
+- ✅ `docs/deployment/usaspending-ec2-automation.md` - EC2 automation guide
 
 To switch to Batch later, you'll have:
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -1228,7 +1228,7 @@ For CI/CD pipelines:
 - Build image using Buildx/cache
 - Run tests using `docker compose --profile ci`
 - Push artifacts to registry only when tests pass
-- See `scripts/ci/build_container.sh` and `.github/workflows/container-ci.yml` for examples
+- See `scripts/ci/build_container.sh` and `.github/workflows/build-images.yml` for examples
 
 ## Entrypoint Scripts
 

--- a/docs/deployment/usaspending-ec2-automation.md
+++ b/docs/deployment/usaspending-ec2-automation.md
@@ -254,7 +254,7 @@ aws ssm list-commands --instance-id $INSTANCE_ID
 
 **Solution:**
 
-- Increase workflow timeout in `.github/workflows/usaspending-database-download.yml`
+- Increase workflow timeout in `.github/workflows/data-refresh.yml`
 - Check network speed (may need larger instance type)
 - Verify source URL is accessible
 

--- a/docs/development/logging-standards.md
+++ b/docs/development/logging-standards.md
@@ -580,7 +580,6 @@ class MockLogger:
 
 - [Exception Handling Guide](exception-handling.md)
 - [Configuration Overview](../configuration.md)
-- [CLI Reference](../cli/README.md)
 
 ## Change Log
 

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -26,15 +26,14 @@ Developer's Machine                    GitHub Actions (CI)
 └─ git commit                          └─ Pull Request / Push
    └─ pre-commit hooks run            └─ .github/workflows/ci.yml
       ├─ Standard file checks            ├─ code-quality job
-      ├─ Ruff (lint/format)             │  (runs all pre-commit hooks)
-      ├─ MyPy (types)                   │
-      ├─ Bandit (security)              ├─ lint job (Ruff)
-      ├─ Detect-secrets                 ├─ types job (MyPy)
-                                        ├─ security job (Bandit)
-                                        ├─ docs-link-check job
+      ├─ Ruff (lint/format)             │  (Ruff lint/format, MyPy for sbir_etl,
+      ├─ MyPy (types)                   │   removed-src reference check)
+      ├─ Bandit (security)              ├─ package-type-checks job (per-package MyPy)
+      ├─ Detect-secrets                 ├─ workflow-lint job (YAML validation)
+                                        └─ test job (unit / integration matrix)
 ```
 
-**Key Principle:** Pre-commit hooks define what developers must fix locally. The same tools run in CI. Individual CI jobs provide visibility and parallelization.
+**Key Principle:** Pre-commit hooks define what developers must fix locally. CI runs the same Ruff + MyPy + (removed-src) gates as the `code-quality` job, with per-package MyPy and tests as additional jobs. Bandit and Detect-secrets currently run only as pre-commit hooks locally, not as standalone CI jobs.
 
 ---
 
@@ -183,9 +182,9 @@ This workflow runs on:
    - Purpose: Keeps GitHub Actions workflow files parseable
    - Time: ~1 minute
 
-4. **tests**
-   - Runs: unit, integration, and smoke tests selected by the CI change-detection outputs
-   - Purpose: Functional validation for affected code paths
+4. **test**
+   - Runs: unit and integration test suites via a fixed matrix in `.github/workflows/ci.yml`
+   - Purpose: Functional validation across the test matrix (does not include smoke tests, which run in separate workflows)
    - Time: varies by selected suite
 
 ### Why Multiple Jobs?

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -24,8 +24,8 @@ This document defines the **single source of truth** for code quality tools and 
 ```text
 Developer's Machine                    GitHub Actions (CI)
 └─ git commit                          └─ Pull Request / Push
-   └─ pre-commit hooks run            └─ .github/workflows/static-analysis.yml
-      ├─ Standard file checks            ├─ pre-commit-check job
+   └─ pre-commit hooks run            └─ .github/workflows/ci.yml
+      ├─ Standard file checks            ├─ code-quality job
       ├─ Ruff (lint/format)             │  (runs all pre-commit hooks)
       ├─ MyPy (types)                   │
       ├─ Bandit (security)              ├─ lint job (Ruff)
@@ -158,43 +158,39 @@ Some rule failed
 
 ## CI Configuration
 
-### Workflow: `.github/workflows/static-analysis.yml`
+### Workflow: `.github/workflows/ci.yml`
 
 This workflow runs on:
 
 - Every push to `main` or `develop`
 - Every pull request
 
-**Jobs (in parallel):**
+**Jobs (in parallel/sequence):**
 
-1. **pre-commit-check** (NEW)
-   - Runs: `pre-commit run --all-files`
-   - Purpose: Comprehensive local/CI consistency check
-   - Covers: All pre-commit hooks (Ruff, MyPy, Bandit, Detect-secrets, Standard checks)
+1. **code-quality**
+   - Runs: Ruff lint/format, MyPy for `sbir_etl`, and `scripts/ci/check_removed_src_references.py`
+   - Purpose: CI visibility for the same core quality gates defined by local configuration
+   - Covers: Production source roots plus tests where applicable
    - Time: ~5-10 minutes
 
-2. **lint** (Ruff)
-   - Runs: `ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests` + `ruff format --check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests`
-   - Purpose: Visibility into linting results
-   - Time: ~1-2 minutes
+2. **package-type-checks** (MyPy)
+   - Runs: `mypy` for `packages/sbir-analytics/sbir_analytics`, `packages/sbir-ml/sbir_ml`, and `packages/sbir-graph/sbir_graph`
+   - Purpose: Package-level type-checking visibility
+   - Time: ~5-10 minutes
 
-3. **types** (MyPy)
-   - Runs: `mypy sbir_etl`
-   - Purpose: Type checking visibility
-   - Time: ~1-2 minutes
-
-4. **security** (Bandit)
-   - Runs: `bandit -r sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph -c pyproject.toml`
-   - Purpose: Security scanning visibility
+3. **workflow-lint**
+   - Runs: YAML syntax validation for `.github/workflows/*.yml`
+   - Purpose: Keeps GitHub Actions workflow files parseable
    - Time: ~1 minute
 
-5. **docs-link-check** (on docs changes)
-   - External link validation
-   - Not included in pre-commit (external checks)
+4. **tests**
+   - Runs: unit, integration, and smoke tests selected by the CI change-detection outputs
+   - Purpose: Functional validation for affected code paths
+   - Time: varies by selected suite
 
 ### Why Multiple Jobs?
 
-- **pre-commit-check:** Ensures all local checks pass in CI
+- **code-quality:** Runs Ruff, MyPy, and removed source-root reference checks in CI
 - **Individual jobs:** Provide clear, separate visibility in GitHub checks
 - **Parallelization:** Faster overall execution
 - **Debugging:** Easier to identify which check failed
@@ -208,7 +204,7 @@ This workflow runs on:
 Tool versions are pinned in:
 
 - `.pre-commit-config.yaml` (local)
-- `.github/workflows/static-analysis.yml` (CI)
+- `.github/workflows/ci.yml` (CI)
 - `pyproject.toml` (tool configuration)
 
 **Update process:**
@@ -219,7 +215,7 @@ Tool versions are pinned in:
    # Don't update just one - keep them in sync!
    # Update in:
    # - .pre-commit-config.yaml (rev field)
-   # - .github/workflows/static-analysis.yml (setup-python-uv action versions)
+   # - .github/workflows/ci.yml (setup-python-uv action versions)
    # - pyproject.toml (if tool config changes)
    ```
 
@@ -232,7 +228,7 @@ Tool versions are pinned in:
 3. **Commit the changes:**
 
    ```bash
-   git add .pre-commit-config.yaml .github/workflows/static-analysis.yml pyproject.toml
+   git add .pre-commit-config.yaml .github/workflows/ci.yml pyproject.toml
    git commit -m "chore: update pre-commit tools to [version]"
    ```
 
@@ -253,11 +249,11 @@ Tool versions are pinned in:
 | Item | Local | CI | Notes |
 |------|-------|----|----|
 | Tool versions | `.pre-commit-config.yaml` | `.pre-commit-config.yaml` | Identical |
-| Ruff scope | `.pre-commit-config.yaml` | `static-analysis.yml` | Both: all production roots plus `tests` |
+| Ruff scope | `.pre-commit-config.yaml` | `ci.yml` | Both: all production roots plus `tests` |
 | Ruff config | `pyproject.toml` | `pyproject.toml` | Identical |
-| MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `static-analysis.yml` | Both: `sbir_etl` only |
+| MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `ci.yml` | Both: `sbir_etl` only |
 | MyPy config | `pyproject.toml` | `pyproject.toml` | Identical |
-| Bandit scope | `.pre-commit-config.yaml` | `static-analysis.yml` | Both: all production roots |
+| Bandit scope | `.pre-commit-config.yaml` | `ci.yml` | Both: all production roots |
 | Bandit config | `pyproject.toml` | `pyproject.toml` | Identical |
 
 ---
@@ -281,7 +277,7 @@ Tool versions are pinned in:
    pre-commit run --all-files
    ```
 
-3. Check `.pre-commit-config.yaml` against `.github/workflows/static-analysis.yml`
+3. Check `.pre-commit-config.yaml` against `.github/workflows/ci.yml`
 
 4. **Report as bug:** This indicates a configuration mismatch
 
@@ -377,7 +373,7 @@ pre-commit run ruff
 ### How do I add a new pre-commit hook?
 
 1. Add to `.pre-commit-config.yaml`
-2. Add equivalent CI job to `.github/workflows/static-analysis.yml`
+2. Add equivalent CI job to `.github/workflows/ci.yml`
 3. Update this documentation
 4. Test locally: `pre-commit run --all-files`
 5. Submit PR with changes to all three files
@@ -416,5 +412,5 @@ If you need type checking for a specific file, add:
 Project files:
 
 - `.pre-commit-config.yaml` - Local hook configuration
-- `.github/workflows/static-analysis.yml` - CI configuration
+- `.github/workflows/ci.yml` - CI configuration
 - `pyproject.toml` - Tool-specific configuration

--- a/docs/guides/quality-assurance.md
+++ b/docs/guides/quality-assurance.md
@@ -25,7 +25,7 @@ This guide centralizes performance and data quality practices.
 ## CI
 
 - CI checks in `.github/workflows/ci.yml`
-- Nightly tests in `.github/workflows/nightly.yml`
+- Nightly tests in `.github/workflows/weekly.yml`
 
 Ensure PRs that change performance-sensitive paths update baselines/thresholds when appropriate.
 

--- a/docs/guides/statistical-reporting.md
+++ b/docs/guides/statistical-reporting.md
@@ -459,4 +459,4 @@ For large datasets (>100K records):
 - **Configuration**: `config/base.yaml` (statistical_reporting section)
 - **CI Integration**: `.github/workflows/ci.yml`
 - **Quality Assurance Guide**: [`quality-assurance.md`](quality-assurance.md)
-- **Performance Monitoring**: [`../performance/index.md`
+- **Performance Monitoring**: [`../performance.md`](../performance.md)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -602,7 +602,7 @@ sbir_enrichment_fuzzy_matches: gauge
 Use automated regression detection script:
 
 ```bash
-python scripts/detect_performance_regression.py \
+python scripts/performance/detect_performance_regression.py \
 
   --output-json regression.json \
   --fail-on-regression
@@ -754,7 +754,7 @@ cat regression.json | jq '.baseline_comparison'
 
 ## Re-run locally to verify
 
-python scripts/detect_performance_regression.py \
+python scripts/performance/detect_performance_regression.py \
 
   --output-markdown /tmp/local_report.md
 ```
@@ -775,13 +775,13 @@ Common causes:
 1. **Run benchmarks locally**
 
    ```bash
-   python scripts/benchmark_enrichment.py --sample-size 500
+   python scripts/performance/benchmark_enrichment.py --sample-size 500
    ```
 
 2. **Create a baseline early**
 
    ```bash
-   python scripts/benchmark_enrichment.py --save-as-baseline
+   python scripts/performance/benchmark_enrichment.py --save-as-baseline
    ```
 
 3. **Test with realistic data volumes**
@@ -791,7 +791,7 @@ Common causes:
 4. **Monitor regressions**
 
    ```bash
-   python scripts/detect_performance_regression.py
+   python scripts/performance/detect_performance_regression.py
    ```
 
 ### For Production
@@ -802,7 +802,7 @@ Common causes:
    - Set up alerts
 
 2. **Use the deployment checklist**
-   - See `docs/DEPLOYMENT_CHECKLIST.md`
+   - See `docs/deployment/README.md`
    - Verify all quality gates passing
    - Test failover scenarios
 
@@ -825,7 +825,7 @@ Common causes:
    ls -la reports/benchmarks/baseline.json
 
    # Check recent performance
-   python scripts/detect_performance_regression.py
+   python scripts/performance/detect_performance_regression.py
    ```
 
 2. **Handle quality gate failures**
@@ -904,19 +904,19 @@ Variation depends on:
 
 ## Run benchmark with sample
 
-python scripts/benchmark_enrichment.py --sample-size 1000
+python scripts/performance/benchmark_enrichment.py --sample-size 1000
 
 ## Save as new baseline
 
-python scripts/benchmark_enrichment.py --save-as-baseline
+python scripts/performance/benchmark_enrichment.py --save-as-baseline
 
 ## Detect regression vs baseline
 
-python scripts/detect_performance_regression.py
+python scripts/performance/detect_performance_regression.py
 
 ## Generate performance report
 
-python scripts/detect_performance_regression.py \
+python scripts/performance/detect_performance_regression.py \
 
   --output-markdown report.md \
   --output-html report.html
@@ -1622,11 +1622,11 @@ cp reports/benchmarks/baseline.json reports/benchmarks/baseline.backup.json
 
 ## Run benchmark with new config
 
-python scripts/benchmark_enrichment.py --sample-size 1000
+python scripts/performance/benchmark_enrichment.py --sample-size 1000
 
 ## Compare results
 
-python scripts/detect_performance_regression.py --output-markdown report.md
+python scripts/performance/detect_performance_regression.py --output-markdown report.md
 ```
 
 ### 2. Review Impact
@@ -1662,7 +1662,7 @@ Make one change at a time:
 Once satisfied with new configuration:
 
 ```bash
-python scripts/benchmark_enrichment.py --save-as-baseline
+python scripts/performance/benchmark_enrichment.py --save-as-baseline
 ```
 
 ### 5. Monitor Production
@@ -1803,7 +1803,7 @@ python -c "from sbir_etl.config.loader import get_config; print(get_config().enr
 
 ## Run with validation
 
-python scripts/benchmark_enrichment.py --sample-size 100
+python scripts/performance/benchmark_enrichment.py --sample-size 100
 
 ## Check for warnings
 
@@ -1819,7 +1819,7 @@ python scripts/benchmark_enrichment.py --sample-size 100
 For configuration questions:
 
 1. Check this guide first
-2. Review performance documentation: `docs/performance/index.md`
+2. Review performance documentation: `docs/performance.md`
 3. Check configuration examples above
 4. Review logs for specific errors
 5. Create GitHub issue with benchmark data if needed

--- a/docs/steering/quick-reference.md
+++ b/docs/steering/quick-reference.md
@@ -165,7 +165,7 @@ make neo4j-reset   # Fresh instance
 
 ## Related Documents
 
-- **[README.md](README.md)** - Complete navigation guide
+- **[Documentation index](../index.md)** - Complete navigation guide
 - **[configuration-patterns.md](configuration-patterns.md)** - Full configuration examples
 - **[data-quality.md](data-quality.md)** - Quality framework details
 - **[enrichment-patterns.md](enrichment-patterns.md)** - Enrichment strategy details

--- a/docs/testing/e2e-testing-guide.md
+++ b/docs/testing/e2e-testing-guide.md
@@ -133,12 +133,12 @@ CI jobs are organized into three priority tiers:
 
 #### Workflow-Specific Behavior
 
-- **PR/Commit Workflows** (`on-pr.yml`, `on-commit.yml`, `on-push-main.yml`):
+- **PR/Commit Workflow** (`.github/workflows/ci.yml`):
   - Tier 1: Fast tests run immediately
   - Tier 2: User story jobs run conditionally (based on path filters for PRs)
   - Tier 3: Performance checks run last, non-blocking
 
-- **Nightly Builds** (`nightly.yml`):
+- **Scheduled Builds** (`.github/workflows/weekly.yml`):
   - Runs comprehensive test suite in parallel:
     - `test-unit`: All unit tests (fast + slow)
     - `test-integration`: Integration tests with Neo4j service
@@ -154,9 +154,9 @@ CI jobs are organized into three priority tiers:
 
 ### Workflow Files
 
-- `container-ci.yml` runs the containerized suites in GitHub Actions
-- `neo4j-smoke.yml` validates graph connectivity and schema expectations
-- `performance-regression-check.yml` compares benchmark artifacts and alerts on drift
+- `.github/workflows/ci.yml` and `.github/workflows/build-images.yml` cover CI checks and image builds in GitHub Actions
+- `.github/workflows/weekly.yml` includes scheduled smoke, security, and comprehensive test targets
+- Performance checks run through `scripts/performance/detect_performance_regression.py` when invoked by CI or maintainers
 - Artifacts (logs, coverage, metrics) publish to `reports/` and the CI UI for inspection
 
 ## Contributing to Tests
@@ -219,7 +219,7 @@ CI jobs are organized into three priority tiers:
   ```
 
 - Threshold flags control warning/failure levels; the script returns non-zero on regression when `--fail-on-regression` is supplied.
-- GitHub Actions integration (`.github/workflows/performance-regression-check.yml`) runs the script and posts the Markdown summary as a PR comment.
+- GitHub Actions can invoke `scripts/performance/detect_performance_regression.py` from existing CI workflows and attach the Markdown summary as an artifact or PR comment.
 
 ## Test Scenarios
 

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -21,7 +21,6 @@ This directory hosts the complete testing playbook for SBIR ETL. The [Testing In
 - [Test Coverage Strategy](testing-strategy.md)
 - [Categorization Testing](categorization-testing.md)
 - [Validation Testing](validation-testing.md)
-- [CLI Testing Guide](../cli/TESTING.md)
 
 ## Best Practices Snapshot
 
@@ -100,8 +99,8 @@ Env vars: copy `.env.example` to `.env` and set `NEO4J_USER`, `NEO4J_PASSWORD` b
 GitHub Actions workflows wire these commands:
 
 - `.github/workflows/ci.yml` – runs `uv run pytest -v --cov=sbir_etl` plus lint/type checks.
-- `.github/workflows/nightly.yml` – nightly security scans and smoke tests.
-- `.github/workflows/weekly.yml` – weekly comprehensive test suite.
+- `.github/workflows/weekly.yml` – scheduled nightly smoke/security targets and weekly comprehensive tests.
+- `.github/workflows/build-images.yml` – container image build validation.
 
 Use `gh workflow run <name>` for manual triggers or inspect [Actions](https://github.com/<org>/<repo>/actions).
 
@@ -121,6 +120,5 @@ See [docs/guides/quality-assurance.md](../guides/quality-assurance.md) for thres
 - [E2E Testing Guide](e2e-testing-guide.md) – scenarios, data prep, CI integration.
 - [Test Coverage Strategy](testing-strategy.md) – coverage goals and focus areas.
 - [Categorization Testing](categorization-testing.md) / [Validation Testing](validation-testing.md) – domain-specific instructions.
-- [CLI Testing Guide](../cli/TESTING.md) – CLI-specific fixtures and snapshot tests.
 
 > ⚠️ Whenever you add a new Make target, pytest marker, or workflow, update this index and link to it from README/Quick Start instead of duplicating the command.

--- a/docs/testing/test-scheduling.md
+++ b/docs/testing/test-scheduling.md
@@ -94,7 +94,7 @@ pytest -m "fast and not integration and not e2e" -n auto --maxfail=5
 
 #### Estimated Runtime: 20-30 minutes
 
-#### Current Implementation: Already in `.github/workflows/nightly.yml`
+#### Current Implementation: Already in `.github/workflows/weekly.yml`
 
 ---
 
@@ -296,7 +296,7 @@ jobs:
 
 1. Modify ci.yml to run only fast tests on commit
 2. Add conditional integration tests on PR
-3. Update nightly.yml to run slow tests
+3. Update weekly.yml to run slow tests
 
 ### Phase 3: Create weekly workflow (Week 2)
 

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -417,7 +417,7 @@ pytest --json-report --json-report-file=test-results.json
 
 ## Completed Improvements
 
-See [archive/testing/IMPROVEMENTS.md](../../archive/testing/IMPROVEMENTS.md) for historical improvements.
+Historical testing improvements were consolidated into this testing strategy and the docs in `docs/testing/`.
 
 ## Related Documentation
 

--- a/docs/testing/usaspending-ec2-testing.md
+++ b/docs/testing/usaspending-ec2-testing.md
@@ -262,11 +262,11 @@ Test the workflow without actually running it:
 
 ```bash
 # Check workflow syntax
-act -l --workflows .github/workflows/usaspending-database-download.yml
+act -l --workflows .github/workflows/data-refresh.yml
 
 # Dry run (requires act: https://github.com/nektos/act)
 act workflow_dispatch \
-  --workflows .github/workflows/usaspending-database-download.yml \
+  --workflows .github/workflows/data-refresh.yml \
   --eventpath test-event.json
 
 # Create test event file

--- a/docs/testing/usaspending-ec2-testing.md
+++ b/docs/testing/usaspending-ec2-testing.md
@@ -273,7 +273,8 @@ act workflow_dispatch \
 cat > test-event.json << EOF
 {
   "inputs": {
-    "database_type": "test",
+    "source": "usaspending",
+    "environment": "test",
     "force_refresh": "false"
   }
 }
@@ -282,9 +283,9 @@ EOF
 
 **Or test manually via GitHub UI:**
 
-1. Go to Actions → USAspending Database Download
+1. Go to Actions → Data Refresh
 2. Click "Run workflow"
-3. Select `database_type: test` (smaller file)
+3. Select `source: usaspending` and `environment: test`
 4. Monitor execution
 
 ## 7. Test EC2 Automation (Full Test)


### PR DESCRIPTION
### Motivation
- Remove or update broken/backticked paths in `docs/` that pointed to files or workflows no longer present in the repository. 
- Prefer pointing readers to existing documentation or code (current workflow names, script locations, and config schema files) instead of leaving stale/aspirational links.

### Description
- Repointed SAM.gov schema references from `sbir_etl/config/schemas/data_pipeline.py` to `sbir_etl/config/schemas/data.py` and updated related examples in `docs/SAM_GOV_INTEGRATION.md`.
- Replaced references to removed performance scripts/workflow names with current paths in `docs/performance.md` and `docs/guides/statistical-reporting.md` (e.g. moved references to `scripts/performance/*` and `docs/performance.md`).
- Updated CI/workflow documentation to use the current GitHub Actions files (`.github/workflows/ci.yml`, `.github/workflows/weekly.yml`, `.github/workflows/build-images.yml`, `.github/workflows/data-refresh.yml`) and adjusted wording for the `code-quality`/`ci` jobs in `docs/development/pre-commit-ci-consistency.md` and several testing guides.
- Cleaned up additional stale links and navigation targets (examples: `docs/data/awards-refresh.md`, `docs/deployment/docker.md`, `docs/deployment/deployment-comparison.md`, `docs/testing/*`, `docs/steering/quick-reference.md`, `docs/development/logging-standards.md`) to reference existing files or the docs index instead of removed files.

### Testing
- Ran `git diff --check` to ensure no whitespace or conflict markers remained and the commit was clean, which passed successfully. 
- Executed a custom Python resolver that visits `docs/**/*.md` and validates internal Markdown links, confirming `All internal markdown links resolve` after edits. 
- Searched the `docs/` tree with `rg` for the known stale patterns (`DEPLOYMENT_CHECKLIST`, `performance/index`, `sbir_etl/config/schemas/data_pipeline.py`, `static-analysis.yml`, etc.) to verify replacements, which returned no remaining occurrences of the original stale references.
- Committed the changes as `docs: repair stale internal references` after verification (commit short hash shown in run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a870d55ec83228bb366209de356db)