### PR TITLE
Capture USAspending's true transaction action_date on FederalContract

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -246,11 +246,12 @@ _CONTRACT_COLUMN_ALIASES = {
 def normalize_contract_columns(df: pd.DataFrame) -> pd.DataFrame:
     """Rename extractor/raw contract columns to the flat transition-sample schema.
 
-    The extractor output is already flat (``vendor_uei`` / ``vendor_duns`` /
-    ``vendor_name`` match directly); this fills the remaining canonical columns
-    (``obligated_amount`` / ``action_date`` / ``awarding_agency_name``) from their
-    differently-named sources. Only fills a target column when it is **absent**, so
-    an already-canonical seeded sample passes through unchanged. No-op on empty.
+    The extractor output is already flat — ``vendor_uei`` / ``vendor_duns`` /
+    ``vendor_name`` / ``action_date`` match the canonical schema directly. This fills
+    the remaining canonical columns (``obligated_amount`` / ``awarding_agency_name``)
+    from their differently-named sources. Only fills a target column when it is
+    **absent**, so an already-canonical seeded sample passes through unchanged. No-op
+    on empty.
     """
     if df.empty:
         return df
@@ -269,8 +270,9 @@ def normalize_contract_columns(df: pd.DataFrame) -> pd.DataFrame:
         "Accepts either a flat seeded sample or the raw extractor output "
         "(contracts_ingestion.parquet) — extractor/raw column names are normalized to "
         "the canonical flat schema (e.g. obligation_amount -> obligated_amount, "
-        "start_date -> action_date). If no file is found, an empty dataframe with the "
-        "expected schema is produced. Writes checks JSON with coverage metrics."
+        "agency -> awarding_agency_name; action_date maps through directly). If no file "
+        "is found, an empty dataframe with the expected schema is produced. Writes "
+        "checks JSON with coverage metrics."
     ),
 )
 def validated_contracts_sample(context) -> Output[pd.DataFrame]:

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/contracts.py
@@ -236,11 +236,9 @@ _CONTRACT_COLUMN_ALIASES = {
     "federal_action_obligation": "obligated_amount",
     "awarding_agency": "awarding_agency_name",
     # Extractor output (transition_models.FederalContract) -> canonical sample schema.
+    # action_date is now a real top-level field (the true USAspending transaction
+    # action_date, column 2), so it maps through directly and needs no alias.
     "obligation_amount": "obligated_amount",
-    # NOTE: the extractor stores period_of_performance_start_date as `start_date` and
-    # does not carry the transaction action_date (column 2); start_date is the best
-    # available action-date proxy until the extractor captures the true action_date.
-    "start_date": "action_date",
     "agency": "awarding_agency_name",
 }
 

--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -370,6 +370,7 @@ class ContractExtractor:
                 vendor_uei=vendor_uei,
                 vendor_cage=cage_code,  # CAGE code from column 98
                 vendor_duns=vendor_duns,
+                action_date=action_date,  # transaction action_date (column 2)
                 start_date=start_date,
                 end_date=end_date,
                 obligation_amount=obligation_amount,

--- a/sbir_etl/models/transition_models.py
+++ b/sbir_etl/models/transition_models.py
@@ -217,6 +217,14 @@ class FederalContract(BaseModel):
     vendor_uei: str | None = Field(None, description="Vendor UEI if available.")
     vendor_cage: str | None = Field(None, description="Vendor CAGE code if available.")
     vendor_duns: str | None = Field(None, description="Vendor DUNS if available (legacy).")
+    action_date: date | None = Field(
+        None,
+        description=(
+            "USAspending transaction action_date (the date of the obligating action) — "
+            "the canonical transaction date for temporal scoring. Distinct from "
+            "start_date, which is the period-of-performance start."
+        ),
+    )
     start_date: date | None = Field(None, description="Contract start/award effective date.")
     end_date: date | None = Field(None, description="Contract end date (if present).")
     obligation_amount: float | None = Field(
@@ -247,7 +255,7 @@ class FederalContract(BaseModel):
     )
     metadata: dict[str, object] = Field(default_factory=dict)
 
-    @field_validator("start_date", "end_date", mode="before")
+    @field_validator("action_date", "start_date", "end_date", mode="before")
     @classmethod
     def validate_and_parse_dates(cls, v):
         """Parse and validate date fields from various input formats."""

--- a/sbir_etl/models/transition_models.py
+++ b/sbir_etl/models/transition_models.py
@@ -225,7 +225,14 @@ class FederalContract(BaseModel):
             "start_date, which is the period-of-performance start."
         ),
     )
