### PR TITLE
Stream USAspending contracts directly from the remote DB zip (no full download)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ cloud = [
     "boto3>=1.34.0,<2.0.0",
     "cloudpathlib[s3]>=0.23.0,<1.0.0",
 ]
+# Stream a single member out of a remote USAspending database .zip over HTTP range,
+# avoiding the full ~217GB download (contract_extractor.stream_remote_zip_member).
+streaming = ["remotezip>=0.12.0,<1.0.0"]
 # Phonetic matching (enrichers — fallback to built-in if absent)
 phonetic = ["jellyfish>=1.0.0,<2.0.0"]
 # Process memory monitoring (falls back to timing-only if absent)
@@ -179,6 +182,7 @@ module = [
     "tenacity.*",  # Retry library
     "cloudpathlib.*",  # Cloud storage path library
     "jellyfish.*",  # Phonetic matching library
+    "remotezip.*",  # Optional remote-zip streaming (extra: streaming)
 ]
 ignore_missing_imports = true
 

--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -500,16 +500,19 @@ class ContractExtractor:
             from remotezip import RemoteZip
         except ImportError as e:  # pragma: no cover - exercised via import guard
             raise ImportError(
-                "Remote zip streaming requires the 'remotezip' package "
-                "(uv add remotezip / pip install remotezip)."
+                "Remote zip streaming requires the optional 'streaming' extra "
+                "(uv sync --extra streaming / pip install 'sbir-etl[streaming]')."
             ) from e
 
         logger.info(f"Streaming member {member_name} from {zip_url} (HTTP range)")
