### PR TITLE
spec: plan to unify legacy :Award node onto :FinancialTransaction (Phase 1)

### DIFF
--- a/docs/schemas/financial-transaction-schema.md
+++ b/docs/schemas/financial-transaction-schema.md
@@ -201,18 +201,19 @@ updated_at: DateTime (nullable)
 - `FUNDED_BY`: (FinancialTransaction) → (Organization {agency})
 - `CONDUCTED_AT`: (FinancialTransaction) → (Organization {research institution})
 - `TRANSITIONED_TO`: (FinancialTransaction {AWARD}) → (Transition)
+- `APPLICABLE_TO`: (FinancialTransaction {AWARD}) → (CETArea) - CET classification
 - `FOLLOWS`: (FinancialTransaction) → (FinancialTransaction) - Phase progressions
 
 ### Incoming Relationships
 
 - `PARTICIPATED_IN`: (Individual) → (FinancialTransaction)
 - `RESULTED_IN`: (Transition) → (FinancialTransaction {CONTRACT})
+- `GENERATED_FROM`: (Patent) → (FinancialTransaction {AWARD}) - SBIR-funded patents
 
-> **Note — patents link to the legacy `:Award` label, not this node.** The patent
-> loader creates `(:Patent)-[:GENERATED_FROM]->(:Award)`, where `:Award` is a separate
-> legacy label written by the sbir-graph package (CET / patent loaders), *not* the
-> `:FinancialTransaction` node described here. See [neo4j.md](neo4j.md) for the two
-> coexisting label families.
+> CET enrichment, `APPLICABLE_TO`, and `GENERATED_FROM` attach to the award
+> `FinancialTransaction` (matched on its `award_id` property), not to a separate
+> `:Award` node. The legacy `:Award` label was unified onto `FinancialTransaction`
+> in migration `006`. See [neo4j.md](neo4j.md) for the remaining legacy labels.
 
 ## Example Cypher Queries
 

--- a/docs/schemas/neo4j.md
+++ b/docs/schemas/neo4j.md
@@ -39,13 +39,17 @@ and links to the per-node reference docs.
 > researchers and patent individuals. Several sbir-graph package loaders still write
 > **legacy** labels and actively link to them:
 >
-> - `:Award` — `cet.py` (`APPLICABLE_TO`) and `patents.py` (`GENERATED_FROM`)
 > - `:Company` — `categorization.py`, `cet.py`, `sec_edgar.py`
 > - `:Contract` — `transition/loading.py`
 > - `:PatentEntity` — `patents.py` (individual assignors/assignees; `ASSIGNED_FROM`/`ASSIGNED_TO`)
 >
 > Treat the legacy labels as **active until those loaders migrate** to the unified
 > model; the relationship table below lists the edges that target them.
+>
+> `:Award` has been unified onto `:FinancialTransaction` (migration `006`): CET
+> enrichment, `APPLICABLE_TO`, and `GENERATED_FROM` now attach to the
+> `FinancialTransaction` with `transaction_type = "AWARD"`, matched on its
+> `award_id` property. No loader writes a separate `:Award` node any more.
 
 ## Relationship Types
 
@@ -63,18 +67,18 @@ and links to the per-node reference docs.
 | `ENABLED_BY` | `Transition` → `Patent` | `transitions.py` |
 | `INVOLVES_TECHNOLOGY` | `Transition` → `CETArea` | `transitions.py` |
 | `ACHIEVED` | `Organization` (COMPANY) → `TransitionProfile` | `profiles.py` |
-| `APPLICABLE_TO` | `Award` → `CETArea` (CET classification; legacy node target) | `cet.py` |
+| `APPLICABLE_TO` | `FinancialTransaction` (AWARD) → `CETArea` (CET classification) | `cet.py` |
 | `SPECIALIZES_IN` | `Organization` (COMPANY) → `CETArea` | `cet.py` |
 | `OWNS` | `Organization` (COMPANY) → `Patent` | `patents.py` |
 | `ASSIGNED_VIA` | `Patent` → `PatentAssignment` | `patents.py` |
 | `ASSIGNED_TO` | `PatentAssignment` → `Organization` / `Individual` | `patents.py` |
 | `ASSIGNED_FROM` | `PatentAssignment` → `Organization` / `Individual` | `patents.py` |
 | `CHAIN_OF` | `PatentAssignment` → `PatentAssignment` | `patents.py` |
-| `GENERATED_FROM` | `Patent` → `Award` (SBIR-funded patents) | `patents.py` |
+| `GENERATED_FROM` | `Patent` → `FinancialTransaction` (AWARD; SBIR-funded patents) | `patents.py` |
 
-> `GENERATED_FROM` targets an `award_id` key; in the unified model an SBIR award is a
-> `FinancialTransaction` with `transaction_type = "AWARD"` (key `transaction_id =
-> "txn_award_<award_id>"`).
+> `GENERATED_FROM` is resolved by matching the `FinancialTransaction` on its
+> `award_id` property; an SBIR award is a `FinancialTransaction` with
+> `transaction_type = "AWARD"` (key `transaction_id = "txn_award_<award_id>"`).
 
 ## Transition, TransitionProfile, and CETArea nodes
 
@@ -130,7 +134,7 @@ Source: `cet.py`. Key: `cet_id` (UNIQUE). Critical & Emerging Technology taxonom
 
 Indexes: `cet_id` (constraint), `name`, `taxonomy_version`.
 CET classifications are also written as enrichment properties on `Organization` (companies)
-and `Award` nodes, and as `SPECIALIZES_IN` / `APPLICABLE_TO` relationships.
+and `FinancialTransaction` (AWARD) nodes, and as `SPECIALIZES_IN` / `APPLICABLE_TO` relationships.
 
 ## Per-node reference docs
 

