### PR TITLE
Reframe docs as research/experimental and qualify production/cloud language

### DIFF
--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -2,17 +2,17 @@
 
 ## Executive Summary
 
-The **sbir-analytics** is a robust, cloud-native ETL (Extract, Transform, Load) pipeline for processing Small Business Innovation Research (SBIR) program data into a Neo4j graph database. It orchestrates multi-source data ingestion, complex transformations, and sophisticated analysis workflows through Dagster asset definitions.
+**sbir-analytics** is an experimental ETL (Extract, Transform, Load) research pipeline for linking Small Business Innovation Research (SBIR) program data to commercialization signals in a Neo4j graph database. It orchestrates multi-source data ingestion, transformations, and exploratory analysis workflows through Dagster asset definitions. As described in the README, this is a personal side project rather than production software; the architecture below describes the current documented approach, including an optional cloud setup.
 
 **Key Characteristics:**
 
 - **Data Sources**: SBIR.gov awards, USAspending contracts, USPTO patents, transition detection
 - **Processing**: DuckDB (extraction), Pandas/Python (transformation), Neo4j (graph storage)
-- **Orchestration**: GitHub Actions (primary), AWS Step Functions (scheduled workflows)
-- **Compute**: AWS Lambda functions (serverless processing), GitHub Actions runners
-- **Storage**: AWS S3 (primary data lake), local filesystem (development fallback)
-- **Database**: Neo4j (EC2 production), Docker Neo4j (local development)
-- **Deployment**: Cloud-first (GitHub Actions + AWS + Neo4j EC2), Docker (local development)
+- **Orchestration**: GitHub Actions and optional AWS Step Functions for documented repeatable runs
+- **Compute**: GitHub Actions runners, with optional AWS Lambda functions for cloud experiments
+- **Storage**: Local filesystem for development, with optional AWS S3 data lake paths
+- **Database**: Neo4j via Docker for local development, with optional EC2-hosted Neo4j notes
+- **Deployment**: Docker for local development, plus an experimental GitHub Actions + AWS + Neo4j EC2 deployment path
 - **Tech Stack**: Python 3.11/3.12, Neo4j 5.x, AWS Lambda, S3, DuckDB, Pandas, Pydantic, scikit-learn
 
 ---
@@ -722,9 +722,9 @@ Each transition is flagged with:
 |-----------|-----------|---------|
 | **Orchestration** | GitHub Actions Solo Plan | Managed workflow DAG, asset dependencies, cloud observability |
 | **Compute** | AWS Lambda | Serverless compute for scheduled data refresh workflows |
-| **Storage** | AWS S3 | Primary data lake for CSV files, intermediate results, artifacts |
+| **Storage** | AWS S3 | Optional cloud data lake for CSV files, intermediate results, artifacts |
 | **Secrets Management** | AWS Secrets Manager | Secure storage for Neo4j credentials, API keys |
-| **Database (Production)** | Neo4j (EC2) | Self-hosted graph database |
+| **Database (Optional Cloud Setup)** | Neo4j (EC2) | Self-hosted graph database for cloud experiments |
 | **Database (Development)** | Neo4j 5.x (Docker) | Local graph database for development and testing |
 | **Data Processing** | DuckDB + Pandas | Efficient CSV/SQL processing + transformation |
 | **Configuration** | Pydantic 2.x | Type-safe YAML loading with validation |
@@ -734,9 +734,9 @@ Each transition is flagged with:
 | **Logging** | Loguru | Structured logging |
 | **CLI** | Typer + Rich | Interactive dashboard commands |
 | **Testing** | Pytest + Pytest-Cov | Unit/integration/E2E tests |
-| **Local Development** | Docker + Docker Compose | Local dev/test environment (secondary deployment) |
+| **Local Development** | Docker + Docker Compose | Local dev/test environment |
 
-### 6.2 Data Flow Connections (Cloud Architecture)
+### 6.2 Data Flow Connections (Optional Cloud Architecture)
 
 ```
 ┌─────────────────────────────────────────┐
@@ -808,10 +808,10 @@ Local Development Alternative:
 
 ### 6.3 Neo4j Integration
 
-**Production (Neo4j EC2):**
+**Optional cloud setup (Neo4j EC2):**
 
 ```python
-# 1. Configure Neo4j (Production)
+# 1. Configure Neo4j (optional cloud setup)
 neo4j_config = Neo4jConfig(
     uri=os.getenv("NEO4J_URI", "bolt://your-ec2-host:7687"),
     username=os.getenv("NEO4J_USERNAME", "neo4j"),
@@ -1099,7 +1099,7 @@ class CETClassifier(Protocol):
 
 ## Summary
 
-The **sbir-analytics** codebase is a comprehensive, production-grade ETL system that:
+The **sbir-analytics** codebase is an experimental research ETL system that currently:
 
 1. **Ingests** multi-source government data (SBIR awards, USAspending, USPTO patents)
 2. **Validates & Enriches** with external APIs and ML classification

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -814,7 +814,7 @@ Local Development Alternative:
 # 1. Configure Neo4j (optional cloud setup)
 neo4j_config = Neo4jConfig(
     uri=os.getenv("NEO4J_URI", "bolt://your-ec2-host:7687"),
-    username=os.getenv("NEO4J_USERNAME", "neo4j"),
+    username=os.getenv("NEO4J_USER", "neo4j"),
     password=os.getenv("NEO4J_PASSWORD"),  # Stored in AWS Secrets Manager
     database="neo4j",
     batch_size=5000
@@ -823,7 +823,7 @@ neo4j_config = Neo4jConfig(
 # Local Development Alternative
 neo4j_config = Neo4jConfig(
     uri=os.getenv("NEO4J_URI", "bolt://localhost:7687"),
-    username=os.getenv("NEO4J_USERNAME", "neo4j"),
+    username=os.getenv("NEO4J_USER", "neo4j"),
     password=os.getenv("NEO4J_PASSWORD", "neo4j"),
     database="neo4j",
     batch_size=5000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,9 +7,9 @@
 
 ## Overview
 
-The SBIR ETL pipeline uses a flexible, configuration-driven approach to file system paths that supports both cloud storage (AWS S3) and local filesystem. All paths are configurable via YAML configuration files and can be overridden using environment variables, making the pipeline portable across different deployment environments.
+The SBIR ETL pipeline uses a flexible, configuration-driven approach to file system paths that supports both local filesystem storage and optional cloud storage (AWS S3). All paths are configurable via YAML configuration files and can be overridden using environment variables, making the research pipeline portable across local runs and the current documented cloud setup.
 
-**Cloud-First Architecture**: The pipeline automatically detects S3 paths (`s3://bucket/key`) and uses boto3 for cloud storage operations, with automatic fallback to local filesystem for development.
+**Optional cloud setup**: The pipeline can detect S3 paths (`s3://bucket/key`) and use boto3 for cloud storage operations, while local filesystem paths remain the default development path.
 
 ## Table of Contents
 
@@ -26,11 +26,11 @@ The SBIR ETL pipeline uses a flexible, configuration-driven approach to file sys
 
 ### S3 Path Support
 
-The pipeline supports AWS S3 paths for cloud-first deployments:
+The pipeline supports AWS S3 paths for the optional cloud deployment path:
 
 ```yaml
 paths:
-  # S3 paths (production)
+  # S3 paths (optional cloud setup)
   data_root: "s3://sbir-analytics-data-prod"
   raw_data: "s3://sbir-analytics-data-prod/raw"
   usaspending_dump_file: "s3://sbir-analytics-data-prod/usaspending/dump.zip"
@@ -45,7 +45,7 @@ paths:
 Enable S3 storage via environment variables:
 
 ```bash
-# Production (S3)
+# Optional cloud setup (S3)
 export SBIR_ETL_USE_S3=true
 export SBIR_ETL_S3_BUCKET=sbir-analytics-data-prod
 export AWS_REGION=us-east-1
@@ -114,7 +114,7 @@ df = duckdb.sql("""
 
 ### S3 Best Practices
 
-1. **Use S3 for production** - Scalable, durable, managed
+1. **Use S3 for larger or repeatable cloud runs** - Scalable, durable, managed
 2. **Use local filesystem for development** - Faster iteration, no AWS costs
 3. **Store credentials securely** - Use AWS Secrets Manager or IAM roles
 4. **Enable versioning** - Protect against accidental deletions
@@ -206,7 +206,7 @@ cd /home/user/sbir-analytics
 uv run dagster dev
 ```
 
-#### Production Environment (Mounted Volumes)
+#### Cloud or Server Environment (Mounted Volumes)
 
 ```bash
 # Override paths to use mounted volumes

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -74,9 +74,9 @@ The documented approach can use GitHub Actions for orchestration with optional A
 | [Neo4j Runbook](neo4j-runbook.md) | Neo4j operations |
 | [GitHub Actions ML](github-actions-ml.md) | ML job configuration |
 
-## Required Secrets
+## Secrets (for optional GitHub Actions / AWS deployment)
 
-Set these in GitHub → Settings → Secrets:
+These secrets are only required if you use the optional GitHub Actions / AWS deployment path; local runs do not need them. Set them in GitHub → Settings → Secrets:
 
 | Secret | Description |
 |--------|-------------|

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -7,18 +7,17 @@ Status: active
 
 # Deployment Documentation
 
+This directory documents the current experimental deployment path for the SBIR ETL project. The repository is a personal research project, not production software; these notes preserve useful operational details for repeatable runs and optional cloud experimentation without implying a production-grade service.
+
 > **Operational data caveat.** No SBIR/STTR award data is committed to this repository. Local-development commands in these docs are intended to bring up services, run tests, or exercise pipeline components against small/local inputs after you provide `.env` values. Full dataset reproduction requires downloading the source/bulk datasets yourself, supplying the relevant API credentials, and running supporting services such as Neo4j; reproducing the analyses end-to-end is non-trivial setup, not a one-command deployment.
-
-
-This directory contains deployment documentation for the SBIR ETL project.
 
 ## Deployment Overview
 
-The SBIR ETL project uses GitHub Actions for orchestration with AWS infrastructure:
+The documented approach can use GitHub Actions for orchestration with optional AWS infrastructure:
 
-1. **GitHub Actions (Primary)** - Orchestrates all ETL pipelines via `dagster job execute`
-2. **AWS Batch** - Heavy compute jobs (ML, fiscal analysis)
-3. **AWS Lambda + Step Functions** - Data download workflows
+1. **GitHub Actions** - Orchestrates ETL pipelines via `dagster job execute`
+2. **AWS Batch** - Optional heavy compute jobs (ML, fiscal analysis)
+3. **AWS Lambda + Step Functions** - Optional data download workflows
 4. **Docker (Development)** - Local development and testing
 
 ## Architecture
@@ -82,9 +81,9 @@ Set these in GitHub → Settings → Secrets:
 | Secret | Description |
 |--------|-------------|
 | `AWS_ROLE_ARN` | IAM role for AWS access |
-| `NEO4J_URI` | Production Neo4j connection URI |
+| `NEO4J_URI` | Cloud Neo4j connection URI, if using the optional cloud setup |
 | `NEO4J_USER` | Neo4j username |
-| `NEO4J_PASSWORD` | Production Neo4j password |
+| `NEO4J_PASSWORD` | Cloud Neo4j password, if using the optional cloud setup |
 | `NEO4J_TEST_URI` | Test Neo4j connection URI (used when `environment: test`) |
 | `NEO4J_TEST_PASSWORD` | Test Neo4j password (used when `environment: test`) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,25 +9,25 @@ Status: active
 
 # SBIR ETL Documentation
 
-Welcome. This site is the canonical documentation for the SBIR ETL pipeline.
+Welcome. This site collects the current documentation for the SBIR/STTR commercialization analytics research project. Like the README notes, this is a personal side project rather than production software, so the docs should be read as the current documented approach and working notes rather than polished, authoritative product documentation.
 
-- **specifications** (`specs/`) are the source of truth for designs, tasks, and requirements.
+- **specifications** (`specs/`) capture design notes, tasks, and requirements as they evolved.
 - User and developer documentation lives under `docs/` (this site).
 - Steering documents live in `docs/steering/` (architectural patterns and guidance).
 
 ## What is this project?
 
-Cloud-native, graph-based ETL pipeline that ingests SBIR/USAspending/USPTO data and loads a Neo4j graph database.
+Experimental, graph-based ETL pipeline that ingests SBIR/USAspending/USPTO data and loads a Neo4j graph database for exploratory analysis. The cloud pieces described below are an optional deployment path that has been documented for repeatability, not a claim that the project is production-grade.
 
-**Production Architecture**:
+**Current documented deployment approach**:
 
 - **Orchestration**: GitHub Actions Solo Plan, AWS Step Functions
 - **Compute**: AWS Lambda (serverless)
 - **Storage**: AWS S3 (data lake)
-- **Database**: Neo4j (Docker locally, EC2 in production)
+- **Database**: Neo4j (Docker locally, EC2 in the optional cloud setup)
 - **Processing**: DuckDB/Pandas
 
-**Development**: Docker Compose + local Dagster (secondary/failover option)
+**Local development**: Docker Compose + local Dagster (recommended for iteration)
 
 ## Quick links
 
@@ -37,11 +37,11 @@ Cloud-native, graph-based ETL pipeline that ingests SBIR/USAspending/USPTO data 
 - Architecture overview: [`architecture/detailed-overview.md`](architecture/detailed-overview.md)
 - Shared tech stack: [`architecture/shared-tech-stack.md`](architecture/shared-tech-stack.md)
 
-### Deployment (Cloud-First)
+### Deployment (Optional Cloud Setup)
 
-- **[Production deployment](deployment/README.md)** - GitHub Actions (Primary)
-- **[AWS Infrastructure](deployment/aws-deployment.md)** - Lambda + S3 + Step Functions
-- [Containerization guide](deployment/containerization.md) - Docker (Development/Failover)
+- **[Experimental deployment path](deployment/README.md)** - GitHub Actions orchestration notes
+- **[AWS Infrastructure](deployment/aws-deployment.md)** - Optional Lambda + S3 + Step Functions setup
+- [Containerization guide](deployment/containerization.md) - Docker for local development and fallback testing
 
 ### Development Guides
 


### PR DESCRIPTION
### Motivation
- Align documentation language with the repository README by framing the project as a personal side research project rather than production software.
- Avoid implying that the repository contains canonical or production-grade infrastructure by qualifying claims about production architecture, cloud-first deployment, and authoritative documentation.
- Preserve operational and reproducible details while making the documented deployment path explicit as experimental and optional.

### Description
- Updated `docs/index.md` to describe the site as the current documentation for a research project, change the landing wording around specifications, and replace the “Production Architecture” / “Cloud-First” framing with a qualified “Current documented deployment approach” / “Optional Cloud Setup.”
- Rewrote `docs/deployment/README.md` to present the GitHub Actions + AWS flow as an experimental/optional deployment path, and adjusted secrets/docs entries to reference an optional cloud setup rather than a production service.
- Revised `docs/configuration.md` to present S3/cloud storage as an optional cloud setup (keeping local filesystem as the default), update examples and best-practices language, and rename the “Production Environment (Mounted Volumes)” heading to a neutral cloud/server wording.
- Modified `docs/architecture/detailed-overview.md` to label the codebase and architecture as an experimental research ETL system, qualify orchestration/compute/storage/database entries as optional cloud components, and remove/soften the “production-grade” summary while preserving the architecture and operational instructions.

### Testing
- Ran `rg` across the modified docs for production-related phrases to verify that claims like “production architecture,” “production-grade,” and “cloud-first” were removed or suitably qualified, and results were reviewed for acceptable remaining references (e.g., `prod.yaml` filenames). 
- Ran `git diff --check` to ensure no whitespace or diff-check issues were introduced and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a85db517483229fd403f92a8dc337)