### PR TITLE
draft(ma): discovery + verification toolkit (paused 2026-05-31)

### DIFF
--- a/sbir_etl/models/ma_models.py
+++ b/sbir_etl/models/ma_models.py
@@ -1,6 +1,19 @@
 from datetime import date
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+
+def _confidence_tier(score: float) -> str:
+    """Map a numeric confidence_score to the low/medium/high tier used downstream.
+
+    Matches the {"high", "medium"} keep-set in
+    sbir_etl/capital_events/sources/ma_events.py.
+    """
+    if score >= 0.8:
+        return "high"
+    if score >= 0.5:
+        return "medium"
+    return "low"
 
 
 class MAEvent(BaseModel):
@@ -13,6 +26,14 @@ class MAEvent(BaseModel):
     confidence_score: float = Field(
         description="A numerical score (0.0-1.0) indicating confidence in the event."
     )
-    confidence: str = Field(
-        description="Categorical confidence tier (low, medium, high) derived from the score."
+    confidence: str | None = Field(
+        default=None,
+        description="Categorical confidence tier (low, medium, high). "
+        "Derived from confidence_score when not supplied explicitly.",
     )
+
+    @model_validator(mode="after")
+    def _fill_confidence(self) -> "MAEvent":
+        if self.confidence is None:
+            self.confidence = _confidence_tier(self.confidence_score)
+        return self

--- a/sbir_etl/models/ma_models.py
+++ b/sbir_etl/models/ma_models.py
@@ -11,5 +11,8 @@ class MAEvent(BaseModel):
     acquisition_date: date = Field(description="The date of the acquisition event.")
     source: str = Field(description="The source of the M&A event information.")
     confidence_score: float = Field(
-        description="A score indicating the confidence in the M&A event."
+        description="A numerical score (0.0-1.0) indicating confidence in the event."
+    )
+    confidence: str = Field(
+        description="Categorical confidence tier (low, medium, high) derived from the score."
     )

--- a/scripts/enrich_ma_with_press.py
+++ b/scripts/enrich_ma_with_press.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Enrich existing SBIR M&A events with press-wire signals.
+
+Loads `data/sbir_ma_events.jsonl`, builds a watchlist of company names, polls
+press-wire feeds via `SyncPressWireClient`, and merges any matched press
+releases back into each event as `press_wire_signals`. Writes the result to
+`data/enriched_sbir_ma_events.jsonl`.
+
+The press-wire client does substring matching across all monitored feeds, so
+watchlist size has little effect on poll latency — the limiting factor is
+feed size, not watchlist size.
+
+Inputs:
+  data/sbir_ma_events.jsonl
+Outputs:
+  data/enriched_sbir_ma_events.jsonl
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import defaultdict
+
+from sbir_etl.enrichers.sync_wrappers import SyncPressWireClient
+
+
+async def main() -> None:
+    # 1. Load existing M&A events and create a watchlist of company names
+    ma_events: list[dict] = []
+    watchlist: set[str] = set()
+    try:
+        with open("data/sbir_ma_events.jsonl") as f:
+            for line in f:
+                try:
+                    data = json.loads(line)
+                    ma_events.append(data)
+                    name = data.get("company_name")
+                    if name:
+                        watchlist.add(name)
+                except json.JSONDecodeError:
+                    continue
+    except FileNotFoundError:
+        print("Error: data/sbir_ma_events.jsonl not found.")
+        return
+
+    print(f"Loaded {len(ma_events)} M&A events. Watchlist size: {len(watchlist)}")
+
+    # 2. Poll Press Wire feeds for these companies
+    print("Polling Press Wire feeds... (this may take a minute)")
+    press_hits = []
+    try:
+        with SyncPressWireClient() as client:
+            client.set_watchlist(list(watchlist))
+            press_hits = client.poll()
+    except Exception as e:
+        print(f"Error polling press wire: {e}")
+
+    print(f"Found {len(press_hits)} press release matches.")
+
+    # 3. Index press hits by matched company name
+    company_press: dict[str, list[dict]] = defaultdict(list)
+    for hit in press_hits:
+        company_press[hit.matched_company].append({
+            "title": hit.title,
+            "link": hit.link,
+            "published": hit.published,
+            "summary": hit.summary,
+            "source": hit.source,
+        })
+
+    # 4. Merge press signals into each event
+    enriched_events = []
+    for event in ma_events:
+        company = event.get("company_name")
+        if company in company_press:
+            event["press_wire_signals"] = company_press[company]
+            event["signal_count"] = event.get("signal_count", 0) + 1
+            event["enriched"] = True
+        else:
+            event["press_wire_signals"] = []
+            event["enriched"] = False
+        enriched_events.append(event)
+
+    # 5. Write enriched output
+    output_path = "data/enriched_sbir_ma_events.jsonl"
+    with open(output_path, "w") as f:
+        for event in enriched_events:
+            f.write(json.dumps(event) + "\n")
+
+    print(f"Successfully wrote enriched data to {output_path}")
+    enriched_count = sum(1 for e in enriched_events if e["enriched"])
+    print(f"Enriched {enriched_count} out of {len(ma_events)} events with press wire data.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/generate_ma_search_queries.py
+++ b/scripts/generate_ma_search_queries.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate web-search queries for unverified M&A candidates.
+
+Reads `data/sbir_ma_events.jsonl`, picks rows that have an acquirer claim but
+no Form D detail backing it, and emits a CSV of search queries to feed into
+`ma_discovery_orchestrator.py`. Company names are normalized (corporate
+suffixes stripped) to widen recall.
+
+Inputs:
+  data/sbir_ma_events.jsonl  — one JSON M&A candidate per line
+Output:
+  data/ma_search_queries.csv — columns: company_name, acquirer, query
+"""
+from __future__ import annotations
+
+import csv
+import json
+import re
+
+
+def clean_name(name: str | None) -> str:
+    """Uppercase and strip common corporate suffixes for fuzzier matching."""
+    if not name:
+        return ""
+    suffixes = [
+        r"\bINC\.?\b",
+        r"\bLLC\b",
+        r"\bCORP\.?\b",
+        r"\bLTD\.?\b",
+        r"\bCORPORATION\b",
+        r"\bCOMPANY\b",
+        r"\bCO\.?\b",
+        r"\bPLC\b",
+        r"/DE/",
+    ]
+    cleaned = name.upper()
+    for s in suffixes:
+        cleaned = re.sub(s, "", cleaned, flags=re.IGNORECASE)
+    return cleaned.strip().rstrip(",")
+
+
+def generate_queries(company_name: str | None, acquirer: str | None) -> list[str]:
+    """Return four web-search query strings exploring the (company, acquirer) pair."""
+    if not company_name or not acquirer:
+        return []
+    c_name = clean_name(company_name)
+    a_name = clean_name(acquirer)
+    return [
+        f'"{c_name}" acquired by "{a_name}" press release',
+        f'"{c_name}" "{a_name}" merger announcement',
+        f'"{c_name}" bought by "{a_name}"',
+        f'"{a_name}" announces acquisition of "{c_name}"',
+    ]
+
+
+def main() -> None:
+    candidates = []
+    with open("data/sbir_ma_events.jsonl") as f:
+        for line in f:
+            try:
+                data = json.loads(line)
+                if not data.get("form_d_detail") and data.get("acquirer"):
+                    candidates.append({
+                        "company_name": data.get("company_name"),
+                        "acquirer": data.get("acquirer"),
+                        "confidence": data.get("confidence"),
+                    })
+            except json.JSONDecodeError:
+                continue
+
+    print(f"Generating queries for {len(candidates)} candidates...")
+
+    output_path = "data/ma_search_queries.csv"
+    with open(output_path, "w", newline="") as csvfile:
+        fieldnames = ["company_name", "acquirer", "query"]
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for cand in candidates:
+            for q in generate_queries(cand["company_name"], cand["acquirer"]):
+                writer.writerow({
+                    "company_name": cand["company_name"],
+                    "acquirer": cand["acquirer"],
+                    "query": q,
+                })
+
+    print(f"Queries saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ma_discovery_orchestrator.py
+++ b/scripts/ma_discovery_orchestrator.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Run web searches for M&A query candidates and verify the snippets.
+
+Reads the candidate query CSV emitted by `generate_ma_search_queries.py`,
+runs each query through a pluggable `search_tool`, and feeds the snippets
+into `verify_acquisition` from `ma_verifier`. Confirmed hits are written
+to a JSONL output for downstream integration.
+
+The included `MockSearchTool` is a placeholder for testing the pipeline
+end-to-end; in production swap it for a real search-API client (Bing,
+Brave, Tavily, etc.) that returns `[{"snippet": ..., "link": ...}, ...]`.
+
+Inputs:
+  data/ma_search_queries.csv      — queries produced upstream
+Outputs:
+  data/discovered_acquisitions.jsonl — one verified M&A event per line
+"""
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+from typing import Any, Protocol
+
+from ma_verifier import verify_acquisition
+
+
+class SearchTool(Protocol):
+    async def search(self, query: str) -> list[dict[str, Any]]: ...
+
+
+async def process_batch(
+    queries: list[dict[str, str]], search_tool: SearchTool
+) -> list[dict[str, Any]]:
+    """Run a batch of (company, acquirer, query) rows and return verified events."""
+    verified = []
+    for row in queries:
+        company = row["company_name"]
+        acquirer = row["acquirer"]
+        query = row["query"]
+        results = await search_tool.search(query)
+        for res in results:
+            snippet = res.get("snippet", "")
+            verification = verify_acquisition(company, acquirer, snippet)
+            if verification["confirmed"]:
+                verified.append({
+                    "company_name": company,
+                    "acquirer": acquirer,
+                    "date": verification["date"],
+                    "value": verification["value"],
+                    "source": res.get("link", "Unknown"),
+                    "evidence": snippet,
+                })
+                break  # one hit per (company, acquirer) is enough
+    return verified
+
+
+async def main() -> None:
+    print("M&A Discovery Orchestrator started.")
+
+    with open("data/ma_search_queries.csv") as f:
+        queries = list(csv.DictReader(f))
+
+    # Placeholder: swap MockSearchTool for a real search-API client in production.
+    class MockSearchTool:
+        async def search(self, query: str) -> list[dict[str, Any]]:
+            if "Physical Optics" in query and "Mercury Systems" in query:
+                return [{
+                    "snippet": "Mercury Systems announced the acquisition of Physical Optics Corporation.",
+                    "link": "http://example.com",
+                }]
+            return []
+
+    search_tool = MockSearchTool()
+
+    batch_size = 100
+    all_verified: list[dict[str, Any]] = []
+    for i in range(0, len(queries), batch_size):
+        batch = queries[i:i + batch_size]
+        print(f"Processing batch {i // batch_size + 1}...")
+        all_verified.extend(await process_batch(batch, search_tool))
+
+    with open("data/discovered_acquisitions.jsonl", "w") as f:
+        for item in all_verified:
+            f.write(json.dumps(item) + "\n")
+
+    print(f"Automation complete. Found {len(all_verified)} verified acquisitions.")
+    print("Results saved to data/discovered_acquisitions.jsonl")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/ma_verifier.py
+++ b/scripts/ma_verifier.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Heuristic verifier for M&A acquisition signals in text snippets.
+
+Given a candidate (company, acquirer) pair and a text snippet (e.g. a search
+result or press release excerpt), returns a structured verdict on whether the
+snippet confirms the acquisition. Used by `ma_discovery_orchestrator.py` as a
+pluggable verification step.
+
+Current implementation is a keyword heuristic — both names must appear in the
+text and a recognized acquisition verb must be present. In production this
+should be replaced by an LLM call that can also extract date and deal value.
+"""
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class VerificationResult(TypedDict):
+    confirmed: bool
+    date: str | None
+    value: float | None
+    reason: str
+
+
+def verify_acquisition(company: str, acquirer: str, snippet: str) -> VerificationResult:
+    """Return whether `snippet` confirms `company` was acquired by `acquirer`."""
+    text = snippet.lower()
+    c = company.lower()
+    a = acquirer.lower()
+
+    keywords = ["acquired", "acquisition", "bought", "merger", "merged", "purchase"]
+
+    if c in text and a in text and any(k in text for k in keywords):
+        return {
+            "confirmed": True,
+            "date": "Unknown",  # LLM would extract; heuristic cannot
+            "value": None,
+            "reason": "Confirmed via keyword match",
+        }
+
+    return {
+        "confirmed": False,
+        "date": None,
+        "value": None,
+        "reason": "No clear acquisition signal found",
+    }


### PR DESCRIPTION
## Status: PAUSED — preserved for findability

Opened as a **draft** to surface this work in the PR queue rather than leave it stranded on a local branch. Not ready to merge.

## What this is

A four-stage M&A discovery pipeline added on `2026-05-31` (single commit `cb42b03a`):

1. `scripts/generate_ma_search_queries.py` — reads `sbir_ma_events.jsonl`, emits web-search queries for M&A candidates lacking Form D backing. Normalizes company names (strips INC/LLC/CORP/etc.) for wider recall.
2. `scripts/ma_discovery_orchestrator.py` — pluggable `SearchTool` interface; ships a `MockSearchTool` for E2E testing. Production swap targets noted: Bing / Brave / Tavily.
3. `scripts/ma_verifier.py` — keyword heuristic confirming `(company, acquirer)` pairs in snippets. Source comment notes it should be replaced by an LLM call that also extracts deal date and value.
4. `scripts/enrich_ma_with_press.py` — press-mention enrichment layer.
5. Also extends `MAEvent` with a categorical `confidence` tier (high/medium/low) alongside the existing numeric `confidence_score`.

## Why it was paused

Subsequent capital-events work landed on `main` (#286, #307, #313, #342, #343, #350) using the Form D high-confidence cohort path. That path doesn't replace this toolkit's purpose — discovery exists specifically to close the gap **where Form D doesn't help** (acquisitions of firms that never raised priced rounds and so never filed Form D). That gap remains open.

## What's needed before this can land

- Swap `MockSearchTool` for a real client (decide on Bing / Brave / Tavily and add API-key handling per repo SAM.gov / SEC EDGAR patterns)
- Replace the keyword verifier with an LLM call (extract acquirer, deal date, value)
- Integration with the existing capital-events ETL — does this feed `MAEvent` records into `capital_events.parquet`, or stand alongside as a separate detection layer?
- Test coverage (currently zero unit tests on these scripts)
- Decide where the scripts live long-term — `scripts/` root is a temporary home; a `sbir_etl/enrichers/ma_discovery/` module would match repo conventions

## Companion cleanup

Companion PR #370 ignores Claude Code / Playwright harness local state. Four stale snapshot copies of the scripts above (left at repo root after a working-tree checkout) were also deleted locally — the canonical copies live on this branch.