### PR TITLE
chore(gitignore): ignore harness/tool local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,11 @@ results.csv
 # Git worktrees (project-local, ignored to keep git status clean)
 .worktrees/
 
+# Claude Code local harness state (settings.json is shared; .local.json is per-user)
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+
+# Playwright MCP browser-automation traces (local debugging only)
+.playwright-mcp/
+


### PR DESCRIPTION
## Summary

First slice of repo cleanup. Stops three categories of harness/tool files from cluttering `git status`:

- `.claude/settings.local.json` — per-user local Claude Code config
- `.claude/scheduled_tasks.lock` — session lock file
- `.claude/worktrees/` — ephemeral worktrees created by `EnterWorktree`
- `.playwright-mcp/` — local browser-automation traces

## Deliberately *not* ignored

- `.claude/settings.json` — kept as the shared project config slot
- `.claude/agents/` and `.claude/skills/` — currently tracked custom agents and skills

## Verification

```
$ git check-ignore -v .claude/scheduled_tasks.lock .claude/worktrees/foo .playwright-mcp/x.log .claude/settings.local.json
.gitignore:227:.claude/scheduled_tasks.lock      .claude/scheduled_tasks.lock
.gitignore:228:.claude/worktrees/                .claude/worktrees/foo
.gitignore:231:.playwright-mcp/                  .playwright-mcp/x.log
.gitignore:226:.claude/settings.local.json       .claude/settings.local.json
```

## Out of scope (separate decisions)

Several other untracked items showed up in the cleanup sweep but were left alone pending a decision:

- Four orphaned M&A discovery scripts at repo root (`scripts/{enrich_ma_with_press,generate_ma_search_queries,ma_discovery_orchestrator,ma_verifier}.py`) — snapshot of the never-merged `chore/ma-discovery-toolkit` branch; investigation summary in the PR thread.
- `scripts/data/audit_one_firm.py`, `scripts/ml/snapshot_benchmark.py`, `docs/nsf-vc-comparison/`, `docs/superpowers/plans/2026-04-30-nsf-vc-phase2.md` — appear to be in-flight WIP, not abandoned.
- Two orphaned worktree refs in `/private/tmp/` — local `git worktree prune` cleanup, not a PR-shaped change.