### PR TITLE
Consume the true action_date in transition timing scoring

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/assets.py
@@ -206,7 +206,9 @@ def _row_to_federal_contract(row: pd.Series) -> FederalContract:
         contract_id=str(row.get("target_id") or uuid.uuid4().hex),
         agency=row.get("target_agency") if pd.notna(row.get("target_agency")) else None,
         sub_agency=row.get("target_sub_agency") if pd.notna(row.get("target_sub_agency")) else None,
-        start_date=_to_date(row.get("target_action_date")),
+        # target_action_date IS the contract's transaction action_date — carry it in the
+        # action_date field (the scorer reads action_date, falling back to start_date).
+        action_date=_to_date(row.get("target_action_date")),
         obligation_amount=float(row.get("target_obligated_amount"))  # type: ignore[arg-type]
         if pd.notna(row.get("target_obligated_amount"))
         else None,

--- a/packages/sbir-ml/sbir_ml/transition/detection/detector.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/detector.py
@@ -145,10 +145,13 @@ class TransitionDetector:
 
         filtered = []
         for contract in contracts:
-            if not contract.start_date:
+            # Prefer the true transaction action_date; fall back to the
+            # period-of-performance start when action_date is absent.
+            contract_date = contract.action_date or contract.start_date
+            if not contract_date:
                 continue
 
-            if min_date <= contract.start_date <= max_date:
+            if min_date <= contract_date <= max_date:
                 filtered.append(contract)
 
         logger.debug(

--- a/packages/sbir-ml/sbir_ml/transition/detection/scoring.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/scoring.py
@@ -210,22 +210,24 @@ class TransitionScorer:
             TimingSignal with days/months and timing score
         """
         award_completion_date = award_data.get("completion_date")
-        contract_start_date = contract.start_date
+        # Prefer the true transaction action_date (the obligating-action date); fall
+        # back to the period-of-performance start when action_date is absent.
+        contract_date = contract.action_date or contract.start_date
 
-        if not award_completion_date or not contract_start_date:
+        if not award_completion_date or not contract_date:
             return TimingSignal(timing_score=0.0)
 
         # Calculate days between
-        days_between = (contract_start_date - award_completion_date).days
+        days_between = (contract_date - award_completion_date).days
 
         # Handle contracts before award completion (negative days)
         if days_between < 0:
             logger.warning(
-                "Contract starts before award completion",
+                "Contract action precedes award completion",
                 extra={
                     "days_between": days_between,
                     "award_completion": award_completion_date.isoformat(),
-                    "contract_start": contract_start_date.isoformat(),
+                    "contract_date": contract_date.isoformat(),
                 },
             )
             return TimingSignal(

--- a/packages/sbir-ml/sbir_ml/transition/detection/scoring.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/scoring.py
@@ -197,10 +197,12 @@ class TransitionScorer:
         contract: FederalContract,
     ) -> TimingSignal:
         """
-        Score timing proximity between award completion and contract start.
+        Score timing proximity between award completion and contract date.
 
-        Closer timing indicates stronger likelihood of transition. Uses
-        configured time windows with decay multipliers.
+        Uses the contract's true transaction ``action_date`` (the obligating-action
+        date), falling back to the period-of-performance ``start_date`` when
+        ``action_date`` is absent. Closer timing indicates stronger likelihood of
+        transition. Uses configured time windows with decay multipliers.
 
         Args:
             award_data: Award information

--- a/tests/unit/transition/detection/test_detector_init.py
+++ b/tests/unit/transition/detection/test_detector_init.py
@@ -196,3 +196,45 @@ class TestFilterByTimingWindow:
         filtered = detector.filter_by_timing_window(completion_date, [contract])
 
         assert len(filtered) == 0
