### PR TITLE
Create CONTRACT FinancialTransaction node inline in RESULTED_IN writer (Slice B)

### DIFF
--- a/docs/schemas/neo4j.md
+++ b/docs/schemas/neo4j.md
@@ -51,10 +51,14 @@ and links to the per-node reference docs.
 >
 > `:Contract` has been unified onto `:FinancialTransaction` with
 > `transaction_type = "CONTRACT"`: the `RESULTED_IN` writer (`transitions.py`) and the
-> transition-pathway read queries (`pathway_queries.py`) all target it, matched on its
-> indexed `contract_id` property. Note that **federal-contract node ingestion is not
-> yet built** — no loader writes `FinancialTransaction {transaction_type: "CONTRACT"}`
-> nodes, so `RESULTED_IN` / contract pathways stay empty until that writer lands.
+> transition-pathway read queries (`pathway_queries.py`) all target it. The contract
+> node is created **inline by the `RESULTED_IN` writer** — when a transition carries a
+> `contract_id`, the writer `MERGE`s the `FinancialTransaction {transaction_type:
+> "CONTRACT"}` node on its primary key (`transaction_id = "txn_contract_<contract_id>"`)
+> and then the edge, so the endpoint always exists. There is no standalone
+> contract-ingestion loader yet; the nodes are sparse (carry `contract_id` only) and
+> the pathway returns rows only once the transition pipeline has contract data to detect
+> from (the contract sample input is empty in-repo until seeded).
 
 ## Relationship Types
 

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/transitions.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/transitions.py
@@ -210,10 +210,20 @@ class TransitionLoader(BaseNeo4jLoader):
         transitions_df: pd.DataFrame,
     ) -> int:
         """
-        Create RESULTED_IN relationships from Transitions to Contracts.
+        Create RESULTED_IN relationships from Transitions to their follow-on
+        contract :FinancialTransaction nodes.
+
+        The contract node is created here (``MERGE`` on its primary key
+        ``transaction_id = "txn_contract_<contract_id>"``) because no upstream loader
+        writes ``:FinancialTransaction {transaction_type: "CONTRACT"}`` nodes — without
+        it the RESULTED_IN endpoint would not exist and the edge would never be
+        created. MERGE is keyed on the PK (never on the non-key ``contract_id``), so no
+        duplicate nodes are minted; the disjoint ``txn_contract_`` / ``txn_award_``
+        prefixes keep contract and award PKs from colliding. Rows with a missing
+        ``contract_id`` are skipped.
 
         Args:
-            transitions_df: DataFrame with transition_id and contract_id
+            transitions_df: DataFrame with transition_id, contract_id, confidence
 
         Returns:
             Number of relationships created
@@ -227,25 +237,36 @@ class TransitionLoader(BaseNeo4jLoader):
             for i in range(0, len(transitions_df), batch_size):
                 batch = transitions_df.iloc[i : i + batch_size]
 
+                rows = [
+                    {
+                        "transition_id": t["transition_id"],
+                        "contract_id": str(t["contract_id"]),
+                        "confidence": t["confidence"],
+                    }
+                    for _, t in batch.iterrows()
+                    if pd.notna(t.get("contract_id")) and str(t["contract_id"]).strip()
+                ]
+                if not rows:
+                    continue
+
                 try:
                     result = session.run(
                         """
                         UNWIND $transitions AS t
                         MATCH (trans:Transition {transition_id: t.transition_id})
-                        MATCH (ft:FinancialTransaction {contract_id: t.contract_id, transaction_type: 'CONTRACT'})
+                        MERGE (ft:FinancialTransaction
+                               {transaction_id: 'txn_contract_' + t.contract_id})
+                          ON CREATE SET ft.transaction_type = 'CONTRACT',
+                                        ft.contract_id = t.contract_id
+                          ON MATCH SET ft.transaction_type = coalesce(
+                                           ft.transaction_type, 'CONTRACT'),
+                                       ft.contract_id = t.contract_id
                         MERGE (trans)-[r:RESULTED_IN]->(ft)
                         SET r.confidence = t.confidence,
                             r.creation_date = datetime()
                         RETURN count(r) as created
                         """,
-                        transitions=[
-                            {
-                                "transition_id": t["transition_id"],
-                                "contract_id": t["contract_id"],
-                                "confidence": t["confidence"],
-                            }
-                            for _, t in batch.iterrows()
-                        ],
+                        transitions=rows,
                     )
                     single_result = result.single()
                     count = (

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/transitions.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/transitions.py
@@ -240,7 +240,10 @@ class TransitionLoader(BaseNeo4jLoader):
                 rows = [
                     {
                         "transition_id": t["transition_id"],
-                        "contract_id": str(t["contract_id"]),
+                        # Strip the sent value too (not just the filter) so the MERGE
+                        # key matches the filter — otherwise padded ids would mint
+                        # distinct txn_contract_ PKs for the same logical contract.
+                        "contract_id": str(t["contract_id"]).strip(),
                         "confidence": t["confidence"],
                     }
                     for _, t in batch.iterrows()

--- a/specs/load-contract-nodes/design.md
+++ b/specs/load-contract-nodes/design.md
@@ -1,0 +1,90 @@
+# Design: Make `RESULTED_IN` resolve (CONTRACT FinancialTransaction nodes)
+
+> **Revised after scope-guard (TRIM).** Default approach is now the inline MERGE in
+> the existing relationship writer. The separate-asset/transformer design is kept
+> below only as a documented alternative.
+
+## Current state (verified)
+
+| Piece | Status | Location |
+|-------|--------|----------|
+| `RESULTED_IN` writer — UNWINDs `transitions_df` (has `contract_id`), MATCHes CONTRACT node | exists, traverses nothing | `loaders/neo4j/transitions.py:208-267` (MATCH at `:235`) |
+| `RESULTED_IN` read pathway | exists, empty | `queries/pathway_queries.py` |
+| `transition_relationships_check` counts `RESULTED_IN` (always 0) | exists | `assets/transition/loading.py:324-327` |
+| FT `transaction_id` constraint + `contract_id` index | exists | `migrations/versions/001_initial_schema.py:27,58` |
+| Award writer builds **raw dicts**, never instantiates the model | exists (so validator never fires) | `assets/sbir_neo4j_loading.py:395,621` |
+| Contract sample input | **empty** (`generated_empty` fallback; parquet absent) | `assets/transition/contracts.py:212-214` |
+| CONTRACT node writer | **MISSING** | — |
+
+`RESULTED_IN` MATCHes on the non-key `contract_id`; FT's PK is `transaction_id`. A
+CONTRACT node must carry `contract_id` (the PIID) and a stable PK.
+
+## Recommended approach — inline MERGE (default)
+
+`create_resulted_in_relationships` already iterates `transitions_df` rows with
+`transition_id`, `contract_id`, `confidence`. Change its Cypher to create the CONTRACT
+node by its PK in the same statement, then MERGE the edge:
+
+```cypher
+UNWIND $transitions AS t
+MATCH (trans:Transition {transition_id: t.transition_id})
+MERGE (ft:FinancialTransaction {transaction_id: "txn_contract_" + t.contract_id})
+  ON CREATE SET ft.transaction_type = "CONTRACT", ft.contract_id = t.contract_id
+  ON MATCH  SET ft.transaction_type = coalesce(ft.transaction_type, "CONTRACT"),
+                ft.contract_id      = t.contract_id
+MERGE (trans)-[r:RESULTED_IN]->(ft)
+SET r.confidence = t.confidence, r.creation_date = datetime()
+RETURN count(r) AS created
+```
+
+- MERGE on the **PK** `transaction_id` (`txn_contract_<contract_id>`) — never on the
+  non-key `contract_id` — so no duplicate FT nodes.
+- If the sample DataFrame carries cheap human-readable columns (`recipient_name`,
+  `obligated_amount`, agency), set them `ON CREATE` too; otherwise leave the node
+  minimal (the goal needs only `contract_id` + `transaction_type`).
+- **Eliminates** the transformer, the new asset, and all cross-asset sequencing (the
+  node is guaranteed to exist before the edge — same statement).
+
+**Trade-off:** nodes are sparse (no rich contract props) and are minted from transition
+rows. That's acceptable because no query reads rich contract props today. If/when one
+does, promote to the alternative below.
+
+## Alternative — separate `loaded_contracts` asset (deferred; only if a consumer needs rich nodes)
+
+A transformer `_contract_transaction_props(contract)` symmetric to
+`_transaction_props(award)` + a `loaded_contracts` Dagster asset
+(`batch_upsert_nodes`, key `transaction_id`), sequenced before
+`loaded_transition_relationships`. Richer nodes + idempotent PK, but materially more
+surface area (asset wiring, ordering) for node detail nothing currently consumes.
+**Do not build unless a named query needs the extra props.** RECIPIENT_OF / FUNDED_BY
+are out of scope either way (see requirements non-goals).
+
+## Files touched (inline approach)
+
+- `loaders/neo4j/transitions.py` — modify `create_resulted_in_relationships` Cypher
+  (the ~10-line change above) + docstring.
+- `docs/schemas/neo4j.md:53-57` — replace the "federal-contract node ingestion is not
+  yet built / pathways stay empty" caveat with: CONTRACT nodes are now created by the
+  `RESULTED_IN` writer when transitions carry a `contract_id`; pathway returns rows
+  once contract sample data is seeded.
+- Tests: extend `tests/unit/loaders/neo4j/test_transitions*.py` — assert the writer
+  MERGEs a `FinancialTransaction{transaction_id:"txn_contract_…", transaction_type:
+  "CONTRACT", contract_id:…}` and the `RESULTED_IN` edge; idempotent on re-run; MERGE
+  is keyed on `transaction_id` (not `contract_id`).
+
+## Risks & mitigations
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Duplicate FT nodes | High | MERGE on PK `transaction_id`, never on `contract_id` |
+| Minting a CONTRACT node that collides with an AWARD's `transaction_id` | Low | Disjoint prefixes: `txn_award_*` vs `txn_contract_*` |
+| Sparse nodes mislead a future rich query | Low | Documented; promote to the separate-asset alternative when a consumer exists |
+| Pathway still returns 0 | Expected | Input is empty today; criterion 1 tests on a seeded graph; precondition stated in the PR |
+| `contract_id` PIID non-unique → coalesced nodes | Low | PK is `transaction_id`; same-PIID rows coalesce (acceptable; revisit if real) |
+
+## Deferred
+
+- Rich contract node props + separate loader/asset (until a consumer exists).
+- RECIPIENT_OF / FUNDED_BY contract edges (→ `leverage-ratio-analysis` if needed).
+- Full USAspending contract ingestion; seeding `contracts_sample.parquet`; source
+  reconciliation.

--- a/specs/load-contract-nodes/requirements.md
+++ b/specs/load-contract-nodes/requirements.md
@@ -1,0 +1,80 @@
+# Requirements: Make `RESULTED_IN` resolve (CONTRACT FinancialTransaction nodes)
+
+> **Revised after scope-guard (verdict: TRIM).** Original draft proposed a
+> transformer + new `loaded_contracts` asset + RECIPIENT_OF/FUNDED_BY edges +
+> sequencing. Scope-guard (verified) showed that's over-built for the goal and that
+> the contract input is empty in the repo today. This revision trims to the minimal
+> structural fix and records the precondition.
+
+## Problem
+
+The graph models awards and contracts under one label, `:FinancialTransaction`
+(`transaction_type` = `"AWARD"` | `"CONTRACT"`). Awards are written; **no writer
+creates CONTRACT nodes.** The transition loader MATCHes them —
+`MATCH (ft:FinancialTransaction {contract_id: t.contract_id, transaction_type: "CONTRACT"})`
+(`loaders/neo4j/transitions.py:235`) — and `pathway_queries.py` traverses
+`(:Transition)-[:RESULTED_IN]->(:FinancialTransaction{CONTRACT})`. Both resolve to
+nothing, so `RESULTED_IN` is structurally always 0 (a missing-writer split-brain).
+
+## Goal
+
+Make `RESULTED_IN` **structurally resolvable**: when a transition carries a
+`contract_id`, the CONTRACT node it points to exists, so the edge is created and the
+award→transition→contract pathway can return rows.
+
+## Precondition (important — verified)
+
+The transition contract input is **empty in the current repo**:
+`data/processed/contracts_sample.parquet` is absent, and `validated_contracts_sample`
+(`assets/transition/contracts.py:212-214`) falls back to a `generated_empty`
+DataFrame. The whole transition chain short-circuits on `.empty`. So this change
+makes the pathway *resolvable*, but it returns **0 rows until real contract sample
+data is seeded**. This is a structural fix, not a newly-live pathway. The PR must
+not claim otherwise.
+
+## Why this matters (north star)
+
+`RESULTED_IN` is the graph edge for M1's "SBIR award → follow-on federal contract"
+linkage — the exact relationship the research plan says doesn't exist today. Closing
+the structural gap now is cheap and on-mission; lighting it up requires seed data
+(separate work).
+
+## Scope (trimmed)
+
+**Recommended (inline):** in `create_resulted_in_relationships`
+(`loaders/neo4j/transitions.py:208-267`, which already UNWINDs `transitions_df`
+carrying `contract_id`), `MERGE` the CONTRACT node on its PK
+(`transaction_id = "txn_contract_" + contract_id`), set `contract_id` +
+`transaction_type="CONTRACT"` in the same query, then `MERGE` the `RESULTED_IN` edge.
+~10 lines in one existing function. No transformer, no new asset, no sequencing.
+
+## Non-goals (cut or deferred)
+
+- **RECIPIENT_OF / FUNDED_BY edges — CUT.** Not needed for the goal (the edge and
+  pathway only need the node + `contract_id`). The award `FUNDED_BY` path *mints*
+  agency orgs (`sbir_neo4j_loading.py:806-868`); a MATCH-only contract version would
+  be silently empty. Add later, in `leverage-ratio-analysis`, if a consumer needs them.
+- **Rich node props (psc_code, competition_type, parent_uei, …) — CUT** until a query
+  reads them. Load only the load-bearing fields (`transaction_id`, `contract_id`,
+  `transaction_type`, and a human-readable `recipient_name`/`amount`/`agency` if cheap).
+- **Separate `loaded_contracts` asset + transformer — DEFERRED**, justified only if a
+  downstream query needs rich, independently-loaded contract nodes.
+- **Full USAspending contract ingestion / source reconciliation / migration** — out of
+  scope (schema already has the `transaction_id` constraint + `contract_id` index).
+- **Amount filtering as a "validator requirement" — REMOVED:** the loader builds raw
+  dicts and never instantiates the Pydantic model, so `validate_amount`
+  (`financial_transaction.py:95`) never fires. Any amount rule is a chosen business
+  rule, not a gate; the inline path doesn't need one.
+
+## Acceptance criteria
+
+1. On a **seeded** graph (awards + transitions whose rows carry `contract_id`s),
+   running the transition relationships step creates
+   `:FinancialTransaction{transaction_type:"CONTRACT"}` nodes carrying `contract_id`,
+   and `RESULTED_IN > 0` (was structurally 0).
+2. `TransitionPathwayQueries.award_to_transition_to_contract` returns non-empty on the
+   seeded graph.
+3. Node creation is idempotent (MERGE on `transaction_id`; re-run does not duplicate).
+4. The PR states the empty-input precondition (pathway returns 0 until contract sample
+   data is seeded).
+5. Lint, types, and unit tests pass.

--- a/specs/load-contract-nodes/tasks.md
+++ b/specs/load-contract-nodes/tasks.md
@@ -6,15 +6,16 @@
 
 ## Status
 
-Spec revised, not implemented. No code blockers (schema pre-positioned). **Value is
-gated on seed data** — the transition contract input is empty today
-(`data/processed/contracts_sample.parquet` absent), so this is a structural fix that
-returns 0 rows until contract sample data is seeded.
+Implemented (inline approach). The `RESULTED_IN` writer now creates the CONTRACT
+node inline; unit tests + docs updated. **Value remains gated on seed data** — the
+transition contract input is empty today (`data/processed/contracts_sample.parquet`
+absent), so the pathway returns 0 rows until contract sample data is seeded (separate
+effort).
 
 ## Tasks (inline approach)
 
 ### 1. Inline-MERGE the CONTRACT node in the RESULTED_IN writer → verify: unit test
-- [ ] In `create_resulted_in_relationships` (`loaders/neo4j/transitions.py:208-267`),
+- [x] In `create_resulted_in_relationships` (`loaders/neo4j/transitions.py:208-267`),
       change the Cypher to `MERGE (ft:FinancialTransaction {transaction_id:
       "txn_contract_" + t.contract_id}) ON CREATE SET ft.transaction_type="CONTRACT",
       ft.contract_id=t.contract_id` before the `MERGE (trans)-[:RESULTED_IN]->(ft)`.
@@ -24,7 +25,7 @@ returns 0 rows until contract sample data is seeded.
       then the edge; idempotent on re-run.
 
 ### 2. Docs → verify: caveat replaced
-- [ ] `docs/schemas/neo4j.md:53-57`: replace the "contract ingestion not built /
+- [x] `docs/schemas/neo4j.md:53-57`: replace the "contract ingestion not built /
       pathways stay empty" caveat — CONTRACT nodes are created by the `RESULTED_IN`
       writer when a transition carries `contract_id`; pathway returns rows once contract
       sample data is seeded. Note the seed-data precondition.

--- a/specs/load-contract-nodes/tasks.md
+++ b/specs/load-contract-nodes/tasks.md
@@ -32,7 +32,7 @@ effort).
 - **Verify:** no doc claims a separate writer is missing; precondition is stated.
 
 ### 3. PR + expectations → verify: reviewer-ready
-- [ ] State plainly: structural fix; pathway returns 0 until `contracts_sample.parquet`
+- [x] State plainly: structural fix; pathway returns 0 until `contracts_sample.parquet`
       is seeded; rich nodes / RECIPIENT_OF / FUNDED_BY / full ingestion deferred; no
       migration; the amount-validator does not fire on this path.
 

--- a/specs/load-contract-nodes/tasks.md
+++ b/specs/load-contract-nodes/tasks.md
@@ -1,0 +1,44 @@
+# Tasks: Make `RESULTED_IN` resolve (CONTRACT nodes)
+
+> **Revised after scope-guard (TRIM).** Collapsed from 7 tasks (transformer + asset +
+> edges + sequencing) to the inline-MERGE change. Original task list preserved in git
+> history.
+
+## Status
+
+Spec revised, not implemented. No code blockers (schema pre-positioned). **Value is
+gated on seed data** — the transition contract input is empty today
+(`data/processed/contracts_sample.parquet` absent), so this is a structural fix that
+returns 0 rows until contract sample data is seeded.
+
+## Tasks (inline approach)
+
+### 1. Inline-MERGE the CONTRACT node in the RESULTED_IN writer → verify: unit test
+- [ ] In `create_resulted_in_relationships` (`loaders/neo4j/transitions.py:208-267`),
+      change the Cypher to `MERGE (ft:FinancialTransaction {transaction_id:
+      "txn_contract_" + t.contract_id}) ON CREATE SET ft.transaction_type="CONTRACT",
+      ft.contract_id=t.contract_id` before the `MERGE (trans)-[:RESULTED_IN]->(ft)`.
+      MERGE on the PK only (never `contract_id`). Update the docstring.
+- **Verify:** unit test asserts the writer MERGEs the CONTRACT node keyed on
+      `transaction_id` (`txn_contract_…`) carrying `contract_id` + `transaction_type`,
+      then the edge; idempotent on re-run.
+
+### 2. Docs → verify: caveat replaced
+- [ ] `docs/schemas/neo4j.md:53-57`: replace the "contract ingestion not built /
+      pathways stay empty" caveat — CONTRACT nodes are created by the `RESULTED_IN`
+      writer when a transition carries `contract_id`; pathway returns rows once contract
+      sample data is seeded. Note the seed-data precondition.
+- **Verify:** no doc claims a separate writer is missing; precondition is stated.
+
+### 3. PR + expectations → verify: reviewer-ready
+- [ ] State plainly: structural fix; pathway returns 0 until `contracts_sample.parquet`
+      is seeded; rich nodes / RECIPIENT_OF / FUNDED_BY / full ingestion deferred; no
+      migration; the amount-validator does not fire on this path.
+
+## Deferred (do not build without a named consumer)
+
+- Separate `loaded_contracts` asset + `_contract_transaction_props` transformer (rich
+  node props).
+- RECIPIENT_OF / FUNDED_BY contract edges (→ `leverage-ratio-analysis`).
+- Full USAspending contract ingestion; seeding `contracts_sample.parquet`; FPDS-dump
+  vs DuckDB source reconciliation.

--- a/tests/unit/loaders/neo4j/test_transitions.py
+++ b/tests/unit/loaders/neo4j/test_transitions.py
@@ -217,3 +217,59 @@ class TestTransitionLoaderEdgeCases:
 
         # Should execute statements each time (idempotent with IF NOT EXISTS)
         assert mock_session.run.call_count == 8  # 4 indexes × 2 calls
+
+
+class TestResultedInInlineContractNode:
+    """RESULTED_IN must create the CONTRACT FinancialTransaction node inline."""
+
+    def _loader_with_capture(self):
+        mock_session = Neo4jMocks.session()
+        mock_result = Neo4jMocks.result()
+        mock_result.single.return_value = {"created": 1}
+        mock_session.run.return_value = mock_result
+        mock_client = create_mock_client_with_session(mock_session)
+        return TransitionLoader(mock_client), mock_session
+
+    def test_merges_contract_node_on_primary_key(self):
+        """The writer MERGEs the CONTRACT node on its PK, never MATCHes contract_id."""
+        loader, mock_session = self._loader_with_capture()
+
+        df = pd.DataFrame(
+            {
+                "transition_id": ["t1"],
+                "contract_id": ["c1"],
+                "confidence": ["high"],
+            }
+        )
+
+        created = loader.create_resulted_in_relationships(df)
+        assert created == 1
+
+        query = mock_session.run.call_args.args[0]
+        # CONTRACT node is created inline, keyed on the transaction_id PK.
+        assert "MERGE (ft:FinancialTransaction" in query
+        assert "'txn_contract_' + t.contract_id" in query
+        assert "ON CREATE SET ft.transaction_type = 'CONTRACT'" in query
+        assert "MERGE (trans)-[r:RESULTED_IN]->(ft)" in query
+        # Must NOT MATCH on the non-key contract_id (the old split-brain pattern).
+        assert "MATCH (ft:FinancialTransaction {contract_id" not in query
+
+    def test_skips_rows_without_contract_id(self):
+        """Rows with a missing contract_id are skipped (no node minted for them)."""
+        loader, mock_session = self._loader_with_capture()
+
+        # contract_id is a PIID string in practice; one row has none.
+        df = pd.DataFrame(
+            {
+                "transition_id": ["t1", "t2"],
+                "contract_id": ["W911NF20C0001", None],
+                "confidence": ["high", "low"],
+            }
+        )
+
+        loader.create_resulted_in_relationships(df)
+
+        rows = mock_session.run.call_args.kwargs["transitions"]
+        assert len(rows) == 1  # the None-contract_id row is dropped
+        assert rows[0]["transition_id"] == "t1"
+        assert rows[0]["contract_id"] == "W911NF20C0001"

--- a/tests/unit/loaders/neo4j/test_transitions.py
+++ b/tests/unit/loaders/neo4j/test_transitions.py
@@ -273,3 +273,21 @@ class TestResultedInInlineContractNode:
         assert len(rows) == 1  # the None-contract_id row is dropped
         assert rows[0]["transition_id"] == "t1"
         assert rows[0]["contract_id"] == "W911NF20C0001"
+
+    def test_strips_whitespace_from_contract_id(self):
+        """The sent contract_id is stripped so the MERGE PK matches the filter."""
+        loader, mock_session = self._loader_with_capture()
+
+        df = pd.DataFrame(
+            {
+                "transition_id": ["t1"],
+                "contract_id": ["  W911NF20C0001  "],
+                "confidence": ["high"],
+            }
+        )
+
+        loader.create_resulted_in_relationships(df)
+
+        rows = mock_session.run.call_args.kwargs["transitions"]
+        # Stripped value → stable txn_contract_<id> PK (no whitespace-duplicated nodes).
+        assert rows[0]["contract_id"] == "W911NF20C0001"


### PR DESCRIPTION
## Description

No loader wrote `:FinancialTransaction {transaction_type: "CONTRACT"}` nodes, so the transition loader's `RESULTED_IN` MATCH (`loaders/neo4j/transitions.py`) and the award→transition→contract pathway queries (`queries/pathway_queries.py`) resolved to nothing — a missing-writer split-brain, the last gap left after the graph label-unification work.

This closes the structural gap with the minimal change: `create_resulted_in_relationships` now creates the contract node **inline**. It `MERGE`s the `FinancialTransaction` on its **primary key** (`transaction_id = "txn_contract_" + contract_id`) — never on the non-key `contract_id`, so no duplicate nodes — sets `transaction_type`/`contract_id` `ON CREATE`, then `MERGE`s the `RESULTED_IN` edge in the same statement. Rows with a missing `contract_id` are skipped; the disjoint `txn_contract_`/`txn_award_` PK prefixes prevent collisions with award nodes.

**Important — this is a structural fix, not a newly-live pathway.** The transition contract input is empty in-repo (`data/processed/contracts_sample.parquet` is absent; `validated_contracts_sample` falls back to an empty frame), so the pathway is now correct-by-construction but returns **0 rows until contract sample data is seeded** (a separate data-engineering effort).

Scoped per `scope-guard` (spec at `specs/load-contract-nodes/`): the inline approach replaces a proposed transformer + new asset + sequencing. `RECIPIENT_OF`/`FUNDED_BY` contract edges, rich node props, and a standalone contract-ingestion loader are **deferred** until a consumer needs them.

This branch also carries the spec (`specs/load-contract-nodes/`) documenting the decision and the deferred alternatives.

Fixes # (n/a)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

`uv run pytest tests/unit/loaders/neo4j/test_transitions*.py` — 16 passed. Added `TestResultedInInlineContractNode`: asserts the writer MERGEs the CONTRACT node keyed on the `transaction_id` PK (carrying `contract_id` + `transaction_type`), that it does **not** MATCH on the non-key `contract_id` (the old split-brain pattern), and that rows without a `contract_id` are skipped. `ruff check` / `ruff format --check` / `mypy` clean on the changed files.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_