### PR TITLE
docs: update usaspending iterative refresh package paths

### DIFF
--- a/docs/enrichment/usaspending-iterative-refresh.md
+++ b/docs/enrichment/usaspending-iterative-refresh.md
@@ -10,22 +10,24 @@ The USAspending iterative enrichment system automatically refreshes enrichment d
 
 ### Components
 
-1. **USAspending API Client** (`sbir_etl/enrichers/usaspending_api_client.py`)
-   - Async HTTP client with rate limiting and retry logic
+1. **USAspending Package** (`sbir_etl/enrichers/usaspending/client.py`, `sbir_etl/enrichers/usaspending/enricher.py`, `sbir_etl/enrichers/usaspending/index.py`)
+   - `USAspendingAPIClient` async HTTP client with rate limiting and retry logic
+   - `enrich_sbir_with_usaspending` batch enrichment helper
+   - `parse_toc_table_dat_map` and `extract_table_sample` helpers for USAspending bulk download indexes
    - Delta detection via payload hashing
    - State management for cursors/ETags
 
-2. **Freshness Store** (`sbir_etl/utils/enrichment_freshness.py`)
-   - Persists enrichment freshness records to Parquet
+2. **Freshness Store** (`sbir_etl/utils/enrichment/freshness.py`)
+   - `FreshnessStore` persists enrichment freshness records to Parquet
    - Tracks `last_attempt_at`, `last_success_at`, `payload_hash`, and `status` per award/source
    - Identifies stale records based on SLA thresholds
 
-3. **Checkpoint Store** (`sbir_etl/utils/enrichment_checkpoints.py`)
-   - Enables resume functionality for interrupted refresh runs
+3. **Checkpoint Store** (`sbir_etl/utils/enrichment/checkpoints.py`)
+   - `CheckpointStore` and `EnrichmentCheckpoint` enable resume functionality for interrupted refresh runs
    - Tracks partition progress and last processed award ID
 
-4. **Metrics Collector** (`sbir_etl/utils/enrichment_metrics.py`)
-   - Emits freshness coverage metrics
+4. **Metrics Collector** (`sbir_etl/utils/enrichment/metrics.py`)
+   - `EnrichmentMetricsCollector` and `EnrichmentFreshnessMetrics` emit freshness coverage metrics
    - Tracks success rates, error rates, and SLA compliance
    - Logs to `reports/metrics/enrichment_freshness.json`
 


### PR DESCRIPTION
### Motivation
- The documentation referenced obsolete module paths that no longer match the current package layout and needed to be updated to avoid confusion.

### Description
- Updated `docs/enrichment/usaspending-iterative-refresh.md` to replace obsolete references to `sbir_etl/enrichers/usaspending_api_client.py`, `sbir_etl/utils/enrichment_freshness.py`, `sbir_etl/utils/enrichment_checkpoints.py`, and `sbir_etl/utils/enrichment_metrics.py` with the current files under `sbir_etl/enrichers/usaspending/` and `sbir_etl/utils/enrichment/`.
- Documented the concrete symbols present in the current modules, including `USAspendingAPIClient`, `enrich_sbir_with_usaspending`, `parse_toc_table_dat_map`, `extract_table_sample`, `FreshnessStore`, `CheckpointStore` / `EnrichmentCheckpoint`, and `EnrichmentMetricsCollector` / `EnrichmentFreshnessMetrics`.
- Kept the rest of the architecture, configuration, workflow, and troubleshooting guidance intact while aligning file paths and class/function names with the codebase.

### Testing
- Ran an import verification using `uv run python` to import the documented classes and functions from the updated modules and confirmed the imports succeeded.
- Executed a Python scan that checks the doc for obsolete module path strings and confirmed no obsolete references remain.}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a870b3e6c83229b6e6192d269baf8)