-        with RemoteZip(zip_url) as remote_zip, remote_zip.open(member_name) as member:
+        with (
+            RemoteZip(zip_url) as remote_zip,
+            remote_zip.open(member_name) as member,
             # `member` yields the gzip-compressed .dat.gz bytes; decompress streaming.
-            with gzip.GzipFile(fileobj=member) as gz:
-                text = io.TextIOWrapper(gz, encoding="utf-8", errors="replace")
-                yield from self._parse_lines(text, member_name)
+            gzip.GzipFile(fileobj=member) as gz,
+            io.TextIOWrapper(gz, encoding="utf-8", errors="replace") as text,
+        ):
+            yield from self._parse_lines(text, member_name)
         logger.info(
             f"Completed streaming {member_name}: "
             f"{self.stats['records_extracted']} contracts extracted"

--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -11,8 +11,9 @@ We filter specifically for contract transactions (type code 'contract').
 """
 
 import gzip
+import io
 import json
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 
 import pandas as pd
@@ -405,12 +406,58 @@ class ContractExtractor:
             logger.debug(f"Failed to parse contract row: {e}")
             return None
 
+    def _parse_lines(
+        self,
+        lines: Iterable[str],
+        source_name: str = "stream",
+    ) -> Iterator[FederalContract]:
+        """Parse tab-delimited transaction_normalized lines into FederalContracts.
+
+        Transport-agnostic core shared by the local-file and remote-stream readers:
+        it consumes any iterable of text lines (a gzip file handle, a decompressed
+        remote member, a test fixture) and applies the same type / vendor filtering
+        and row parsing.
+        """
+        for line_num, line in enumerate(lines, 1):
+            self.stats["records_scanned"] += 1
+
+            # Progress logging
+            if line_num % 100000 == 0:
+                logger.info(
+                    f"  [{source_name}] processed {line_num:,} records, "
+                    f"found {self.stats['records_extracted']} contracts"
+                )
+
+            # Split tab-delimited row
+            row_data = line.strip().split("\t")
+
+            # Check if it's a contract type (columns 4 and 6)
+            if len(row_data) > 5:
+                type_code = row_data[3]  # Column 4: type
+                award_type_code = row_data[5]  # Column 6: award_type_code
+                if not self._is_contract_type(type_code, award_type_code):
+                    continue
+
+                self.stats["contracts_found"] += 1
+
+            # Check vendor filter
+            if not self._matches_vendor_filter(row_data):
+                continue
+
+            self.stats["vendor_matches"] += 1
+
+            # Parse into FederalContract
+            contract = self._parse_contract_row(row_data)
+            if contract:
+                self.stats["records_extracted"] += 1
+                yield contract
+
     def stream_dat_gz_file(
         self,
         dat_file: Path,
     ) -> Iterator[FederalContract]:
         """
-        Stream and parse a single .dat.gz file.
+        Stream and parse a single local .dat.gz file.
 
         Args:
             dat_file: Path to .dat.gz file
@@ -419,44 +466,53 @@ class ContractExtractor:
             FederalContract instances that match vendor filters
         """
         logger.info(f"Processing {dat_file.name}...")
-
         with gzip.open(dat_file, "rt", encoding="utf-8", errors="replace") as f:
-            for line_num, line in enumerate(f, 1):
-                self.stats["records_scanned"] += 1
-
-                # Progress logging
-                if line_num % 100000 == 0:
-                    logger.info(
-                        f"  Processed {line_num:,} records, "
-                        f"found {self.stats['records_extracted']} contracts"
-                    )
-
-                # Split tab-delimited row
-                row_data = line.strip().split("\t")
-
-                # Check if it's a contract type (columns 4 and 6)
-                if len(row_data) > 5:
-                    type_code = row_data[3]  # Column 4: type
-                    award_type_code = row_data[5]  # Column 6: award_type_code
-                    if not self._is_contract_type(type_code, award_type_code):
-                        continue
-
-                    self.stats["contracts_found"] += 1
-
-                # Check vendor filter
-                if not self._matches_vendor_filter(row_data):
-                    continue
-
-                self.stats["vendor_matches"] += 1
-
-                # Parse into FederalContract
-                contract = self._parse_contract_row(row_data)
-                if contract:
-                    self.stats["records_extracted"] += 1
-                    yield contract
-
+            yield from self._parse_lines(f, dat_file.name)
         logger.info(
             f"Completed {dat_file.name}: {self.stats['records_extracted']} contracts extracted"
+        )
+
+    def stream_remote_zip_member(
+        self,
+        zip_url: str,
+        member_name: str,
+    ) -> Iterator[FederalContract]:
+        """Stream-parse one ``.dat.gz`` member directly from a remote ``.zip``.
+
+        Uses HTTP Range requests (via ``remotezip``) to read **only** the bytes of
+        ``member_name`` (e.g. the ``transaction_normalized`` table) out of the
+        USAspending database zip — never downloading the full ~217GB archive, and
+        without staging it on local disk. The member is itself gzip-compressed
+        (``.dat.gz``), so it is decompressed on the fly as bytes arrive.
+
+        Requires the server to support HTTP Range (``files.usaspending.gov`` does)
+        and the optional ``remotezip`` dependency.
+
+        Args:
+            zip_url: ``https://`` URL of the database zip (e.g.
+                ``https://files.usaspending.gov/database_download/usaspending-db-subset_YYYYMMDD.zip``).
+            member_name: Path of the ``.dat.gz`` member inside the zip.
+
+        Yields:
+            FederalContract instances that match vendor filters.
+        """
+        try:
+            from remotezip import RemoteZip
+        except ImportError as e:  # pragma: no cover - exercised via import guard
+            raise ImportError(
+                "Remote zip streaming requires the 'remotezip' package "
+                "(uv add remotezip / pip install remotezip)."
+            ) from e
+
+        logger.info(f"Streaming member {member_name} from {zip_url} (HTTP range)")
+        with RemoteZip(zip_url) as remote_zip, remote_zip.open(member_name) as member:
+            # `member` yields the gzip-compressed .dat.gz bytes; decompress streaming.
+            with gzip.GzipFile(fileobj=member) as gz:
+                text = io.TextIOWrapper(gz, encoding="utf-8", errors="replace")
+                yield from self._parse_lines(text, member_name)
+        logger.info(
+            f"Completed streaming {member_name}: "
+            f"{self.stats['records_extracted']} contracts extracted"
         )
 
     def extract_from_dump(
@@ -493,32 +549,62 @@ class ContractExtractor:
                 f"Auto-selected largest file: {table_files[0]} ({dat_files[0].stat().st_size / 1e9:.1f} GB)"
             )
 
-        # Process files and collect contracts
-        all_contracts = []
-        batch_contracts = []
+        # Scan each table file (streaming) and write the filtered contracts.
+        def _stream_all() -> Iterator[FederalContract]:
+            for table_file in table_files:
+                yield from self.stream_dat_gz_file(dump_dir / table_file)
 
-        for table_file in table_files:
-            dat_path = dump_dir / table_file
+        return self._collect_and_write(_stream_all(), output_file)
 
-            for contract in self.stream_dat_gz_file(dat_path):
-                batch_contracts.append(contract.model_dump())
+    def extract_from_remote_zip(
+        self,
+        zip_url: str,
+        member_name: str,
+        output_file: Path,
+    ) -> int:
+        """Extract SBIR-relevant contracts by streaming one member from a remote zip.
 
-                # Write batch to avoid memory issues
-                if len(batch_contracts) >= self.batch_size:
-                    all_contracts.extend(batch_contracts)
-                    logger.info(f"Batch accumulated: {len(all_contracts):,} total contracts")
-                    batch_contracts = []
+        The remote counterpart to :meth:`extract_from_dump`: streams ``member_name``
+        (the ``transaction_normalized`` ``.dat.gz``) straight from ``zip_url`` over
+        HTTP range, applies the same vendor/type filtering, and writes the filtered
+        Parquet. No full ~217GB download and nothing staged on local disk.
 
-        # Add remaining contracts
-        if batch_contracts:
-            all_contracts.extend(batch_contracts)
+        Args:
+            zip_url: ``https://`` URL of the USAspending database zip.
+            member_name: Path of the ``.dat.gz`` member inside the zip.
+            output_file: Parquet output path.
 
-        # Write to Parquet
-        if all_contracts:
-            logger.info(f"Writing {len(all_contracts):,} contracts to {output_file}")
-            df = pd.DataFrame(all_contracts)
+        Returns:
+            Number of contracts extracted.
+        """
+        output_file = Path(output_file)
+        return self._collect_and_write(
+            self.stream_remote_zip_member(zip_url, member_name), output_file
+        )
+
+    def _collect_and_write(
+        self,
+        contracts: Iterable[FederalContract],
+        output_file: Path,
+    ) -> int:
+        """Materialize matched contracts, write Parquet, log stats. Returns row count.
+
+        The source table is *scanned* streaming (line by line); only the matched,
+        vendor-filtered contracts accumulate here — a tiny fraction of the input — so
+        holding them in memory before a single Parquet write is safe even for the
+        full dump.
+        """
+        rows: list[dict] = []
+        for contract in contracts:
+            rows.append(contract.model_dump())
+            if len(rows) % self.batch_size == 0:
+                logger.info(f"Accumulated {len(rows):,} matched contracts")
+
+        if rows:
+            logger.info(f"Writing {len(rows):,} contracts to {output_file}")
             from sbir_etl.utils.data.file_io import save_dataframe_parquet
 
+            df = pd.DataFrame(rows)
             save_dataframe_parquet(df, output_file, index=False, compression="snappy")
             logger.success(f"Contracts saved to {output_file}")
         else:
@@ -534,7 +620,7 @@ class ContractExtractor:
             logger.info(f"  {key}: {value:,}")
         logger.info("=" * 60)
 
-        return len(all_contracts)
+        return len(rows)
 
 
 __all__ = ["ContractExtractor"]

--- a/scripts/extract_federal_contracts.py
+++ b/scripts/extract_federal_contracts.py
@@ -43,7 +43,8 @@ def main():
         type=str,
         help=(
             "Stream one member from a remote USAspending database .zip over HTTP range "
-            "(no full download). Requires the 'streaming' extra and --member."
+            "(no full download). Requires the 'streaming' extra; the member streamed is "
+            "set by --member (defaults to the transaction_normalized table)."
         ),
     )
     parser.add_argument(

--- a/scripts/extract_federal_contracts.py
+++ b/scripts/extract_federal_contracts.py
@@ -6,11 +6,18 @@ This script extracts contracts for SBIR vendors only, filtering the
 large USAspending dataset to manageable size.
 
 Usage:
-    # Extract from subset (17GB)
-    poetry run python scripts/extract_federal_contracts.py --subset
+    # Extract from a locally-extracted subset dump
+    python scripts/extract_federal_contracts.py --subset
 
-    # Extract from full dataset (200GB)
-    poetry run python scripts/extract_federal_contracts.py --full
+    # Extract from a locally-extracted full dump
+    python scripts/extract_federal_contracts.py --full
+
+    # Stream one table member straight from the remote USAspending .zip over HTTP
+    # range — no full ~217GB download, nothing staged on local disk (needs the
+    # 'streaming' extra: uv sync --extra streaming):
+    python scripts/extract_federal_contracts.py \\
+        --remote-zip https://files.usaspending.gov/database_download/usaspending-db-subset_20240101.zip \\
+        --member 5530.dat.gz
 """
 
 import argparse
@@ -31,11 +38,56 @@ def main():
     parser.add_argument("--full", action="store_true", help="Extract from full dump (200GB)")
     parser.add_argument("--dump-dir", type=Path, help="Custom dump directory path")
     parser.add_argument("--output", type=Path, help="Custom output file path")
+    parser.add_argument(
+        "--remote-zip",
+        type=str,
+        help=(
+            "Stream one member from a remote USAspending database .zip over HTTP range "
+            "(no full download). Requires the 'streaming' extra and --member."
+        ),
+    )
+    parser.add_argument(
+        "--member",
+        type=str,
+        default="5530.dat.gz",
+        help=(
+            "Name of the .dat.gz member inside --remote-zip to stream "
+            "(default: 5530.dat.gz, the transaction_normalized table)."
+        ),
+    )
 
     args = parser.parse_args()
 
     # Load configuration for default paths
     config = get_config()
+
+    vendor_filter_file = config.paths.resolve_path("transition_vendor_filters")
+    if not vendor_filter_file.exists():
+        logger.error(f"Vendor filter file not found: {vendor_filter_file}")
+        logger.info("Run: python scripts/extract_sbir_vendors.py")
+        return
+
+    # Remote-zip streaming path: no local dump required.
+    if args.remote_zip:
+        output_file = args.output or config.paths.resolve_path("transition_contracts_output")
+        logger.info("Initializing ContractExtractor (remote-zip streaming)...")
+        extractor = ContractExtractor(
+            vendor_filter_file=vendor_filter_file,
+            batch_size=10000,
+        )
+        logger.info(f"Streaming member {args.member} from {args.remote_zip}")
+        logger.info(f"Output will be saved to {output_file}")
+        try:
+            num_contracts = extractor.extract_from_remote_zip(
+                zip_url=args.remote_zip,
+                member_name=args.member,
+                output_file=output_file,
+            )
+            logger.success(f"Extraction complete! {num_contracts:,} contracts extracted")
+        except Exception as e:
+            logger.error(f"Remote-zip extraction failed: {e}")
+            raise
+        return
 
     # Determine paths
     if args.dump_dir:
@@ -54,19 +106,12 @@ def main():
     else:
         output_file = config.paths.resolve_path("transition_contracts_output")
 
-    vendor_filter_file = config.paths.resolve_path("transition_vendor_filters")
-
     # Validate inputs
     if not dump_dir.exists():
         logger.error(f"Dump directory not found: {dump_dir}")
         if not args.subset:
             logger.info("For subset extraction, the dump should be extracted to:")
             logger.info(f"  {dump_dir}")
-        return
-
-    if not vendor_filter_file.exists():
-        logger.error(f"Vendor filter file not found: {vendor_filter_file}")
-        logger.info("Run: poetry run python scripts/extract_sbir_vendors.py")
         return
 
     # Initialize extractor

--- a/tests/unit/extractors/test_contract_extractor_streaming.py
+++ b/tests/unit/extractors/test_contract_extractor_streaming.py
@@ -106,5 +106,6 @@ def test_stream_remote_zip_member_missing_dependency_raises(sample_vendor_filter
     extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
     # Force the lazy `from remotezip import RemoteZip` to fail.
     with patch.dict(sys.modules, {"remotezip": None}):
-        with pytest.raises(ImportError, match="remotezip"):
+        # The message points users at the optional 'streaming' extra.
+        with pytest.raises(ImportError, match="streaming"):
             list(extractor.stream_remote_zip_member("https://x/y.zip", "m.dat.gz"))

--- a/tests/unit/extractors/test_contract_extractor_streaming.py
+++ b/tests/unit/extractors/test_contract_extractor_streaming.py
@@ -1,0 +1,110 @@
+"""Tests for the streaming (remote-zip) contract extraction path.
+
+Validates the transport-agnostic parser and the remote-zip member streaming
+offline — a fake ``remotezip`` module is injected so no network or real
+USAspending endpoint is touched.
+"""
+
+import gzip
+import io
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+from sbir_etl.extractors.contract_extractor import ContractExtractor
+
+
+def _row_text(*rows: list[str]) -> str:
+    """Join 103-column rows into tab-delimited, newline-separated text."""
+    return "\n".join("\t".join(r) for r in rows)
+
+
+def _fake_remotezip_module(member_gzip: bytes) -> types.ModuleType:
+    """A stand-in ``remotezip`` whose RemoteZip.open() yields gzip member bytes."""
+    mod = types.ModuleType("remotezip")
+
+    class _FakeRemoteZip:
+        def __init__(self, url):
+            self.url = url
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def open(self, member_name):  # used as a context manager
+            return io.BytesIO(member_gzip)
+
+    mod.RemoteZip = _FakeRemoteZip  # type: ignore[attr-defined]
+    return mod
+
+
+def test_parse_lines_filters_and_parses(
+    sample_vendor_filters, sample_contract_row_full, sample_grant_row
+):
+    """The shared parser keeps vendor-matching contracts and drops grants."""
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+    lines = [
+        "\t".join(sample_contract_row_full),  # matches (UEI ABC123456789, contract)
+        "\t".join(sample_grant_row),  # grant → filtered out
+    ]
+
+    contracts = list(extractor._parse_lines(lines, "test"))
+
+    assert len(contracts) == 1
+    assert contracts[0].contract_id == "SPE4A924D0001"
+    assert contracts[0].vendor_uei == "ABC123456789"  # pragma: allowlist secret
+
+
+def test_stream_remote_zip_member_streams_and_parses(
+    sample_vendor_filters, sample_contract_row_full, sample_grant_row
+):
+    """stream_remote_zip_member: RemoteZip → open member → gunzip → parse."""
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+    member_gzip = gzip.compress(
+        _row_text(sample_contract_row_full, sample_grant_row).encode("utf-8")
+    )
+    fake_mod = _fake_remotezip_module(member_gzip)
+
+    with patch.dict(sys.modules, {"remotezip": fake_mod}):
+        contracts = list(
+            extractor.stream_remote_zip_member(
+                "https://files.usaspending.gov/database_download/usaspending-db-subset_20240101.zip",
+                "5530.dat.gz",
+            )
+        )
+
+    assert len(contracts) == 1
+    assert contracts[0].contract_id == "SPE4A924D0001"
+
+
+def test_extract_from_remote_zip_writes_parquet(
+    tmp_path, sample_vendor_filters, sample_contract_row_full, sample_grant_row
+):
+    """extract_from_remote_zip streams, filters, and writes the Parquet output."""
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+    member_gzip = gzip.compress(
+        _row_text(sample_contract_row_full, sample_grant_row).encode("utf-8")
+    )
+    out = tmp_path / "contracts.parquet"
+
+    with patch.dict(sys.modules, {"remotezip": _fake_remotezip_module(member_gzip)}):
+        count = extractor.extract_from_remote_zip(
+            "https://files.usaspending.gov/x.zip", "5530.dat.gz", out
+        )
+
+    assert count == 1
+    assert out.exists()
+    assert out.stat().st_size > 0
+
+
+def test_stream_remote_zip_member_missing_dependency_raises(sample_vendor_filters):
+    """A clear ImportError is raised when remotezip is not installed."""
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+    # Force the lazy `from remotezip import RemoteZip` to fail.
+    with patch.dict(sys.modules, {"remotezip": None}):
+        with pytest.raises(ImportError, match="remotezip"):
+            list(extractor.stream_remote_zip_member("https://x/y.zip", "m.dat.gz"))

--- a/uv.lock
+++ b/uv.lock
@@ -825,6 +825,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -835,6 +836,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -2475,6 +2477,18 @@ wheels = [
 ]
 
 [[package]]
+name = "remotezip"
+version = "0.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/8d/908ad46bff752568a409ee6ac797c3c6817501db06f142989e3208414569/remotezip-0.12.3.tar.gz", hash = "sha256:bf1ebe2be9f07a6e1c14d0e52ecffccd7a3e808dff4f9ba523c5e84d867a3fe3", size = 7835, upload-time = "2024-02-26T19:51:04.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/18/22316545b712dbed0119c7d3b8683a566c7da26353e344a4188b99f12692/remotezip-0.12.3-py3-none-any.whl", hash = "sha256:f70a4026879439ecb0a2cf848a7c176ae5ee142bbe51ec69e3344e150b2a52de", size = 8099, upload-time = "2024-02-26T19:51:02.968Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2641,8 +2655,8 @@ requires-dist = [
     { name = "sbir-etl", extras = ["dev"], marker = "extra == 'dev'" },
     { name = "sbir-etl", extras = ["r"], marker = "extra == 'r'" },
     { name = "sbir-graph" },
-    { name = "sbir-ml", extras = ["nlp"] },
     { name = "sbir-ml", extras = ["modernbert-local"], marker = "extra == 'modernbert-local'" },
+    { name = "sbir-ml", extras = ["nlp"] },
 ]
 provides-extras = ["r", "modernbert-local", "dev"]
 
@@ -2715,6 +2729,9 @@ stack-dev = [
     { name = "types-pyyaml" },
     { name = "types-tqdm" },
 ]
+streaming = [
+    { name = "remotezip" },
+]
 ucc1-pilot = [
     { name = "curl-cffi" },
 ]
@@ -2764,6 +2781,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0,<7.0.0" },
     { name = "rapidfuzz", specifier = ">=3.0.0,<4.0.0" },
+    { name = "remotezip", marker = "extra == 'streaming'", specifier = ">=0.12.0,<1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5.0,<1.0.0" },
     { name = "sbir-analytics", marker = "extra == 'stack-dev'", editable = "packages/sbir-analytics" },
     { name = "sbir-etl", extras = ["dev"], marker = "extra == 'stack-dev'" },
@@ -2775,7 +2793,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
     { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.67.3.20260408,<5.0.0" },
 ]
-provides-extras = ["ucc1-pilot", "uspto", "cloud", "phonetic", "monitoring", "viz", "dev", "stack-dev"]
+provides-extras = ["ucc1-pilot", "uspto", "cloud", "streaming", "phonetic", "monitoring", "viz", "dev", "stack-dev"]
 
 [package.metadata.requires-dev]
 notebooks = [


### PR DESCRIPTION
## Description

Adds a remote-streaming source for the contract extractor: pull **only** the `transaction_normalized` member out of the USAspending database `.zip` over HTTP **range** requests, never downloading the full ~217GB archive and staging nothing on local disk. This is the no-AWS path discussed earlier (Option B) and unblocks real-data validation of the `action_date` work (#390) without the local 13GB/217GB download.

### Changes

**`sbir_etl/extractors/contract_extractor.py`**
- `_parse_lines(lines, source_name)` — transport-agnostic core: consumes any iterable of text lines (local gzip handle, decompressed remote member, or a test fixture) and applies the same type/vendor filtering + row parsing.
- `stream_dat_gz_file` refactored to delegate to `_parse_lines` (behavior unchanged).
- `stream_remote_zip_member(zip_url, member_name)` — opens the remote zip via `remotezip` (HTTP range), reads just the one `.dat.gz` member, gunzips it on the fly, and yields matched `FederalContract`s. Lazy import with a clear `ImportError` if the optional dep is missing.
- `extract_from_remote_zip(zip_url, member_name, output_file)` — remote counterpart of `extract_from_dump`; both now share a `_collect_and_write` helper (the source table is *scanned* streaming; only the tiny matched/vendor-filtered subset is held before a single Parquet write).

**`scripts/extract_federal_contracts.py`**
- New `--remote-zip URL` / `--member NAME` flags (default member `5530.dat.gz`, the `transaction_normalized` table). Vendor-filter resolution hoisted so it's shared by the local and remote paths.

**`pyproject.toml`**
- New optional `streaming` extra (`remotezip`); `remotezip.*` added to the mypy `ignore_missing_imports` override so the lazy import type-checks in CI without the extra installed. `uv.lock` updated.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation update

## Testing

`tests/unit/extractors/test_contract_extractor_streaming.py` (4 tests) validates the path **offline** — a fake `remotezip` module is injected via `patch.dict(sys.modules, ...)` so no network/endpoint is touched:
- `_parse_lines` keeps vendor-matching contracts, drops grants;
- `stream_remote_zip_member` does RemoteZip → open member → gunzip → parse;
- `extract_from_remote_zip` streams, filters, and writes Parquet;
- a missing `remotezip` raises a clear `ImportError`.

Verified `mypy` and the streaming tests **pass with `remotezip` not installed** (matching CI). `ruff` clean. Existing extractor unit + integration tests still pass (the one `test_large_batch_accumulation` xdist failure is the pre-existing pyarrow `pandas.period already defined` flake in `save_dataframe_parquet`, reproducible on `main`, unrelated to this change).

### ⚠️ Real-endpoint validation: not performed here — manual step required

I could **not** smoke-test against the live endpoint from this environment:
- `files.usaspending.gov` is **denied by the network egress policy** (proxy returns 403);
- the allowlisted file host I tried as a mechanism proxy (`files.pythonhosted.org`, since a wheel is a zip) returns **501 Not Implemented** for the suffix-range request `remotezip` uses to read the zip's end-of-central-directory.

So the HTTP-range path is proven **logically** (offline tests) but not against a live server here. It needs a one-time manual smoke test from an environment with outbound access to `files.usaspending.gov`:

```bash
uv sync --extra streaming
python scripts/extract_federal_contracts.py \
    --remote-zip https://files.usaspending.gov/database_download/usaspending-db-subset_<YYYYMMDD>.zip \
    --member 5530.dat.gz \
    --output data/usaspending/contracts_ingestion.parquet
```

USAspending is S3/CloudFront-backed and documents Range support (incl. suffix ranges), so this is expected to work; flagging it explicitly so it's validated before relying on it in production.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works (offline)
- [ ] Real-endpoint smoke test (blocked by env egress policy — see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_