### PR TITLE
spec: unify legacy :Company node onto :Organization (Phase 2)

### DIFF
--- a/specs/unify-company-into-organization/design.md
+++ b/specs/unify-company-into-organization/design.md
@@ -1,0 +1,96 @@
+# Design Document
+
+## Overview
+
+Phase 2 unifies the legacy `:Company` node onto `:Organization`, matched by the
+indexed `uei` property. It is mechanically the same as Phase 1's `:Award` →
+`:FinancialTransaction` retarget, and **simpler**: `:Company` holds enrichment
+properties only (no relationships), so there are no edges to re-home — just merge
+properties and delete. It reuses Phase 1's MATCH-and-SET primitive.
+
+## Current State (verified)
+
+| Concern | Writer / Reader | Label | Key |
+|---------|-----------------|-------|-----|
+| Firm node (authoritative) | `sbir_neo4j_loading.py` | `:Organization` | `organization_id` (+ indexed `uei`, `duns` props) |
+| Business categorization | `loaders/neo4j/categorization.py` (~L106-220) | `:Company` | `uei` (rows w/o uei skipped) |
+| SEC EDGAR enrichment | `loaders/neo4j/sec_edgar.py` (~L76-160) | `:Company` | `uei` (rows w/o uei skipped) |
+| CET company enrichment | `loaders/neo4j/cet.py` (~L160-230) | **`:Organization`** (already unified) | `uei` |
+| Legacy `:Company` constraint/index | `categorization.py:92-98`, `sec_edgar.py:68-72`, `cet.py:77`, `client.py` | `:Company` | `company_id` (constraint), `classification`, `sec_cik`, `sec_ticker`, … |
+| Readers | 4 scripts (smoke/reset/apply_schema/validate) | `:Company` | — |
+
+No relationship type has a `:Company` endpoint (`OWNS`/`SPECIALIZES_IN`/`ACHIEVED`
+already use `:Organization`). `:Company` is a property-only enrichment node.
+
+## Approach
+
+### 1. Retarget the two writers (reuse Phase 1's primitive)
+
+- `categorization.py`: replace its `:Company` `MERGE`/upsert with
+  `client.batch_set_existing_node_properties(label="Organization",
+  key_property="uei", nodes=...)`. Orphans (uei absent from `:Organization`) log +
+  skip. Remove the `:Company` constraint/index from its `create_constraints`/
+  `create_indexes`.
+- `sec_edgar.py`: same retarget to `:Organization{uei}`; remove its `:Company`
+  index list. Note `sec_cik`/`sec_ticker`/`sec_is_publicly_traded` indexes move to
+  `:Organization` if we want them indexed there — decide in tasks (likely yes, since
+  SEC lookups now hit `:Organization`).
+
+**MATCH-not-MERGE** (same rule as Phase 1): `uei` is a non-key property of
+`:Organization` (key is `organization_id`); MERGE-on-`uei` would mint duplicates.
+The `batch_set_existing_node_properties` primitive already MATCHes only.
+
+### 2. Update readers in lockstep
+
+The 4 scripts that MATCH `:Company` → `:Organization`. Where a script counts or
+deletes `:Company` (reset/smoke), point it at `:Organization` (or drop the now-empty
+`:Company` cleanup). `apply_schema.py` / `validate_patent_etl_deployment.py`: update
+label references. No production query module reads `:Company`, so blast radius is
+scripts only.
+
+### 3. Migration `007_unify_company_into_organization.py`
+
+Subclass `migrations.base.Migration` (pattern from 006). `upgrade()`:
+1. Report `:Company` orphans (no `:Organization{uei}`); leave in place.
+2. Batched: `MATCH (c:Company) MATCH (o:Organization {uei:c.uei}) WITH c,o LIMIT $n
+   SET o += properties(c) DETACH DELETE c` (no edges to re-home — simpler than 006).
+3. Drop legacy `:Company` constraint (`company_id`) and the categorization/SEC
+   indexes (`classification`, `categorization_confidence`, `sec_cik`, `sec_ticker`,
+   `sec_is_publicly_traded`). If we keep SEC lookups on `:Organization`, create the
+   equivalent `:Organization` indexes here.
+- **Property-collision check (design step):** `:Company` and `:Organization` share
+  no property names that would clobber meaningful data (categorization/SEC props are
+  distinct namespaces: `classification`, `sec_*`). Confirm during task 1 inventory;
+  exclude any `__hash`/internal flags from the copy.
+
+`downgrade()`: recreate the `:Company` constraint/indexes; document that the merge
+is not perfectly reversible (restore from backup for a true rollback).
+
+### 4. Verification
+
+One Cypher check: `count(:Company)` == orphan count (ideally 0); a sampled
+`:Organization` carries the expected `classification` / `sec_*` props.
+
+## Files Touched
+
+- `loaders/neo4j/categorization.py`, `loaders/neo4j/sec_edgar.py` — retarget writers.
+- `loaders/neo4j/cet.py`, `client.py` — drop leftover `:Company` constraint/index.
+- `migrations/versions/007_unify_company_into_organization.py` — new.
+- 4 reader scripts; tests; `docs/schemas/neo4j.md` (drop `:Company` from legacy note),
+  `docs/schemas/organization-schema.md` (note categorization/SEC props now here).
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Duplicate `:Organization` from MERGE-on-`uei` | High | MATCH-on-`uei` only (Phase 1 primitive); never MERGE the node |
+| Reader left matching `:Company` | Med | Update all 4 scripts; `grep ':Company'` to zero in live code |
+| Orphan `:Company` deleted | Med | Log + leave unmatched `:Company` (no blind delete) |
+| Property name collision on merge | Low | Inventory in task 1; distinct namespaces; exclude `__`-prefixed |
+| Coverage drop (categorization for a firm not yet an `:Organization`) | Low | Same as Phase 1 award reasoning — categorization is keyed on SBIR-recipient UEIs, which the SBIR loader writes as `:Organization`; orphans logged |
+| Depends on PR #379 (Phase 1 primitive) | — | Stack on `claude/unify-graph-node-labels`; rebase onto main once #379 merges |
+
+## Deferred
+
+- `:Contract` writer (M1 feature). `:PatentEntity` constraint cleanup (after
+  confirming no readers). After Phase 2, no property-only legacy node remains.

--- a/specs/unify-company-into-organization/requirements.md
+++ b/specs/unify-company-into-organization/requirements.md
@@ -1,0 +1,104 @@
+# Requirements Document
+
+## Introduction
+
+Phase 2 of the graph label-unification work (Phase 1 unified `:Award` onto
+`:FinancialTransaction`, PR #379). The authoritative SBIR loader writes
+`:Organization` nodes (key `organization_id`, format `org_company_<id>`) that
+**also store `uei` and `duns` as properties** and are indexed on `uei`
+(`organization_uei`). Two enrichment loaders still write/enrich a separate legacy
+`:Company` node:
+
+- `categorization.py` upserts business-categorization properties onto `:Company`,
+  keyed on `uei` (rows without a `uei` are skipped);
+- `sec_edgar.py` enriches `:Company` with SEC EDGAR fields, also keyed on `uei`
+  (rows without a `uei` are skipped).
+
+Because `:Company` and `:Organization` are disjoint nodes for the same firm, the
+categorization and SEC-EDGAR enrichment never appears on the `:Organization` nodes
+the rest of the graph uses — a split-brain identical in shape to the `:Award` one.
+
+**Key finding (de-risks this phase):** every `:Company` writer keys on `uei` and
+skips rows without it, and `:Organization` carries an indexed `uei` property. So
+this is a clean `:Company{uei}` → `MATCH :Organization{uei}` retarget — the same
+mechanical pattern as Phase 1, **not** the entity-resolution problem originally
+feared. `cet.py`'s company CET enrichment already targets `:Organization{uei}`;
+only its leftover `:Company` constraint remains. `:Company` nodes hold enrichment
+**properties only** — no relationships have a `:Company` endpoint — so there is
+nothing to re-home, making this strictly simpler than Phase 1.
+
+**Dependency:** the implementation reuses the `batch_set_existing_node_properties`
+(MATCH-and-SET, never creates) primitive added in Phase 1, so it stacks on PR #379
+(must merge first, or this branch rebases onto it).
+
+## Glossary
+
+- **`:Organization`**: canonical firm/agency/institution node; key `organization_id`
+  (`org_company_<uei>` or `org_company_DUNS:<duns>`); stores `uei`/`duns`; indexed
+  on `uei`.
+- **`:Company`**: legacy firm node enriched by `categorization.py` / `sec_edgar.py`;
+  keyed on `uei`.
+- **Label-retarget**: change a loader's `:Company{uei}` upsert to a MATCH-and-SET on
+  `:Organization{uei}`, without changing its ingestion semantics otherwise.
+
+## Requirements
+
+### Requirement 1 — Categorization enrichment targets Organization
+
+- WHEN `categorization.py` writes business-categorization properties, it SHALL
+  `MATCH (o:Organization {uei:$uei}) SET o += $props` (via
+  `batch_set_existing_node_properties`), not MERGE/SET a separate `:Company` node.
+- It SHALL NOT create `:Organization` nodes (no MERGE on `uei`, a non-key property);
+  rows whose `uei` matches no `:Organization` are orphans → log + skip.
+
+### Requirement 2 — SEC EDGAR enrichment targets Organization
+
+- WHEN `sec_edgar.py` enriches with SEC fields, it SHALL MATCH-and-SET onto
+  `:Organization {uei}`; same orphan handling as R1.
+
+### Requirement 3 — No duplicate Organization nodes
+
+- `:Organization`'s key is `organization_id`; the `:Company` writers only carry
+  `uei`. Resolution SHALL be MATCH-on-`uei` (indexed), never MERGE-on-`uei`.
+
+### Requirement 4 — Readers updated in lockstep
+
+- WHEN `:Company` is unified, all readers SHALL be updated so none MATCHes a label
+  that is no longer written: `scripts/data/run_neo4j_smoke_checks.py`,
+  `scripts/data/reset_neo4j_sbir.py`, `scripts/neo4j/apply_schema.py`,
+  `scripts/validation/validate_patent_etl_deployment.py`. (No production query
+  module reads `:Company`.)
+
+### Requirement 5 — One-time migration of existing graph data
+
+- A numbered migration (`007_*`) SHALL, for each `:Company c`,
+  `MATCH (o:Organization {uei:c.uei}) SET o += properties(c)`, then `DETACH DELETE c`.
+  `:Company` orphans (no matching `:Organization`) SHALL be logged and LEFT IN PLACE.
+- It SHALL drop the legacy `:Company` constraint and its indexes
+  (`categorization.py`, `sec_edgar.py`, `cet.py`, `client.py` constraint/index lists).
+- Idempotent, batched; `downgrade()` recreates the legacy schema and documents that
+  the node-merge is not perfectly reversible.
+
+### Requirement 6 — Verification
+
+- AFTER the migration, a single Cypher check SHALL confirm zero `:Company` nodes
+  remain (excluding logged orphans) and that the categorization/SEC properties now
+  live on `:Organization`. No standing asset-check.
+
+## Non-Goals (deferred)
+
+- **`:Contract`** — a missing *writer* (follow-on-contract loading), not a relabel;
+  M1 feature work.
+- **`:PatentEntity`** — still live (individual assignors/assignees). Out of scope;
+  only its unused constraint may be dropped later after confirming no readers.
+
+## Acceptance Criteria
+
+1. `categorization.py` + `sec_edgar.py` write enrichment onto `:Organization{uei}`;
+   no loader writes `:Company`.
+2. No duplicate `:Organization` nodes (MATCH-on-`uei`).
+3. All `:Company` readers updated; `grep ':Company'` clean in live source (migration
+   + tests excepted).
+4. Migration `007` merges existing `:Company` data with no property loss; orphans
+   preserved; working `downgrade()`.
+5. Verification passes; CI green.

--- a/specs/unify-company-into-organization/tasks.md
+++ b/specs/unify-company-into-organization/tasks.md
@@ -1,0 +1,77 @@
+# Implementation Plan
+
+## Task Overview
+
+Phase 2: unify the legacy `:Company` node onto `:Organization`, matched by `uei`.
+Stacks on Phase 1 (PR #379) — reuses `batch_set_existing_node_properties`. Ordered
+so the graph is never left broken: inventory → writers → readers → migration →
+verification → docs.
+
+## Status
+
+All tasks pending. Blocked on Phase 1 (PR #379) merging or this branch rebasing
+onto it (needs the `batch_set_existing_node_properties` primitive).
+
+## Tasks
+
+### 1. Inventory `:Company` properties → verify: documented, no collisions
+- [ ] Enumerate every property written onto `:Company` by `categorization.py` and
+      `sec_edgar.py`; confirm none collide with meaningful `:Organization` props
+      (categorization: `classification`, `categorization_confidence`, …; SEC:
+      `sec_cik`, `sec_ticker`, `sec_is_publicly_traded`, …).
+- [ ] Confirm (grep) no relationship type has a `:Company` endpoint (so the
+      migration needs no edge re-homing).
+- **Verify:** inventory table in the PR; grep-backed.
+
+### 2. Retarget `categorization.py` → verify: writes to Organization, no :Company
+- [ ] Replace the `:Company{uei}` upsert with
+      `batch_set_existing_node_properties(label="Organization", key_property="uei")`.
+      Orphans log + skip. Remove the `:Company` constraint/index from its helpers.
+- **Verify:** unit test asserts categorization props land on `:Organization{uei}`
+      and zero `:Company` nodes are written.
+
+### 3. Retarget `sec_edgar.py` → verify: writes to Organization
+- [ ] Same retarget to `:Organization{uei}`. Decide + implement whether `sec_cik`/
+      `sec_ticker` indexes move to `:Organization` (likely yes).
+- **Verify:** unit test asserts SEC props land on `:Organization{uei}`; no `:Company`.
+
+### 4. Drop leftover `:Company` constraint in `cet.py`/`client.py` → verify: removed
+- [ ] Remove the `:Company company_id` constraint (cet.py:77) and any `:Company`
+      index from `client.py`'s deprecated helpers.
+- **Verify:** integration test `TestNeo4jConstraintsAndIndexes` updated (no
+      `:Company` constraint asserted) — mirror the Phase 1 fix.
+
+### 5. Update readers in lockstep → verify: zero `:Company` in live code
+- [ ] `run_neo4j_smoke_checks.py`, `reset_neo4j_sbir.py`, `apply_schema.py`,
+      `validate_patent_etl_deployment.py`: `:Company` → `:Organization` (or drop the
+      empty `:Company` cleanup blocks).
+- **Verify:** `grep -rn ':Company' packages/ sbir_etl/ scripts/` returns only the
+      migration + tests.
+
+### 6. Migration `007_unify_company_into_organization.py` → verify: dry-run on seed
+- [ ] `upgrade()`: batched `MATCH (c:Company) MATCH (o:Organization {uei:c.uei})
+      SET o += properties(c) DETACH DELETE c`; orphans logged + left. Drop legacy
+      `:Company` constraint + indexes (create `:Organization` SEC indexes if kept).
+      Idempotent. `downgrade()`: recreate legacy schema; document partial.
+- **Verify:** seed `:Company` + `:Organization` sharing a `uei`; run `upgrade()`;
+      props merged, `:Company` gone, orphan left; run twice (idempotent).
+
+### 7. Post-migration verification → verify: counts
+- [ ] One Cypher check: `count(:Company)` == orphan count; sampled `:Organization`
+      carries `classification` / `sec_*`.
+- **Verify:** passes on the seeded graph.
+
+### 8. Update schema docs → verify: docs match
+- [ ] `docs/schemas/neo4j.md`: drop `:Company` from the legacy-labels note (only
+      `:Contract`/`:PatentEntity` remain). `organization-schema.md`: note
+      categorization + SEC props now live on `:Organization`.
+- **Verify:** no doc claim that `:Company` is written.
+
+### 9. PR + expectations → verify: reviewer-ready
+- [ ] Note: stacks on #379; `:Contract`/`:PatentEntity` still deferred. Back-up +
+      dry-run note for the `DETACH DELETE` migration.
+
+## Out of Scope
+
+- `:Contract` writer (M1). `:PatentEntity` constraint cleanup (after confirming no
+  readers). Standing validation asset-check.


### PR DESCRIPTION
## Description

Phase 2 of the graph label-unification effort (Phase 1 = `:Award` → `:FinancialTransaction`, #379). This PR adds the **spec only** (`specs/unify-company-into-organization/` — requirements / design / tasks); no implementation yet.

Investigation reframed and de-risked the scope: all `:Company` writers (`categorization.py`, `sec_edgar.py`) key on `uei` and skip rows without it; `cet.py`'s company enrichment already targets `:Organization`; and `:Organization` carries an **indexed `uei` property**. So this is a clean `:Company{uei}` → `MATCH :Organization{uei}` retarget — the same mechanical pattern as Phase 1, **not** the entity-resolution problem originally feared — and **simpler**, since `:Company` holds enrichment properties only (no relationships to re-home).

**Dependency / stacking:** the implementation reuses the `batch_set_existing_node_properties` (MATCH-and-SET, never creates) primitive added in #379, so this PR is **stacked on #379** (base = `claude/unify-graph-node-labels`). GitHub will retarget it to `main` once #379 merges.

Deferred (unchanged): `:Contract` (a missing writer = M1 feature work, not a relabel) and `:PatentEntity` (still live; only its unused constraint may be dropped later).

## Type of Change

- [x] Documentation update (specification; implementation in a follow-up)

## Testing

No code in this PR. The spec's tasks define the verification for the implementation phase (unit tests for the retargeted writers, migration `007` dry-run on a seeded graph, post-migration count check, and the `grep ':Company'`-clean gate).

- [ ] Unit tests added/updated (implementation phase)
- [ ] Integration tests added/updated (implementation phase)
- [x] N/A — spec only

## Checklist

- [x] Follows the project's spec format (requirements / design / tasks)
- [x] Self-reviewed; grounded against the loaders (`categorization.py`, `sec_edgar.py`, `cet.py`, `sbir_neo4j_loading.py`) and migrations
- [x] Documents the dependency on #379 and the deferred items
- [ ] N/A — no code changes / warnings / tests in this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_