### PR TITLE
Add external OT Phase III transition claim coverage

### DIFF
--- a/packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py
+++ b/packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py
@@ -1,0 +1,69 @@
+"""Classify external OT Phase III transition claim strength.
+
+The classifier is intentionally benchmark-neutral: it evaluates the strength of
+an externally supplied Phase III transition assertion and does not apply SBA
+commercialization benchmark thresholds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+
+@dataclass(frozen=True)
+class OTTransitionClaimClassification:
+    """Tiered classification for an external OT Phase III transition claim."""
+
+    tier: str
+    benchmark_neutral: bool
+    matched_signals: tuple[str, ...]
+
+
+def classify_external_ot_transition_claim(claim_text: str | None) -> OTTransitionClaimClassification:
+    """Classify analyst/vendor/source assertions into generic T1-T4 claim tiers.
+
+    T1 is strongest (explicit OT + Phase III + transition/follow-on language).
+    T4 is weakest (no recognizable external OT Phase III transition assertion).
+    """
+
+    text = (claim_text or "").lower()
+    signals: list[str] = []
+
+    has_ot = bool(
+        re.search(r"\b(other transaction|ota|ot agreement|ot consortium|consortium)\b", text)
+    )
+    has_phase_iii = bool(re.search(r"\b(phase iii|phase 3|phase three)\b", text))
+    has_transition = bool(
+        re.search(
+            r"\b(transition(?:ed)?|follow-?on|production|prototype|derives from|commerciali[sz]ation)\b",
+            text,
+        )
+    )
+    has_lineage = bool(
+        re.search(r"\b(sbir|sttr|phase ii|phase 2|prior award|prior effort)\b", text)
+    )
+
+    if has_ot:
+        signals.append("ot_vehicle")
+    if has_phase_iii:
+        signals.append("phase_iii")
+    if has_transition:
+        signals.append("transition_language")
+    if has_lineage:
+        signals.append("sbir_sttr_lineage")
+
+    if has_ot and has_phase_iii and has_transition:
+        tier = "T1"
+    elif has_phase_iii and has_transition and has_lineage:
+        tier = "T2"
+    elif has_phase_iii or (has_ot and has_transition):
+        tier = "T3"
+    else:
+        tier = "T4"
+
+    return OTTransitionClaimClassification(
+        tier=tier,
+        benchmark_neutral=True,
+        matched_signals=tuple(signals),
+    )

--- a/packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py
+++ b/packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py
@@ -30,9 +30,10 @@ def classify_external_ot_transition_claim(claim_text: str | None) -> OTTransitio
     text = (claim_text or "").lower()
     signals: list[str] = []
 
-    has_ot = bool(
-        re.search(r"\b(other transaction|ota|ot agreement|ot consortium|consortium)\b", text)
-    )
+    # Explicit OT/OTA phrasing only. Bare "consortium" is too generic (any text
+    # mentioning a consortium + a transition word would false-positive into an
+    # OT-related tier), so it is intentionally excluded.
+    has_ot = bool(re.search(r"\b(other transaction|ota|ot agreement|ot consortium)\b", text))
     has_phase_iii = bool(re.search(r"\b(phase iii|phase 3|phase three)\b", text))
     has_transition = bool(
         re.search(

--- a/tests/unit/analysis/test_ot_transition_claims.py
+++ b/tests/unit/analysis/test_ot_transition_claims.py
@@ -1,0 +1,68 @@
+"""Tests for generic external OT Phase III transition claim classification."""
+
+import pytest
+
+from sbir_ml.transition.analysis.ot_transition_claims import (
+    classify_external_ot_transition_claim,
+)
+
+
+@pytest.fixture
+def external_ot_transition_claims():
+    """Generic OT-transition claim fixtures spanning expected T1-T4 tiers."""
+
+    return {
+        "explicit_ot_phase_iii_transition": (
+            "The OT consortium award is an SBIR Phase III transition for follow-on "
+            "prototype production derived from the prior Phase II effort."
+        ),
+        "phase_iii_lineage_without_ot_vehicle": (
+            "Analyst note: Phase III follow-on production derives from the prior "
+            "SBIR Phase II award."
+        ),
+        "ot_transition_without_phase_iii": (
+            "The OTA prototype transitioned to a follow-on production effort "
+            "through the consortium."
+        ),
+        "unrelated_market_update": (
+            "Company announced a commercial product update with no federal transition claim."
+        ),
+    }
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_tier"),
+    [
+        ("explicit_ot_phase_iii_transition", "T1"),
+        ("phase_iii_lineage_without_ot_vehicle", "T2"),
+        ("ot_transition_without_phase_iii", "T3"),
+        ("unrelated_market_update", "T4"),
+    ],
+)
+def test_external_transition_claim_fixtures_produce_expected_tiers(
+    external_ot_transition_claims, fixture_name, expected_tier
+):
+    result = classify_external_ot_transition_claim(external_ot_transition_claims[fixture_name])
+
+    assert result.tier == expected_tier
+    assert result.benchmark_neutral is True
+    assert not hasattr(result, "benchmark_tier")
+    assert not hasattr(result, "commercialization_benchmark_status")
+
+
+def test_input_mode_classifies_external_transition_claims(external_ot_transition_claims):
+    """Input mode accepts an analyst-supplied OT Phase III assertion, not covered sales."""
+
+    analyst_supplied_input = {
+        "source_type": "analyst_supplied_assertion",
+        "claim_text": external_ot_transition_claims["explicit_ot_phase_iii_transition"],
+    }
+
+    result = classify_external_ot_transition_claim(analyst_supplied_input["claim_text"])
+
+    assert analyst_supplied_input["source_type"] == "analyst_supplied_assertion"
+    assert result.tier == "T1"
+    assert result.benchmark_neutral is True
+    assert "ot_vehicle" in result.matched_signals
+    assert "phase_iii" in result.matched_signals
+    assert "transition_language" in result.matched_signals


### PR DESCRIPTION
### Motivation
- Provide a lightweight, benchmark-neutral classifier to validate externally supplied OT (Other Transaction) Phase III transition claims instead of relying on covered-sales-specific fixtures.
- Ensure tests and fixtures exercise generic T1–T4 claim tiers for analyst- or vendor-supplied assertions.
- Make it straightforward to accept input-mode assertions (e.g., analyst-supplied claim text) and verify classifier behavior.

### Description
- Added `packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py` which implements `classify_external_ot_transition_claim` and the `OTTransitionClaimClassification` dataclass that returns `tier`, `benchmark_neutral`, and `matched_signals`.
- Classification is rule-based using regex signals (`ot_vehicle`, `phase_iii`, `transition_language`, `sbir_sttr_lineage`) and maps combinations to generic tiers `T1`–`T4` while remaining benchmark-neutral.
- Added tests in `tests/unit/analysis/test_ot_transition_claims.py` that provide fixtures for explicit OT Phase III transition, Phase III lineage (no OT), OT transition (no Phase III), and unrelated text, plus an input-mode test that simulates an `analyst_supplied_assertion` claim.

### Testing
- Compiled new files with `python -m compileall -q` to ensure syntax sanity, which succeeded.
- Ran the unit test file with `PYTHONPATH=packages/sbir-ml uv run pytest -o addopts='' tests/unit/analysis/test_ot_transition_claims.py -q`, and all tests passed (`5 passed`, 2 pytest config warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dc2e361988322b52e3a6122d123d9)