### PR TITLE
Fix USAspending smoke-test rough edges: auto-detect member, lazy boto3, correct awards CSV name

### DIFF
--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -472,6 +472,66 @@ class ContractExtractor:
             f"Completed {dat_file.name}: {self.stats['records_extracted']} contracts extracted"
         )
 
+    @staticmethod
+    def find_transaction_member(zip_url: str) -> str:
+        """Probe a remote USAspending DB zip for the transaction_normalized member.
+
+        The dump's per-table file id (e.g. ``5530.dat.gz``) is a PostgreSQL OID and
+        varies between dumps. Open each ``.dat.gz`` (largest first), read one row,
+        and return the first member whose layout matches the
+        ``transaction_normalized`` signature: ≥100 tab-separated columns, col[2] is
+        an 8-digit YYYYMMDD action_date, and col[3] is one of {A, B, C, D, \\N}.
+
+        Raises:
+            ImportError: if ``remotezip`` (the ``streaming`` extra) is not installed.
+            RuntimeError: if no member matches the signature.
+        """
+        try:
+            from remotezip import RemoteZip
+        except ImportError as e:  # pragma: no cover - exercised via import guard
+            raise ImportError(
+                "Remote zip streaming requires the optional 'streaming' extra "
+                "(uv sync --extra streaming / pip install 'sbir-etl[streaming]')."
+            ) from e
+
+        valid_type_codes = {"A", "B", "C", "D", "\\N"}
+
+        with RemoteZip(zip_url) as remote_zip:
+            members = sorted(
+                (i for i in remote_zip.infolist() if i.filename.endswith(".dat.gz")),
+                key=lambda i: -i.file_size,
+            )
+            for info in members:
+                try:
+                    with (
+                        remote_zip.open(info.filename) as raw,
+                        gzip.GzipFile(fileobj=raw) as gz,
+                    ):
+                        first = gz.readline()
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.debug(f"Skipping {info.filename}: {exc}")
+                    continue
+                if not first:
+                    continue
+                cols = first.decode("utf-8", errors="replace").rstrip("\n").split("\t")
+                if len(cols) < 100:
+                    continue
+                col2, col3 = cols[2], cols[3]
+                if len(col2) != 8 or not col2.isdigit():
+                    continue
+                if col3 not in valid_type_codes:
+                    continue
+                logger.info(
+                    f"Auto-detected transaction member: {info.filename} "
+                    f"(ncols={len(cols)}, action_date={col2}, type={col3!r})"
+                )
+                return info.filename
+
+        raise RuntimeError(
+            f"No .dat.gz member in {zip_url} matched the transaction_normalized "
+            "signature (≥100 cols, 8-digit col[2], col[3] in A/B/C/D)."
+        )
+
     def stream_remote_zip_member(
         self,
         zip_url: str,
@@ -562,7 +622,7 @@ class ContractExtractor:
     def extract_from_remote_zip(
         self,
         zip_url: str,
-        member_name: str,
+        member_name: str | None,
         output_file: Path,
     ) -> int:
         """Extract SBIR-relevant contracts by streaming one member from a remote zip.
@@ -574,13 +634,17 @@ class ContractExtractor:
 
         Args:
             zip_url: ``https://`` URL of the USAspending database zip.
-            member_name: Path of the ``.dat.gz`` member inside the zip.
+            member_name: Path of the ``.dat.gz`` member inside the zip. If ``None``,
+                :meth:`find_transaction_member` probes the zip and picks the member
+                whose layout matches transaction_normalized.
             output_file: Parquet output path.
 
         Returns:
             Number of contracts extracted.
         """
         output_file = Path(output_file)
+        if member_name is None:
+            member_name = self.find_transaction_member(zip_url)
         return self._collect_and_write(
             self.stream_remote_zip_member(zip_url, member_name), output_file
         )

--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -529,7 +529,7 @@ class ContractExtractor:
 
         raise RuntimeError(
             f"No .dat.gz member in {zip_url} matched the transaction_normalized "
-            "signature (≥100 cols, 8-digit col[2], col[3] in A/B/C/D)."
+            "signature (≥100 cols, 8-digit col[2], col[3] in A/B/C/D/\\N)."
         )
 
     def stream_remote_zip_member(

--- a/scripts/extract_federal_contracts.py
+++ b/scripts/extract_federal_contracts.py
@@ -14,10 +14,10 @@ Usage:
 
     # Stream one table member straight from the remote USAspending .zip over HTTP
     # range — no full ~217GB download, nothing staged on local disk (needs the
-    # 'streaming' extra: uv sync --extra streaming):
+    # 'streaming' extra: uv sync --extra streaming). The transaction_normalized
+    # member is auto-detected from the zip's layout; pass --member to override.
     python scripts/extract_federal_contracts.py \\
-        --remote-zip https://files.usaspending.gov/database_download/usaspending-db-subset_20240101.zip \\
-        --member 5530.dat.gz
+        --remote-zip https://files.usaspending.gov/database_download/usaspending-db-subset_20240101.zip
 """
 
 import argparse
@@ -50,10 +50,11 @@ def main():
     parser.add_argument(
         "--member",
         type=str,
-        default="5530.dat.gz",
+        default=None,
         help=(
-            "Name of the .dat.gz member inside --remote-zip to stream "
-            "(default: 5530.dat.gz, the transaction_normalized table)."
+            "Override the .dat.gz member inside --remote-zip to stream. "
+            "When omitted, the transaction_normalized member is auto-detected by "
+            "sniffing the zip's .dat.gz layouts (per-table OIDs vary between dumps)."
         ),
     )
 
@@ -76,7 +77,8 @@ def main():
             vendor_filter_file=vendor_filter_file,
             batch_size=10000,
         )
-        logger.info(f"Streaming member {args.member} from {args.remote_zip}")
+        member_label = args.member or "(auto-detect)"
+        logger.info(f"Streaming member {member_label} from {args.remote_zip}")
         logger.info(f"Output will be saved to {output_file}")
         try:
             num_contracts = extractor.extract_from_remote_zip(

--- a/scripts/extract_sbir_vendors.py
+++ b/scripts/extract_sbir_vendors.py
@@ -105,14 +105,15 @@ def main():
     """Main execution."""
     # Paths
     project_root = Path(__file__).parent.parent
-    awards_file = project_root / "data" / "raw" / "sbir" / "awards_data.csv"
+    awards_file = project_root / "data" / "raw" / "sbir" / "award_data.csv"
 
-    # Determine output file from config if available
+    # Determine paths from config if available (output + awards input)
     output_file = project_root / "data" / "transition" / "sbir_vendor_filters.json"
     if _config_available:
         try:
             config = get_config()
             output_file = config.paths.resolve_path("transition_vendor_filters")
+            awards_file = project_root / config.extraction.sbir.csv_path
         except Exception:
             pass  # Fall back to default
 

--- a/scripts/usaspending/check_new_file.py
+++ b/scripts/usaspending/check_new_file.py
@@ -131,11 +131,12 @@ def check_file_availability(
     return result
 
 
-def find_latest_file_in_s3(s3_bucket: str, database_type: str) -> dict:
+def find_latest_file_in_s3(s3_bucket: str, database_type: str) -> dict | None:
     """Find the most recent file in S3 for a given database type.
 
     Returns:
         dict with s3_key, last_modified, and date_str of the latest file, or None
+        (when no file is found, on S3 errors, or when ``boto3`` is not installed).
     """
     try:
         import boto3

--- a/scripts/usaspending/check_new_file.py
+++ b/scripts/usaspending/check_new_file.py
@@ -24,8 +24,6 @@ import sys
 from datetime import datetime, timedelta, UTC
 from urllib.request import Request, urlopen
 
-import boto3
-
 # USAspending database download base URL
 USASPENDING_DB_BASE_URL = "https://files.usaspending.gov/database_download"
 
@@ -95,6 +93,12 @@ def check_file_availability(
 
     # Compare with S3 if bucket and key provided
     if s3_bucket and s3_key:
+        try:
+            import boto3
+        except ImportError:
+            print("boto3 not installed — skipping S3 comparison", file=sys.stderr)
+            return result
+
         s3_client = boto3.client("s3")
         try:
             s3_obj = s3_client.head_object(Bucket=s3_bucket, Key=s3_key)
@@ -133,6 +137,12 @@ def find_latest_file_in_s3(s3_bucket: str, database_type: str) -> dict:
     Returns:
         dict with s3_key, last_modified, and date_str of the latest file, or None
     """
+    try:
+        import boto3
+    except ImportError:
+        print("boto3 not installed — skipping S3 lookup", file=sys.stderr)
+        return None
+
     s3_client = boto3.client("s3")
     prefix = "raw/usaspending/database/"
 

--- a/tests/unit/extractors/test_contract_extractor_streaming.py
+++ b/tests/unit/extractors/test_contract_extractor_streaming.py
@@ -42,6 +42,40 @@ def _fake_remotezip_module(member_gzip: bytes) -> types.ModuleType:
     return mod
 
 
+def _fake_remotezip_module_multi(members: dict[str, bytes]) -> types.ModuleType:
+    """Multi-member fake ``remotezip`` for auto-detection tests.
+
+    ``members`` maps ``filename → gzip-compressed bytes``. ``infolist()`` exposes
+    each member with a ``file_size`` equal to the gzip blob's length so the
+    largest-first probe ordering inside ``find_transaction_member`` is exercised.
+    """
+    mod = types.ModuleType("remotezip")
+
+    class _Info:
+        def __init__(self, filename, file_size):
+            self.filename = filename
+            self.file_size = file_size
+
+    class _FakeRemoteZip:
+        def __init__(self, url):
+            self.url = url
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def infolist(self):
+            return [_Info(name, len(blob)) for name, blob in members.items()]
+
+        def open(self, member_name):
+            return io.BytesIO(members[member_name])
+
+    mod.RemoteZip = _FakeRemoteZip  # type: ignore[attr-defined]
+    return mod
+
+
 def test_parse_lines_filters_and_parses(
     sample_vendor_filters, sample_contract_row_full, sample_grant_row
 ):
@@ -109,3 +143,66 @@ def test_stream_remote_zip_member_missing_dependency_raises(sample_vendor_filter
         # The message points users at the optional 'streaming' extra.
         with pytest.raises(ImportError, match="streaming"):
             list(extractor.stream_remote_zip_member("https://x/y.zip", "m.dat.gz"))
+
+
+def test_find_transaction_member_skips_wrong_layout(
+    sample_vendor_filters, sample_contract_row_full
+):
+    """find_transaction_member skips short/wrong-shape members and picks the match."""
+    # Two decoys (too few cols / non-date col[2]) plus the real transaction member.
+    decoy_short = gzip.compress(b"\t".join([b"x"] * 20) + b"\n")
+    decoy_no_date = gzip.compress(
+        ("\t".join(["123", "id1", "NOT_A_DATE", "A"] + ["x"] * 99)).encode("utf-8") + b"\n"
+    )
+    txn_blob = gzip.compress(("\t".join(sample_contract_row_full) + "\n").encode("utf-8"))
+    # Order the dict so the decoys are larger → probed first → skipped first.
+    members = {
+        "pruned_data_store_api_dump/9999.dat.gz": b"x" * (len(txn_blob) + 200) + decoy_short,
+        "pruned_data_store_api_dump/9998.dat.gz": b"x" * (len(txn_blob) + 100) + decoy_no_date,
+        "pruned_data_store_api_dump/5183.dat.gz": txn_blob,
+    }
+    # Use the real gzip blobs (decoys above were padded only to inflate file_size);
+    # restore them so the parser sees valid gzip when opened.
+    members["pruned_data_store_api_dump/9999.dat.gz"] = decoy_short
+    members["pruned_data_store_api_dump/9998.dat.gz"] = decoy_no_date
+
+    fake = _fake_remotezip_module_multi(members)
+    with patch.dict(sys.modules, {"remotezip": fake}):
+        picked = ContractExtractor.find_transaction_member("https://x/y.zip")
+
+    assert picked == "pruned_data_store_api_dump/5183.dat.gz"
+
+
+def test_find_transaction_member_raises_when_none_match(sample_vendor_filters):
+    """find_transaction_member raises RuntimeError when no member has the signature."""
+    members = {
+        "a.dat.gz": gzip.compress(b"\t".join([b"x"] * 5) + b"\n"),
+        "b.dat.gz": gzip.compress(b"\t".join([b"y"] * 10) + b"\n"),
+    }
+    fake = _fake_remotezip_module_multi(members)
+    with patch.dict(sys.modules, {"remotezip": fake}):
+        with pytest.raises(RuntimeError, match="transaction_normalized signature"):
+            ContractExtractor.find_transaction_member("https://x/y.zip")
+
+
+def test_extract_from_remote_zip_auto_detects_member(
+    tmp_path, sample_vendor_filters, sample_contract_row_full
+):
+    """extract_from_remote_zip(member_name=None) sniffs the zip and streams the match."""
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+    decoy = gzip.compress(b"\t".join([b"x"] * 8) + b"\n")
+    txn_blob = gzip.compress(("\t".join(sample_contract_row_full) + "\n").encode("utf-8"))
+    members = {
+        "pruned_data_store_api_dump/9999.dat.gz": decoy,
+        "pruned_data_store_api_dump/5183.dat.gz": txn_blob,
+    }
+    out = tmp_path / "contracts.parquet"
+    fake = _fake_remotezip_module_multi(members)
+
+    with patch.dict(sys.modules, {"remotezip": fake}):
+        count = extractor.extract_from_remote_zip(
+            "https://x/y.zip", member_name=None, output_file=out
+        )
+
+    assert count == 1
+    assert out.exists()

--- a/tests/unit/extractors/test_contract_extractor_streaming.py
+++ b/tests/unit/extractors/test_contract_extractor_streaming.py
@@ -72,8 +72,7 @@ def _fake_remotezip_module_multi(
 
         def infolist(self):
             return [
-                _Info(name, (sizes or {}).get(name, len(blob)))
-                for name, blob in members.items()
+                _Info(name, (sizes or {}).get(name, len(blob))) for name, blob in members.items()
             ]
 
         def open(self, member_name):

--- a/tests/unit/extractors/test_contract_extractor_streaming.py
+++ b/tests/unit/extractors/test_contract_extractor_streaming.py
@@ -42,12 +42,16 @@ def _fake_remotezip_module(member_gzip: bytes) -> types.ModuleType:
     return mod
 
 
-def _fake_remotezip_module_multi(members: dict[str, bytes]) -> types.ModuleType:
+def _fake_remotezip_module_multi(
+    members: dict[str, bytes],
+    sizes: dict[str, int] | None = None,
+) -> types.ModuleType:
     """Multi-member fake ``remotezip`` for auto-detection tests.
 
-    ``members`` maps ``filename → gzip-compressed bytes``. ``infolist()`` exposes
-    each member with a ``file_size`` equal to the gzip blob's length so the
-    largest-first probe ordering inside ``find_transaction_member`` is exercised.
+    ``members`` maps ``filename → gzip-compressed bytes`` used by ``open()``.
+    ``sizes`` optionally overrides each entry's reported ``file_size`` — useful
+    for exercising ``find_transaction_member``'s largest-first probe ordering
+    without bloating the actual gzip payloads. Defaults to the blob length.
     """
     mod = types.ModuleType("remotezip")
 
@@ -67,7 +71,10 @@ def _fake_remotezip_module_multi(members: dict[str, bytes]) -> types.ModuleType:
             return False
 
         def infolist(self):
-            return [_Info(name, len(blob)) for name, blob in members.items()]
+            return [
+                _Info(name, (sizes or {}).get(name, len(blob)))
+                for name, blob in members.items()
+            ]
 
         def open(self, member_name):
             return io.BytesIO(members[member_name])
@@ -148,25 +155,30 @@ def test_stream_remote_zip_member_missing_dependency_raises(sample_vendor_filter
 def test_find_transaction_member_skips_wrong_layout(
     sample_vendor_filters, sample_contract_row_full
 ):
-    """find_transaction_member skips short/wrong-shape members and picks the match."""
-    # Two decoys (too few cols / non-date col[2]) plus the real transaction member.
+    """find_transaction_member skips short/wrong-shape members and picks the match.
+
+    The decoys are declared *larger* than the real match via the ``sizes`` override
+    so the largest-first probe ordering inside ``find_transaction_member`` is
+    actually exercised: decoys get probed first and skipped, then the match wins.
+    """
     decoy_short = gzip.compress(b"\t".join([b"x"] * 20) + b"\n")
     decoy_no_date = gzip.compress(
         ("\t".join(["123", "id1", "NOT_A_DATE", "A"] + ["x"] * 99)).encode("utf-8") + b"\n"
     )
     txn_blob = gzip.compress(("\t".join(sample_contract_row_full) + "\n").encode("utf-8"))
-    # Order the dict so the decoys are larger → probed first → skipped first.
     members = {
-        "pruned_data_store_api_dump/9999.dat.gz": b"x" * (len(txn_blob) + 200) + decoy_short,
-        "pruned_data_store_api_dump/9998.dat.gz": b"x" * (len(txn_blob) + 100) + decoy_no_date,
+        "pruned_data_store_api_dump/9999.dat.gz": decoy_short,
+        "pruned_data_store_api_dump/9998.dat.gz": decoy_no_date,
         "pruned_data_store_api_dump/5183.dat.gz": txn_blob,
     }
-    # Use the real gzip blobs (decoys above were padded only to inflate file_size);
-    # restore them so the parser sees valid gzip when opened.
-    members["pruned_data_store_api_dump/9999.dat.gz"] = decoy_short
-    members["pruned_data_store_api_dump/9998.dat.gz"] = decoy_no_date
+    # Force decoys to appear larger so largest-first ordering probes them first.
+    sizes = {
+        "pruned_data_store_api_dump/9999.dat.gz": len(txn_blob) + 200,
+        "pruned_data_store_api_dump/9998.dat.gz": len(txn_blob) + 100,
+        "pruned_data_store_api_dump/5183.dat.gz": len(txn_blob),
+    }
 
-    fake = _fake_remotezip_module_multi(members)
+    fake = _fake_remotezip_module_multi(members, sizes=sizes)
     with patch.dict(sys.modules, {"remotezip": fake}):
         picked = ContractExtractor.find_transaction_member("https://x/y.zip")
 


### PR DESCRIPTION
## Summary

Three rough edges surfaced when PR #392's remote-zip streaming path was first run against the live USAspending endpoint. None are bugs in the streaming code itself — they're papercuts in the surrounding scripts:

1. **Auto-detect the transaction member** in `scripts/extract_federal_contracts.py`. The script's default `--member 5530.dat.gz` is a stale PostgreSQL OID — the per-table file id rotates between dumps. The current subset's transaction_normalized member is actually `pruned_data_store_api_dump/5183.dat.gz`. Worse, a wrong member name *silently parses columns from an unrelated table*, producing plausible-looking garbage. New `ContractExtractor.find_transaction_member(zip_url)` probes each `.dat.gz` (largest first), opens the first row, and returns the one whose layout matches transaction_normalized (≥100 cols + 8-digit col[2] action_date + col[3] ∈ {A,B,C,D,\N}). The CLI default becomes auto-detect; `--member` stays as an explicit override.

2. **Correct the hardcoded awards CSV name** in `scripts/extract_sbir_vendors.py`. It expected `awards_data.csv` (plural), but `config/base.yaml` and 70+ call sites use `award_data.csv` (singular). The script would fail on a fresh checkout. Now routes through `cfg.extraction.sbir.csv_path` like everything else.

3. **Lazify the `boto3` import** in `scripts/usaspending/check_new_file.py`. Top-level `import boto3` made the `--source-url` path (which doesn't touch S3) unrunnable in any env without boto3. Now imported lazily inside the two functions that need it, with graceful degradation (warn + skip the S3 comparison) when missing.

## Test plan

- [x] `pytest tests/unit/extractors/test_contract_extractor_streaming.py` — 7 passed (4 existing + 3 new for auto-detect: happy path, skip-decoys, no-match-raises).
- [x] `pytest tests/unit/extractors/ tests/unit/transition/detection/test_scoring.py` — 237 passed, 1 skipped (confirms PR #393 scorer tests still green).
- [x] `ruff check` on the 5 changed files — clean.
- [x] `python scripts/usaspending/check_new_file.py --source-url ...` runs in an env without boto3 — works, prints the degraded-S3 warning.
- [x] `python scripts/extract_sbir_vendors.py` runs against the canonical `award_data.csv` filename — produces vendor filter JSON.
- [x] End-to-end smoke test against `https://files.usaspending.gov/database_download/usaspending-db-subset_20260606.zip` with no `--member` (auto-detected `pruned_data_store_api_dump/5183.dat.gz`, 110 SBIR-vendor matches, 100% action_date coverage, 94.5% action_date ≠ start_date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)