-    start_date: date | None = Field(None, description="Contract start/award effective date.")
+    start_date: date | None = Field(
+        None,
+        description=(
+            "Period-of-performance start date (USAspending "
+            "period_of_performance_start_date). Distinct from action_date, the "
+            "transaction/obligating-action date; falls back to action_date when absent."
+        ),
+    )
     end_date: date | None = Field(None, description="Contract end date (if present).")
     obligation_amount: float | None = Field(
         None, description="Contract obligation/award amount. Can be negative for deobligations."

--- a/tests/integration/extractors/test_contract_extraction_integration.py
+++ b/tests/integration/extractors/test_contract_extraction_integration.py
@@ -8,12 +8,14 @@ Tests cover end-to-end extraction scenarios:
 - Parent/child relationship tracking
 """
 
+import datetime
 import gzip
 import json
 
 import pandas as pd
 import pytest
 
+from sbir_analytics.assets.transition.contracts import normalize_contract_columns
 from sbir_etl.extractors.contract_extractor import ContractExtractor
 
 
@@ -358,6 +360,73 @@ class TestExtractFromDump:
 
         # Should have selected large.dat.gz (7 rows instead of 6)
         assert extractor.stats["records_scanned"] == 7
+
+
+class TestActionDateEndToEnd:
+    """End-to-end: the true transaction action_date survives extract→parquet→bridge.
+
+    Drives the real pipeline (``extract_from_dump`` writes Parquet, then
+    ``normalize_contract_columns`` maps it to the sample schema) on a row where the
+    transaction action_date (column 2) deliberately differs from the
+    period-of-performance start (column 71), proving action_date is carried as the
+    true obligating-action date — not the start_date proxy the bridge used before.
+    """
+
+    @pytest.fixture
+    def action_date_dat_gz_file(self, tmp_path):
+        """A single contract whose action_date (col 2) ≠ start_date (col 71)."""
+        data_file = tmp_path / "action_date.dat.gz"
+
+        row = ["\\N"] * 103
+        row[0] = "5001"  # transaction_id
+        row[1] = "CONT_AWD_ACTION_DATE_001"
+        row[2] = "20221101"  # action_date — the obligating-action date
+        row[3] = "A"  # type (contract)
+        row[5] = "A"  # award_type_code
+        row[9] = "TEST CONTRACTOR ONE"  # recipient_name
+        row[10] = "TEST123456789"  # recipient_unique_id
+        row[12] = "Department of Defense"
+        row[28] = "ACT001"  # piid
+        row[29] = "100000.00"  # obligation
+        row[71] = "20230801"  # period_of_performance_start_date — later, distinct
+        row[96] = "TEST123456789"  # recipient_uei
+        row[99] = "FULL"  # extent_competed
+
+        with gzip.open(data_file, "wt", encoding="utf-8") as f:
+            f.write("\t".join(row) + "\n")
+
+        return data_file
+
+    def test_true_action_date_survives_extract_and_bridge(
+        self, tmp_path, action_date_dat_gz_file, vendor_filter_file
+    ):
+        output_file = tmp_path / "output" / "action_date.parquet"
+        dump_dir = tmp_path / "dump"
+        dump_dir.mkdir()
+
+        import shutil
+
+        target_file = dump_dir / "action_date.dat.gz"
+        shutil.copy(action_date_dat_gz_file, target_file)
+
+        extractor = ContractExtractor(vendor_filter_file=vendor_filter_file)
+        count = extractor.extract_from_dump(
+            dump_dir=dump_dir,
+            output_file=output_file,
+            table_files=["action_date.dat.gz"],
+        )
+        assert count == 1
+
+        # Read the extractor's real Parquet output and run the sample bridge on it.
+        df = normalize_contract_columns(pd.read_parquet(output_file))
+        r = df.iloc[0]
+
+        assert r["contract_id"] == "ACT001"
+        # action_date is the transaction action_date (col 2), NOT the PoP start (col 71).
+        assert pd.Timestamp(r["action_date"]).date() == datetime.date(2022, 11, 1)
+        assert pd.Timestamp(r["start_date"]).date() == datetime.date(2023, 8, 1)
+        # The bridge no longer overwrites action_date with start_date.
+        assert r["action_date"] != r["start_date"]
 
 
 class TestContractExtractorEdgeCasesIntegration:

--- a/tests/unit/assets/test_contracts_normalize.py
+++ b/tests/unit/assets/test_contracts_normalize.py
@@ -1,8 +1,9 @@
 """Tests for normalize_contract_columns — the extractor→sample column bridge.
 
 The extractor writes the FLAT ``transition_models.FederalContract`` schema, so the
-bridge is a set of flat renames (obligation_amount -> obligated_amount, start_date ->
-action_date, agency -> awarding_agency_name); vendor_uei/duns/name already match.
+bridge is a set of flat renames (obligation_amount -> obligated_amount, agency ->
+awarding_agency_name); vendor_uei/duns/name and action_date already match (action_date
+is now a real top-level field carrying USAspending's true transaction action_date).
 """
 
 import datetime
@@ -22,6 +23,7 @@ def test_normalizes_real_extractor_model_dump():
         vendor_duns="123456789",
         vendor_name="Acme Robotics",
         obligation_amount=500000.0,
+        action_date=datetime.date(2023, 3, 15),
         start_date=datetime.date(2023, 8, 1),
         agency="Department of Defense",
     )
@@ -34,9 +36,12 @@ def test_normalizes_real_extractor_model_dump():
     assert r["vendor_duns"] == "123456789"
     assert r["vendor_name"] == "Acme Robotics"
     assert r["contract_id"] == "W911NF20C0001"
+    # action_date is a real top-level field — the true transaction date, distinct from
+    # the period-of-performance start_date — and passes through untouched.
+    assert str(r["action_date"]) == "2023-03-15"
+    assert str(r["start_date"]) == "2023-08-01"
     # Renamed fields are populated from their extractor sources.
     assert r["obligated_amount"] == 500000.0  # <- obligation_amount
-    assert str(r["action_date"]) == "2023-08-01"  # <- start_date
     assert r["awarding_agency_name"] == "Department of Defense"  # <- agency
 
 

--- a/tests/unit/extractors/test_contract_extractor.py
+++ b/tests/unit/extractors/test_contract_extractor.py
@@ -288,8 +288,23 @@ class TestParseContractRow:
         assert contract.obligation_amount == 250000.00
         assert contract.competition_type == CompetitionType.FULL_AND_OPEN
         assert contract.is_deobligation is False
+        assert contract.action_date == date(2023, 3, 15)  # transaction action_date (col 2)
         assert contract.start_date == date(2023, 3, 15)
         assert contract.end_date == date(2024, 3, 15)
+
+    def test_parse_contract_row_captures_action_date_from_column_2(self, sample_contract_row_full):
+        """action_date is the true transaction date (col 2), independent of start_date (col 71)."""
+        row = list(sample_contract_row_full)
+        row[2] = "20221101"  # action_date: obligating-action date
+        row[71] = "20230801"  # period_of_performance_start_date: later, distinct
+
+        extractor = ContractExtractor()
+        contract = extractor._parse_contract_row(row)
+
+        assert contract is not None
+        # action_date follows the transaction action_date (col 2), NOT the PoP start.
+        assert contract.action_date == date(2022, 11, 1)
+        assert contract.start_date == date(2023, 8, 1)
 
     def test_parse_contract_row_minimal(self, sample_contract_row_minimal):
         """Test parsing a minimal contract row."""


### PR DESCRIPTION
## Description

Stacked on #389. That PR notes a known limitation: the extractor stores `period_of_performance_start_date` as `start_date` and does **not** carry the transaction `action_date` (USAspending column 2), so the sample bridge aliased `start_date → action_date` as a proxy. Temporal scoring therefore used the period-of-performance start rather than the real obligating-action date.

This PR closes that gap by capturing the **genuine** USAspending transaction `action_date` (column 2) as a first-class field on the flat `transition_models.FederalContract`.

**Changes:**
- `transition_models.FederalContract`: add an `action_date: date | None` field (the canonical transaction date, distinct from `start_date` = period-of-performance start); include it in the date-parsing `field_validator`.
- `contract_extractor`: populate `action_date` from the already-parsed column 2 value (it was previously parsed only into `metadata`). `start_date` continues to read column 71 with the existing action_date fallback.
- `contracts.py` (`_CONTRACT_COLUMN_ALIASES`): remove the now-obsolete `start_date → action_date` proxy alias — `action_date` is a real top-level field and maps through directly.

| extractor column | canonical sample column |
|---|---|
| `action_date` | `action_date` (direct passthrough — no longer a `start_date` proxy) |
| `obligation_amount` | `obligated_amount` |
| `agency` | `awarding_agency_name` |

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`uv run pytest tests/unit/extractors/test_contract_extractor.py tests/unit/assets/test_contracts_normalize.py` — 48 passed. New assertions prove `action_date` is captured from column 2 **independently** of `start_date` (column 71), and that it passes through the sample bridge unchanged. `ruff format` / `ruff check` / `mypy` clean.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (field/alias comments)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

> **Note:** Targets `claude/fix-contract-flatten-model` (#389). Once #389 merges, this PR's base should be retargeted to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_