### PR TITLE
ci(perf): only fail Performance Check on FAILURE severity, not WARNING

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -789,23 +789,25 @@ jobs:
             echo "match_rate=$MATCH_RATE" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set check status - Success
+      - name: Set check status - Pass or Warning
         # Gate on severity, not on the regression step's exit code. The detector exits
         # non-zero for ANY regression (incl. WARNING), so steps.regression.outcome is
         # 'failure' even for sub-threshold warnings. Only a FAILURE-severity regression
         # should be a red check — matching the "Fail if FAILURE severity detected" gate.
-        # WARNING is surfaced as a non-blocking 'neutral' check; PASS as 'success'.
+        # PASS -> success; WARNING -> non-blocking 'neutral'. Fire only when a real
+        # result was parsed: an empty severity means the detector produced no JSON
+        # (e.g. crashed), so post no status rather than a misleading green pass.
         if: >-
           github.event_name == 'pull_request' &&
-          steps.regression.outcome != 'skipped' &&
-          steps.parse_results.outputs.severity != 'FAILURE'
+          (steps.parse_results.outputs.severity == 'PASS' ||
+           steps.parse_results.outputs.severity == 'WARNING')
         uses: actions/github-script@v9
         env:
           PERF_SEVERITY: ${{ steps.parse_results.outputs.severity }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const severity = process.env.PERF_SEVERITY || 'PASS';
+            const severity = process.env.PERF_SEVERITY;
             const warned = severity === 'WARNING';
             github.rest.checks.create({
               owner: context.repo.owner,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -790,27 +790,45 @@ jobs:
           fi
 
       - name: Set check status - Success
-        if: steps.regression.outcome == 'success' && github.event_name == 'pull_request'
+        # Gate on severity, not on the regression step's exit code. The detector exits
+        # non-zero for ANY regression (incl. WARNING), so steps.regression.outcome is
+        # 'failure' even for sub-threshold warnings. Only a FAILURE-severity regression
+        # should be a red check — matching the "Fail if FAILURE severity detected" gate.
+        # WARNING is surfaced as a non-blocking 'neutral' check; PASS as 'success'.
+        if: >-
+          github.event_name == 'pull_request' &&
+          steps.regression.outcome != 'skipped' &&
+          steps.parse_results.outputs.severity != 'FAILURE'
         uses: actions/github-script@v9
+        env:
+          PERF_SEVERITY: ${{ steps.parse_results.outputs.severity }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            const severity = process.env.PERF_SEVERITY || 'PASS';
+            const warned = severity === 'WARNING';
             github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: 'Performance Check',
               head_sha: context.payload.pull_request.head.sha,
               status: 'completed',
-              conclusion: 'success',
+              conclusion: warned ? 'neutral' : 'success',
               output: {
-                title: '✓ Performance Check Passed',
-                summary: 'No performance regressions detected',
-                text: 'All performance metrics are within acceptable thresholds'
+                title: warned
+                  ? '⚠️ Performance Check — warnings (non-blocking)'
+                  : '✓ Performance Check Passed',
+                summary: warned
+                  ? 'Performance warnings detected (below the failure threshold)'
+                  : 'No performance regressions detected',
+                text: warned
+                  ? 'Warnings are informational and do not block merge. Review the PR comment and artifacts.'
+                  : 'All performance metrics are within acceptable thresholds'
               }
             });
 
       - name: Set check status - Failure
-        if: steps.regression.outcome == 'failure' && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.parse_results.outputs.severity == 'FAILURE'
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -852,8 +870,9 @@ jobs:
               if (results.severity === 'FAILURE' || results.severity === 'WARNING') {
                 comment_body += '\n\n## 🚨 Performance Alerts\n\n';
                 if (results.issues && results.issues.length > 0) {
+                  // results.issues is a list of human-readable strings.
                   results.issues.forEach(issue => {
-                    comment_body += `- **${issue.alert_type}:** ${issue.message}\n`;
+                    comment_body += `- ${issue}\n`;
                   });
                 }
               }


### PR DESCRIPTION
## Description

The **Performance Regression Check** posts a red `Performance Check` status for sub-threshold **WARNING** regressions — e.g. sub-millisecond benchmark jitter like `0.0018s → 0.0021s` (+15.5%) — even though the job's own `Fail if FAILURE severity detected` gate treats WARNING as non-blocking. This has been failing PRs spuriously (observed repeatedly on #390).

### Root cause

The two gates disagreed:
- `detect_performance_regression.py --fail-on-regression` exits non-zero for **any** `regression_detected`, including WARNING.
- The regression step runs with `continue-on-error: true`, so `steps.regression.outcome` becomes `failure` for warnings.
- `Set check status - Failure` keyed off `steps.regression.outcome == 'failure'` → red check for WARNING.
- Meanwhile `Fail if FAILURE severity detected` only `exit 1`s when severity is `FAILURE`, so the **job** stays green. Net result: green job, red check.

### Fix

Gate the `Performance Check` status on the **parsed severity** (already computed in `Parse regression results`) instead of the regression step's exit code:

| severity | `Performance Check` | blocks merge? |
|---|---|---|
| `FAILURE` | ❌ failure | yes (unchanged intent) |
| `WARNING` | ⚪ neutral | no (informational) |
| `PASS` / no regression | ✓ success | no |
| step skipped (no AWS) | no status created | — (as before) |

`WARNING` now renders as a **non-blocking `neutral`** check rather than a misleading green pass, so the signal is still visible without gating the PR.

Also fixes the PR comment's alert rendering: `results.issues` is a list of **strings**, but the script read `issue.alert_type` / `issue.message`, producing the literal `**undefined:** undefined` alert line. Each issue string is now rendered directly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`.github/workflows/ci.yml` parses as valid YAML. The change is confined to the `Performance Regression Check` job's check-status conditions and the PR-comment script; the `FAILURE`-severity hard-fail path is unchanged, so genuine regressions still block. Behavior on the next push to any PR: WARNING-severity benchmark noise yields a neutral (non-blocking) Performance Check instead of a red one.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_