--- a/migrations/versions/006_unify_award_into_financial_transaction.py
+++ b/migrations/versions/006_unify_award_into_financial_transaction.py
@@ -1,0 +1,164 @@
+"""Unify the legacy :Award node onto :FinancialTransaction.
+
+Phase 1 of the unify-graph-node-labels spec. The authoritative SBIR loader writes
+``:FinancialTransaction`` nodes (key ``transaction_id``, also carrying ``award_id``),
+while legacy enrichment loaders wrote a disjoint ``:Award`` node (key ``award_id``)
+that held CET enrichment and was the endpoint of ``APPLICABLE_TO`` and
+``GENERATED_FROM``. Because the two node sets are disjoint for the same award, every
+cross-model query silently traversed nothing.
+
+This migration re-homes, for each ``:Award`` whose ``award_id`` matches a
+``:FinancialTransaction``:
+  * all ``:Award`` properties (``SET ft += properties(a)``);
+  * ``(a)-[:APPLICABLE_TO]->(c)``  ⇒  ``(ft)-[:APPLICABLE_TO]->(c)``;
+  * ``(p)-[:GENERATED_FROM]->(a)``  ⇒  ``(p)-[:GENERATED_FROM]->(ft)``;
+
+then ``DETACH DELETE``s the matched ``:Award``. Orphan ``:Award`` nodes (no matching
+FinancialTransaction) are logged and LEFT IN PLACE so no data is lost.
+
+It is idempotent (re-runs find no remaining matched ``:Award``) and batched via
+``apoc``-free Cypher. Finally it drops the legacy ``:Award`` unique constraint and
+the ``award_date`` / ``award_topic_code`` indexes.
+
+WARNING: this migration ``DETACH DELETE``s nodes. Back up the graph and run a
+dry-run before applying to a live database.
+"""
+
+from loguru import logger
+from migrations.base import Migration
+from neo4j import Driver  # type: ignore[attr-defined]
+
+# Batch size for the re-home loop (number of :Award nodes processed per write tx).
+_BATCH_SIZE = 1000
+
+
+class UnifyAwardIntoFinancialTransaction(Migration):
+    """Re-home legacy :Award nodes onto :FinancialTransaction and drop legacy schema."""
+
+    def __init__(self) -> None:
+        super().__init__("006", "Unify Award into FinancialTransaction")
+
+    def upgrade(self, driver: Driver) -> None:
+        """Re-home matched :Award nodes onto :FinancialTransaction, then drop legacy schema."""
+        with driver.session() as session:
+            # 1. Report orphans (no matching FinancialTransaction) up front; leave them in place.
+            orphan_record = session.run(
+                """
+                MATCH (a:Award)
+                WHERE NOT EXISTS {
+                    MATCH (ft:FinancialTransaction {award_id: a.award_id})
+                }
+                RETURN count(a) AS n
+                """
+            ).single()
+            orphan_count = orphan_record["n"] if orphan_record else 0
+            if orphan_count:
+                logger.warning(
+                    "{} :Award node(s) have no matching :FinancialTransaction; "
+                    "leaving them in place (data preserved, not deleted).",
+                    orphan_count,
+                )
+
+            # 2. Re-home matched :Award nodes in batches until none remain.
+            total_rehomed = 0
+            while True:
+                record = session.execute_write(self._rehome_batch)
+                rehomed = record["rehomed"]
+                total_rehomed += rehomed
+                if rehomed < _BATCH_SIZE:
+                    break
+
+            logger.info(
+                "Unified {} :Award node(s) onto :FinancialTransaction "
+                "({} orphan(s) left in place).",
+                total_rehomed,
+                orphan_count,
+            )
+
+            # 3. Drop legacy :Award constraint and indexes (safe if already absent).
+            for stmt in (
+                "DROP CONSTRAINT award_id IF EXISTS",
+                "DROP INDEX award_date IF EXISTS",
+                "DROP INDEX award_topic_code IF EXISTS",
+            ):
+                try:
+                    session.run(stmt)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.debug("Legacy schema drop statement skipped: {} ({})", stmt, e)
+
+    @staticmethod
+    def _rehome_batch(tx) -> dict:  # type: ignore[no-untyped-def]
+        """Re-home a single batch of matched :Award nodes within one transaction.
+
+        Copies :Award properties onto the matched FinancialTransaction, re-homes
+        APPLICABLE_TO and GENERATED_FROM edges (copying relationship properties),
+        then DETACH DELETEs the consumed :Award node. Returns the number re-homed.
+        """
+        result = tx.run(
+            """
+            MATCH (a:Award)
+            MATCH (ft:FinancialTransaction {award_id: a.award_id})
+            WITH a, ft
+            LIMIT $batch_size
+
+            // Copy all :Award properties onto the matched FinancialTransaction.
+            SET ft += properties(a)
+
+            // Re-home APPLICABLE_TO edges (a)->(c), copying relationship properties.
+            WITH a, ft
+            CALL {
+                WITH a, ft
+                MATCH (a)-[r:APPLICABLE_TO]->(c)
+                MERGE (ft)-[r2:APPLICABLE_TO]->(c)
+                SET r2 += properties(r)
+                RETURN count(r) AS applicable_to
+            }
+
+            // Re-home GENERATED_FROM edges (p)->(a), copying relationship properties.
+            WITH a, ft, applicable_to
+            CALL {
+                WITH a, ft
+                MATCH (p)-[r:GENERATED_FROM]->(a)
+                MERGE (p)-[r2:GENERATED_FROM]->(ft)
+                SET r2 += properties(r)
+                RETURN count(r) AS generated_from
+            }
+
+            // Remove the now-consumed :Award node and any remaining edges.
+            WITH a, applicable_to, generated_from
+            DETACH DELETE a
+            RETURN count(a) AS rehomed,
+                   sum(applicable_to) AS applicable_to,
+                   sum(generated_from) AS generated_from
+            """,
+            batch_size=_BATCH_SIZE,
+        )
+        record = result.single()
+        return {
+            "rehomed": record["rehomed"] if record else 0,
+            "applicable_to": (record["applicable_to"] or 0) if record else 0,
+            "generated_from": (record["generated_from"] or 0) if record else 0,
+        }
+
+    def downgrade(self, driver: Driver) -> None:
+        """Recreate the legacy :Award constraint and indexes.
+
+        NOTE: this downgrade is intentionally partial. The node-split is NOT
+        perfectly reversible: once :Award properties and edges have been merged
+        onto :FinancialTransaction and the :Award nodes deleted, there is no
+        reliable way to re-derive which properties/edges originated on the legacy
+        :Award node. This restores the legacy schema objects only; it does not
+        re-split nodes. Restore from a pre-migration backup if a full rollback is
+        required.
+        """
+        statements = (
+            "CREATE CONSTRAINT award_id IF NOT EXISTS FOR (a:Award) REQUIRE a.award_id IS UNIQUE",
+            "CREATE INDEX award_date IF NOT EXISTS FOR (a:Award) ON (a.award_date)",
+            "CREATE INDEX award_topic_code IF NOT EXISTS FOR (a:Award) ON (a.topic_code)",
+        )
+        with driver.session() as session:
+            for stmt in statements:
+                try:
+                    session.run(stmt)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.debug("Legacy schema recreate statement skipped: {} ({})", stmt, e)

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/loading.py
@@ -317,7 +317,8 @@ def transition_relationships_check(
         with driver.session(database=DEFAULT_NEO4J_DATABASE) as session:
             # Count relationships
             tt_count = session.run(
-                "MATCH (a:Award)-[r:TRANSITIONED_TO]->(t:Transition) RETURN count(r) as n"
+                "MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})"
+                "-[r:TRANSITIONED_TO]->(t:Transition) RETURN count(r) as n"
             ).single()["n"]
 
             ri_count = session.run(

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/cet.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/cet.py
@@ -6,13 +6,13 @@ Implements Section 12 (Neo4j CET Graph Model - Nodes):
 12.2 Add uniqueness constraints for CETArea
 12.3 Add CETArea properties (id, name, keywords, taxonomy_version)
 12.4 Create Company node CET enrichment properties
-12.5 Create Award node CET enrichment properties
+12.5 Set FinancialTransaction node CET enrichment properties
 12.6 Add batching + idempotent merges
 
 This module provides CETLoader with helpers to:
 - Create constraints and indexes for CETArea
 - Upsert CETArea nodes (idempotent MERGE via Neo4jClient)
-- Upsert Company and Award enrichment properties related to CET classifications
+- Enrich Company and FinancialTransaction nodes with CET classifications
 
 Notes:
 - Relies on Neo4jClient for batching and transaction mgmt
@@ -41,7 +41,7 @@ class CETLoader(BaseNeo4jLoader):
     Responsibilities:
       - Define CETArea schema (constraints + indexes)
       - Idempotently upsert CETArea nodes
-      - Add CET enrichment properties to Company and Award nodes
+      - Add CET enrichment properties to Company and FinancialTransaction nodes
 
     Refactored to inherit from BaseNeo4jLoader for consistency.
 
@@ -72,9 +72,7 @@ class CETLoader(BaseNeo4jLoader):
                 # CETArea uniqueness on cet_id
                 "CREATE CONSTRAINT cetarea_cet_id IF NOT EXISTS "
                 "FOR (c:CETArea) REQUIRE c.cet_id IS UNIQUE",
-                # Optional: ensure Award and Company constraints exist for enrichment keys
-                "CREATE CONSTRAINT award_award_id IF NOT EXISTS "
-                "FOR (a:Award) REQUIRE a.award_id IS UNIQUE",
+                # Optional: ensure Company constraint exists for enrichment keys
                 "CREATE CONSTRAINT company_id IF NOT EXISTS "
                 "FOR (c:Company) REQUIRE c.company_id IS UNIQUE",
             ]
@@ -233,7 +231,7 @@ class CETLoader(BaseNeo4jLoader):
         return metrics
 
     # -------------------------------------------------------------------------
-    # Award enrichment properties
+    # Award-level CET enrichment (on FinancialTransaction)
     # -------------------------------------------------------------------------
 
     def upsert_award_cet_enrichment(
@@ -243,7 +241,12 @@ class CETLoader(BaseNeo4jLoader):
         key_property: str = "award_id",
         metrics: LoadMetrics | None = None,
     ) -> LoadMetrics:
-        """Upsert CET enrichment properties onto Award nodes.
+        """Set CET enrichment properties onto existing FinancialTransaction nodes.
+
+        Resolves each award by MATCH on the FinancialTransaction ``award_id``
+        property (never MERGE on it, which would mint a duplicate FT keyed by
+        ``transaction_id``). Awards with no matching FinancialTransaction are
+        logged and skipped, not created.
 
         Each enrichment dict must include key_property (default 'award_id').
         Allowed enrichment properties:
@@ -256,11 +259,11 @@ class CETLoader(BaseNeo4jLoader):
 
         Args:
             enrichments: iterable of mappings with key_property and enrichment fields
-            key_property: Award key to MERGE on (default 'award_id')
+            key_property: FinancialTransaction property to MATCH on (default 'award_id')
             metrics: optional LoadMetrics
 
         Returns:
-            LoadMetrics with counts of updated nodes
+            LoadMetrics with counts of matched/updated nodes
         """
         metrics = metrics or LoadMetrics()
         nodes: list[dict[str, Any]] = []
@@ -268,7 +271,11 @@ class CETLoader(BaseNeo4jLoader):
         for raw in enrichments:
             key_val = _as_str(raw.get(key_property))
             if not key_val:
-                logger.warning("Skipping Award enrichment missing key {}: {}", key_property, raw)
+                logger.warning(
+                    "Skipping FinancialTransaction CET enrichment missing key {}: {}",
+                    key_property,
+                    raw,
+                )
                 metrics.errors += 1
                 continue
 
@@ -295,18 +302,25 @@ class CETLoader(BaseNeo4jLoader):
             nodes.append(node)
 
         if not nodes:
-            logger.info("No Award CET enrichments to upsert")
+            logger.info("No FinancialTransaction CET enrichments to set")
             return metrics
 
-        logger.info("Upserting {} Award CET enrichment nodes (key={})", len(nodes), key_property)
+        logger.info(
+            "Setting CET enrichment on {} FinancialTransaction nodes (key={})",
+            len(nodes),
+            key_property,
+        )
         self.client.config.batch_size = self.config.batch_size
-        metrics = self.client.batch_upsert_nodes(
-            label="Award", key_property=key_property, nodes=nodes, metrics=metrics
+        metrics = self.client.batch_set_existing_node_properties(
+            label="FinancialTransaction",
+            key_property=key_property,
+            nodes=nodes,
+            metrics=metrics,
         )
         return metrics
 
     # -------------------------------------------------------------------------
-    # Award -> CETArea relationships
+    # FinancialTransaction -> CETArea relationships
     # -------------------------------------------------------------------------
 
     def create_award_cet_relationships(
@@ -316,10 +330,14 @@ class CETLoader(BaseNeo4jLoader):
         rel_type: str = "APPLICABLE_TO",
         metrics: LoadMetrics | None = None,
     ) -> LoadMetrics:
-        """Create Award -> CETArea relationships with MERGE semantics.
+        """Create FinancialTransaction -> CETArea relationships with MERGE semantics.
+
+        The FinancialTransaction is resolved by MATCH on its ``award_id`` property
+        and only the relationship is MERGEd, so no FinancialTransaction node is
+        ever created (which a MERGE on ``award_id`` would do).
 
         Relationship schema:
-            (a:Award)-[:APPLICABLE_TO {
+            (a:FinancialTransaction)-[:APPLICABLE_TO {
                 score: FLOAT,
                 primary: BOOLEAN,
                 role: STRING,    # 'PRIMARY' or 'SUPPORTING'
@@ -344,7 +362,9 @@ class CETLoader(BaseNeo4jLoader):
         for row in classifications:
             aid = _as_str(row.get("award_id"))
             if not aid:
-                logger.warning("Skipping Award->CET mapping with missing award_id: {}", row)
+                logger.warning(
+                    "Skipping FinancialTransaction->CET mapping with missing award_id: {}", row
+                )
                 metrics.errors += 1
                 continue
 
@@ -377,7 +397,16 @@ class CETLoader(BaseNeo4jLoader):
                 # remove None values to avoid overwriting with nulls
                 props = {k: v for k, v in props.items() if v is not None}
                 relationships.append(
-                    ("Award", "award_id", aid, "CETArea", "cet_id", primary_id, rel_type, props)
+                    (
+                        "FinancialTransaction",
+                        "award_id",
+                        aid,
+                        "CETArea",
+                        "cet_id",
+                        primary_id,
+                        rel_type,
+                        props,
+                    )
                 )
 
             # Supporting
@@ -399,17 +428,26 @@ class CETLoader(BaseNeo4jLoader):
                         }
                         props = {k: v for k, v in props.items() if v is not None}
                         relationships.append(
-                            ("Award", "award_id", aid, "CETArea", "cet_id", cid, rel_type, props)
+                            (
+                                "FinancialTransaction",
+                                "award_id",
+                                aid,
+                                "CETArea",
+                                "cet_id",
+                                cid,
+                                rel_type,
+                                props,
+                            )
                         )
                     except Exception:
                         continue
 
         if not relationships:
-            logger.info("No Award -> CETArea relationships to create")
+            logger.info("No FinancialTransaction -> CETArea relationships to create")
             return metrics
 
         logger.info(
-            "Creating {} Award -> CETArea relationships (type={})",
+            "Creating {} FinancialTransaction -> CETArea relationships (type={})",
             len(relationships),
             rel_type,
         )

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/client.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/client.py
@@ -147,7 +147,6 @@ class Neo4jClient:
         constraints = [
             # Legacy constraints (kept for backward compatibility)
             "CREATE CONSTRAINT company_id IF NOT EXISTS FOR (c:Company) REQUIRE c.company_id IS UNIQUE",
-            "CREATE CONSTRAINT award_id IF NOT EXISTS FOR (a:Award) REQUIRE a.award_id IS UNIQUE",
             "CREATE CONSTRAINT researcher_id IF NOT EXISTS FOR (r:Researcher) REQUIRE r.researcher_id IS UNIQUE",
             "CREATE CONSTRAINT patent_id IF NOT EXISTS FOR (p:Patent) REQUIRE p.patent_id IS UNIQUE",
             "CREATE CONSTRAINT institution_name IF NOT EXISTS FOR (i:ResearchInstitution) REQUIRE i.name IS UNIQUE",
@@ -180,7 +179,6 @@ class Neo4jClient:
             "CREATE INDEX company_normalized_name IF NOT EXISTS FOR (c:Company) ON (c.normalized_name)",
             "CREATE INDEX company_uei IF NOT EXISTS FOR (c:Company) ON (c.uei)",
             "CREATE INDEX company_duns IF NOT EXISTS FOR (c:Company) ON (c.duns)",
-            "CREATE INDEX award_date IF NOT EXISTS FOR (a:Award) ON (a.award_date)",
             "CREATE INDEX researcher_name IF NOT EXISTS FOR (r:Researcher) ON (r.name)",
             "CREATE INDEX patent_number IF NOT EXISTS FOR (p:Patent) ON (p.patent_number)",
             "CREATE INDEX institution_name IF NOT EXISTS FOR (i:ResearchInstitution) ON (i.name)",
@@ -360,6 +358,99 @@ class Neo4jClient:
             f"{metrics.nodes_created.get(label, 0)} created, "
             f"{metrics.nodes_updated.get(label, 0)} updated, "
             f"{metrics.errors} errors"
+        )
+
+        return metrics
+
+    def batch_set_existing_node_properties(
+        self,
+        label: str,
+        key_property: str,
+        nodes: list[dict[str, Any]],
+        metrics: LoadMetrics | None = None,
+    ) -> LoadMetrics:
+        """Set properties on existing nodes only (MATCH-and-SET, never create).
+
+        Unlike ``batch_upsert_nodes`` (which ``MERGE``s and would create a node when
+        none exists), this resolves each node by ``MATCH`` on ``key_property`` and
+        ``SET n += row``. It NEVER creates a node. This is the safe primitive for
+        enriching ``:FinancialTransaction`` by its non-key ``award_id`` property:
+        a ``MERGE`` on ``award_id`` would mint a duplicate FinancialTransaction.
+
+        Rows whose ``key_property`` does not match an existing node are orphans:
+        they are logged and skipped (counted as updates of 0), never created.
+
+        Args:
+            label: Node label to match (e.g. "FinancialTransaction")
+            key_property: Property name to MATCH on (e.g. "award_id")
+            nodes: List of property dicts; each must carry ``key_property``
+            metrics: Optional metrics object to update
+
+        Returns:
+            Load metrics with the count of matched/updated nodes recorded under
+            ``nodes_updated[label]``.
+        """
+        if metrics is None:
+            metrics = LoadMetrics()
+
+        batch_size = self.config.batch_size
+        total_batches = (len(nodes) + batch_size - 1) // batch_size
+
+        logger.info(
+            f"Setting properties on existing {label} nodes "
+            f"({len(nodes)} rows in {total_batches} batches of {batch_size}, "
+            f"matched by {key_property})"
+        )
+
+        with self.session() as session:
+            for i in range(0, len(nodes), batch_size):
+                batch = nodes[i : i + batch_size]
+                batch_num = i // batch_size + 1
+
+                # Filter out rows missing the key property
+                valid_batch = [n for n in batch if n.get(key_property) is not None]
+                invalid_count = len(batch) - len(valid_batch)
+                if invalid_count > 0:
+                    logger.error(f"{invalid_count} rows missing key property {key_property}")
+                    metrics.errors += invalid_count
+
+                if not valid_batch:
+                    continue
+
+                try:
+                    query = f"""
+                    UNWIND $batch AS row
+                    MATCH (n:{label} {{{key_property}: row.{key_property}}})
+                    SET n += row
+                    RETURN count(n) AS matched_count
+                    """
+
+                    result = session.run(query, batch=valid_batch)
+                    record = result.single()
+                    matched = record["matched_count"] if record else 0
+                    skipped = len(valid_batch) - matched
+
+                    metrics.nodes_updated[label] = metrics.nodes_updated.get(label, 0) + matched
+
+                    if skipped > 0:
+                        logger.warning(
+                            f"Batch {batch_num}/{total_batches}: {skipped} {label} "
+                            f"rows had no existing node for {key_property} (orphans skipped, "
+                            "not created)"
+                        )
+
+                    logger.debug(
+                        f"Batch {batch_num}/{total_batches} committed "
+                        f"({matched}/{len(valid_batch)} {label} nodes matched and updated)"
+                    )
+
+                except Exception as e:
+                    metrics.errors += len(valid_batch)
+                    logger.error(f"Error in batch {batch_num}/{total_batches} for {label}: {e}")
+
+        logger.info(
+            f"Completed {label} property set: "
+            f"{metrics.nodes_updated.get(label, 0)} matched/updated, {metrics.errors} errors"
         )
 
         return metrics

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py
@@ -676,14 +676,17 @@ class PatentLoader(BaseNeo4jLoader):
         patent_awards: list[dict[str, str]],
         metrics: LoadMetrics | None = None,
     ) -> LoadMetrics:
-        """Create GENERATED_FROM relationships (Patent → Award).
+        """Create GENERATED_FROM relationships (Patent → FinancialTransaction).
 
-        Phase 4: Link Patent nodes to Award nodes for SBIR-funded patents.
+        Phase 4: Link Patent nodes to the FinancialTransaction (AWARD) node for
+        SBIR-funded patents. The FinancialTransaction is resolved by MATCH on its
+        ``award_id`` property; only the relationship is MERGEd, so no
+        FinancialTransaction node is ever created.
 
         Args:
             patent_awards: List of patent-award pairs with:
                 - grant_doc_num: Patent key
-                - award_id: Award key
+                - award_id: FinancialTransaction award_id
 
             metrics: Optional LoadMetrics to accumulate results
 
@@ -715,7 +718,7 @@ class PatentLoader(BaseNeo4jLoader):
                     "Patent",
                     "grant_doc_num",
                     str(grant_doc_num).strip(),
-                    "Award",
+                    "FinancialTransaction",
                     "award_id",
                     str(award_id).strip(),
                     "GENERATED_FROM",

--- a/packages/sbir-graph/sbir_graph/queries/pathway_queries.py
+++ b/packages/sbir-graph/sbir_graph/queries/pathway_queries.py
@@ -66,12 +66,12 @@ class TransitionPathwayQueries:
         award_filter = "" if not award_id else f"WHERE a.award_id = '{award_id}'"
 
         query = f"""
-        MATCH (a:Award) {award_filter}
+        MATCH (a:FinancialTransaction {{transaction_type: 'AWARD'}}) {award_filter}
         MATCH (a)-[r:TRANSITIONED_TO]->(trans:Transition)-[r2:RESULTED_IN]->(c:Contract)
         WHERE r.score >= {min_score} {confidence_filter}
         RETURN {{
             award_id: a.award_id,
-            award_name: a.award_title,
+            award_name: a.title,
             transition_id: trans.transition_id,
             transition_score: r.score,
             transition_confidence: r.confidence,
@@ -115,14 +115,14 @@ class TransitionPathwayQueries:
         award_filter = "" if not award_id else f"WHERE a.award_id = '{award_id}'"
 
         query = f"""
-        MATCH (a:Award) {award_filter}
+        MATCH (a:FinancialTransaction {{transaction_type: 'AWARD'}}) {award_filter}
         MATCH (p:Patent)-[:GENERATED_FROM]->(a)
         MATCH (trans:Transition)-[r:ENABLED_BY]->(p)
         WHERE r.contribution_score >= {min_patent_contribution}
         MATCH (trans)-[r2:RESULTED_IN]->(c:Contract)
         RETURN {{
             award_id: a.award_id,
-            award_name: a.award_title,
+            award_name: a.title,
             patent_id: p.patent_id,
             patent_title: p.title,
             patent_contribution: r.contribution_score,
@@ -167,13 +167,13 @@ class TransitionPathwayQueries:
         cet_filter = "" if not cet_area else f"WHERE cet.cet_id = '{cet_area}'"
 
         query = f"""
-        MATCH (a:Award)
+        MATCH (a:FinancialTransaction {{transaction_type: 'AWARD'}})
         MATCH (trans:Transition)-[r1:TRANSITIONED_TO]-(a)
         MATCH (trans)-[r2:INVOLVES_TECHNOLOGY]->(cet:CETArea) {cet_filter}
         WHERE trans.likelihood_score >= {min_score}
         RETURN {{
             award_id: a.award_id,
-            award_title: a.award_title,
+            award_title: a.title,
             transition_id: trans.transition_id,
             transition_score: trans.likelihood_score,
             cet_area: cet.cet_id,
@@ -264,7 +264,7 @@ class TransitionPathwayQueries:
              COUNT(DISTINCT trans) as transition_count,
              AVG(trans.likelihood_score) as avg_score,
              COUNT(CASE WHEN trans.confidence = 'high' THEN 1 END) as high_conf_count
-        MATCH (cet)<-[:APPLICABLE_TO]-(a:Award)
+        MATCH (cet)<-[:APPLICABLE_TO]-(a:FinancialTransaction {{transaction_type: 'AWARD'}})
         WITH cet,
              transition_count,
              avg_score,
@@ -309,7 +309,7 @@ class TransitionPathwayQueries:
         WITH cet,
              COUNT(DISTINCT trans) as patent_backed_transitions,
              AVG(trans.likelihood_score) as avg_score
-        MATCH (cet)<-[:APPLICABLE_TO]-(a:Award)
+        MATCH (cet)<-[:APPLICABLE_TO]-(a:FinancialTransaction {{transaction_type: 'AWARD'}})
         WITH cet,
              patent_backed_transitions,
              avg_score,

--- a/packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py
+++ b/packages/sbir-ml/sbir_ml/transition/analysis/ot_transition_claims.py
@@ -20,7 +20,9 @@ class OTTransitionClaimClassification:
     matched_signals: tuple[str, ...]
 
 
-def classify_external_ot_transition_claim(claim_text: str | None) -> OTTransitionClaimClassification:
+def classify_external_ot_transition_claim(
+    claim_text: str | None,
+) -> OTTransitionClaimClassification:
     """Classify analyst/vendor/source assertions into generic T1-T4 claim tiers.
 
     T1 is strongest (explicit OT + Phase III + transition/follow-on language).

--- a/sbir_etl/utils/enrichment/freshness.py
+++ b/sbir_etl/utils/enrichment/freshness.py
@@ -333,7 +333,7 @@ def persist_to_neo4j(
         neo4j_driver: Neo4j driver instance
     """
     query = """
-    MATCH (a:Award {award_id: $award_id})
+    MATCH (a:FinancialTransaction {award_id: $award_id})
     SET a.`enrichment_freshness_` + $source + `_last_attempt_at` = $last_attempt_at,
         a.`enrichment_freshness_` + $source + `_last_success_at` = $last_success_at,
         a.`enrichment_freshness_` + $source + `_payload_hash` = $payload_hash,

--- a/scripts/data/reset_neo4j_sbir.py
+++ b/scripts/data/reset_neo4j_sbir.py
@@ -31,41 +31,45 @@ def reset_neo4j(
         with driver.session(database=database) as session:
             if dry_run:
                 # Count what would be deleted
-                award_count = session.run("MATCH (a:Award) RETURN count(a) as count").single()[
-                    "count"
-                ]
+                award_count = session.run(
+                    "MATCH (a:FinancialTransaction {transaction_type: 'AWARD'}) "
+                    "RETURN count(a) as count"
+                ).single()["count"]
                 company_count = session.run("MATCH (c:Company) RETURN count(c) as count").single()[
                     "count"
                 ]
                 rel_count = session.run(
-                    "MATCH (a:Award)-[r:AWARDS]->(c:Company) RETURN count(r) as count"
+                    "MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})"
+                    "-[r:RECIPIENT_OF]->(o:Organization) RETURN count(r) as count"
                 ).single()["count"]
                 print(
-                    f"Would delete: {award_count} Awards, {company_count} Companies, {rel_count} AWARDS relationships"
+                    f"Would delete: {award_count} Awards (FinancialTransaction), "
+                    f"{company_count} Companies, {rel_count} RECIPIENT_OF relationships"
                 )
                 return 0
 
-            # Delete AWARDS relationships first
+            # Delete RECIPIENT_OF relationships first
             rel_result = session.run(
                 """
-                MATCH (a:Award)-[r:AWARDS]->(c:Company)
+                MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})
+                      -[r:RECIPIENT_OF]->(o:Organization)
                 DELETE r
                 RETURN count(r) as deleted
                 """
             )
             rel_deleted = rel_result.single()["deleted"]
-            print(f"Deleted {rel_deleted} AWARDS relationships")
+            print(f"Deleted {rel_deleted} RECIPIENT_OF relationships")
 
-            # Delete Award nodes
+            # Delete award FinancialTransaction nodes (DETACH to drop remaining edges)
             award_result = session.run(
                 """
-                MATCH (a:Award)
-                DELETE a
+                MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})
+                DETACH DELETE a
                 RETURN count(a) as deleted
                 """
             )
             awards_deleted = award_result.single()["deleted"]
-            print(f"Deleted {awards_deleted} Award nodes")
+            print(f"Deleted {awards_deleted} award FinancialTransaction nodes")
 
             # Delete Company nodes (only those not connected to other entities)
             # Note: We're being conservative - only delete Companies that aren't connected

--- a/scripts/data/run_neo4j_smoke_checks.py
+++ b/scripts/data/run_neo4j_smoke_checks.py
@@ -42,8 +42,10 @@ def run_smoke_checks(uri: str, username: str, password: str, database: str) -> d
 
     try:
         with driver.session(database=database) as session:
-            # Check 1: Award node count
-            award_count_result = session.run("MATCH (a:Award) RETURN count(a) as count")
+            # Check 1: Award node count (FinancialTransaction AWARD)
+            award_count_result = session.run(
+                "MATCH (a:FinancialTransaction {transaction_type: 'AWARD'}) RETURN count(a) as count"
+            )
             award_count = award_count_result.single()["count"]
             results["checks"].append(
                 {
@@ -68,9 +70,10 @@ def run_smoke_checks(uri: str, username: str, password: str, database: str) -> d
             )
             results["summary"]["company_count"] = company_count
 
-            # Check 3: AWARDS relationship count
+            # Check 3: RECIPIENT_OF relationship count
             awards_rel_result = session.run(
-                "MATCH (a:Award)-[r:AWARDS]->(c:Company) RETURN count(r) as count"
+                "MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})"
+                "-[r:RECIPIENT_OF]->(o:Organization) RETURN count(r) as count"
             )
             awards_rel_count = awards_rel_result.single()["count"]
             results["checks"].append(
@@ -78,7 +81,7 @@ def run_smoke_checks(uri: str, username: str, password: str, database: str) -> d
                     "name": "awards_relationship_count",
                     "passed": awards_rel_count > 0,
                     "value": awards_rel_count,
-                    "message": f"Found {awards_rel_count} AWARDS relationships",
+                    "message": f"Found {awards_rel_count} RECIPIENT_OF relationships",
                 }
             )
             results["summary"]["awards_relationship_count"] = awards_rel_count
@@ -86,9 +89,9 @@ def run_smoke_checks(uri: str, username: str, password: str, database: str) -> d
             # Check 4: Sample award properties
             sample_award_result = session.run(
                 """
-                MATCH (a:Award)
+                MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})
                 WHERE a.award_id IS NOT NULL
