### PR TITLE
fix(reporting): reconcile CET analyzer to canonical 21-area taxonomy

### DIFF
--- a/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
@@ -34,27 +34,32 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
             "max_unclassified_rate": self.config.get("max_unclassified_rate", 0.15),
         }
 
-        # CET taxonomy areas (major categories)
+        # Canonical CET taxonomy areas — the 21 NSTC-2025Q1 cet_ids defined in
+        # config/cet/taxonomy.yaml and enforced by the classifier's
+        # taxonomy_loader. Keep this list in sync with that file; the
+        # test suite guards against drift (test_cet_areas_match_canonical_taxonomy).
         self.cet_areas = [
-            "artificial_intelligence",
-            "quantum_information_technologies",
-            "biotechnology",
-            "advanced_materials",
-            "advanced_manufacturing",
-            "microelectronics",
-            "space_technology",
-            "renewable_energy",
             "advanced_computing",
-            "hypersonics",
-            "networked_sensors",
-            "data_science",
+            "advanced_engineering_materials",
+            "advanced_gas_turbine_engine_technologies",
+            "advanced_manufacturing",
+            "advanced_and_networked_sensing_and_signature_management",
+            "advanced_nuclear_energy_systems",
+            "artificial_intelligence",
             "autonomous_systems",
-            "human_machine_interfaces",
+            "biotechnologies",
+            "communication_and_networking_technologies",
             "directed_energy",
             "financial_technologies",
-            "semiconductors",
-            "advanced_nuclear",
-            "cybersecurity",
+            "human_machine_interfaces",
+            "hypersonics",
+            "integrated_sensing_and_cyber",
+            "quantum_information_science",
+            "renewable_energy_generation_and_storage",
+            "semiconductors_and_microelectronics",
+            "space_technologies_and_systems",
+            "trusted_ai_and_autonomy",
+            "integrated_network_systems_of_systems",
         ]
 
         # Classification confidence bands

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -473,16 +473,15 @@ class TestCetClassificationAnalyzer:
 
         import yaml
 
-        taxonomy_path = (
-            Path(__file__).parents[4] / "config" / "cet" / "taxonomy.yaml"
-        )
+        taxonomy_path = Path(__file__).parents[4] / "config" / "cet" / "taxonomy.yaml"
         taxonomy = yaml.safe_load(taxonomy_path.read_text())
-        canonical_ids = {area["cet_id"] for area in taxonomy["cet_areas"]}
+        canonical_ids = [area["cet_id"] for area in taxonomy["cet_areas"]]
 
         analyzer = CetClassificationAnalyzer()
 
-        assert set(analyzer.cet_areas) == canonical_ids
-        assert len(analyzer.cet_areas) == len(canonical_ids) == 21
+        # Ordered comparison: catches membership *and* ordering drift vs the YAML.
+        assert analyzer.cet_areas == canonical_ids
+        assert len(analyzer.cet_areas) == 21
 
 
 # =============================================================================

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -307,8 +307,8 @@ class TestCetClassificationAnalyzer:
                 "award_id": [1, 2, 3, 4, 5],
                 "primary_cet_area": [
                     "artificial_intelligence",
-                    "quantum_information_technologies",
-                    "biotechnology",
+                    "quantum_information_science",
+                    "biotechnologies",
                     "artificial_intelligence",
                     None,
                 ],
@@ -347,8 +347,8 @@ class TestCetClassificationAnalyzer:
 
         assert "artificial_intelligence" in distribution
         assert distribution["artificial_intelligence"] == 0.4  # 2 out of 5
-        assert "quantum_information_technologies" in distribution
-        assert "biotechnology" in distribution
+        assert "quantum_information_science" in distribution
+        assert "biotechnologies" in distribution
 
     def test_calculate_category_distribution_empty(self):
         """Test category distribution with empty DataFrame."""
@@ -462,6 +462,27 @@ class TestCetClassificationAnalyzer:
 
         assert report.total_records == 0
         assert "error" in report.module_metrics
+
+    def test_cet_areas_match_canonical_taxonomy(self):
+        """Analyzer's CET areas must match the canonical config/cet/taxonomy.yaml.
+
+        Guards against the divergent-taxonomy drift that previously left this
+        analyzer with a stale 19-area list using non-canonical ids.
+        """
+        from pathlib import Path
+
+        import yaml
+
+        taxonomy_path = (
+            Path(__file__).parents[4] / "config" / "cet" / "taxonomy.yaml"
+        )
+        taxonomy = yaml.safe_load(taxonomy_path.read_text())
+        canonical_ids = {area["cet_id"] for area in taxonomy["cet_areas"]}
+
+        analyzer = CetClassificationAnalyzer()
+
+        assert set(analyzer.cet_areas) == canonical_ids
+        assert len(analyzer.cet_areas) == len(canonical_ids) == 21
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

While merging the DIB/supply-chain research questions (separate docs branch), I found the repo carries **three divergent CET taxonomies**:

| Source | Count | Notes |
|---|---|---|
| `config/cet/taxonomy.yaml` + `taxonomy_loader.py` (canonical) | **21** | `NSTC-2025Q1`, hard-validated to exactly 21 |
| `sbir_etl/utils/reporting/analyzers/cet_analyzer.py` | 19 | hardcoded, **non-canonical ids** |
| `packages/sbir-ml/sbir_ml/transition/features/cet_analyzer.py` | 10 | `CET_KEYWORD_MAPPINGS`, feeds transition scoring |

This PR fixes the **reporting-analyzer** divergence only.

## The bug

`CetClassificationAnalyzer` hardcoded a stale 19-area list using ids that don't exist in the canonical taxonomy — `quantum_information_technologies` (canonical: `quantum_information_science`), `biotechnology` (`biotechnologies`), `advanced_materials` (`advanced_engineering_materials`), `microelectronics` (`semiconductors_and_microelectronics`), plus `networked_sensors`, `data_science`, `cybersecurity` (not canonical at all), and it was missing 6 canonical areas.

The analyzer uses this list as the **authoritative universe** for `coverage_rate`, `taxonomy_utilization`, and the records-per-category intersection (`cet_analyzer.py:456-483`). Real classifier output emits canonical `cet_id`s, so coverage was scored against the wrong set — undercounting coverage and silently dropping valid areas from per-category stats.

## Changes

- Replace the 19-area list with the canonical **21 `cet_id`s** from `config/cet/taxonomy.yaml`.
- Update the analyzer's test fixture to use real classifier ids.
- Add a **drift-guard test** (`test_cet_areas_match_canonical_taxonomy`) that asserts the list equals the YAML so it can't silently diverge again.

## Verification

```
pytest tests/unit/utils/reporting/test_analyzers.py  →  53 passed
ruff check (changed files)                            →  All checks passed
```

## Deliberately out of scope

The transition system's separate **10-area** `CET_KEYWORD_MAPPINGS` (including non-canonical entries like "Climate Resilience" and "Biotechnology and Biodefense") infers contract CET and feeds **transition scoring** — which is gated by the **≥85% precision benchmark** (per `CLAUDE.md`). That benchmark isn't runnable in a unit-test pass, so changing the map there is a scoring change that needs benchmark validation and is left for a separate, validated PR. Tracked in the `research-questions.md` Maintenance section on the docs branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KjkNwuzLU4dBco2xNL3f4B)_