+
+    def test_filter_prefers_action_date_over_start_date(self, default_config):
+        """Window membership uses action_date, not the PoP start_date."""
+        detector = TransitionDetector(config=default_config)  # window [0, 730] days
+        completion_date = date(2023, 6, 1)
+
+        contract = FederalContract(
+            contract_id="CTR001",
+            agency="DOD",
+            vendor_name="Acme",
+            action_date=completion_date + timedelta(days=90),  # inside the window
+            start_date=completion_date + timedelta(days=800),  # outside — must be ignored
+            amount=100000,
+            description="Services",
+            naics_code="541715",
+        )
+
+        filtered = detector.filter_by_timing_window(completion_date, [contract])
+
+        assert len(filtered) == 1
+        assert filtered[0].contract_id == "CTR001"
+
+    def test_filter_falls_back_to_start_date_when_action_date_none(self, default_config):
+        """When action_date is absent, window membership falls back to start_date."""
+        detector = TransitionDetector(config=default_config)
+        completion_date = date(2023, 6, 1)
+
+        contract = FederalContract(
+            contract_id="CTR001",
+            agency="DOD",
+            vendor_name="Acme",
+            action_date=None,
+            start_date=completion_date + timedelta(days=90),  # inside the window
+            amount=100000,
+            description="Services",
+            naics_code="541715",
+        )
+
+        filtered = detector.filter_by_timing_window(completion_date, [contract])
+
+        assert len(filtered) == 1
+        assert filtered[0].contract_id == "CTR001"

--- a/tests/unit/transition/detection/test_scoring.py
+++ b/tests/unit/transition/detection/test_scoring.py
@@ -230,6 +230,42 @@ class TestScoreTimingProximity:
 
         assert signal.timing_score == 0.0
 
+    def test_score_timing_prefers_action_date_over_start_date(self, default_config):
+        """Timing uses the true transaction action_date, not the PoP start_date."""
+        scorer = TransitionScorer(default_config)
+
+        award_data = {"completion_date": date(2023, 1, 1)}
+        contract = FederalContract(
+            contract_id="C123",
+            vendor_name="Vendor",
+            agency="DOD",
+            action_date=date(2023, 2, 1),  # 31 days after completion (the real date)
+            start_date=date(2023, 6, 1),  # PoP start, much later — must NOT be used
+            competition_type=CompetitionType.SOLE_SOURCE,
+        )
+
+        signal = scorer.score_timing_proximity(award_data, contract)
+
+        assert signal.days_between_award_and_contract == 31
+
+    def test_score_timing_falls_back_to_start_date(self, default_config):
+        """When action_date is absent, timing falls back to start_date."""
+        scorer = TransitionScorer(default_config)
+
+        award_data = {"completion_date": date(2023, 1, 1)}
+        contract = FederalContract(
+            contract_id="C123",
+            vendor_name="Vendor",
+            agency="DOD",
+            action_date=None,
+            start_date=date(2023, 2, 1),  # 31 days after completion
+            competition_type=CompetitionType.SOLE_SOURCE,
+        )
+
+        signal = scorer.score_timing_proximity(award_data, contract)
+
+        assert signal.days_between_award_and_contract == 31
+
 
 class TestScoreCompetitionType:
     """Tests for score_competition_type method."""


### PR DESCRIPTION
## Description

Completes the #390 thread. #390 captured USAspending's true transaction `action_date` as a first-class field on `FederalContract`, but the timing scorers still read the period-of-performance `start_date`. This makes them consume the real obligating-action date.

### Changes
- `scoring.score_timing_proximity` and `detector.filter_by_timing_window` → use `contract.action_date or contract.start_date` (prefer the true transaction date; fall back to the PoP start when `action_date` is absent).
- `phase_iii_candidates._row_to_federal_contract` → carry `target_action_date` in the `action_date` field (it *is* the action_date) instead of `start_date`, so the field the scorer reads is the honestly-named one.

### Why this is safe for the ≥85% precision gate
**Numerically a no-op for the precision-gated Phase III retrospective path.** There, `pairing.py` already sets `target_action_date = action_date` and `_row_to_federal_contract` fed it into timing via `start_date`; now it feeds the same value via `action_date`. Same value, same timing, same scores — the ≥85% benchmark is preserved **by construction**. The change additionally makes any consumer fed *raw extractor output* (where `action_date` and `start_date` differ) time on the correct date.

> Note: the `phase_iii_precision_backtest.py` gate requires real data (`contracts_ingestion.parquet`, `phase_ii_awards.parquet`) not present in CI, so it was not executed here; the "no-op by construction" argument above is the basis for preservation.

## Type of Change

- [x] Bug fix (non-breaking — completes #390)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

`tests/unit/transition/detection/test_scoring.py` — 49 passed, including 2 new cases asserting `action_date` is preferred over `start_date` and that timing falls back to `start_date` when `action_date` is absent. Broader sweep: 472 transition unit tests + 35 phase_iii tests pass (1 skipped — backtest needs real data). `ruff` + `mypy` clean on all three changed packages.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove the change works
- [x] New and existing unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RG38KYVYEYEpiwmcZhXcaw)_