### PR TITLE
S3-source the transition contract inputs (dump prefix + vendor filter)

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -27,6 +27,9 @@ paths:
 
   # Transition detection outputs
   transition_contracts_output: "data/transition/contracts_ingestion.parquet"
+  # Optional s3:// URL to upload the extracted contracts parquet to after writing
+  # it locally (cross-run reuse). Empty = local only.
+  transition_contracts_output_s3_path: ""
   transition_dump_dir: "data/transition/pruned_data_store_api_dump"
   # Optional s3:// prefix holding the dump objects (.dat.gz + toc.dat). When set,
   # the transition contracts asset syncs only the needed table file(s) + toc.dat

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -29,6 +29,9 @@ paths:
   transition_contracts_output: "data/transition/contracts_ingestion.parquet"
   transition_dump_dir: "data/transition/pruned_data_store_api_dump"
   transition_vendor_filters: "data/transition/sbir_vendor_filters.json"
+  # Optional s3:// URL for the vendor-filter JSON (S3-first, local fallback).
+  # Empty = local only. Format: s3://bucket-name/path/to/sbir_vendor_filters.json
+  transition_vendor_filters_s3_path: ""
 
   # Scripts output
   scripts_output: "data/scripts_output"

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -28,6 +28,11 @@ paths:
   # Transition detection outputs
   transition_contracts_output: "data/transition/contracts_ingestion.parquet"
   transition_dump_dir: "data/transition/pruned_data_store_api_dump"
+  # Optional s3:// prefix holding the dump objects (.dat.gz + toc.dat). When set,
+  # the transition contracts asset syncs only the needed table file(s) + toc.dat
+  # into transition_dump_dir (selective; avoids the full ~17GB dump). Empty = local.
+  # Format: s3://bucket-name/raw/transition/pruned_data_store_api_dump/
+  transition_dump_s3_prefix: ""
   transition_vendor_filters: "data/transition/sbir_vendor_filters.json"
   # Optional s3:// URL for the vendor-filter JSON (S3-first, local fallback).
   # Empty = local only. Format: s3://bucket-name/path/to/sbir_vendor_filters.json

--- a/infrastructure/cdk/stacks/batch.py
+++ b/infrastructure/cdk/stacks/batch.py
@@ -126,6 +126,24 @@ _JOB_CONFIGS = [
         log_prefix="usaspending-extract",
         ephemeral_storage_gib=200,
     ),
+    JobConfig(
+        id="TransitionJob",
+        name="sbir-analytics-transition-detection",
+        command=[
+            "dagster",
+            "job",
+            "execute",
+            "-m",
+            "sbir_analytics.definitions_ml",
+            "-j",
+            "transition_mvp_job",
+        ],
+        vcpus="2",
+        memory_mb="8192",
+        timeout_seconds=14400,
+        log_prefix="transition",
+        extra_env=_DAGSTER_ENV,
+    ),
 ]
 
 

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -14,7 +14,7 @@ from typing import Any
 import pandas as pd
 
 from sbir_etl.exceptions import FileSystemError
-from sbir_etl.utils.cloud_storage import resolve_data_path
+from sbir_etl.utils.cloud_storage import resolve_data_path, sync_s3_prefix_to_dir
 
 from .utils import (
     ContractExtractor,
@@ -48,9 +48,35 @@ def raw_contracts(context) -> Output[pd.DataFrame]:
     dump_dir = config.paths.resolve_path("transition_dump_dir")
     vendor_filter_path = config.paths.resolve_path("transition_vendor_filters")
 
+    table_files_env = os.getenv("SBIR_ETL__TRANSITION__CONTRACTS__TABLE_FILES")
+    table_files = (
+        [item.strip() for item in table_files_env.split(",") if item.strip()]
+        if table_files_env
+        else None
+    )
+    batch_size = _env_int("SBIR_ETL__TRANSITION__CONTRACTS__BATCH_SIZE", 10000)
+    force_refresh = _env_bool("SBIR_ETL__TRANSITION__CONTRACTS__FORCE_REFRESH", False)
+
+    # Optionally sync the dump from an S3 prefix into the local dump_dir. Selective:
+    # when table_files is set we pull only those + toc.dat (avoids fetching the full
+    # ~17GB dump); otherwise the whole prefix. Lets the asset run in a fresh/ephemeral
+    # env (e.g. AWS Batch). Empty config = local only (unchanged behavior).
+    dump_s3_prefix = config.paths.transition_dump_s3_prefix
+    if dump_s3_prefix:
+        include = ["toc.dat", *table_files] if table_files else None
+        if include is None:
+            context.log.warning(
+                "transition_dump_s3_prefix is set without TABLE_FILES; syncing the "
+                "entire dump prefix (potentially very large). Set "
+                "SBIR_ETL__TRANSITION__CONTRACTS__TABLE_FILES to sync selectively."
+            )
+        try:
+            sync_s3_prefix_to_dir(dump_s3_prefix, dump_dir, include=include)
+            context.log.info(f"Synced dump from {dump_s3_prefix} -> {dump_dir} (include={include})")
+        except Exception as e:
+            context.log.warning(f"S3 dump sync failed ({e}); using local {dump_dir}")
+
     # Optionally source the vendor-filter JSON from S3 (S3-first, local fallback).
-    # Lets the asset run in a fresh/ephemeral env (e.g. AWS Batch) without the file
-    # pre-staged on local disk. Empty config = local only (unchanged behavior).
     vendor_filters_s3 = config.paths.transition_vendor_filters_s3_path
     if vendor_filters_s3:
         try:
@@ -64,14 +90,6 @@ def raw_contracts(context) -> Output[pd.DataFrame]:
             context.log.warning(
                 f"S3 vendor-filter resolution failed ({e}); using local {vendor_filter_path}"
             )
-    table_files_env = os.getenv("SBIR_ETL__TRANSITION__CONTRACTS__TABLE_FILES")
-    table_files = (
-        [item.strip() for item in table_files_env.split(",") if item.strip()]
-        if table_files_env
-        else None
-    )
-    batch_size = _env_int("SBIR_ETL__TRANSITION__CONTRACTS__BATCH_SIZE", 10000)
-    force_refresh = _env_bool("SBIR_ETL__TRANSITION__CONTRACTS__FORCE_REFRESH", False)
 
     context.log.info(
         "Starting contracts_ingestion",

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -14,7 +14,11 @@ from typing import Any
 import pandas as pd
 
 from sbir_etl.exceptions import FileSystemError
-from sbir_etl.utils.cloud_storage import resolve_data_path, sync_s3_prefix_to_dir
+from sbir_etl.utils.cloud_storage import (
+    resolve_data_path,
+    sync_s3_prefix_to_dir,
+    upload_file_to_s3,
+)
 
 from .utils import (
     ContractExtractor,
@@ -183,6 +187,19 @@ def raw_contracts(context) -> Output[pd.DataFrame]:
 
     checks_path = output_path.with_suffix(".checks.json")
     write_json(checks_path, checks)
+
+    # Optionally persist the extracted parquet back to S3 for cross-run reuse
+    # (e.g. so a later/remote run can read it without re-extracting from the dump).
+    # Empty config = local only (unchanged behavior).
+    output_s3 = config.paths.transition_contracts_output_s3_path
+    if output_s3:
+        try:
+            upload_file_to_s3(output_path, output_s3)
+            context.log.info(f"Uploaded contracts output -> {output_s3}")
+        except Exception as e:
+            context.log.warning(
+                f"S3 output upload failed ({e}); output remains local at {output_path}"
+            )
 
     metadata = {
         "rows": total_rows,

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -14,6 +14,7 @@ from typing import Any
 import pandas as pd
 
 from sbir_etl.exceptions import FileSystemError
+from sbir_etl.utils.cloud_storage import resolve_data_path
 
 from .utils import (
     ContractExtractor,
@@ -46,6 +47,23 @@ def raw_contracts(context) -> Output[pd.DataFrame]:
     output_path = config.paths.resolve_path("transition_contracts_output")
     dump_dir = config.paths.resolve_path("transition_dump_dir")
     vendor_filter_path = config.paths.resolve_path("transition_vendor_filters")
+
+    # Optionally source the vendor-filter JSON from S3 (S3-first, local fallback).
+    # Lets the asset run in a fresh/ephemeral env (e.g. AWS Batch) without the file
+    # pre-staged on local disk. Empty config = local only (unchanged behavior).
+    vendor_filters_s3 = config.paths.transition_vendor_filters_s3_path
+    if vendor_filters_s3:
+        try:
+            vendor_filter_path = resolve_data_path(
+                vendor_filters_s3, local_fallback=vendor_filter_path
+            )
+            context.log.info(
+                f"Resolved vendor filters: {vendor_filters_s3} -> {vendor_filter_path}"
+            )
+        except Exception as e:
+            context.log.warning(
+                f"S3 vendor-filter resolution failed ({e}); using local {vendor_filter_path}"
+            )
     table_files_env = os.getenv("SBIR_ETL__TRANSITION__CONTRACTS__TABLE_FILES")
     table_files = (
         [item.strip() for item in table_files_env.split(",") if item.strip()]

--- a/sbir_etl/config/schemas/data.py
+++ b/sbir_etl/config/schemas/data.py
@@ -368,7 +368,16 @@ class PathsConfig(BaseModel):
     )
     transition_dump_dir: str = Field(
         default="data/transition/pruned_data_store_api_dump",
-        description="Transition API dump directory",
+        description="Transition API dump directory (local path)",
+    )
+    transition_dump_s3_prefix: str = Field(
+        default="",
+        description=(
+            "Optional s3:// prefix holding the transition dump objects "
+            "(.dat.gz files + toc.dat). When set, the transition contracts asset "
+            "syncs only the needed table file(s) + toc.dat into transition_dump_dir "
+            "(selective; avoids pulling the full ~17GB dump). Empty = local only."
+        ),
     )
     transition_vendor_filters: str = Field(
         default="data/transition/sbir_vendor_filters.json",

--- a/sbir_etl/config/schemas/data.py
+++ b/sbir_etl/config/schemas/data.py
@@ -364,7 +364,15 @@ class PathsConfig(BaseModel):
     )
     transition_contracts_output: str = Field(
         default="data/transition/contracts_ingestion.parquet",
-        description="Transition contracts output file",
+        description="Transition contracts output file (local path)",
+    )
+    transition_contracts_output_s3_path: str = Field(
+        default="",
+        description=(
+            "Optional s3:// URL to upload the extracted contracts parquet to after "
+            "the transition contracts asset writes it locally (cross-run reuse in a "
+            "fresh/ephemeral env). Empty = local only."
+        ),
     )
     transition_dump_dir: str = Field(
         default="data/transition/pruned_data_store_api_dump",

--- a/sbir_etl/config/schemas/data.py
+++ b/sbir_etl/config/schemas/data.py
@@ -372,7 +372,15 @@ class PathsConfig(BaseModel):
     )
     transition_vendor_filters: str = Field(
         default="data/transition/sbir_vendor_filters.json",
-        description="SBIR vendor filters file",
+        description="SBIR vendor filters file (local path)",
+    )
+    transition_vendor_filters_s3_path: str = Field(
+        default="",
+        description=(
+            "Optional s3:// URL for the SBIR vendor filters JSON. When set, the "
+            "transition contracts asset resolves it S3-first and falls back to the "
+            "local transition_vendor_filters path. Empty = local only."
+        ),
     )
     scripts_output: str = Field(
         default="data/scripts_output", description="Scripts output directory"

--- a/sbir_etl/utils/cloud_storage.py
+++ b/sbir_etl/utils/cloud_storage.py
@@ -168,8 +168,13 @@ def sync_s3_prefix_to_dir(
         The local ``dest_dir`` path.
 
     Raises:
-        ValueError: if ``s3_prefix`` is not an ``s3://`` URL.
-        FileNotFoundError: if no matching objects were found under the prefix.
+        ValueError: if ``s3_prefix`` is not an ``s3://`` URL or has no bucket.
+        FileNotFoundError: if no matching objects were found, or — when ``include``
+            is given — any requested basename is missing under the prefix.
+
+    Resolves the full object list and validates it *before* creating ``dest_dir`` or
+    downloading anything, so a missing requested file never leaves a populated-looking
+    but incomplete directory behind.
     """
     import boto3
 
@@ -177,15 +182,20 @@ def sync_s3_prefix_to_dir(
         raise ValueError(f"Not an S3 prefix: {s3_prefix}")
 
     bucket, _, prefix = str(s3_prefix)[len("s3://") :].partition("/")
-    include_set = set(include) if include is not None else None
+    if not bucket:
+        raise ValueError(f"S3 prefix missing bucket: {s3_prefix}")
+    # Normalize the prefix to end with '/' so string-based listing can't match
+    # sibling keys (e.g. ".../dump" otherwise also matching ".../dump2/...").
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
 
-    dest = Path(dest_dir)
-    dest.mkdir(parents=True, exist_ok=True)
+    include_set = set(include) if include is not None else None
 
     s3_client = boto3.client("s3")
     paginator = s3_client.get_paginator("list_objects_v2")
-    downloaded = 0
 
+    # First pass: resolve the objects to download (no side effects yet).
+    to_download: list[tuple[str, str]] = []  # (key, basename)
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         for obj in page.get("Contents", []):
             key = obj["Key"]
@@ -194,15 +204,29 @@ def sync_s3_prefix_to_dir(
                 continue
             if include_set is not None and name not in include_set:
                 continue
-            target = dest / name
-            logger.info(f"Downloading s3://{bucket}/{key} -> {target}")
-            s3_client.download_file(bucket, key, str(target))
-            downloaded += 1
+            to_download.append((key, name))
 
-    if downloaded == 0:
-        raise FileNotFoundError(f"No objects downloaded from {s3_prefix} (include={include})")
+    # When specific basenames were requested, require all of them up front so a
+    # partial sync can't pass a later dump_dir.exists() check and fail confusingly.
+    if include_set is not None:
+        missing = include_set - {name for _, name in to_download}
+        if missing:
+            raise FileNotFoundError(
+                f"Missing required object(s) under {s3_prefix}: {sorted(missing)}"
+            )
 
-    logger.info(f"Synced {downloaded} object(s) from {s3_prefix} to {dest}")
+    if not to_download:
+        raise FileNotFoundError(f"No objects found under {s3_prefix} (include={include})")
+
+    # Only now create the destination and download.
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+    for key, name in to_download:
+        target = dest / name
+        logger.info(f"Downloading s3://{bucket}/{key} -> {target}")
+        s3_client.download_file(bucket, key, str(target))
+
+    logger.info(f"Synced {len(to_download)} object(s) from {s3_prefix} to {dest}")
     return dest
 
 

--- a/sbir_etl/utils/cloud_storage.py
+++ b/sbir_etl/utils/cloud_storage.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -142,6 +143,67 @@ def _download_s3_to_temp(s3_path: S3Path) -> Path:
         logger.debug(f"Using cached S3 file: {local_file}")
 
     return local_file
+
+
+def sync_s3_prefix_to_dir(
+    s3_prefix: str,
+    dest_dir: str | Path,
+    include: Iterable[str] | None = None,
+) -> Path:
+    """Download objects under an S3 prefix into a local directory.
+
+    Selective by design: when ``include`` is provided, only objects whose basename
+    is in ``include`` are downloaded; otherwise every object under the prefix is
+    pulled. This lets callers fetch just the table file(s) they need from a large
+    multi-file dump (e.g. the ~17GB transition ``pruned_data_store_api_dump``)
+    instead of the whole prefix.
+
+    Args:
+        s3_prefix: ``s3://bucket/prefix/`` URL to list under.
+        dest_dir: Local directory to populate (created if missing).
+        include: Optional basenames to restrict the download (e.g. ``["toc.dat",
+            "best.dat.gz"]``). ``None`` downloads every object under the prefix.
+
+    Returns:
+        The local ``dest_dir`` path.
+
+    Raises:
+        ValueError: if ``s3_prefix`` is not an ``s3://`` URL.
+        FileNotFoundError: if no matching objects were found under the prefix.
+    """
+    import boto3
+
+    if not is_s3_path(s3_prefix):
+        raise ValueError(f"Not an S3 prefix: {s3_prefix}")
+
+    bucket, _, prefix = str(s3_prefix)[len("s3://") :].partition("/")
+    include_set = set(include) if include is not None else None
+
+    dest = Path(dest_dir)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    s3_client = boto3.client("s3")
+    paginator = s3_client.get_paginator("list_objects_v2")
+    downloaded = 0
+
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            name = key.rsplit("/", 1)[-1]
+            if not name:  # skip "directory" placeholder keys
+                continue
+            if include_set is not None and name not in include_set:
+                continue
+            target = dest / name
+            logger.info(f"Downloading s3://{bucket}/{key} -> {target}")
+            s3_client.download_file(bucket, key, str(target))
+            downloaded += 1
+
+    if downloaded == 0:
+        raise FileNotFoundError(f"No objects downloaded from {s3_prefix} (include={include})")
+
+    logger.info(f"Synced {downloaded} object(s) from {s3_prefix} to {dest}")
+    return dest
 
 
 def cleanup_s3_cache(

--- a/sbir_etl/utils/cloud_storage.py
+++ b/sbir_etl/utils/cloud_storage.py
@@ -206,6 +206,42 @@ def sync_s3_prefix_to_dir(
     return dest
 
 
+def upload_file_to_s3(local_path: str | Path, s3_url: str) -> str:
+    """Upload a single local file to an ``s3://`` URL.
+
+    The write-side counterpart to ``resolve_data_path`` — lets an asset persist a
+    produced artifact (e.g. ``contracts_ingestion.parquet``) back to S3 for
+    cross-run reuse in a fresh/ephemeral environment.
+
+    Args:
+        local_path: Local file to upload.
+        s3_url: Destination ``s3://bucket/key`` URL.
+
+    Returns:
+        The destination ``s3_url``.
+
+    Raises:
+        ValueError: if ``s3_url`` is not an ``s3://`` URL or carries no key.
+        FileNotFoundError: if ``local_path`` does not exist.
+    """
+    import boto3
+
+    if not is_s3_path(s3_url):
+        raise ValueError(f"Not an S3 URL: {s3_url}")
+
+    local = Path(local_path)
+    if not local.exists():
+        raise FileNotFoundError(f"Local file not found: {local}")
+
+    bucket, _, key = str(s3_url)[len("s3://") :].partition("/")
+    if not key:
+        raise ValueError(f"S3 URL missing object key: {s3_url}")
+
+    boto3.client("s3").upload_file(str(local), bucket, key)
+    logger.info(f"Uploaded {local} -> {s3_url}")
+    return s3_url
+
+
 def cleanup_s3_cache(
     max_size_gb: float | None = None,
     max_age_hours: float | None = None,

--- a/tests/unit/assets/test_transition_contracts_s3.py
+++ b/tests/unit/assets/test_transition_contracts_s3.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pandas as pd
 import pytest
 
 from sbir_etl.exceptions import FileSystemError
@@ -88,3 +89,36 @@ def test_dump_synced_selectively_with_table_files(
     assert args[1] == dump_local
     # Selective: only the named table file plus the table-of-contents.
     assert kwargs["include"] == ["toc.dat", "best.dat.gz"]
+
+
+@patch("sbir_analytics.assets.transition.contracts.upload_file_to_s3")
+@patch("sbir_analytics.assets.transition.contracts.get_config")
+def test_output_uploaded_to_s3_when_configured(mock_get_config, mock_upload, tmp_path):
+    """When the output S3 url is set, the written parquet is uploaded after extraction."""
+    from sbir_analytics.assets.transition.contracts import raw_contracts
+
+    # Happy path: dump dir + vendor file exist, output parquet already present
+    # (so extraction is skipped), and an output S3 url is configured.
+    out = tmp_path / "contracts.parquet"
+    dump = tmp_path / "dump"
+    dump.mkdir()
+    vendor = tmp_path / "sbir_vendor_filters.json"
+    vendor.write_text('{"uei": [], "duns": [], "company_names": []}')
+    pd.DataFrame({"contract_id": ["c1"], "action_date": ["2023-01-01"]}).to_parquet(out)
+
+    resolved = {
+        "transition_contracts_output": out,
+        "transition_dump_dir": dump,
+        "transition_vendor_filters": vendor,
+    }
+    s3_out = "s3://bucket/raw/transition/contracts_ingestion.parquet"
+    config = MagicMock()
+    config.paths.resolve_path.side_effect = lambda key: resolved[key]
+    config.paths.transition_vendor_filters_s3_path = ""
+    config.paths.transition_dump_s3_prefix = ""
+    config.paths.transition_contracts_output_s3_path = s3_out
+    mock_get_config.return_value = config
+
+    raw_contracts(ContextMocks.context_with_logging())
+
+    mock_upload.assert_called_once_with(out, s3_out)

--- a/tests/unit/assets/test_transition_contracts_s3.py
+++ b/tests/unit/assets/test_transition_contracts_s3.py
@@ -1,0 +1,61 @@
+"""Unit tests for S3-first vendor-filter sourcing in the raw_contracts asset."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sbir_etl.exceptions import FileSystemError
+from tests.mocks import ContextMocks
+
+
+def _config_with_paths(tmp_path: Path, s3_url: str) -> MagicMock:
+    """Build a mock config whose paths resolve to tmp_path and carry an S3 url."""
+    out = tmp_path / "contracts.parquet"
+    dump = tmp_path / "dump"  # intentionally absent → asset bails after S3 resolution
+    vendor = tmp_path / "sbir_vendor_filters.json"
+
+    resolved = {
+        "transition_contracts_output": out,
+        "transition_dump_dir": dump,
+        "transition_vendor_filters": vendor,
+    }
+
+    config = MagicMock()
+    config.paths.resolve_path.side_effect = lambda key: resolved[key]
+    config.paths.transition_vendor_filters_s3_path = s3_url
+    return config, vendor
+
+
+@patch("sbir_analytics.assets.transition.contracts.resolve_data_path")
+@patch("sbir_analytics.assets.transition.contracts.get_config")
+def test_vendor_filters_resolved_s3_first(mock_get_config, mock_resolve, tmp_path):
+    """When the S3 url is set, the asset resolves it S3-first with a local fallback."""
+    from sbir_analytics.assets.transition.contracts import raw_contracts
+
+    s3_url = "s3://test-bucket/raw/transition/sbir_vendor_filters.json"
+    config, vendor_local = _config_with_paths(tmp_path, s3_url)
+    mock_get_config.return_value = config
+    mock_resolve.return_value = tmp_path / "downloaded_filters.json"
+
+    # The dump dir is absent, so the asset raises after the S3 resolution step —
+    # enough to assert the S3-first call happened with the local fallback.
+    with pytest.raises(FileSystemError):
+        raw_contracts(ContextMocks.context_with_logging())
+
+    mock_resolve.assert_called_once_with(s3_url, local_fallback=vendor_local)
+
+
+@patch("sbir_analytics.assets.transition.contracts.resolve_data_path")
+@patch("sbir_analytics.assets.transition.contracts.get_config")
+def test_vendor_filters_local_only_when_s3_unset(mock_get_config, mock_resolve, tmp_path):
+    """Empty S3 url leaves behavior unchanged — resolve_data_path is never called."""
+    from sbir_analytics.assets.transition.contracts import raw_contracts
+
+    config, _ = _config_with_paths(tmp_path, "")
+    mock_get_config.return_value = config
+
+    with pytest.raises(FileSystemError):
+        raw_contracts(ContextMocks.context_with_logging())
+
+    mock_resolve.assert_not_called()

--- a/tests/unit/assets/test_transition_contracts_s3.py
+++ b/tests/unit/assets/test_transition_contracts_s3.py
@@ -1,4 +1,4 @@
-"""Unit tests for S3-first vendor-filter sourcing in the raw_contracts asset."""
+"""Unit tests for S3-first input sourcing in the raw_contracts asset."""
 
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -9,10 +9,14 @@ from sbir_etl.exceptions import FileSystemError
 from tests.mocks import ContextMocks
 
 
-def _config_with_paths(tmp_path: Path, s3_url: str) -> MagicMock:
-    """Build a mock config whose paths resolve to tmp_path and carry an S3 url."""
+def _config_with_paths(tmp_path: Path, *, vendor_s3: str = "", dump_s3: str = ""):
+    """Build a mock config whose paths resolve to tmp_path and carry S3 settings.
+
+    The dump dir is intentionally absent so the asset bails (FileSystemError) right
+    after the S3-sourcing steps — enough to assert what those steps did.
+    """
     out = tmp_path / "contracts.parquet"
-    dump = tmp_path / "dump"  # intentionally absent → asset bails after S3 resolution
+    dump = tmp_path / "dump"  # absent
     vendor = tmp_path / "sbir_vendor_filters.json"
 
     resolved = {
@@ -23,8 +27,9 @@ def _config_with_paths(tmp_path: Path, s3_url: str) -> MagicMock:
 
     config = MagicMock()
     config.paths.resolve_path.side_effect = lambda key: resolved[key]
-    config.paths.transition_vendor_filters_s3_path = s3_url
-    return config, vendor
+    config.paths.transition_vendor_filters_s3_path = vendor_s3
+    config.paths.transition_dump_s3_prefix = dump_s3
+    return config, vendor, dump
 
 
 @patch("sbir_analytics.assets.transition.contracts.resolve_data_path")
@@ -34,28 +39,52 @@ def test_vendor_filters_resolved_s3_first(mock_get_config, mock_resolve, tmp_pat
     from sbir_analytics.assets.transition.contracts import raw_contracts
 
     s3_url = "s3://test-bucket/raw/transition/sbir_vendor_filters.json"
-    config, vendor_local = _config_with_paths(tmp_path, s3_url)
+    config, vendor_local, _ = _config_with_paths(tmp_path, vendor_s3=s3_url)
     mock_get_config.return_value = config
     mock_resolve.return_value = tmp_path / "downloaded_filters.json"
 
-    # The dump dir is absent, so the asset raises after the S3 resolution step —
-    # enough to assert the S3-first call happened with the local fallback.
     with pytest.raises(FileSystemError):
         raw_contracts(ContextMocks.context_with_logging())
 
     mock_resolve.assert_called_once_with(s3_url, local_fallback=vendor_local)
 
 
+@patch("sbir_analytics.assets.transition.contracts.sync_s3_prefix_to_dir")
 @patch("sbir_analytics.assets.transition.contracts.resolve_data_path")
 @patch("sbir_analytics.assets.transition.contracts.get_config")
-def test_vendor_filters_local_only_when_s3_unset(mock_get_config, mock_resolve, tmp_path):
-    """Empty S3 url leaves behavior unchanged — resolve_data_path is never called."""
+def test_local_only_when_s3_unset(mock_get_config, mock_resolve, mock_sync, tmp_path):
+    """Empty S3 settings leave behavior unchanged — no S3 calls are made."""
     from sbir_analytics.assets.transition.contracts import raw_contracts
 
-    config, _ = _config_with_paths(tmp_path, "")
+    config, _, _ = _config_with_paths(tmp_path)
     mock_get_config.return_value = config
 
     with pytest.raises(FileSystemError):
         raw_contracts(ContextMocks.context_with_logging())
 
     mock_resolve.assert_not_called()
+    mock_sync.assert_not_called()
+
+
+@patch("sbir_analytics.assets.transition.contracts.sync_s3_prefix_to_dir")
+@patch("sbir_analytics.assets.transition.contracts.get_config")
+def test_dump_synced_selectively_with_table_files(
+    mock_get_config, mock_sync, tmp_path, monkeypatch
+):
+    """With a dump prefix + TABLE_FILES, the asset syncs only toc.dat + those files."""
+    from sbir_analytics.assets.transition.contracts import raw_contracts
+
+    prefix = "s3://test-bucket/raw/transition/pruned_data_store_api_dump/"
+    config, _, dump_local = _config_with_paths(tmp_path, dump_s3=prefix)
+    mock_get_config.return_value = config
+    monkeypatch.setenv("SBIR_ETL__TRANSITION__CONTRACTS__TABLE_FILES", "best.dat.gz")
+
+    with pytest.raises(FileSystemError):
+        raw_contracts(ContextMocks.context_with_logging())
+
+    mock_sync.assert_called_once()
+    args, kwargs = mock_sync.call_args
+    assert args[0] == prefix
+    assert args[1] == dump_local
+    # Selective: only the named table file plus the table-of-contents.
+    assert kwargs["include"] == ["toc.dat", "best.dat.gz"]

--- a/tests/unit/config/test_schemas.py
+++ b/tests/unit/config/test_schemas.py
@@ -672,8 +672,9 @@ class TestPathsConfig:
         assert config.raw_data == "data/raw"
         assert config.usaspending_dump_dir == "data/usaspending"
         assert config.transition_contracts_output == "data/transition/contracts_ingestion.parquet"
-        # S3 vendor-filter sourcing is opt-in: empty by default (local only).
+        # S3 sourcing is opt-in: empty by default (local only).
         assert config.transition_vendor_filters_s3_path == ""
+        assert config.transition_dump_s3_prefix == ""
 
     def test_custom_paths(self):
         """Test PathsConfig with custom paths."""

--- a/tests/unit/config/test_schemas.py
+++ b/tests/unit/config/test_schemas.py
@@ -672,6 +672,8 @@ class TestPathsConfig:
         assert config.raw_data == "data/raw"
         assert config.usaspending_dump_dir == "data/usaspending"
         assert config.transition_contracts_output == "data/transition/contracts_ingestion.parquet"
+        # S3 vendor-filter sourcing is opt-in: empty by default (local only).
+        assert config.transition_vendor_filters_s3_path == ""
 
     def test_custom_paths(self):
         """Test PathsConfig with custom paths."""

--- a/tests/unit/config/test_schemas.py
+++ b/tests/unit/config/test_schemas.py
@@ -675,6 +675,7 @@ class TestPathsConfig:
         # S3 sourcing is opt-in: empty by default (local only).
         assert config.transition_vendor_filters_s3_path == ""
         assert config.transition_dump_s3_prefix == ""
+        assert config.transition_contracts_output_s3_path == ""
 
     def test_custom_paths(self):
         """Test PathsConfig with custom paths."""

--- a/tests/unit/utils/test_cloud_storage.py
+++ b/tests/unit/utils/test_cloud_storage.py
@@ -15,7 +15,60 @@ from sbir_etl.utils.cloud_storage import (
     check_sbir_data_freshness,
     get_s3_bucket_from_env,
     resolve_data_path,
+    sync_s3_prefix_to_dir,
 )
+
+
+class TestSyncS3PrefixToDir:
+    """Tests for sync_s3_prefix_to_dir (selective prefix download)."""
+
+    def _client_with(self, keys):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value = [{"Contents": [{"Key": k} for k in keys]}]
+        return client
+
+    def test_downloads_only_included_basenames(self, tmp_path):
+        client = self._client_with(
+            [
+                "raw/transition/dump/toc.dat",
+                "raw/transition/dump/a.dat.gz",
+                "raw/transition/dump/b.dat.gz",
+            ]
+        )
+        with patch("boto3.client", return_value=client):
+            dest = sync_s3_prefix_to_dir(
+                "s3://bucket/raw/transition/dump/",
+                tmp_path / "dump",
+                include=["toc.dat", "a.dat.gz"],
+            )
+
+        assert dest == tmp_path / "dump"
+        downloaded_keys = {c.args[1] for c in client.download_file.call_args_list}
+        assert downloaded_keys == {
+            "raw/transition/dump/toc.dat",
+            "raw/transition/dump/a.dat.gz",
+        }
+        assert client.download_file.call_count == 2  # b.dat.gz skipped
+
+    def test_downloads_all_when_include_none(self, tmp_path):
+        client = self._client_with(["p/toc.dat", "p/a.dat.gz", "p/b.dat.gz"])
+        with patch("boto3.client", return_value=client):
+            sync_s3_prefix_to_dir("s3://bucket/p/", tmp_path / "d", include=None)
+        assert client.download_file.call_count == 3
+
+    def test_raises_on_non_s3_prefix(self, tmp_path):
+        with pytest.raises(ValueError):
+            sync_s3_prefix_to_dir("/local/dir", tmp_path / "d")
+
+    def test_raises_when_no_objects_match(self, tmp_path):
+        client = self._client_with(["p/toc.dat", "p/a.dat.gz"])
+        with patch("boto3.client", return_value=client):
+            with pytest.raises(FileNotFoundError):
+                sync_s3_prefix_to_dir(
+                    "s3://bucket/p/", tmp_path / "d", include=["nope.dat.gz"]
+                )
 
 
 class TestResolveDataPath:

--- a/tests/unit/utils/test_cloud_storage.py
+++ b/tests/unit/utils/test_cloud_storage.py
@@ -16,6 +16,7 @@ from sbir_etl.utils.cloud_storage import (
     get_s3_bucket_from_env,
     resolve_data_path,
     sync_s3_prefix_to_dir,
+    upload_file_to_s3,
 )
 
 
@@ -66,9 +67,36 @@ class TestSyncS3PrefixToDir:
         client = self._client_with(["p/toc.dat", "p/a.dat.gz"])
         with patch("boto3.client", return_value=client):
             with pytest.raises(FileNotFoundError):
-                sync_s3_prefix_to_dir(
-                    "s3://bucket/p/", tmp_path / "d", include=["nope.dat.gz"]
-                )
+                sync_s3_prefix_to_dir("s3://bucket/p/", tmp_path / "d", include=["nope.dat.gz"])
+
+
+class TestUploadFileToS3:
+    """Tests for upload_file_to_s3."""
+
+    def test_uploads_local_file(self, tmp_path):
+        local = tmp_path / "out.parquet"
+        local.write_bytes(b"data")
+        client = MagicMock()
+        with patch("boto3.client", return_value=client):
+            url = upload_file_to_s3(local, "s3://bucket/raw/out.parquet")
+        assert url == "s3://bucket/raw/out.parquet"
+        client.upload_file.assert_called_once_with(str(local), "bucket", "raw/out.parquet")
+
+    def test_raises_on_non_s3_url(self, tmp_path):
+        local = tmp_path / "out.parquet"
+        local.write_bytes(b"data")
+        with pytest.raises(ValueError):
+            upload_file_to_s3(local, "/local/out.parquet")
+
+    def test_raises_when_local_missing(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            upload_file_to_s3(tmp_path / "missing.parquet", "s3://bucket/out.parquet")
+
+    def test_raises_when_no_object_key(self, tmp_path):
+        local = tmp_path / "out.parquet"
+        local.write_bytes(b"data")
+        with pytest.raises(ValueError):
+            upload_file_to_s3(local, "s3://bucket")
 
 
 class TestResolveDataPath:

--- a/tests/unit/utils/test_cloud_storage.py
+++ b/tests/unit/utils/test_cloud_storage.py
@@ -69,6 +69,31 @@ class TestSyncS3PrefixToDir:
             with pytest.raises(FileNotFoundError):
                 sync_s3_prefix_to_dir("s3://bucket/p/", tmp_path / "d", include=["nope.dat.gz"])
 
+    def test_missing_requested_basename_raises_without_side_effects(self, tmp_path):
+        """If any requested file is absent, raise before creating dir or downloading."""
+        client = self._client_with(["p/toc.dat", "p/a.dat.gz"])
+        dest = tmp_path / "d"
+        with patch("boto3.client", return_value=client):
+            with pytest.raises(FileNotFoundError):
+                sync_s3_prefix_to_dir(
+                    "s3://bucket/p/", dest, include=["toc.dat", "a.dat.gz", "missing.dat.gz"]
+                )
+        # No partial sync: nothing downloaded and no directory left behind.
+        client.download_file.assert_not_called()
+        assert not dest.exists()
+
+    def test_raises_on_empty_bucket(self, tmp_path):
+        with pytest.raises(ValueError):
+            sync_s3_prefix_to_dir("s3:///raw/dump/", tmp_path / "d")
+
+    def test_normalizes_prefix_trailing_slash(self, tmp_path):
+        """A prefix without a trailing slash is normalized so siblings can't match."""
+        client = self._client_with(["raw/dump/toc.dat"])
+        with patch("boto3.client", return_value=client):
+            sync_s3_prefix_to_dir("s3://bucket/raw/dump", tmp_path / "d", include=["toc.dat"])
+        _, kwargs = client.get_paginator.return_value.paginate.call_args
+        assert kwargs["Prefix"] == "raw/dump/"
+
 
 class TestUploadFileToS3:
     """Tests for upload_file_to_s3."""


### PR DESCRIPTION
## Description

Foundational infra for running the transition contract pipeline in a fresh / ephemeral environment (e.g. AWS Batch) without inputs pre-staged on local disk. The `raw_contracts` asset can now source **both** of its inputs from S3, mirroring the established S3-first → local-fallback pattern (`usaspending_ingestion.py` / `resolve_data_path`). Both are **opt-in** (empty config = local only, behavior unchanged).

**Vendor-filter JSON (single small file):** new config key `paths.transition_vendor_filters_s3_path`. When set, the asset resolves it S3-first with the local path as fallback via `resolve_data_path`.

**Dump (~17GB, multi-file) — selective prefix sync:** new config key `paths.transition_dump_s3_prefix`. A single archive would force a monolithic ~17GB download plus a same-size extraction, so instead the dump lives in S3 as a **prefix** (one object per `.dat.gz` + `toc.dat`) and the asset downloads only what the extractor needs — `toc.dat` + the file(s) named in `SBIR_ETL__TRANSITION__CONTRACTS__TABLE_FILES`. With no `TABLE_FILES` it syncs the whole prefix and warns. New helper `cloud_storage.sync_s3_prefix_to_dir(prefix, dest, include=None)` uses boto3 `list_objects_v2` + selective `download_file`, matching the repo's existing S3-listing pattern.

On any S3 failure, both paths log and fall back to the local files.

This is part of the contract-data "Slice C" effort. **Remaining (follow-ups):** persist the `contracts_ingestion.parquet` output back to S3 for cross-run reuse, and add the transition Batch job definition; then validate end-to-end on a synthetic seed.

Fixes # (n/a)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update (config comments)

## Testing

`uv run pytest tests/unit/utils/test_cloud_storage.py tests/unit/assets/test_transition_contracts_s3.py tests/unit/config/test_schemas.py` — 38 passed. New coverage: selective vs full prefix download, non-s3 / no-match errors (`sync_s3_prefix_to_dir`); the asset resolves the vendor filter S3-first with local fallback, wires the dump `include` list as `[toc.dat, *table_files]`, and makes no S3 calls when unset; config defaults are empty. `ruff check` / `ruff format --check` / `mypy` clean on changed files.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_