### PR TITLE
Bridge contract extractor output into the transition sample (flatten nested schema)

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -210,14 +210,19 @@ def flatten_contract_records(df: pd.DataFrame) -> pd.DataFrame:
             return None
         return df[col].apply(lambda v: v.get(key) if isinstance(v, dict) else None)
 
+    # Record which flat targets were absent up front, so we never touch values that
+    # a flat seed already provided (the "absent only" contract).
+    action_date_derived = "action_date" not in df.columns
+
     for dst, (col, key) in _CONTRACT_NESTED_FLATTEN.items():
         if dst not in df.columns:
             values = _from_nested(col, key)
             if values is not None:
                 df[dst] = values
 
-    # action_date falls back to the signed date when effective_date is missing.
-    if "action_date" in df.columns:
+    # signed_date fallback applies only to an action_date we just derived from the
+    # nested period (effective_date) — never to a pre-existing flat action_date.
+    if action_date_derived and "action_date" in df.columns:
         signed = _from_nested("period", "signed_date")
         if signed is not None:
             df["action_date"] = df["action_date"].where(df["action_date"].notna(), signed)

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -170,12 +170,74 @@ def raw_contracts(context) -> Output[pd.DataFrame]:
 # -----------------------------
 
 
+# Maps the nested FederalContract.model_dump() schema (what raw_contracts writes to
+# contracts_ingestion.parquet) onto the flat columns the transition sample expects.
+# Each entry: flat_target -> (nested_column, key_inside_that_dict).
+_CONTRACT_NESTED_FLATTEN = {
+    "vendor_uei": ("vendor", "uei"),
+    "vendor_duns": ("vendor", "duns_number"),
+    "vendor_name": ("vendor", "name"),
+    "vendor_cage": ("vendor", "cage_code"),
+    "obligated_amount": ("value", "obligated_amount"),
+    "action_date": ("period", "effective_date"),
+}
+# Flat renames where the extractor's column name differs from the expected one.
+_CONTRACT_FLAT_RENAME = {
+    "agency_code": "awarding_agency_code",
+    "agency_name": "awarding_agency_name",
+}
+
+
+def flatten_contract_records(df: pd.DataFrame) -> pd.DataFrame:
+    """Flatten a FederalContract-dump DataFrame to the flat transition-sample schema.
+
+    ``raw_contracts`` writes ``FederalContract.model_dump()`` rows, where ``vendor`` /
+    ``value`` / ``period`` are **nested dicts** — so the flat ``vendor_uei`` /
+    ``obligated_amount`` / ``action_date`` columns the detection chain needs are
+    absent. This lifts those nested values up to flat columns (and renames
+    ``agency_code`` → ``awarding_agency_code``), letting ``validated_contracts_sample``
+    consume the extractor output directly (e.g. via ``CONTRACTS_SAMPLE__PATH`` pointed
+    at ``contracts_ingestion.parquet``).
+
+    Only fills a flat target when it is **absent**, so an already-flat seeded sample
+    passes through unchanged. No-op on an empty frame.
+    """
+    if df.empty:
+        return df
+
+    def _from_nested(col: str, key: str) -> pd.Series | None:
+        if col not in df.columns:
+            return None
+        return df[col].apply(lambda v: v.get(key) if isinstance(v, dict) else None)
+
+    for dst, (col, key) in _CONTRACT_NESTED_FLATTEN.items():
+        if dst not in df.columns:
+            values = _from_nested(col, key)
+            if values is not None:
+                df[dst] = values
+
+    # action_date falls back to the signed date when effective_date is missing.
+    if "action_date" in df.columns:
+        signed = _from_nested("period", "signed_date")
+        if signed is not None:
+            df["action_date"] = df["action_date"].where(df["action_date"].notna(), signed)
+
+    for src_col, dst_col in _CONTRACT_FLAT_RENAME.items():
+        if src_col in df.columns and dst_col not in df.columns:
+            df[dst_col] = df[src_col]
+
+    return df
+
+
 @asset(
     name="validated_contracts_sample",
     group_name="validation",
     compute_kind="pandas",
     description=(
         "Load or create a sample of federal contracts for transition detection. "
+        "Accepts either a flat seeded sample or the raw extractor output "
+        "(contracts_ingestion.parquet, nested FederalContract schema) — the nested "
+        "vendor/value/period columns are flattened to the expected flat schema. "
         "If no file is found, an empty dataframe with expected schema is produced. "
         "Writes checks JSON with coverage metrics."
     ),
@@ -212,6 +274,10 @@ def validated_contracts_sample(context) -> Output[pd.DataFrame]:
     else:
         df = pd.DataFrame({c: pd.Series(dtype="object") for c in expected_cols})
         src = "generated_empty"
+
+    # Flatten the extractor's nested vendor/value/period schema (no-op for flat seeds),
+    # so contracts_ingestion.parquet can be used directly as the sample source.
+    df = flatten_contract_records(df)
 
     # Column aliases -> canonical names (best-effort)
     alias_map = {

--- a/tests/unit/assets/test_contracts_flatten.py
+++ b/tests/unit/assets/test_contracts_flatten.py
@@ -1,0 +1,119 @@
+"""Tests for flatten_contract_records — the extractor→sample schema bridge.
+
+The nested key names (vendor.uei, vendor.duns_number, vendor.cage_code,
+value.obligated_amount, period.effective_date/signed_date) were verified against
+sbir_etl.models.contract_models (FederalContract / ContractParty / ContractValue /
+ContractPeriod).
+"""
+
+import pandas as pd
+
+from sbir_analytics.assets.transition.contracts import flatten_contract_records
+
+
+def _nested_row(**overrides):
+    """A row shaped like FederalContract.model_dump()."""
+    row = {
+        "contract_id": "W911NF20C0001",
+        "piid": "W911NF20C0001",
+        "agency_code": "9700",
+        "agency_name": "DOD",
+        "vendor": {
+            "uei": "ABC123DEF456",
+            "duns_number": "123456789",
+            "name": "Acme Robotics",
+            "cage_code": "1ABC1",
+        },
+        "value": {"obligated_amount": 500000.0},
+        "period": {"effective_date": "2023-08-01", "signed_date": "2023-07-15"},
+    }
+    row.update(overrides)
+    return row
+
+
+def test_flattens_nested_vendor_value_period():
+    out = flatten_contract_records(pd.DataFrame([_nested_row()]))
+    r = out.iloc[0]
+    assert r["vendor_uei"] == "ABC123DEF456"
+    assert r["vendor_duns"] == "123456789"
+    assert r["vendor_name"] == "Acme Robotics"
+    assert r["vendor_cage"] == "1ABC1"
+    assert r["obligated_amount"] == 500000.0
+    assert r["action_date"] == "2023-08-01"
+    # agency_code is renamed to the expected awarding_agency_code
+    assert r["awarding_agency_code"] == "9700"
+    assert r["awarding_agency_name"] == "DOD"
+
+
+def test_action_date_falls_back_to_signed_date():
+    row = _nested_row(period={"effective_date": None, "signed_date": "2023-07-15"})
+    out = flatten_contract_records(pd.DataFrame([row]))
+    assert out.iloc[0]["action_date"] == "2023-07-15"
+
+
+def test_flat_seed_passes_through_unchanged():
+    """An already-flat seeded sample (no nested cols) is left as-is."""
+    flat = pd.DataFrame(
+        [
+            {
+                "contract_id": "C1",
+                "vendor_uei": "UEI000000001",
+                "obligated_amount": 100.0,
+                "action_date": "2022-01-01",
+            }
+        ]
+    )
+    out = flatten_contract_records(flat)
+    assert out.iloc[0]["vendor_uei"] == "UEI000000001"
+    assert out.iloc[0]["obligated_amount"] == 100.0
+    assert "vendor" not in out.columns  # nothing invented
+
+
+def test_does_not_clobber_existing_flat_columns():
+    """If a flat target already exists, the nested value does not overwrite it."""
+    row = _nested_row(vendor_uei="PRESET_UEI00")
+    out = flatten_contract_records(pd.DataFrame([row]))
+    assert out.iloc[0]["vendor_uei"] == "PRESET_UEI00"
+
+
+def test_empty_frame_is_noop():
+    empty = pd.DataFrame()
+    out = flatten_contract_records(empty)
+    assert out.empty
+
+
+def test_flattens_real_federal_contract_model_dump():
+    """Pin the bridge to the real model: a FederalContract.model_dump() must flatten.
+
+    Guards against the nested model field names drifting out from under the bridge.
+    """
+    from sbir_etl.models.contract_models import (
+        ContractDescription,
+        ContractParty,
+        ContractPeriod,
+        ContractValue,
+        FederalContract,
+    )
+
+    contract = FederalContract(
+        contract_id="W911NF20C0001",
+        piid="W911NF20C0001",
+        agency_code="9700",
+        agency_name="DOD",
+        vendor=ContractParty(
+            name="Acme", uei="ABC123DEF456", duns_number="123456789", cage_code="1ABC1"
+        ),
+        value=ContractValue(obligated_amount=500000.0),
+        period=ContractPeriod(effective_date="2023-08-01"),
+        description_info=ContractDescription(),
+    )
+
+    out = flatten_contract_records(pd.DataFrame([contract.model_dump()]))
+    r = out.iloc[0]
+    assert r["vendor_uei"] == "ABC123DEF456"
+    assert r["vendor_duns"] == "123456789"
+    assert r["obligated_amount"] == 500000.0
+    # model_dump yields a date object for effective_date; the pipeline's
+    # pd.to_datetime handles it. Compare on the ISO string.
+    assert str(r["action_date"]) == "2023-08-01"
+    assert r["awarding_agency_code"] == "9700"

--- a/tests/unit/assets/test_contracts_flatten.py
+++ b/tests/unit/assets/test_contracts_flatten.py
@@ -76,6 +76,23 @@ def test_does_not_clobber_existing_flat_columns():
     assert out.iloc[0]["vendor_uei"] == "PRESET_UEI00"
 
 
+def test_preexisting_action_date_not_backfilled_from_signed_date():
+    """A pre-existing flat action_date (even null) is never backfilled, even if a
+    period column is also present (the 'absent only' contract)."""
+    df = pd.DataFrame(
+        [
+            {
+                "contract_id": "C1",
+                "action_date": None,  # flat, pre-existing, null
+                "period": {"effective_date": None, "signed_date": "2023-07-15"},
+            }
+        ]
+    )
+    out = flatten_contract_records(df)
+    # action_date existed up front → signed_date fallback must NOT touch it.
+    assert out.iloc[0]["action_date"] is None
+
+
 def test_empty_frame_is_noop():
     empty = pd.DataFrame()
     out = flatten_contract_records(empty)


### PR DESCRIPTION
## Description

Closes the end-to-end discontinuity in the award→transition→contract pipeline that the recent review surfaced.

`raw_contracts` writes `FederalContract.model_dump()` rows, where `vendor` / `value` / `period` are **nested objects**. But `validated_contracts_sample` — and the whole detection chain downstream (vendor resolution, scoring) — needs **flat** columns (`vendor_uei`, `vendor_duns`, `vendor_name`, `obligated_amount`, `action_date`, `awarding_agency_code`). The schemas never lined up, and the asset's `alias_map` only handled flat renames whose source names aren't even present in the extractor output. Net effect: pointing the sample at `contracts_ingestion.parquet` mapped only `contract_id`/`piid`, so vendor resolution resolved nothing and **0 transitions** were produced.

This adds `flatten_contract_records(df)`, which lifts the (verified) nested keys up to the flat schema:

```
vendor.uei            → vendor_uei
vendor.duns_number    → vendor_duns
vendor.name           → vendor_name
vendor.cage_code      → vendor_cage
value.obligated_amount→ obligated_amount
period.effective_date → action_date   (falls back to period.signed_date)
agency_code           → awarding_agency_code   (rename)
```

It only fills a flat target when **absent**, so an already-flat seeded sample (`scripts/run_transition.py`) passes through unchanged; it's a no-op on empty frames. `validated_contracts_sample` now runs it right after reading, so **`SBIR_ETL__TRANSITION__CONTRACTS_SAMPLE__PATH` can point directly at `contracts_ingestion.parquet`** — the config-only bridge that was impossible before now works, with no DAG-wiring or naming-standard changes (the assets depend by parameter name and `contracts_sample` already maps to this asset).

This is the load-bearing link between the contract extraction (which the open #387 wires to S3) and the transition detection chain; with it, a seeded/extracted run produces real `RESULTED_IN` edges (paired with the inline CONTRACT-node writer in #386).

Fixes # (n/a)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`uv run pytest tests/unit/assets/test_contracts_flatten.py` — 6 passed: nested→flat mapping, `signed_date` fallback, flat-seed passthrough, no-clobber of preset flat columns, empty no-op, and a **model-backed** test that pins the bridge to the real `FederalContract.model_dump()` so a model change can't silently break it. Broader sweep (asset discovery + phase_transition) green. `ruff check` / `ruff format --check` / `mypy` clean.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (asset description)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_