### PR TITLE
cleanup: remove vestigial :PatentEntity constraint/index and stale references

### DIFF
--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -807,8 +807,8 @@ LIMIT 100
 
 -- Identify patent-backed transitions
 MATCH (a:Award)<-[:GENERATED_FROM]-(p:Patent)-[:ASSIGNED_VIA]->(pa:PatentAssignment)
-  -[:ASSIGNMENT_FROM]-(assignor:PatentEntity)
-  -[:ASSIGNMENT_TO]-(assignee:PatentEntity)
+  -[:ASSIGNMENT_FROM]-(assignor:Organization)
+  -[:ASSIGNMENT_TO]-(assignee:Organization)
 WHERE a.award_id = "SBIR-2020-PHASE-II-001"
 RETURN p.title, assignor.name, pa.recorded_date, assignee.name
 

--- a/docs/schemas/neo4j.md
+++ b/docs/schemas/neo4j.md
@@ -41,7 +41,6 @@ and links to the per-node reference docs.
 >
 > - `:Company` — `categorization.py`, `cet.py`, `sec_edgar.py`
 > - `:Contract` — `transition/loading.py`
-> - `:PatentEntity` — `patents.py` (individual assignors/assignees; `ASSIGNED_FROM`/`ASSIGNED_TO`)
 >
 > Treat the legacy labels as **active until those loaders migrate** to the unified
 > model; the relationship table below lists the edges that target them.