-                RETURN a.award_id, a.company_name, a.award_amount, a.program, a.phase
+                RETURN a.award_id, a.recipient_name, a.amount, a.program, a.phase
                 LIMIT 5
                 """
             )
@@ -104,10 +107,11 @@ def run_smoke_checks(uri: str, username: str, password: str, database: str) -> d
             )
             results["summary"]["sample_awards"] = len(sample_awards)
 
-            # Check 5: Award-Company connectivity
+            # Check 5: Award-Organization connectivity
             connected_count_result = session.run(
                 """
-                MATCH (a:Award)-[:AWARDS]->(c:Company)
+                MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})
+                      -[:RECIPIENT_OF]->(o:Organization)
                 RETURN count(DISTINCT a) as connected_awards
                 """
             )

--- a/scripts/neo4j/apply_schema.py
+++ b/scripts/neo4j/apply_schema.py
@@ -50,8 +50,9 @@ SCHEMA_STATEMENTS: list[str] = [
     # "CREATE CONSTRAINT IF NOT EXISTS FOR (c:Company) REQUIRE c.uei IS UNIQUE",
     # Older Neo4j (3.x) syntax would be different; adapt as needed.
     "CREATE CONSTRAINT IF NOT EXISTS FOR (c:Company) REQUIRE c.uei IS UNIQUE",
-    # Unique constraint on award id if present in domain
-    "CREATE CONSTRAINT IF NOT EXISTS FOR (a:Award) REQUIRE a.award_id IS UNIQUE",
+    # Unique constraint on the authoritative award node (FinancialTransaction)
+    "CREATE CONSTRAINT IF NOT EXISTS FOR (ft:FinancialTransaction) "
+    "REQUIRE ft.transaction_id IS UNIQUE",
     # Example index for frequently queried property (e.g., company name)
     "CREATE INDEX IF NOT EXISTS FOR (c:Company) ON (c.name)",
     # Add any additional constraints/indexes your schema requires here

--- a/scripts/validation/validate_patent_etl_deployment.py
+++ b/scripts/validation/validate_patent_etl_deployment.py
@@ -400,7 +400,7 @@ class PatentETLValidator:
             },
             {
                 "name": "SBIR-Funded Patents",
-                "query": "MATCH (a:Award)-[:GENERATED_FROM]->(p:Patent) RETURN a.title, p.grant_doc_num LIMIT 10",
+                "query": "MATCH (p:Patent)-[:GENERATED_FROM]->(a:FinancialTransaction {transaction_type: 'AWARD'}) RETURN a.title, p.grant_doc_num LIMIT 10",
                 "description": "Find SBIR-funded patents",
             },
             {

--- a/specs/unify-graph-node-labels/design.md
+++ b/specs/unify-graph-node-labels/design.md
@@ -17,7 +17,7 @@ surface (two loaders, one query module) plus a one-time data migration.
 | Patent `GENERATED_FROM` | `loaders/neo4j/patents.py` (~L679–733) | `:Award` (target) | `award_id` |
 | Pathway query API (reader) | `queries/pathway_queries.py` (L118–122, 170–171, 312) | `:Award`, `:Contract` | — |
 | Transitions (already unified) | `loaders/neo4j/transitions.py` (L168, 235) | `:FinancialTransaction` | — |
-| Legacy constraint/index | `client.py`, `migrations/001`, `migrations/004` | `:Award` | `award_id`, `award_date`, `award_topic_code` |
+| Legacy constraint/index | `client.py`, `migrations/001`, `migrations/004` | `:Award` | unique constraint on `award_id`; indexes on properties `award_date` and `topic_code` (index name `award_topic_code`) |
 
 `:Award` and `:FinancialTransaction{award_id}` are disjoint nodes for the same
 award. `transitions.py` already attaches to `:FinancialTransaction`, so the public

--- a/specs/unify-graph-node-labels/design.md
+++ b/specs/unify-graph-node-labels/design.md
@@ -1,0 +1,134 @@
+# Design Document
+
+## Overview
+
+Phase 1 unifies the legacy `:Award` node onto `:FinancialTransaction` so that CET
+classifications and patent linkages attach to the same node the SBIR graph already
+uses for an award. The approach is a **label-retarget on the existing upsert** —
+not a MERGE→MATCH rewrite and not a new ingestion pipeline. The change is small in
+surface (two loaders, one query module) plus a one-time data migration.
+
+## Current State (verified)
+
+| Concern | Writer / Reader | Label | Key |
+|---------|-----------------|-------|-----|
+| SBIR award node (authoritative) | `sbir_neo4j_loading.py` / `client.py` | `:FinancialTransaction` | `transaction_id` (+ `award_id` prop) |
+| CET enrichment + `APPLICABLE_TO` | `loaders/neo4j/cet.py` (~L300–420) | `:Award` | `award_id` |
+| Patent `GENERATED_FROM` | `loaders/neo4j/patents.py` (~L679–733) | `:Award` (target) | `award_id` |
+| Pathway query API (reader) | `queries/pathway_queries.py` (L118–122, 170–171, 312) | `:Award`, `:Contract` | — |
+| Transitions (already unified) | `loaders/neo4j/transitions.py` (L168, 235) | `:FinancialTransaction` | — |
+| Legacy constraint/index | `client.py`, `migrations/001`, `migrations/004` | `:Award` | `award_id`, `award_date`, `award_topic_code` |
+
+`:Award` and `:FinancialTransaction{award_id}` are disjoint nodes for the same
+award. `transitions.py` already attaches to `:FinancialTransaction`, so the public
+pathway query is *internally inconsistent today*: it matches `:Award` for one hop
+and the transition layer lives on `:FinancialTransaction`.
+
+## Approach
+
+### 1. Label-retarget the loaders (keep upsert semantics)
+
+`cet.py`'s award upsert is already parameterized (`label=`, `key_property=`). The
+core change is to point CET enrichment and `APPLICABLE_TO` at
+`:FinancialTransaction`, and patent `GENERATED_FROM` likewise.
+
+**The make-or-break decision — MATCH on `award_id`, never MERGE on it.**
+`:FinancialTransaction`'s key is `transaction_id`; CET/patent rows only carry
+`award_id`. `MERGE (ft:FinancialTransaction {award_id: $award_id})` would create a
+*second* FT node when the real one (keyed by `transaction_id`) already exists.
+Therefore:
+
+- **Enrichment (CET properties):** `MATCH (ft:FinancialTransaction {award_id:$award_id}) SET ft += $props`.
+  No node creation. If no match, skip and log (orphan handling, R3).
+- **Relationship endpoints (`APPLICABLE_TO`, `GENERATED_FROM`):** resolve the FT
+  with `MATCH ... {award_id}` and `MERGE` only the *relationship*; never `MERGE`
+  the FT node. Guard with `ON CREATE` only on the edge.
+
+This preserves today's effective behaviour (an award present in CET/patent data but
+absent from the financial graph contributes nothing) **without** introducing a
+job-ordering contract. Rejected alternative: switching the loaders to hard `MATCH`
++ enforcing Dagster ordering — it adds an orphan-drop failure mode worse than the
+labeling bug, for no benefit here.
+
+### 2. Update readers in lockstep
+
+`pathway_queries.py` must change `:Award` → `:FinancialTransaction` in the same PR
+(public API; otherwise the silent-zero just moves). Audit and update the other
+readers found in the surface map: `scripts/data/run_neo4j_smoke_checks.py`,
+`scripts/data/reset_neo4j_sbir.py`, `scripts/neo4j/apply_schema.py`,
+`scripts/validation/validate_patent_etl_deployment.py`,
+`sbir_etl/utils/enrichment/freshness.py`, and the relevant unit tests
+(`test_neo4j_client.py`, `test_query_builder.py`).
+
+> **Expectation to set:** `pathway_queries.py` also matches `:Contract`, which has
+> no writer. Award unification fixes the CET and patent→award hops; the full
+> patent→transition→**contract** pathway stays empty until a Contract writer exists
+> (deferred, M1). Call this out in the PR so reviewers don't expect the whole
+> pathway to light up.
+
+### 3. One-time migration (`006_unify_award_into_financial_transaction.py`)
+
+Subclass `migrations.base.Migration` (same pattern as `004`/`005`).
+
+**`upgrade()`** (idempotent, batched):
+1. **Property inventory first** (design-time, not runtime): enumerate properties
+   that exist on `:Award` to ensure none are dropped. Copy `:Award`-only props onto
+   the matched FT.
+2. For each `:Award a`: `MATCH (ft:FinancialTransaction {award_id: a.award_id})`,
+   `SET ft += properties(a)` (excluding the redundant key), then re-home edges:
+   - `(a)-[r:APPLICABLE_TO]->(c)` ⇒ `MERGE (ft)-[:APPLICABLE_TO]->(c)`
+   - `(p)-[r:GENERATED_FROM]->(a)` ⇒ `MERGE (p)-[:GENERATED_FROM]->(ft)`
+   - copy any other edge types discovered on `:Award` during inventory
+3. `DETACH DELETE` the `:Award` node once its edges are re-homed.
+4. Drop the legacy `:Award` constraint and the `award_date` / `award_topic_code`
+   indexes.
+- **Orphan `:Award`** (no matching FT): do **not** delete blindly — log and leave,
+  or relabel to a quarantine label, so data isn't lost. Decide in tasks; default to
+  log + leave so the migration is safe.
+
+**`downgrade()`**: recreate the `:Award` constraint/indexes and (best-effort)
+re-split — note that a perfect inverse may not be possible once nodes are merged;
+document the limitation rather than pretend.
+
+Back up the graph and dry-run before applying (the migration `DETACH DELETE`s).
+
+### 4. Verification
+
+A single Cypher check (run in the migration's validation step or a one-off script),
+asserting:
+- `MATCH (a:Award) RETURN count(a)` == 0
+- `APPLICABLE_TO` / `GENERATED_FROM` counts equal pre-migration counts
+- those edges now have a `:FinancialTransaction` endpoint
+
+No standing asset-check framework (gold-plating for a one-time migration; revisit
+only if M5 monitoring needs it).
+
+## Files Touched
+
+- `packages/sbir-graph/sbir_graph/loaders/neo4j/cet.py` — retarget award upsert +
+  `APPLICABLE_TO` to `:FinancialTransaction` (MATCH-on-`award_id`).
+- `packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py` — `GENERATED_FROM`
+  target → `:FinancialTransaction` (MATCH-on-`award_id`).
+- `packages/sbir-graph/sbir_graph/queries/pathway_queries.py` — readers.
+- `migrations/versions/006_unify_award_into_financial_transaction.py` — new.
+- Readers/scripts/tests enumerated above.
+- Docs: `docs/schemas/neo4j.md` (drop `:Award` from the legacy-labels note once
+  done), `docs/schemas/financial-transaction-schema.md` (fold `GENERATED_FROM` /
+  `APPLICABLE_TO` back in as real FT edges).
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Duplicate `:FinancialTransaction` from MERGE-on-`award_id` | High | MATCH-on-`award_id` for enrichment; MERGE only the edge, never the FT node |
+| Reader left matching `:Award` → new silent-zero | High | Update all readers (esp. `pathway_queries.py`) in the same PR; grep `:Award` to zero in non-archived code |
+| Property loss during merge | Medium | Property inventory before writing the migration; `SET ft += properties(a)` |
+| `award_id` not unique / missing on some FT | Medium | Index `FinancialTransaction(award_id)`; handle multi/zero match explicitly |
+| Orphan `:Award` deleted, data lost | Medium | Log + leave (or quarantine label); never blind `DETACH DELETE` of unmatched awards |
+| Expectation that the whole pathway lights up | Low | Document the `:Contract`-writer gap in the PR |
+
+## Deferred (separate specs)
+
+- `:Company` → `:Organization` (entity-resolution; no clean key).
+- `:Contract` writer (follow-on-contract loading; M1).
+- `:PatentEntity` constraint cleanup (only after confirming no readers).

--- a/specs/unify-graph-node-labels/requirements.md
+++ b/specs/unify-graph-node-labels/requirements.md
@@ -1,0 +1,125 @@
+# Requirements Document
+
+## Introduction
+
+The Neo4j graph currently carries a **dual node-label model** for SBIR awards. The
+authoritative SBIR loader (`packages/sbir-analytics/.../sbir_neo4j_loading.py`,
+via `sbir-graph`'s `client.py`) writes `:FinancialTransaction` nodes (key
+`transaction_id`, also storing `award_id`). Several enrichment loaders in the
+`sbir-graph` package instead write/target a separate legacy `:Award` node
+(key `award_id`):
+
+- the CET loader (`cet.py`) upserts CET enrichment onto `:Award` and creates
+  `(:Award)-[:APPLICABLE_TO]->(:CETArea)`;
+- the patent loader (`patents.py`) creates `(:Patent)-[:GENERATED_FROM]->(:Award)`.
+
+Because `:Award` and `:FinancialTransaction` are **disjoint node sets for the same
+award**, every cross-model query — "what CET areas apply to this transaction",
+"what patents were generated from this award" — silently traverses nothing. This
+is a correctness bug on the critical path for the technology-transition and
+CET-alignment analyses.
+
+This spec covers **Phase 1: unify `:Award` onto `:FinancialTransaction`**. It is
+deliberately scoped to the `:Award` split, which has a clean join key
+(`FinancialTransaction.award_id == Award.award_id`) and a concrete, verifiable
+failure mode. Other legacy labels are explicitly deferred (see Non-Goals).
+
+## Glossary
+
+- **Unified label**: `:FinancialTransaction` / `:Organization` / `:Individual` —
+  the labels the authoritative SBIR loader writes.
+- **Legacy label**: `:Award` (and, out of scope here, `:Company` / `:Contract` /
+  `:PatentEntity`) — written/targeted by `sbir-graph` enrichment loaders.
+- **`:FinancialTransaction`**: canonical award/contract node; key `transaction_id`
+  (format `txn_award_<award_id>`); carries `award_id` as a property.
+- **`:Award`**: legacy award node, key `award_id`; target of CET enrichment and
+  patent `GENERATED_FROM`.
+- **Label-retarget**: changing a loader so its existing upsert/relationship writes
+  to `:FinancialTransaction` instead of `:Award`, without otherwise changing its
+  ingestion semantics.
+- **Reader**: code that issues Cypher `MATCH` against a label (e.g. the public
+  `pathway_queries.py` API).
+
+## Requirements
+
+### Requirement 1 — CET enrichment and APPLICABLE_TO target FinancialTransaction
+
+CET classification must attach to the same node the SBIR graph uses for an award.
+
+- WHEN the CET loader upserts award-level CET enrichment, it SHALL set those
+  properties on the `:FinancialTransaction` node whose `award_id` matches, not on a
+  separate `:Award` node.
+- WHEN the CET loader creates `APPLICABLE_TO`, the edge SHALL originate from the
+  `:FinancialTransaction` for that award: `(:FinancialTransaction)-[:APPLICABLE_TO]->(:CETArea)`.
+- The loader SHALL NOT create duplicate `:FinancialTransaction` nodes (see R3).
+
+### Requirement 2 — Patent GENERATED_FROM targets FinancialTransaction
+
+- WHEN the patent loader links a patent to its SBIR award, it SHALL create
+  `(:Patent)-[:GENERATED_FROM]->(:FinancialTransaction)` matched on `award_id`,
+  not `(:Patent)-[:GENERATED_FROM]->(:Award)`.
+
+### Requirement 3 — No duplicate FinancialTransaction nodes
+
+`:FinancialTransaction`'s real key is `transaction_id`; CET/patent rows only carry
+`award_id`. A naive `MERGE` on `award_id` would create a second FT node.
+
+- WHEN a loader resolves an award by `award_id`, it SHALL `MATCH` on the
+  `award_id` property (not `MERGE` on it) for enrichment, and SHALL guard
+  relationship creation so it never mints a duplicate `:FinancialTransaction`.
+- WHEN no `:FinancialTransaction` exists for an `award_id` (orphan), the loader's
+  behaviour SHALL be explicit and documented (skip + log, matching today's
+  effective coverage), and SHALL NOT silently drop enrichment without a log line.
+
+### Requirement 4 — Readers updated in lockstep
+
+- WHEN `:Award` is unified, the public query API `pathway_queries.py` and any other
+  reader of `:Award` SHALL be updated in the same change so no reader matches a
+  label that is no longer written.
+- The change SHALL NOT introduce a new silent-zero: queries that worked before
+  (against `:Award`) SHALL return equivalent results against `:FinancialTransaction`.
+
+### Requirement 5 — One-time migration of existing graph data
+
+- The repo SHALL add a numbered migration (`006_*`) that, for every existing
+  `:Award` node, re-homes its CET properties and its `APPLICABLE_TO` /
+  `GENERATED_FROM` relationships onto the matching `:FinancialTransaction`
+  (by `award_id`), then removes the orphaned `:Award` node and its legacy
+  constraint/index.
+- The migration SHALL NOT lose data: any property present on `:Award` but absent
+  on the corresponding `:FinancialTransaction` SHALL be copied over (property
+  inventory is a design step).
+- The migration SHALL provide a `downgrade()` and SHALL be safe to run against a
+  graph that has already been partially migrated (idempotent).
+
+### Requirement 6 — Verification
+
+- AFTER the migration, a single verification check SHALL confirm: zero `:Award`
+  nodes remain, `APPLICABLE_TO` / `GENERATED_FROM` edge counts are preserved, and
+  those edges now land on `:FinancialTransaction`. A one-off Cypher count query is
+  sufficient; a standing asset-check is out of scope.
+
+## Non-Goals (explicitly deferred)
+
+- **`:Company` → `:Organization` unification.** No single clean join key
+  (`uei`/`duns`, often null); this is an entity-resolution problem that overlaps
+  the existing enrichment/dedup pipeline. Deferred to a separate spec.
+- **`:Contract`.** It has no writer — it is a *missing writer* (follow-on-contract
+  loading), not a relabel. The patent→transition→contract pathway will remain
+  partial until that writer exists; this spec does not fix it.
+- **`:PatentEntity`.** Still actively used as a relationship endpoint for
+  individual assignors/assignees. Out of scope; do not remove its nodes. (The
+  unused standalone constraint/index may be dropped in a later trivial PR after
+  confirming nothing reads bare `:PatentEntity`.)
+- **MERGE→MATCH conversion + Dagster job-ordering enforcement.** Rejected: it
+  trades a labeling bug for a worse orphan-drop/coverage bug. See design.
+
+## Acceptance Criteria (summary)
+
+1. CET enrichment + `APPLICABLE_TO` and patent `GENERATED_FROM` land on
+   `:FinancialTransaction`; no `:Award` nodes are written by any loader.
+2. No duplicate `:FinancialTransaction` nodes are created (MATCH-on-`award_id`).
+3. `pathway_queries.py` and all `:Award` readers updated; no new silent-zeros.
+4. Migration `006_*` re-homes existing data with no property loss and a working
+   `downgrade()`.
+5. Post-migration verification passes (no `:Award`, edge counts preserved).

--- a/specs/unify-graph-node-labels/tasks.md
+++ b/specs/unify-graph-node-labels/tasks.md
@@ -20,11 +20,12 @@ All tasks pending — this is a fresh plan from the `unify-graph-node-labels` sp
 - **Verify:** a short inventory table committed in the PR description / design note;
       `grep`-backed, no guesses.
 
-### 2. Add `FinancialTransaction(award_id)` index → verify: index exists
-- [ ] If not already indexed, add an index on `:FinancialTransaction(award_id)` so
-      the MATCH-on-`award_id` upserts are not full scans. (Fold into migration 006
-      or a small prior statement.)
-- **Verify:** `SHOW INDEXES` lists it; loader queries use it (PROFILE shows NodeIndexSeek).
+### 2. Confirm `FinancialTransaction(award_id)` index (already exists) → verify: index present
+- [ ] No new index needed — `:FinancialTransaction(award_id)` is already created as
+      `financial_transaction_award_id` in `migrations/versions/001_initial_schema.py`.
+      Just confirm the MATCH-on-`award_id` upserts use it.
+- **Verify:** `SHOW INDEXES` lists `financial_transaction_award_id`; loader queries
+      hit it (PROFILE shows NodeIndexSeek, not NodeByLabelScan).
 
 ### 3. Retarget CET loader to `:FinancialTransaction` → verify: unit tests + no `:Award` written
 - [ ] In `cet.py`, change the award CET upsert to `MATCH (ft:FinancialTransaction

--- a/specs/unify-graph-node-labels/tasks.md
+++ b/specs/unify-graph-node-labels/tasks.md
@@ -8,44 +8,44 @@ readers → migration → verification → docs. Each task lists how to verify i
 
 ## Status
 
-All tasks pending — this is a fresh plan from the `unify-graph-node-labels` spec.
+Phase 1 implemented (Tasks 1–8). Task 9 (PR) is handled at review time.
 
 ## Tasks
 
 ### 1. Inventory `:Award` properties and edges → verify: documented list
-- [ ] Enumerate every property written onto `:Award` (across `cet.py`, `patents.py`,
+- [x] Enumerate every property written onto `:Award` (across `cet.py`, `patents.py`,
       migrations `001`/`004`) and every relationship type with an `:Award` endpoint.
-- [ ] Confirm which `:Award` properties are absent from `:FinancialTransaction` (so
+- [x] Confirm which `:Award` properties are absent from `:FinancialTransaction` (so
       the migration copies them).
 - **Verify:** a short inventory table committed in the PR description / design note;
       `grep`-backed, no guesses.
 
 ### 2. Confirm `FinancialTransaction(award_id)` index (already exists) → verify: index present
-- [ ] No new index needed — `:FinancialTransaction(award_id)` is already created as
+- [x] No new index needed — `:FinancialTransaction(award_id)` is already created as
       `financial_transaction_award_id` in `migrations/versions/001_initial_schema.py`.
       Just confirm the MATCH-on-`award_id` upserts use it.
 - **Verify:** `SHOW INDEXES` lists `financial_transaction_award_id`; loader queries
       hit it (PROFILE shows NodeIndexSeek, not NodeByLabelScan).
 
 ### 3. Retarget CET loader to `:FinancialTransaction` → verify: unit tests + no `:Award` written
-- [ ] In `cet.py`, change the award CET upsert to `MATCH (ft:FinancialTransaction
+- [x] In `cet.py`, change the award CET upsert to `MATCH (ft:FinancialTransaction
       {award_id:$award_id}) SET ft += $props` (no node creation).
-- [ ] Change `APPLICABLE_TO` creation to resolve FT by `award_id` and `MERGE` only
+- [x] Change `APPLICABLE_TO` creation to resolve FT by `award_id` and `MERGE` only
       the edge: `(:FinancialTransaction)-[:APPLICABLE_TO]->(:CETArea)`.
-- [ ] Orphan handling: skip + log when no FT matches (R3).
+- [x] Orphan handling: skip + log when no FT matches (R3).
 - **Verify:** existing CET-loader unit tests updated and green; a test asserts the
       loader writes zero `:Award` nodes and creates `APPLICABLE_TO` off
       `:FinancialTransaction`.
 
 ### 4. Retarget patent `GENERATED_FROM` to `:FinancialTransaction` → verify: unit tests
-- [ ] In `patents.py`, change `GENERATED_FROM` to target the FT matched on
+- [x] In `patents.py`, change `GENERATED_FROM` to target the FT matched on
       `award_id`; `MERGE` only the edge, never the FT node.
 - **Verify:** patent-loader unit test asserts `(:Patent)-[:GENERATED_FROM]->(:FinancialTransaction)`
       and no new FT/`:Award` nodes.
 
 ### 5. Update readers in lockstep → verify: zero `:Award` matches in live code
-- [ ] `pathway_queries.py`: `:Award` → `:FinancialTransaction` (public API).
-- [ ] Update `scripts/data/run_neo4j_smoke_checks.py`,
+- [x] `pathway_queries.py`: `:Award` → `:FinancialTransaction` (public API).
+- [x] Update `scripts/data/run_neo4j_smoke_checks.py`,
       `scripts/data/reset_neo4j_sbir.py`, `scripts/neo4j/apply_schema.py`,
       `scripts/validation/validate_patent_etl_deployment.py`,
       `sbir_etl/utils/enrichment/freshness.py`, and tests
@@ -54,25 +54,25 @@ All tasks pending — this is a fresh plan from the `unify-graph-node-labels` sp
       the migration file (and archived specs); pathway query tests green.
 
 ### 6. Write migration `006_unify_award_into_financial_transaction.py` → verify: dry-run on a seeded graph
-- [ ] Subclass `migrations.base.Migration`; `upgrade()` copies `:Award` props onto
+- [x] Subclass `migrations.base.Migration`; `upgrade()` copies `:Award` props onto
       the matched FT, re-homes `APPLICABLE_TO` / `GENERATED_FROM`, `DETACH DELETE`s
       matched `:Award`, drops legacy `:Award` constraint + `award_date` /
       `award_topic_code` indexes. Batched + idempotent.
-- [ ] Orphan `:Award` (no FT match): log + leave (do not delete). 
-- [ ] `downgrade()`: recreate constraint/indexes; document that node-split is not
+- [x] Orphan `:Award` (no FT match): log + leave (do not delete). 
+- [x] `downgrade()`: recreate constraint/indexes; document that node-split is not
       perfectly reversible.
 - **Verify:** seed a small graph with `:Award` + `:FinancialTransaction`, run
       `upgrade()`, confirm edges re-homed and `:Award` gone; run twice (idempotent).
 
 ### 7. Post-migration verification → verify: counts preserved
-- [ ] One Cypher check: `count(:Award)==0`; `APPLICABLE_TO` / `GENERATED_FROM`
+- [x] One Cypher check: `count(:Award)==0`; `APPLICABLE_TO` / `GENERATED_FROM`
       counts equal pre-migration; edges now land on `:FinancialTransaction`.
 - **Verify:** the check passes on the seeded graph; capture before/after counts.
 
 ### 8. Update schema docs → verify: docs match the new graph
-- [ ] `docs/schemas/neo4j.md`: drop `:Award` from the legacy-labels note; move
+- [x] `docs/schemas/neo4j.md`: drop `:Award` from the legacy-labels note; move
       `APPLICABLE_TO` / `GENERATED_FROM` to standard `:FinancialTransaction` edges.
-- [ ] `docs/schemas/financial-transaction-schema.md`: fold `GENERATED_FROM` /
+- [x] `docs/schemas/financial-transaction-schema.md`: fold `GENERATED_FROM` /
       `APPLICABLE_TO` back in as real FT relationships; remove the "separate `:Award`
       label" note.
 - **Verify:** no remaining doc claim that `:Award` is written; links resolve.

--- a/specs/unify-graph-node-labels/tasks.md
+++ b/specs/unify-graph-node-labels/tasks.md
@@ -1,0 +1,90 @@
+# Implementation Plan
+
+## Task Overview
+
+Phase 1: unify the legacy `:Award` node onto `:FinancialTransaction`. Tasks are
+ordered so the graph is never left in a broken state: inventory → loaders →
+readers → migration → verification → docs. Each task lists how to verify it.
+
+## Status
+
+All tasks pending — this is a fresh plan from the `unify-graph-node-labels` spec.
+
+## Tasks
+
+### 1. Inventory `:Award` properties and edges → verify: documented list
+- [ ] Enumerate every property written onto `:Award` (across `cet.py`, `patents.py`,
+      migrations `001`/`004`) and every relationship type with an `:Award` endpoint.
+- [ ] Confirm which `:Award` properties are absent from `:FinancialTransaction` (so
+      the migration copies them).
+- **Verify:** a short inventory table committed in the PR description / design note;
+      `grep`-backed, no guesses.
+
+### 2. Add `FinancialTransaction(award_id)` index → verify: index exists
+- [ ] If not already indexed, add an index on `:FinancialTransaction(award_id)` so
+      the MATCH-on-`award_id` upserts are not full scans. (Fold into migration 006
+      or a small prior statement.)
+- **Verify:** `SHOW INDEXES` lists it; loader queries use it (PROFILE shows NodeIndexSeek).
+
+### 3. Retarget CET loader to `:FinancialTransaction` → verify: unit tests + no `:Award` written
+- [ ] In `cet.py`, change the award CET upsert to `MATCH (ft:FinancialTransaction
+      {award_id:$award_id}) SET ft += $props` (no node creation).
+- [ ] Change `APPLICABLE_TO` creation to resolve FT by `award_id` and `MERGE` only
+      the edge: `(:FinancialTransaction)-[:APPLICABLE_TO]->(:CETArea)`.
+- [ ] Orphan handling: skip + log when no FT matches (R3).
+- **Verify:** existing CET-loader unit tests updated and green; a test asserts the
+      loader writes zero `:Award` nodes and creates `APPLICABLE_TO` off
+      `:FinancialTransaction`.
+
+### 4. Retarget patent `GENERATED_FROM` to `:FinancialTransaction` → verify: unit tests
+- [ ] In `patents.py`, change `GENERATED_FROM` to target the FT matched on
+      `award_id`; `MERGE` only the edge, never the FT node.
+- **Verify:** patent-loader unit test asserts `(:Patent)-[:GENERATED_FROM]->(:FinancialTransaction)`
+      and no new FT/`:Award` nodes.
+
+### 5. Update readers in lockstep → verify: zero `:Award` matches in live code
+- [ ] `pathway_queries.py`: `:Award` → `:FinancialTransaction` (public API).
+- [ ] Update `scripts/data/run_neo4j_smoke_checks.py`,
+      `scripts/data/reset_neo4j_sbir.py`, `scripts/neo4j/apply_schema.py`,
+      `scripts/validation/validate_patent_etl_deployment.py`,
+      `sbir_etl/utils/enrichment/freshness.py`, and tests
+      (`test_neo4j_client.py`, `test_query_builder.py`).
+- **Verify:** `grep -rn ':Award' packages/ sbir_etl/ scripts/ tests/` returns only
+      the migration file (and archived specs); pathway query tests green.
+
+### 6. Write migration `006_unify_award_into_financial_transaction.py` → verify: dry-run on a seeded graph
+- [ ] Subclass `migrations.base.Migration`; `upgrade()` copies `:Award` props onto
+      the matched FT, re-homes `APPLICABLE_TO` / `GENERATED_FROM`, `DETACH DELETE`s
+      matched `:Award`, drops legacy `:Award` constraint + `award_date` /
+      `award_topic_code` indexes. Batched + idempotent.
+- [ ] Orphan `:Award` (no FT match): log + leave (do not delete). 
+- [ ] `downgrade()`: recreate constraint/indexes; document that node-split is not
+      perfectly reversible.
+- **Verify:** seed a small graph with `:Award` + `:FinancialTransaction`, run
+      `upgrade()`, confirm edges re-homed and `:Award` gone; run twice (idempotent).
+
+### 7. Post-migration verification → verify: counts preserved
+- [ ] One Cypher check: `count(:Award)==0`; `APPLICABLE_TO` / `GENERATED_FROM`
+      counts equal pre-migration; edges now land on `:FinancialTransaction`.
+- **Verify:** the check passes on the seeded graph; capture before/after counts.
+
+### 8. Update schema docs → verify: docs match the new graph
+- [ ] `docs/schemas/neo4j.md`: drop `:Award` from the legacy-labels note; move
+      `APPLICABLE_TO` / `GENERATED_FROM` to standard `:FinancialTransaction` edges.
+- [ ] `docs/schemas/financial-transaction-schema.md`: fold `GENERATED_FROM` /
+      `APPLICABLE_TO` back in as real FT relationships; remove the "separate `:Award`
+      label" note.
+- **Verify:** no remaining doc claim that `:Award` is written; links resolve.
+
+### 9. PR + expectations → verify: reviewer-ready
+- [ ] PR notes: scope is `:Award` only; `:Company`/`:Contract`/`:PatentEntity`
+      deferred; the patent→transition→**contract** pathway stays partial until a
+      Contract writer lands (M1).
+- [ ] Back-up + dry-run note for operators before applying the migration to a live graph.
+
+## Out of Scope (tracked elsewhere)
+
+- `:Company` → `:Organization` (entity-resolution; separate spec).
+- `:Contract` writer (M1 follow-on-contract loading).
+- `:PatentEntity` constraint cleanup (trivial later PR, after confirming no readers).
+- Standing validation asset-check (revisit only if M5 monitoring requires it).

--- a/tests/e2e/transition/test_graph_queries.py
+++ b/tests/e2e/transition/test_graph_queries.py
@@ -79,3 +79,22 @@ def test_pathway_query_execution_structure():
     assert hasattr(result, "records_count")
     assert hasattr(result, "records")
     assert hasattr(result, "metadata")
+
+
+def test_pathway_queries_target_financial_transaction_not_award():
+    """All award-anchored pathway queries match :FinancialTransaction, never :Award."""
+    queries, session = _build_mock_queries()
+    session.run.return_value = []
+
+    queries.award_to_transition_to_contract()
+    queries.award_to_patent_to_transition_to_contract()
+    queries.award_to_cet_to_transition()
+    queries.transition_rates_by_cet_area()
+    queries.patent_backed_transition_rates_by_cet_area()
+
+    executed = [call.args[0] for call in session.run.call_args_list]
+    assert executed, "expected pathway queries to issue Cypher"
+    for query in executed:
+        assert ":Award" not in query
+        if "FinancialTransaction" in query:
+            assert "transaction_type: 'AWARD'" in query

--- a/tests/integration/test_neo4j_client.py
+++ b/tests/integration/test_neo4j_client.py
@@ -68,13 +68,17 @@ class TestNeo4jConstraintsAndIndexes:
 
         # Verify constraints exist. `create_constraints()` (see
         # sbir_graph.loaders.neo4j.client) creates legacy constraints keyed by
-        # the primary-id of each entity — `company_id`, `award_id`, etc.
+        # the primary-id of each entity — e.g. `company_id`. The legacy `:Award`
+        # constraint was removed when `:Award` was unified onto
+        # `:FinancialTransaction` (migration 006).
         with neo4j_client.session() as session:
             result = session.run("SHOW CONSTRAINTS")
             constraints = [record["name"] for record in result]
 
             assert any("company_id" in c for c in constraints)
-            assert any("award_id" in c for c in constraints)
+            # No `:Award` constraint assertion: `:Award` was unified onto
+            # `:FinancialTransaction` (migration 006) and `create_constraints()`
+            # no longer creates an `award_id` constraint.
 
     def test_create_indexes(self, neo4j_client):
         """Test creating indexes."""
@@ -86,7 +90,8 @@ class TestNeo4jConstraintsAndIndexes:
             indexes = [record["name"] for record in result]
 
             assert any("company_name" in idx for idx in indexes)
-            assert any("award_date" in idx for idx in indexes)
+            # No `:Award` index assertion: the legacy `award_date` index was removed
+            # when `:Award` was unified onto `:FinancialTransaction` (migration 006).
 
 
 @pytest.mark.integration

--- a/tests/unit/loaders/neo4j/test_cet.py
+++ b/tests/unit/loaders/neo4j/test_cet.py
@@ -103,8 +103,9 @@ class TestCETLoaderConstraints:
         loader = CETLoader(mock_client)
         loader.create_constraints()
 
-        # Should run 3 constraint statements (CETArea, Award, Company)
-        assert mock_session.run.call_count == 3
+        # Should run 2 constraint statements (CETArea, Company);
+        # the legacy Award constraint was removed in the FinancialTransaction unification.
+        assert mock_session.run.call_count == 2
 
     def test_create_constraints_handles_existing(self):
         """Test create_constraints handles already existing constraints."""
@@ -123,7 +124,7 @@ class TestCETLoaderConstraints:
         loader.create_constraints()
 
         # Should have attempted all constraints
-        assert mock_session.run.call_count == 3
+        assert mock_session.run.call_count == 2
 
     def test_create_constraints_cetarea_uniqueness(self):
         """Test CETArea constraint is for cet_id uniqueness."""
@@ -144,7 +145,7 @@ class TestCETLoaderConstraints:
         assert "UNIQUE" in constraint_query
 
     def test_create_constraints_includes_entity_constraints(self):
-        """Test constraints include Award and Company."""
+        """Test constraints include CETArea and Company (no legacy Award)."""
         mock_session = Neo4jMocks.session()
         mock_client = _create_mock_client_with_session(mock_session)
         mock_session = Neo4jMocks.session()
@@ -156,8 +157,10 @@ class TestCETLoaderConstraints:
         # Collect all queries
         all_queries = " ".join([call[0][0] for call in mock_session.run.call_args_list])
 
-        assert "Award" in all_queries
+        assert "CETArea" in all_queries
         assert "Company" in all_queries
+        # The legacy :Award constraint must no longer be created.
+        assert ":Award" not in all_queries
 
 
 class TestCETLoaderIndexes:
@@ -270,7 +273,7 @@ class TestCETLoaderEdgeCases:
         loader.create_constraints()
 
         # Should execute statements each time (idempotent with IF NOT EXISTS)
-        assert mock_session.run.call_count == 6  # 3 constraints × 2 calls
+        assert mock_session.run.call_count == 4  # 2 constraints × 2 calls
 
     def test_multiple_index_creation_calls(self):
         """Test calling create_indexes multiple times."""
@@ -378,8 +381,8 @@ class TestCETLoaderConstraintQueries:
         assert "cet_id" in query
         assert "UNIQUE" in query
 
-    def test_award_constraint_included(self):
-        """Test Award constraint is included."""
+    def test_legacy_award_constraint_not_created(self):
+        """Test the legacy :Award constraint is no longer created."""
         mock_session = Neo4jMocks.session()
         mock_client = _create_mock_client_with_session(mock_session)
         mock_session = Neo4jMocks.session()
@@ -388,12 +391,9 @@ class TestCETLoaderConstraintQueries:
         loader = CETLoader(mock_client)
         loader.create_constraints()
 
-        # One of the constraints should be for Award
+        # No constraint statement should target the legacy :Award label.
         all_queries = [call[0][0] for call in mock_session.run.call_args_list]
-        award_queries = [q for q in all_queries if "Award" in q]
-
-        assert len(award_queries) > 0
-        assert "award_id" in award_queries[0]
+        assert not any(":Award" in q for q in all_queries)
 
     def test_company_constraint_included(self):
         """Test Company constraint is included."""

--- a/tests/unit/loaders/test_neo4j_client.py
+++ b/tests/unit/loaders/test_neo4j_client.py
@@ -85,7 +85,7 @@ class TestLoadMetrics:
     def test_load_metrics_with_data(self):
         """Test LoadMetrics with populated data."""
         metrics = LoadMetrics(
-            nodes_created={"Company": 10, "Award": 5},
+            nodes_created={"Company": 10, "FinancialTransaction": 5},
             nodes_updated={"Company": 3},
             relationships_created={"HAS_AWARD": 5},
             errors=2,
@@ -93,6 +93,7 @@ class TestLoadMetrics:
         )
 
         assert metrics.nodes_created["Company"] == 10
+        assert metrics.nodes_created["FinancialTransaction"] == 5
         assert metrics.nodes_updated["Company"] == 3
         assert metrics.relationships_created["HAS_AWARD"] == 5
         assert metrics.errors == 2
@@ -421,6 +422,98 @@ class TestNeo4jClientBatchOperations:
         assert metrics.errors >= 1
 
 
+class TestBatchSetExistingNodeProperties:
+    """Tests for the MATCH-and-SET primitive (never creates nodes)."""
+
+    @patch.object(Neo4jClient, "session")
+    def test_match_and_set_updates_existing_nodes(self, mock_session_cm, neo4j_config):
+        """All rows match an existing node: counted as updates, query is MATCH+SET."""
+        neo4j_config.auto_migrate = False
+        neo4j_config.batch_size = 1000
+        mock_session = Neo4jMocks.session()
+        mock_session_cm.return_value.__enter__.return_value = mock_session
+
+        mock_result = Neo4jMocks.result()
+        mock_record = MagicMock()
+        mock_record.__getitem__.side_effect = lambda key: {"matched_count": 2}[key]
+        mock_result.single.return_value = mock_record
+        mock_session.run.return_value = mock_result
+
+        client = Neo4jClient(neo4j_config)
+        nodes = [
+            {"award_id": "AWD001", "cet_primary_id": "AI"},
+            {"award_id": "AWD002", "cet_primary_id": "ML"},
+        ]
+
+        metrics = client.batch_set_existing_node_properties(
+            "FinancialTransaction", "award_id", nodes
+        )
+
+        # Recorded as updates, never creates.
+        assert metrics.nodes_updated["FinancialTransaction"] == 2
+        assert "FinancialTransaction" not in metrics.nodes_created
+
+        # The query must MATCH (not MERGE) the node and SET properties.
+        query = mock_session.run.call_args[0][0]
+        assert "MATCH (n:FinancialTransaction {award_id: row.award_id})" in query
+        assert "SET n += row" in query
+        assert "MERGE" not in query
+
+    @patch.object(Neo4jClient, "session")
+    def test_no_match_creates_no_nodes(self, mock_session_cm, neo4j_config):
+        """When no existing node matches, nothing is created (orphans skipped)."""
+        neo4j_config.auto_migrate = False
+        neo4j_config.batch_size = 1000
+        mock_session = Neo4jMocks.session()
+        mock_session_cm.return_value.__enter__.return_value = mock_session
+
+        # matched_count == 0: no existing FinancialTransaction for these award_ids
+        mock_result = Neo4jMocks.result()
+        mock_record = MagicMock()
+        mock_record.__getitem__.side_effect = lambda key: {"matched_count": 0}[key]
+        mock_result.single.return_value = mock_record
+        mock_session.run.return_value = mock_result
+
+        client = Neo4jClient(neo4j_config)
+        nodes = [{"award_id": "ORPHAN1", "cet_primary_id": "AI"}]
+
+        metrics = client.batch_set_existing_node_properties(
+            "FinancialTransaction", "award_id", nodes
+        )
+
+        # No node created, no update recorded; errors not incremented for orphans.
+        assert metrics.nodes_created == {}
+        assert metrics.nodes_updated.get("FinancialTransaction", 0) == 0
+        assert metrics.errors == 0
+
+    @patch.object(Neo4jClient, "session")
+    def test_missing_key_property_is_error(self, mock_session_cm, neo4j_config):
+        """Rows missing the key property are counted as errors and skipped."""
+        neo4j_config.auto_migrate = False
+        neo4j_config.batch_size = 1000
+        mock_session = Neo4jMocks.session()
+        mock_session_cm.return_value.__enter__.return_value = mock_session
+
+        mock_result = Neo4jMocks.result()
+        mock_record = MagicMock()
+        mock_record.__getitem__.side_effect = lambda key: {"matched_count": 1}[key]
+        mock_result.single.return_value = mock_record
+        mock_session.run.return_value = mock_result
+
+        client = Neo4jClient(neo4j_config)
+        nodes = [
+            {"award_id": "AWD001", "cet_primary_id": "AI"},
+            {"cet_primary_id": "ML"},  # missing award_id
+        ]
+
+        metrics = client.batch_set_existing_node_properties(
+            "FinancialTransaction", "award_id", nodes
+        )
+
+        assert metrics.errors == 1
+        assert metrics.nodes_updated["FinancialTransaction"] == 1
+
+
 class TestNeo4jClientRelationshipOperations:
     """Tests for relationship creation operations."""
 
@@ -438,7 +531,7 @@ class TestNeo4jClientRelationshipOperations:
             "Company",
             "uei",
             "ABC123",
-            "Award",
+            "FinancialTransaction",
             "award_id",
             "AWD001",
             "HAS_AWARD",
@@ -461,7 +554,7 @@ class TestNeo4jClientRelationshipOperations:
             "Company",
             "uei",
             "NOTFOUND",
-            "Award",
+            "FinancialTransaction",
             "award_id",
             "AWD001",
             "HAS_AWARD",
@@ -483,7 +576,7 @@ class TestNeo4jClientRelationshipOperations:
             "Company",
             "uei",
             "ABC123",
-            "Award",
+            "FinancialTransaction",
             "award_id",
             "AWD001",
             "HAS_AWARD",
@@ -494,7 +587,7 @@ class TestNeo4jClientRelationshipOperations:
         query = call_args[0][0]
 
         assert "MATCH (source:Company {uei: $source_value})" in query
-        assert "MATCH (target:Award {award_id: $target_value})" in query
+        assert "MATCH (target:FinancialTransaction {award_id: $target_value})" in query
         assert "MERGE (source)-[r:HAS_AWARD]->(target)" in query
         assert "SET r += $properties" in query
 
@@ -523,8 +616,8 @@ class TestNeo4jClientBatchRelationships:
 
         client = Neo4jClient(neo4j_config)
         relationships = [
-            ("Company", "uei", "ABC123", "Award", "award_id", "AWD001", "HAS_AWARD", None),
-            ("Company", "uei", "XYZ789", "Award", "award_id", "AWD002", "HAS_AWARD", None),
+            ("Company", "uei", "ABC123", "FinancialTransaction", "award_id", "AWD001", "HAS_AWARD", None),
+            ("Company", "uei", "XYZ789", "FinancialTransaction", "award_id", "AWD002", "HAS_AWARD", None),
         ]
 
         metrics = client.batch_create_relationships(relationships)
@@ -552,9 +645,9 @@ class TestNeo4jClientBatchRelationships:
 
         client = Neo4jClient(neo4j_config)
         relationships = [
-            ("Company", "uei", "ABC123", "Award", "award_id", "AWD001", "HAS_AWARD", None),
-            ("Company", "uei", "NOTFOUND", "Award", "award_id", "AWD002", "HAS_AWARD", None),
-            ("Company", "uei", "XYZ789", "Award", "award_id", "AWD003", "HAS_AWARD", None),
+            ("Company", "uei", "ABC123", "FinancialTransaction", "award_id", "AWD001", "HAS_AWARD", None),
+            ("Company", "uei", "NOTFOUND", "FinancialTransaction", "award_id", "AWD002", "HAS_AWARD", None),
+            ("Company", "uei", "XYZ789", "FinancialTransaction", "award_id", "AWD003", "HAS_AWARD", None),
         ]
 
         metrics = client.batch_create_relationships(relationships)
@@ -575,7 +668,7 @@ class TestNeo4jClientConstraintsAndIndexes:
         client.create_constraints()
 
         # Should run multiple constraint creation queries
-        assert mock_session.run.call_count >= 4  # Company, Award, Researcher, Patent
+        assert mock_session.run.call_count >= 4  # Company, Researcher, Patent, FinancialTransaction
 
     @patch.object(Neo4jClient, "session")
     def test_create_constraints_handles_existing(self, mock_session_cm, neo4j_config):

--- a/tests/unit/loaders/test_neo4j_client.py
+++ b/tests/unit/loaders/test_neo4j_client.py
@@ -616,8 +616,26 @@ class TestNeo4jClientBatchRelationships:
 
         client = Neo4jClient(neo4j_config)
         relationships = [
-            ("Company", "uei", "ABC123", "FinancialTransaction", "award_id", "AWD001", "HAS_AWARD", None),
-            ("Company", "uei", "XYZ789", "FinancialTransaction", "award_id", "AWD002", "HAS_AWARD", None),
+            (
+                "Company",
+                "uei",
+                "ABC123",
+                "FinancialTransaction",
+                "award_id",
+                "AWD001",
+                "HAS_AWARD",
+                None,
+            ),
+            (
+                "Company",
+                "uei",
+                "XYZ789",
+                "FinancialTransaction",
+                "award_id",
+                "AWD002",
+                "HAS_AWARD",
+                None,
+            ),
         ]
 
         metrics = client.batch_create_relationships(relationships)
@@ -645,9 +663,36 @@ class TestNeo4jClientBatchRelationships:
 
         client = Neo4jClient(neo4j_config)
         relationships = [
-            ("Company", "uei", "ABC123", "FinancialTransaction", "award_id", "AWD001", "HAS_AWARD", None),
-            ("Company", "uei", "NOTFOUND", "FinancialTransaction", "award_id", "AWD002", "HAS_AWARD", None),
-            ("Company", "uei", "XYZ789", "FinancialTransaction", "award_id", "AWD003", "HAS_AWARD", None),
+            (
+                "Company",
+                "uei",
+                "ABC123",
+                "FinancialTransaction",
+                "award_id",
+                "AWD001",
+                "HAS_AWARD",
+                None,
+            ),
+            (
+                "Company",
+                "uei",
+                "NOTFOUND",
+                "FinancialTransaction",
+                "award_id",
+                "AWD002",
+                "HAS_AWARD",
+                None,
+            ),
+            (
+                "Company",
+                "uei",
+                "XYZ789",
+                "FinancialTransaction",
+                "award_id",
+                "AWD003",
+                "HAS_AWARD",
+                None,
+            ),
         ]
 
         metrics = client.batch_create_relationships(relationships)

--- a/tests/unit/test_cet_award_relationships.py
+++ b/tests/unit/test_cet_award_relationships.py
@@ -84,7 +84,7 @@ def test_create_award_cet_relationships_builds_primary_and_supporting(neo4j_avai
         r for r in relationships if r[5] == "artificial_intelligence"
     )  # target_value is index 5
     assert primary[0:7] == (
-        "Award",
+        "FinancialTransaction",
         "award_id",
         "AWD-001",
         "CETArea",

--- a/tests/unit/test_cet_loader.py
+++ b/tests/unit/test_cet_loader.py
@@ -42,7 +42,22 @@ def _make_mock_client_with_capture():
         m.nodes_created[label] = m.nodes_created.get(label, 0) + len(nodes)
         return m
 
+    def _fake_batch_set_existing_node_properties(
+        label: str, key_property: str, nodes: list[dict[str, Any]], metrics=None
+    ):
+        # MATCH-and-SET primitive: capture the same way, but record as updates
+        # (never creates), so tests can assert no :Award node was created.
+        captured["label"] = label
+        captured["key_property"] = key_property
+        captured["nodes"] = nodes
+        m = metrics or LoadMetrics()
+        m.nodes_updated[label] = m.nodes_updated.get(label, 0) + len(nodes)
+        return m
+
     mock_client.batch_upsert_nodes.side_effect = _fake_batch_upsert_nodes
+    mock_client.batch_set_existing_node_properties.side_effect = (
+        _fake_batch_set_existing_node_properties
+    )
     return mock_client, captured
 
 
@@ -235,5 +250,11 @@ class TestCETLoaderAwardEnrichment:
         assert isinstance(metrics, LoadMetrics)
         assert metrics.errors == 1
 
-        assert captured["label"] == "Award"
+        # Enrichment now targets FinancialTransaction via MATCH-and-SET (no node create).
+        assert captured["label"] == "FinancialTransaction"
         assert captured["key_property"] == "award_id"
+        mock_client.batch_set_existing_node_properties.assert_called_once()
+        mock_client.batch_upsert_nodes.assert_not_called()
+        # No :Award node is ever created/updated by the loader.
+        assert "Award" not in metrics.nodes_created
+        assert "Award" not in metrics.nodes_updated

--- a/tests/unit/test_migration_006_unify_award.py
+++ b/tests/unit/test_migration_006_unify_award.py
@@ -9,9 +9,7 @@ import pytest
 pytestmark = pytest.mark.fast
 
 # The migration module name begins with a digit, so import it dynamically.
-_module = importlib.import_module(
-    "migrations.versions.006_unify_award_into_financial_transaction"
-)
+_module = importlib.import_module("migrations.versions.006_unify_award_into_financial_transaction")
 UnifyAwardIntoFinancialTransaction = _module.UnifyAwardIntoFinancialTransaction
 
 

--- a/tests/unit/test_migration_006_unify_award.py
+++ b/tests/unit/test_migration_006_unify_award.py
@@ -1,0 +1,71 @@
+"""Tests for migration 006 (unify :Award into :FinancialTransaction)."""
+
+import importlib
+from unittest.mock import MagicMock
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+# The migration module name begins with a digit, so import it dynamically.
+_module = importlib.import_module(
+    "migrations.versions.006_unify_award_into_financial_transaction"
+)
+UnifyAwardIntoFinancialTransaction = _module.UnifyAwardIntoFinancialTransaction
+
+
+def _mock_driver_with_session():
+    """Return (driver, session) where driver.session() is a context manager."""
+    session = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = session
+    cm.__exit__.return_value = None
+    driver = MagicMock()
+    driver.session.return_value = cm
+    return driver, session
+
+
+def test_migration_metadata():
+    migration = UnifyAwardIntoFinancialTransaction()
+    assert migration.version == "006"
+    assert "FinancialTransaction" in migration.description
+
+
+def test_upgrade_rehomes_then_drops_legacy_schema():
+    migration = UnifyAwardIntoFinancialTransaction()
+    driver, session = _mock_driver_with_session()
+
+    # Orphan count query -> 0 orphans.
+    orphan_record = MagicMock()
+    orphan_record.__getitem__.side_effect = lambda key: {"n": 0}[key]
+    orphan_result = MagicMock()
+    orphan_result.single.return_value = orphan_record
+    session.run.return_value = orphan_result
+
+    # Re-home loop returns a batch with 0 rehomed so the loop terminates immediately.
+    session.execute_write.return_value = {
+        "rehomed": 0,
+        "applicable_to": 0,
+        "generated_from": 0,
+    }
+
+    migration.upgrade(driver)
+
+    # The legacy :Award constraint and indexes must be dropped.
+    drop_statements = [call.args[0] for call in session.run.call_args_list]
+    assert any("DROP CONSTRAINT award_id" in s for s in drop_statements)
+    assert any("DROP INDEX award_date" in s for s in drop_statements)
+    assert any("DROP INDEX award_topic_code" in s for s in drop_statements)
+
+
+def test_downgrade_recreates_legacy_schema():
+    migration = UnifyAwardIntoFinancialTransaction()
+    driver, session = _mock_driver_with_session()
+
+    migration.downgrade(driver)
+
+    statements = [call.args[0] for call in session.run.call_args_list]
+    assert any("CREATE CONSTRAINT award_id" in s and ":Award" in s for s in statements)
+    assert any("award_date" in s and ":Award" in s for s in statements)
+    assert any("award_topic_code" in s and ":Award" in s for s in statements)

--- a/tests/unit/test_patent_loader.py
+++ b/tests/unit/test_patent_loader.py
@@ -535,6 +535,20 @@ class TestGeneratedFromRelationships:
 
         assert result.relationships_created["GENERATED_FROM"] == 1
 
+        # GENERATED_FROM must target the unified FinancialTransaction node (matched on
+        # award_id), never a legacy :Award node.
+        _, kwargs = mock_client.batch_create_relationships.call_args
+        rels = kwargs["relationships"]
+        assert len(rels) == 1
+        tuple_rel = rels[0]
+        # (source_label, source_key, source_value, target_label, target_key, ...)
+        assert tuple_rel[0] == "Patent"
+        assert tuple_rel[3] == "FinancialTransaction"
+        assert tuple_rel[4] == "award_id"
+        assert tuple_rel[6] == "GENERATED_FROM"
+        assert "Award" not in result.nodes_created
+        assert "Award" not in result.nodes_updated
+
 
 class TestOwnsRelationships:
     """Test OWNS relationship creation."""

--- a/tests/unit/test_query_builder.py
+++ b/tests/unit/test_query_builder.py
@@ -26,14 +26,14 @@ def test_build_batch_merge_query_simple():
 def test_build_batch_merge_query_with_hash():
     """Test building a batch MERGE query with hash checking."""
     query = Neo4jQueryBuilder.build_batch_merge_query(
-        label="Award",
+        label="FinancialTransaction",
         key_property="award_id",
         include_hash_check=True,
         return_counts=True,
     )
 
     assert "UNWIND $batch AS node" in query
-    assert "MERGE (n:Award {award_id: node.award_id})" in query
+    assert "MERGE (n:FinancialTransaction {award_id: node.award_id})" in query
     assert "__hash" in query
     assert "created_count" in query
     assert "updated_count" in query
@@ -56,7 +56,7 @@ def test_build_batch_match_update_query():
 def test_build_relationship_merge_query():
     """Test building a relationship MERGE query."""
     query = Neo4jQueryBuilder.build_relationship_merge_query(
-        source_label="Award",
+        source_label="FinancialTransaction",
         source_key="award_id",
         rel_type="AWARDED_TO",
         target_label="Company",
@@ -64,7 +64,7 @@ def test_build_relationship_merge_query():
     )
 
     assert "UNWIND $batch AS rel" in query
-    assert "MATCH (source:Award {award_id: rel.source_key})" in query
+    assert "MATCH (source:FinancialTransaction {award_id: rel.source_key})" in query
     assert "MATCH (target:Company {uei: rel.target_key})" in query
     assert "MERGE (source)-[r:AWARDED_TO]->(target)" in query
 
@@ -72,7 +72,7 @@ def test_build_relationship_merge_query():
 def test_build_relationship_merge_query_with_properties():
     """Test building a relationship MERGE query with properties."""
     query = Neo4jQueryBuilder.build_relationship_merge_query(
-        source_label="Award",
+        source_label="FinancialTransaction",
         source_key="award_id",
         rel_type="TRANSITIONED_TO",
         target_label="Transition",


### PR DESCRIPTION
Adds specs/unify-graph-node-labels/ (requirements / design / tasks) for resolving
the Neo4j dual-model split-brain, scope-guarded down to the minimal valuable slice:

- Phase 1 = :Award unification only. CET enrichment + APPLICABLE_TO and patent
  GENERATED_FROM currently attach to a separate legacy :Award node, disjoint from
  the :FinancialTransaction{award_id} the SBIR loader writes, so cross-model
  queries silently traverse nothing. Clean join key (award_id) makes it mechanical.
- Design pins the make-or-break decision: MATCH on award_id (FT's real key is
  transaction_id), never MERGE on it, to avoid duplicate FinancialTransaction nodes.
  Keeps existing upsert semantics — rejects the MERGE→MATCH + job-ordering approach
  (adds a worse orphan-drop failure mode).
- Readers (esp. the public pathway_queries.py) updated in lockstep; one-time
  migration 006 re-homes existing data with no property loss; one verification
  count query (no standing asset-check).
- Explicitly defers :Company→:Organization (entity-resolution, no clean key),
  :Contract (a missing writer, not a relabel — M1), and :PatentEntity (still live).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw