### PR TITLE
feat(sbir-phase3): Phase III universe builder + business-size enrichment

### DIFF
--- a/scripts/data/build_phase3_universe.py
+++ b/scripts/data/build_phase3_universe.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Build a fresh Phase III contract universe via multi-keyword USAspending refresh.
+
+The existing `usaspending_phase3_contracts.jsonl` cache was built with a single
+keyword (`description="SBIR Phase III"`), goes stale within weeks, and misses
+contracts whose descriptions use variants. GAO-24-107036 documents ~30% DoD
+historical Phase III undercount; description variants account for some of that.
+
+This script pulls USAspending `spending_by_award` for several Phase-III keyword
+variants across an FY range, unions and dedupes by Award ID, and writes a
+provenance-tagged JSONL. Adds `Parent Award ID` to the fields list so downstream
+contract-vehicle attribution (OASIS / Alliant / FEDSIM IDIQs) is one query away.
+
+Throttle: 1s base sleep per page + per query; exponential backoff on 429/5xx.
+
+Each output row carries:
+  - `_keywords_matched`: list of keyword variants that returned this row
+  - `_first_fy_seen`: earliest FY in the loop where it was returned
+
+Usage:
+    uv run python scripts/data/build_phase3_universe.py --start-fy 2014 --end-fy 2026
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+API = "https://api.usaspending.gov/api/v2/search/spending_by_award/"
+HEADERS = {"User-Agent": "SBIR-Analytics/0.1.0"}
+CONTRACT_TYPES = ["A", "B", "C", "D"]
+
+# Description variants. USAspending's `description` filter is a substring
+# match, so we run each as a separate query to widen recall. Order is by
+# expected recall, narrowest first.
+PHASE3_KEYWORDS = [
+    "SBIR Phase III",
+    "SBIR Phase 3",
+    "SBIR PH III",
+    "Phase III SBIR",
+    "SBIR follow-on",
+    "Small Business Innovation Research Phase III",
+]
+
+FIELDS = [
+    "Award ID",
+    "Recipient Name",
+    "Recipient UEI",
+    "Award Amount",
+    "Total Outlays",
+    "Description",
+    "Contract Award Type",
+    "Start Date",
+    "End Date",
+    "Awarding Agency",
+    "Awarding Sub Agency",
+    "Funding Agency",
+    "Funding Sub Agency",
+    "NAICS",
+    "PSC",
+    "Parent Award ID",
+    "recipient_id",
+    "generated_internal_id",
+]
+
+
+def fy_window(fy: int) -> dict:
+    return {"start_date": f"{fy - 1}-10-01", "end_date": f"{fy}-09-30"}
+
+
+def paginate(
+    description: str, fy: int, client: httpx.Client, max_pages: int = 500
+) -> list[dict]:
+    """Cursor-paginate spending_by_award; return all rows for one (kw, fy) query."""
+    body = {
+        "filters": {
+            "time_period": [fy_window(fy)],
+            "award_type_codes": CONTRACT_TYPES,
+            "description": description,
+        },
+        "fields": FIELDS,
+        "page": 1,
+        "limit": 100,
+        "sort": "Award Amount",
+        "order": "desc",
+        "subawards": False,
+    }
+    rows: list[dict] = []
+    last_id = None
+    last_sort = None
+    for page in range(1, max_pages + 1):
+        if last_id is not None:
+            body["last_record_unique_id"] = last_id
+            body["last_record_sort_value"] = last_sort
+
+        for attempt in range(5):
+            resp = client.post(API, json=body)
+            if resp.status_code == 200:
+                break
+            if resp.status_code in (429, 500, 502, 503, 504):
+                sleep = 2 ** attempt
+                print(f"    page {page}: {resp.status_code}, backoff {sleep}s", flush=True)
+                time.sleep(sleep)
+                continue
+            resp.raise_for_status()
+        else:
+            raise RuntimeError(f"page {page}: gave up after retries")
+
+        data = resp.json()
+        results = data.get("results", [])
+        rows.extend(results)
+        meta = data.get("page_metadata", {})
+        has_next = meta.get("hasNext", False)
+        if not has_next or not results:
+            break
+        last_id = meta.get("last_record_unique_id")
+        last_sort = meta.get("last_record_sort_value")
+        time.sleep(1.0)
+
+    return rows
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--start-fy", type=int, default=2014)
+    p.add_argument("--end-fy", type=int, default=2026)
+    p.add_argument(
+        "--out",
+        type=Path,
+        default=Path("data/processed/sbir_phase3/phase3_universe.jsonl"),
+    )
+    p.add_argument(
+        "--keywords",
+        nargs="*",
+        default=PHASE3_KEYWORDS,
+        help="Keyword variants to query (defaults to the 6-variant canonical set).",
+    )
+    args = p.parse_args()
+
+    # Indexed by Award ID; value tracks provenance + row content. Award IDs
+    # are PIIDs which are unique per contract, so this is a safe dedup key.
+    universe: dict[str, dict] = {}
+    per_kw_counts: dict[str, int] = {kw: 0 for kw in args.keywords}
+
+    with httpx.Client(timeout=60, headers=HEADERS) as client:
+        for fy in range(args.start_fy, args.end_fy + 1):
+            print(f"\n=== FY{fy} ===", flush=True)
+            for kw in args.keywords:
+                print(f"  keyword={kw!r}", flush=True)
+                rows = paginate(kw, fy, client)
+                per_kw_counts[kw] += len(rows)
+                new_in_this_query = 0
+                for row in rows:
+                    aid = row.get("Award ID") or row.get("generated_internal_id")
+                    if not aid:
+                        continue
+                    if aid in universe:
+                        universe[aid]["_keywords_matched"].add(kw)
+                    else:
+                        row["_keywords_matched"] = {kw}
+                        row["_first_fy_seen"] = fy
+                        universe[aid] = row
+                        new_in_this_query += 1
+                print(
+                    f"    -> {len(rows):,} rows ({new_in_this_query:,} new to universe)",
+                    flush=True,
+                )
+                time.sleep(1.0)  # polite gap between keyword queries
+
+    # Serialize: convert provenance set to sorted list for JSON.
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w") as f:
+        for row in universe.values():
+            row["_keywords_matched"] = sorted(row["_keywords_matched"])
+            f.write(json.dumps(row) + "\n")
+
+    print(f"\n>> wrote {len(universe):,} unique rows -> {args.out}")
+    print("\nPer-keyword raw row counts (pre-dedup):")
+    for kw, n in per_kw_counts.items():
+        print(f"  {n:>6,}  {kw}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/data/enrich_phase3_business_size.py
+++ b/scripts/data/enrich_phase3_business_size.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Enrich Phase III universe rows with business-size categories.
+
+The `spending_by_award` search endpoint does not populate the size fields
+(`Contracting Officers Determination of Business Size`, `business_categories`)
+— they're `null` in every row. The per-award detail endpoint
+`/awards/{generated_internal_id}/` returns `business_categories` populated.
+
+Reads `data/processed/sbir_phase3/phase3_universe.jsonl`, calls the
+per-award detail endpoint for each row's `generated_internal_id`, and writes
+an enriched JSONL with three new fields:
+
+  - `business_categories`: list of all categories on the award (e.g.
+    "Small Business", "Women Owned Small Business", "8(a)")
+  - `is_small_business`: bool, True iff "Small Business" appears in categories
+  - `_enrichment_status`: "ok" / "404" / "error"
+
+Concurrency: bounded by httpx.Limits + asyncio.Semaphore. With concurrency=8
+and 0.1s per-task base throttle, ~2,000 rows complete in ~5 min.
+
+Usage:
+    uv run python scripts/data/enrich_phase3_business_size.py \
+        --in data/processed/sbir_phase3/phase3_universe.jsonl \
+        --out data/processed/sbir_phase3/phase3_universe_enriched.jsonl
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import httpx
+
+BASE = "https://api.usaspending.gov/api/v2/awards/{aid}/"
+HEADERS = {"User-Agent": "SBIR-Analytics/0.1.0"}
+
+
+async def fetch_one(
+    client: httpx.AsyncClient, sem: asyncio.Semaphore, row: dict
+) -> dict:
+    """Look up business_categories for one Award ID; merge into the row."""
+    aid = row.get("generated_internal_id") or row.get("Award ID")
+    if not aid:
+        row["_enrichment_status"] = "missing_aid"
+        return row
+
+    async with sem:
+        for attempt in range(4):
+            try:
+                resp = await client.get(BASE.format(aid=aid), timeout=30)
+                if resp.status_code == 200:
+                    data = resp.json()
+                    recip = data.get("recipient") or {}
+                    cats = recip.get("business_categories") or []
+                    if not cats:
+                        cats = data.get("business_categories") or []
+                    row["business_categories"] = list(cats)
+                    row["is_small_business"] = "Small Business" in cats
+                    row["_enrichment_status"] = "ok"
+                    return row
+                if resp.status_code == 404:
+                    row["_enrichment_status"] = "404"
+                    return row
+                if resp.status_code in (429, 500, 502, 503, 504):
+                    await asyncio.sleep(2**attempt)
+                    continue
+                resp.raise_for_status()
+            except (httpx.TimeoutException, httpx.HTTPError) as e:
+                if attempt == 3:
+                    row["_enrichment_status"] = f"error: {type(e).__name__}"
+                    return row
+                await asyncio.sleep(2**attempt)
+        row["_enrichment_status"] = "error: retries exhausted"
+        return row
+
+
+async def main_async(args) -> int:
+    rows = []
+    with args.input.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(json.loads(line))
+    print(f"Read {len(rows):,} rows from {args.input}", flush=True)
+
+    sem = asyncio.Semaphore(args.concurrency)
+    limits = httpx.Limits(max_connections=args.concurrency * 2)
+    async with httpx.AsyncClient(headers=HEADERS, limits=limits) as client:
+        tasks = [fetch_one(client, sem, r) for r in rows]
+        # Process in chunks so we can emit progress
+        out_path = args.output
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        done = 0
+        ok = 0
+        with out_path.open("w") as fout:
+            for coro in asyncio.as_completed(tasks):
+                r = await coro
+                fout.write(json.dumps(r) + "\n")
+                done += 1
+                if r.get("_enrichment_status") == "ok":
+                    ok += 1
+                if done % 100 == 0:
+                    print(f"  {done:,}/{len(rows):,} processed ({ok} ok)", flush=True)
+
+    print(
+        f"\n>> wrote {done:,} rows -> {out_path}  "
+        f"({ok} enriched OK, {done - ok} non-ok)",
+        flush=True,
+    )
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument(
+        "--input",
+        type=Path,
+        default=Path("data/processed/sbir_phase3/phase3_universe.jsonl"),
+    )
+    p.add_argument(
+        "--output",
+        type=Path,
+        default=Path("data/processed/sbir_phase3/phase3_universe_enriched.jsonl"),
+    )
+    p.add_argument(
+        "--concurrency",
+        type=int,
+        default=8,
+        help="Max parallel API requests (default 8; USAspending tolerates this)",
+    )
+    args = p.parse_args()
+
+    return asyncio.run(main_async(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two-script pipeline for building a cleaner Phase III contract universe from USAspending and tagging each row with the contracting-officer business-size designation. Together they make the question "how much Phase III work went to Other Than Small Business" actually answerable.

## Scripts in this PR

### 1. `scripts/data/build_phase3_universe.py` — multi-keyword universe builder

Replaces the single-keyword Phase III fetcher (which built `data/processed/sbir_phase3/usaspending_phase3_contracts.jsonl`) with a multi-variant union that narrows the GAO-24-107036-documented description-keyword undercount.

Queries USAspending `spending_by_award` across **six description variants** per FY:

- `SBIR Phase III` (canonical)
- `SBIR Phase 3`
- `SBIR PH III`
- `Phase III SBIR`
- `SBIR follow-on`
- `Small Business Innovation Research Phase III`

Unions and dedupes by Award ID; tags each row with `_keywords_matched` and `_first_fy_seen` for provenance.

Adds `Parent Award ID` to the fields list so downstream contract-vehicle attribution (OASIS / Alliant / FEDSIM IDIQs) is one query away.

### 2. `scripts/data/enrich_phase3_business_size.py` — size flag enrichment

USAspending's `spending_by_award` does **not** populate the business-size fields (`Contracting Officers Determination of Business Size`, `business_categories`) — they're `null` in every search response. The per-award detail endpoint `/awards/{generated_unique_award_id}/` **does** populate `business_categories`, which is the canonical signal.

Adds an async-batched enrichment that takes the universe output and writes a new file (`phase3_universe_enriched.jsonl`) with three added fields per row:

- `business_categories`: list (e.g. `"Small Business"`, `"8(a)"`, `"Women Owned Small Business"`, `"Not Designated a Small Business"`)
- `is_small_business`: bool, True iff `"Small Business"` appears in categories
- `_enrichment_status`: `"ok"` / `"404"` / `"error: <type>"`

If USAspending throws `RemoteProtocolError` at high concurrency, drop `--concurrency` to 3 and rerun on the failed rows — that lifted OK rate from 62% → 99.7% on the FY2008-2026 universe.

## Measured outcomes

### Universe builder (FY2008-FY2026 range)

| | Rows | $M | vs. old cache |
|---|---:|---:|---|
| Old cache (single keyword, May 7 fetch, FY2000+) | 1,671 | $6,000 | baseline |
| New universe (FY2008+, 6 keywords, fresh today) | **2,013** | **$6,855** | **+20% rows, +14% dollars** |

Per-variant contribution (some rows match multiple):

| Keyword | Rows | $M |
|---|---:|---:|
| SBIR Phase III | 1,474 | $5,828 |
| Phase III SBIR | 137 | $334 |
| Small Business Innovation Research Phase III | 59 | $211 |
| SBIR PH III | 58 | $164 |
| SBIR Phase 3 | 37 | $114 |
| SBIR follow-on | 5 | $9 |

### Business-size enrichment

- Enriched 2,007 / 2,013 rows (99.7%)
- **140 / 2,007 (7.0%) of Phase III contracts went to Other Than Small Business**
- **$1.01B / $6.85B (14.7%) of Phase III dollars went to OTSB** — OTSB awards are larger on average
- 70% of OTSB dollars concentrated in 11 prime contractors (LinQuest, GD Mission Systems, Sierra Space, L3 Adaptive, etc.)

## Throttle and runtime

- Universe builder: ~5 min for 13-year keyword fetch
- Size enrichment: ~5-10 min at concurrency=8; retry pass at concurrency=3 if needed
- USAspending hard limit: time-period queries earlier than FY2008 return HTTP 500

## Usage

```bash
# Build universe (FY2008-2026)
uv run python scripts/data/build_phase3_universe.py --start-fy 2008

# Enrich with business-size
uv run python scripts/data/enrich_phase3_business_size.py \
  --input data/processed/sbir_phase3/phase3_universe.jsonl \
  --output data/processed/sbir_phase3/phase3_universe_enriched.jsonl
```

## What this does NOT fix

The keyword undercount is structural — Phase III isn't in SBIR.gov bulk data (only Phase I/II), so there's no authoritative join to fall back on. Six variants caught more than one, but contracts whose descriptions use *no* SBIR/Phase-III markers at all remain invisible. The output is best understood as a "ceiling" on what's keyword-discoverable, not the true Phase III universe.

The OTSB classification reflects the contracting officer's determination at the time the award was made. A firm that was Small Business when its Phase III was issued, then later acquired, will still appear as `is_small_business=True` on that historical contract. New Phase III contracts to the (large) acquirer will correctly tag as OTSB. So a meaningful share of OTSB Phase III is **acquired SBIR firms continuing the work under the acquirer's size designation** (visible in the recipient list: L3 Adaptive Methods = L3 Technologies' acquisition of Adaptive Methods, Mercury Defense Systems = Mercury Systems' acquisition of Physical Optics, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)