--- a/docs/schemas/uspto-patents.md
+++ b/docs/schemas/uspto-patents.md
@@ -202,9 +202,9 @@ unified `Organization` or `Individual` nodes, and SBIR linkage uses `GENERATED_F
 
 > Patent assignees/assignors are routed to the unified `Organization` / `Individual`
 > labels (see [organization-schema.md](organization-schema.md) and
-> [individual-schema.md](individual-schema.md)); the legacy `PatentEntity` constraint/index
-> definitions remain in the loader for backward compatibility but no `:PatentEntity`
-> nodes are created.
+> [individual-schema.md](individual-schema.md)). The legacy `:PatentEntity`
+> constraint/index definitions have been removed from the loader; no `:PatentEntity`
+> nodes were ever created.
 
 ### Relationships
 

--- a/docs/steering/neo4j-patterns.md
+++ b/docs/steering/neo4j-patterns.md
@@ -30,7 +30,7 @@ SET c.name = row.name,
 - **Award**: SBIR/STTR awards with funding and phase information
 - **Patent**: USPTO patents with grant numbers and metadata
 - **PatentAssignment**: Patent ownership transfer events
-- **PatentEntity**: Patent assignees and assignors
+- **Organization / Individual**: Patent assignees and assignors (unified entity labels)
 - **CETArea**: Critical and Emerging Technology categories
 
 ## Relationship Creation Patterns
@@ -158,8 +158,8 @@ def load_nodes_in_batches(data, batch_size=1000):
 (patent:Patent)-[:ASSIGNED_VIA]->(assignment:PatentAssignment)
 
 // Assignment to Entities
-(assignment:PatentAssignment)-[:ASSIGNED_FROM {exec_date: date("1994-12-22")}]->(assignor:PatentEntity)
-(assignment:PatentAssignment)-[:ASSIGNED_TO {record_date: date("1999-07-29")}]->(assignee:PatentEntity)
+(assignment:PatentAssignment)-[:ASSIGNED_FROM {exec_date: date("1994-12-22")}]->(assignor:Organization)
+(assignment:PatentAssignment)-[:ASSIGNED_TO {record_date: date("1999-07-29")}]->(assignee:Organization)
 
 // Current Ownership
 (company:Company)-[:OWNS {as_of_date: date("1999-07-29")}]->(patent:Patent)
@@ -172,10 +172,10 @@ def load_nodes_in_batches(data, batch_size=1000):
 MATCH (p:Patent {grant_doc_num: "5858003"})
 
 -[:ASSIGNED_VIA]->(a:PatentAssignment)
--[:ASSIGNED_FROM]->(originator:PatentEntity)
+-[:ASSIGNED_FROM]->(originator:Organization)
 
 ,
-(a)-[:ASSIGNED_TO]->(recipient:PatentEntity)
+(a)-[:ASSIGNED_TO]->(recipient:Organization)
 RETURN
   a.record_date AS assignment_date,
   originator.name AS from_entity,

--- a/packages/sbir-analytics/sbir_analytics/assets/uspto/loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/uspto/loading.py
@@ -322,15 +322,15 @@ def loaded_patent_assignments(context) -> dict[str, Any]:
 
 
 @asset(
-    description="Load PatentEntity nodes and create relationships in Neo4j",
+    description="Load patent assignee/assignor entities and create relationships in Neo4j",
     group_name="uspto_loading",
     deps=["neo4j_patients", "loaded_patent_assignments", "transformed_patent_entities"],
 )
 def loaded_patent_entities(context) -> dict[str, Any]:
-    """Phase 2 & 3: Load PatentEntity nodes and create relationships.
+    """Phase 2 & 3: Load patent entities (:Organization/:Individual) and create relationships.
 
     Reads transformed patent entities (assignees and assignors), creates
-    PatentEntity nodes, and establishes ASSIGNED_TO/ASSIGNED_FROM relationships.
+    entity nodes (:Organization/:Individual), and establishes ASSIGNED_TO/ASSIGNED_FROM relationships.
     """
     if PatentLoader is None:
         context.log.error("PatentLoader unavailable; skipping entity loading")
@@ -370,8 +370,11 @@ def loaded_patent_entities(context) -> dict[str, Any]:
         metrics = loader.load_patent_entities(assignors, entity_type="ASSIGNOR", metrics=metrics)
 
         duration = time.time() - start_time
-        success_count = metrics.nodes_created.get("PatentEntity", 0) + metrics.nodes_updated.get(
-            "PatentEntity", 0
+        # Patent entities are loaded as :Organization (non-individuals) and
+        # :Individual (individuals) — not a separate :PatentEntity label.
+        success_count = sum(
+            metrics.nodes_created.get(label, 0) + metrics.nodes_updated.get(label, 0)
+            for label in ("Organization", "Individual")
         )
         total_entities = len(assignees) + len(assignors)
         success_rate = (success_count / total_entities) if total_entities else 0.0
@@ -439,8 +442,8 @@ def loaded_patent_relationships(
 
     Creates relationships:
     - ASSIGNED_VIA: Patent → PatentAssignment
-    - ASSIGNED_FROM: PatentAssignment → PatentEntity (assignor)
-    - ASSIGNED_TO: PatentAssignment → PatentEntity (assignee)
+    - ASSIGNED_FROM: PatentAssignment → :Organization/:Individual (assignor)
+    - ASSIGNED_TO: PatentAssignment → :Organization/:Individual (assignee)
     - GENERATED_FROM: Patent → Award (SBIR linkage)
     - OWNS: Company → Patent (current ownership)
     - CHAIN_OF: PatentAssignment → PatentAssignment (sequential)
@@ -486,7 +489,7 @@ def loaded_patent_relationships(
                     }
                 )
 
-            # ASSIGNED_FROM: PatentAssignment → PatentEntity (assignor)
+            # ASSIGNED_FROM: PatentAssignment → :Organization/:Individual (assignor)
             if assignment.get("rf_id") and assignment.get("assignor_entity_id"):
                 assigned_from_rels.append(
                     {
@@ -496,7 +499,7 @@ def loaded_patent_relationships(
                     }
                 )
 
-            # ASSIGNED_TO: PatentAssignment → PatentEntity (assignee)
+            # ASSIGNED_TO: PatentAssignment → :Organization/:Individual (assignee)
             if assignment.get("rf_id") and assignment.get("assignee_entity_id"):
                 assigned_to_rels.append(
                     {

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py
@@ -87,9 +87,13 @@ class PatentLoader(BaseNeo4jLoader):
                 "FOR (p:Patent) ON (p.grant_doc_num)",
                 "CREATE INDEX patent_assignment_rf_id_idx IF NOT EXISTS "
                 "FOR (a:PatentAssignment) ON (a.rf_id)",
-                # Organization indexes for unified entities
+                # Organization / Individual indexes for unified entities. Patent
+                # assignees/assignors are matched by entity_id during ASSIGNED_TO/
+                # ASSIGNED_FROM creation, so both labels need an entity_id index.
                 "CREATE INDEX organization_entity_id_idx IF NOT EXISTS "
                 "FOR (o:Organization) ON (o.entity_id)",
+                "CREATE INDEX individual_entity_id_idx IF NOT EXISTS "
+                "FOR (i:Individual) ON (i.entity_id)",
                 "CREATE INDEX organization_normalized_name_idx IF NOT EXISTS "
                 "FOR (o:Organization) ON (o.normalized_name)",
                 # Tier 2: High value indexes

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/patents.py
@@ -4,7 +4,7 @@ This module provides the PatentLoader class for loading USPTO patent assignment 
 into Neo4j. It implements a multi-phase loading strategy:
 
 Phase 1: Load Patents and PatentAssignments
-Phase 2: Load PatentEntity nodes (assignees and assignors)
+Phase 2: Load entity nodes — :Organization (non-individuals) and :Individual (individuals) — for assignees and assignors
 Phase 3: Link assignments to entities (ASSIGNED_TO, ASSIGNED_FROM relationships)
 Phase 4: SBIR integration (link to Company and Award nodes)
 Phase 5: Compute metrics (assignment chains, entity statistics)
@@ -72,9 +72,6 @@ class PatentLoader(BaseNeo4jLoader):
                 "FOR (p:Patent) REQUIRE p.grant_doc_num IS UNIQUE",
                 "CREATE CONSTRAINT patent_assignment_rf_id IF NOT EXISTS "
                 "FOR (a:PatentAssignment) REQUIRE a.rf_id IS UNIQUE",
-                # Legacy PatentEntity constraint (kept for backward compatibility)
-                "CREATE CONSTRAINT patent_entity_id IF NOT EXISTS "
-                "FOR (e:PatentEntity) REQUIRE e.entity_id IS UNIQUE",
                 # Organization constraint for unified entities
                 "CREATE CONSTRAINT organization_id IF NOT EXISTS "
                 "FOR (o:Organization) REQUIRE o.organization_id IS UNIQUE",
@@ -90,11 +87,6 @@ class PatentLoader(BaseNeo4jLoader):
                 "FOR (p:Patent) ON (p.grant_doc_num)",
                 "CREATE INDEX patent_assignment_rf_id_idx IF NOT EXISTS "
                 "FOR (a:PatentAssignment) ON (a.rf_id)",
-                # Legacy PatentEntity indexes (kept for backward compatibility)
-                "CREATE INDEX patent_entity_normalized_name_idx IF NOT EXISTS "
-                "FOR (e:PatentEntity) ON (e.normalized_name)",
-                "CREATE INDEX patent_entity_type_idx IF NOT EXISTS "
-                "FOR (e:PatentEntity) ON (e.entity_type)",
                 # Organization indexes for unified entities
                 "CREATE INDEX organization_entity_id_idx IF NOT EXISTS "
                 "FOR (o:Organization) ON (o.entity_id)",
@@ -277,10 +269,10 @@ class PatentLoader(BaseNeo4jLoader):
         entity_type: str,
         metrics: LoadMetrics | None = None,
     ) -> LoadMetrics:
-        """Load patent entities as Organization nodes (non-individuals) or PatentEntity (individuals).
+        """Load patent entities as :Organization (non-individuals) or :Individual (individuals).
 
         Phase 2: Create Organization nodes for companies/universities/government entities,
-        and PatentEntity nodes for individuals.
+        and :Individual nodes for individuals.
 
         Args:
             entities: List of entity dictionaries with keys:
@@ -496,14 +488,14 @@ class PatentLoader(BaseNeo4jLoader):
         assignments: list[dict[str, str]],
         metrics: LoadMetrics | None = None,
     ) -> LoadMetrics:
-        """Create ASSIGNED_FROM relationships (PatentAssignment → PatentEntity).
+        """Create ASSIGNED_FROM relationships (PatentAssignment → Organization/Individual).
 
-        Phase 3: Link PatentAssignment nodes to PatentEntity (assignor) nodes.
+        Phase 3: Link PatentAssignment nodes to the assignor :Organization/:Individual nodes.
 
         Args:
             assignments: List of assignments with:
                 - rf_id: PatentAssignment key
-                - assignor_entity_id: PatentEntity key for assignor
+                - assignor_entity_id: entity_id of the assignor :Organization/:Individual
                 - execution_date (optional): date of assignment
 
             metrics: Optional LoadMetrics to accumulate results
@@ -587,14 +579,14 @@ class PatentLoader(BaseNeo4jLoader):
         assignments: list[dict[str, str]],
         metrics: LoadMetrics | None = None,
     ) -> LoadMetrics:
-        """Create ASSIGNED_TO relationships (PatentAssignment → PatentEntity).
+        """Create ASSIGNED_TO relationships (PatentAssignment → Organization/Individual).
 
-        Phase 3: Link PatentAssignment nodes to PatentEntity (assignee) nodes.
+        Phase 3: Link PatentAssignment nodes to the assignee :Organization/:Individual nodes.
 
         Args:
             assignments: List of assignments with:
                 - rf_id: PatentAssignment key
-                - assignee_entity_id: PatentEntity key for assignee
+                - assignee_entity_id: entity_id of the assignee :Organization/:Individual
                 - recorded_date (optional): date of recording
 
             metrics: Optional LoadMetrics to accumulate results

--- a/sbir_etl/utils/reporting/analyzers/patent_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/patent_analyzer.py
@@ -46,7 +46,9 @@ class PatentAnalysisAnalyzer(ModuleAnalyzer):
         ]
 
         # Neo4j node and relationship types
-        self.node_types = ["Patent", "PatentAssignment", "PatentEntity", "Company"]
+        # Patent assignees/assignors are written as unified :Organization
+        # (org_patent_*) and :Individual (ind_patent_*) nodes, not :PatentEntity/:Company.
+        self.node_types = ["Patent", "PatentAssignment", "Organization", "Individual"]
         self.relationship_types = ["ASSIGNED_VIA", "ASSIGNED_FROM", "ASSIGNED_TO", "OWNS"]
 
     def analyze(self, module_data: dict[str, Any]) -> ModuleReport:

--- a/scripts/validation/validate_patent_etl_deployment.py
+++ b/scripts/validation/validate_patent_etl_deployment.py
@@ -405,7 +405,7 @@ class PatentETLValidator:
             },
             {
                 "name": "Entity Relationships",
-                "query": "MATCH (pe:PatentEntity)-[r]-() RETURN pe.entity_type, COUNT(r) LIMIT 5",
+                "query": "MATCH (:PatentAssignment)-[r:ASSIGNED_TO|ASSIGNED_FROM]->(e) RETURN labels(e)[0] AS entity_label, COUNT(r) AS rels LIMIT 5",
                 "description": "Analyze entity relationships",
             },
         ]

--- a/tests/unit/loaders/neo4j/test_patents.py
+++ b/tests/unit/loaders/neo4j/test_patents.py
@@ -85,8 +85,8 @@ class TestPatentLoaderConstraints:
         loader = PatentLoader(mock_client)
         loader.create_constraints()
 
-        # Should run 4 constraint statements (Patent, PatentAssignment, PatentEntity, Organization)
-        assert mock_session.run.call_count == 4
+        # Should run 3 constraint statements (Patent, PatentAssignment, Organization)
+        assert mock_session.run.call_count == 3
 
     def test_create_constraints_handles_existing_constraints(self):
         """Test create_constraints handles already existing constraints."""
@@ -101,8 +101,8 @@ class TestPatentLoaderConstraints:
         # Should not raise exception
         loader.create_constraints()
 
-        # Should have attempted all 4 constraints
-        assert mock_session.run.call_count == 4
+        # Should have attempted all 3 constraints
+        assert mock_session.run.call_count == 3
 
     def test_create_constraints_patent_uniqueness(self):
         """Test Patent constraint is for grant_doc_num uniqueness."""
@@ -171,8 +171,8 @@ class TestPatentLoaderIndexes:
         # Should include indexes for key properties
         assert "grant_doc_num" in all_queries
         assert "rf_id" in all_queries
-        assert "normalized_name" in all_queries
-        assert "entity_type" in all_queries
+        assert "normalized_name" in all_queries  # organization_normalized_name_idx
+        assert "entity_id" in all_queries  # organization_entity_id_idx
 
 
 class TestPatentLoaderBatchOperations:
@@ -279,7 +279,7 @@ class TestPatentLoaderEdgeCases:
         loader.create_constraints()
 
         # Should execute statements each time (idempotent with IF NOT EXISTS)
-        assert mock_session.run.call_count == 8  # 4 constraints × 2 calls
+        assert mock_session.run.call_count == 6  # 3 constraints × 2 calls
 
     def test_multiple_index_creation_calls(self):
         """Test calling create_indexes multiple times."""
@@ -379,23 +379,6 @@ class TestPatentLoaderConstraintQueries:
 
         assert "PatentAssignment" in constraint_query
         assert "rf_id" in constraint_query
-
-    def test_patent_entity_constraint_query(self):
-        """Test PatentEntity constraint includes entity_id."""
-        mock_client = Mock(spec=Neo4jClient)
-        mock_session = Neo4jMocks.session()
-        mock_client.session.return_value = Neo4jMocks.session()
-        mock_client.session.return_value.__enter__.return_value = mock_session
-
-        loader = PatentLoader(mock_client)
-        loader.create_constraints()
-
-        # Check third call (PatentEntity)
-        third_call = mock_session.run.call_args_list[2]
-        constraint_query = third_call[0][0]
-
-        assert "PatentEntity" in constraint_query
-        assert "entity_id" in constraint_query
 
     def test_all_constraints_use_if_not_exists(self):
         """Test all constraints use IF NOT EXISTS for idempotency."""


### PR DESCRIPTION
## Description

`:PatentEntity` is dead in the graph. Verified against the actual loader code (the docstrings were stale): `load_patent_entities` writes `:Organization` (non-individuals) and `:Individual` (individuals) — **never `:PatentEntity`** — and `ASSIGNED_FROM`/`ASSIGNED_TO` target those unified labels by `entity_id`. The only remaining `:PatentEntity` bits were an unused constraint + 2 indexes and a trail of stale docstrings/comments/docs.

This is the deferred `:PatentEntity` cleanup from the graph label-unification work (independent of #379/#381 — different label).

**Changes:**
- **`patents.py`** — drop the unused `:PatentEntity` constraint (`patent_entity_id`) and the `normalized_name`/`entity_type` indexes from `create_constraints`/`create_indexes`; correct the stale `PatentEntity` docstrings to `:Organization`/`:Individual`.
- **`uspto/loading.py`** — fix a **latent bug**: `success_count` read `nodes_created["PatentEntity"]`, which is never populated, so the asset's `success_rate` was always `0.0`. Now counts the real `Organization` + `Individual` labels.
- **`validate_patent_etl_deployment.py`** — replace the dead `MATCH (pe:PatentEntity)` probe (always empty) with one over the real `ASSIGNED_TO`/`ASSIGNED_FROM` edges.
- **`tests/unit/loaders/neo4j/test_patents.py`** — update constraint/index expectations (3 constraints, no `:PatentEntity`); remove the obsolete `test_patent_entity_constraint_query`.
- **docs** — drop `:PatentEntity` from `neo4j.md`'s legacy-labels note; correct `uspto-patents.md` (the constraint/index definitions are now removed, not "kept for compatibility").

**Deferred:** the empty-label `:PatentEntity` constraint/index on *existing* databases is harmless; dropping it from live DBs is left to the next shipping migration to avoid a `006` migration-number collision with the in-flight #379.

## Type of Change

- [x] Bug fix (non-breaking — `success_rate` was always 0.0)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update (schema docs)
- [x] Cleanup / dead-code removal

## Testing

- [x] Unit tests added/updated — `tests/unit/loaders/neo4j/test_patents.py` (29 passed)
- [ ] Integration tests added/updated (none needed)
- [x] All affected tests pass locally — patent tests 29 pass, uspto-loading tests 7 pass; `ruff format`/`ruff check`/`mypy` clean

## Checklist

- [x] Verified `:PatentEntity` is vestigial against the actual code (no node writer, no edge target, no reader)
- [x] `grep ':PatentEntity'` clean in live source after the change
- [x] Self-reviewed; corresponding doc changes made
- [x] No new warnings
- [ ] N/A — `tests/unit/test_patent_loader.py` is a module-level-skipped duplicate with dead `PatentEntity` assertions; left untouched (never runs)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_