### PR TITLE
Add requirements template and refactor leverage-ratio-analysis to user-story format

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -73,7 +73,7 @@ Two lenses run through every tier below — **capability** (does SBIR/STTR build
 ### A2. Relational (Tier 2)
 
 - Do firms show higher transition rates within the same awarding agency (agency continuity signal)? *(deps: ER, ID)*
-- **(cap) DIB integration** — Phase II→III transition rate per CET area via FPDS, plus SAM.gov subaward links to prime contractors. Aligns with NASEM's "knowledge transfer to primes" finding [L1]. **[Answerable now, moderate confidence — FPDS Phase III tagging is historically incomplete; GAO [L14]]** *(deps: ER, ID, CET, transitions)*
+- **(cap) DIB integration** — Phase II→III transition rate per CET area via FPDS, plus SAM.gov subaward links to prime contractors — [../specs/ot-consortium-subaward-attribution/](../specs/ot-consortium-subaward-attribution/) (FFATA/FSRS sub-award T1 recovery). Aligns with NASEM's "knowledge transfer to primes" finding [L1]. **[Answerable now, moderate confidence — FPDS Phase III tagging is historically incomplete; GAO [L14]]** *(deps: ER, ID, CET, transitions)*
 - **(cap/vuln) Awardee-as-IP-chokepoint** *(A-CP6)* — within a CET area, do patent assignment chains (`ASSIGNED_VIA/FROM/TO`) show a small number of awardees as the dominant source of enabling IP flowing to primes (knowledge-supply-chain position)? Builds on the C2 patent-linkage work; the citation-centrality "who-depends-on-whom" variant needs patent-citation edge ingestion (a `PatentCitation` model exists but citations are not yet graph relationships). Aligns with NASEM's knowledge-transfer-to-primes finding [L1]. **[Partial — assignment-chain lens buildable now; citation-centrality needs ingestion]** *(deps: ER, PATLINK, CET)*
 - **(vuln) Adversary-affiliation screening** — entity resolution of awardees and key personnel against the named restricted-entity lists and foreign-country-of-concern ties. **[Partial via public lists; full coverage needs agency-held due-diligence data]** *(deps: ER)*
 - **(vuln) Concentration vs. transition-thinness** *(A-CP5)* — do the most concentrated (thin-base) CET areas also show the thinnest Phase II→III transition pipelines, compounding fragility (concentrated AND failing to graduate)? FPDS Phase III undercount [L14] bounds confidence. **[Research target — not yet scoped]** *(deps: ER, ID, CET, transitions)*
@@ -85,7 +85,7 @@ Two lenses run through every tier below — **capability** (does SBIR/STTR build
 
 **DoD leverage ratio.**
 
-- What is the aggregate leverage ratio (non-SBIR DoD obligations ÷ SBIR/STTR obligations) for DoD SBIR firms? **Target: reproduce NASEM's ~4:1 for 2012–2020** [L1][L2] — [../specs/leverage-ratio-analysis/](../specs/leverage-ratio-analysis/). *(deps: ER, ID)*
+- What is the aggregate leverage ratio (non-SBIR DoD obligations ÷ SBIR/STTR obligations) for DoD SBIR firms? **Target: reproduce NASEM's ~4:1 for 2012–2020** [L1][L2] — [../specs/leverage-ratio-analysis/](../specs/leverage-ratio-analysis/) (FPDS contract-node ingestion: [../specs/load-contract-nodes/](../specs/load-contract-nodes/)). *(deps: ER, ID)*
 - How does the leverage ratio stratify by award vintage, firm size, technology area, and firm experience (new vs. repeat)? NASEM reports SBIR firms = ~1/3 of DoD's extramural R&D base [L1]. *(deps: ER, ID, CET)*
 - How is the leverage ratio changing over time? *(deps: ER, ID)*
 - What is the leverage ratio for civilian agencies (e.g., DOE)? Myers & Lanahan [L9] and NASEM DOE [L5] supply baselines. *(deps: ER, ID)*
@@ -148,7 +148,7 @@ placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
 
 ### B2. Relational (Tier 2)
 
-- Did this SBIR-funded research result in a federal contract? — [transition/overview.md](transition/overview.md). Baselines: NASEM DoD [L1][L2]; Link & Scott ~50% commercialization probability [L12]; NASEM program reviews [L3][L4][L6]. *(deps: ER, ID)*
+- Did this SBIR-funded research result in a federal contract? — [transition/overview.md](transition/overview.md), [../specs/transition-detection/](../specs/transition-detection/). Baselines: NASEM DoD [L1][L2]; Link & Scott ~50% commercialization probability [L12]; NASEM program reviews [L3][L4][L6]. *(deps: ER, ID)*
 - Which SBIR-funded companies transitioned research into federal procurements? — [transition/detection-algorithm.md](transition/detection-algorithm.md). *(deps: ER, ID)*
 - What is the average time from award to transition by technology area? *(deps: ER, ID, CET)*
 - Which SBIR awards transitioned with patent backing, and what share of transitions are patent-enabled? Related to Lerner [L10] and Howell [L11]. *(deps: ER, ID, PATLINK)*
@@ -159,9 +159,9 @@ placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
 - Phase II → III survival probability by agency, firm size, and vintage. *(deps: ER, ID)*
 - Does Phase II → III latency vary by technology area? *(deps: ER, ID, CET)*
 - Transition effectiveness rate by CET area, agency, and firm size — compare to Link & Scott [L12] and NASEM [L1][L3][L4]. *(deps: ER, ID, CET)*
-- How much undercount exists in Phase III coding by agency? Corroborated by GAO [L14] and NASEM [L1][L3]. *(deps: ID)*
+- How much undercount exists in Phase III coding by agency? Corroborated by GAO [L14] and NASEM [L1][L3]. Phase III solicitation monitoring: [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/). *(deps: ID)*
 - How does company categorization relate to transition likelihood? Baseline: Link & Scott commercialization-probability econometrics [L12]. *(deps: ER, ID)*
-- Which Phase II awardees subject to §638(qq)(3) Increased Performance Standards meet the **statutory Commercialization Benchmark** (sales + private investment over the 10-FY covered period ÷ SBIR funding ≥ specified ratio)? Pub. L. 117-183 SBIR/STTR Extension Act of 2022 §638(qq)(3). Implementation on main: `scripts/run_benchmark.py` (evaluate / sensitivity / company-level CLI) backed by `sbir_etl/models/benchmark_models.py`, with tests in `tests/unit/test_benchmark_evaluator.py`. Additional per-firm audit infrastructure and a more comprehensive methodology doc exist as local-only / uncommitted work — see "Output products" section below for the in-progress status. *(deps: ER, ID, transitions, SEC EDGAR)*
+- Which Phase II awardees subject to §638(qq)(3) Increased Performance Standards meet the **statutory Commercialization Benchmark** (sales + private investment over the 10-FY covered period ÷ SBIR funding ≥ specified ratio)? Pub. L. 117-183 SBIR/STTR Extension Act of 2022 §638(qq)(3). Implementation on main: `scripts/run_benchmark.py` (evaluate / sensitivity / company-level CLI) backed by `sbir_etl/models/benchmark_models.py`, with tests in `tests/unit/test_benchmark_evaluator.py`. Spec: [../specs/commercialization-benchmark/](../specs/commercialization-benchmark/). Additional per-firm audit infrastructure and a more comprehensive methodology doc exist as local-only / uncommitted work — see "Output products" section below for the in-progress status. *(deps: ER, ID, transitions, SEC EDGAR)*
 
 ### B4. Predictive (Tier 4)
 
@@ -198,11 +198,11 @@ placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
 ### D1. Descriptive (Tier 1)
 
 - Award totals by state, agency, and phase — SBA annual reports [L18]. *(deps: —)*
-- NAICS-sector coverage and fallback usage. *(deps: IMP for NAICS)*
+- NAICS-sector coverage and fallback usage — [../specs/naics-enricher-consolidation/](../specs/naics-enricher-consolidation/). *(deps: IMP for NAICS)*
 
 ### D2. Relational (Tier 2)
 
-- What are federal fiscal returns (tax receipts) from SBIR program spending? — [fiscal/](fiscal/). TechLink's DoD-wide 1995–2018 study reports ~22:1 total-output ROI, 8.4:1 sales ROI, $39.4B tax revenue [L19]; Air Force ~12:1, Navy ~19.5:1 [L19]; NCI published a separate economic-impact study [L20]. *(deps: ER, ID, NAICS, BEA I-O)*
+- What are federal fiscal returns (tax receipts) from SBIR program spending? — [fiscal/](fiscal/) ([../specs/fiscal-tax-impact-v2.md](../specs/fiscal-tax-impact-v2.md)). TechLink's DoD-wide 1995–2018 study reports ~22:1 total-output ROI, 8.4:1 sales ROI, $39.4B tax revenue [L19]; Air Force ~12:1, Navy ~19.5:1 [L19]; NCI published a separate economic-impact study [L20]. *(deps: ER, ID, NAICS, BEA I-O)*
 - What are employment, wage, proprietor-income, and production impacts by award? *(deps: fiscal model)*
 - How do fiscal returns stratify by state and NAICS sector? *(deps: ER, NAICS)*
 - Which NAICS sectors show the highest fiscal return multipliers? *(deps: fiscal model)*
@@ -221,21 +221,21 @@ placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
 
 ### E1. SBIR identification (foundation, Tier 1–2)
 
-- Which federal awards are SBIR/STTR vs. non-SBIR, and with what confidence? Three-tier classifier (FPDS research field 1.0 → ALN 0.8–1.0 → description parsing 0.5–0.7) — [sbir-identification-methodology.md](sbir-identification-methodology.md). CRS [L15], GAO [L14]. *(deps: —)*
+- Which federal awards are SBIR/STTR vs. non-SBIR, and with what confidence? Three-tier classifier (FPDS research field 1.0 → ALN 0.8–1.0 → description parsing 0.5–0.7) — [sbir-identification-methodology.md](sbir-identification-methodology.md), [../specs/sbir-identification/](../specs/sbir-identification/). CRS [L15], GAO [L14]. *(deps: —)*
 - What are false-positive rates for shared-ALN grant identification (e.g., NIH ~20%)? *(deps: ID)*
 - How does SBIR.gov data reconcile with federal USAspending/FPDS records? GAO [L14] and NASEM [L1][L3] flag tracking-data limits. *(deps: —)*
 
 ### E2. Entity resolution (foundation, Tier 1–2)
 
-- Is this SBIR recipient the same entity that won the federal contract? UEI → CAGE → DUNS → fuzzy-name cascade — [transition/vendor-matching.md](transition/vendor-matching.md). *(deps: —)*
+- Is this SBIR recipient the same entity that won the federal contract? UEI → CAGE → DUNS → fuzzy-name cascade — [transition/vendor-matching.md](transition/vendor-matching.md). Graph schema: [../specs/unify-graph-node-labels/](../specs/unify-graph-node-labels/) (Phase 1, `:Award`→`:FinancialTransaction`) and [../specs/unify-company-into-organization/](../specs/unify-company-into-organization/) (Phase 2, `:Company`→`:Organization`). *(deps: —)*
 - What is the entity-resolution match rate, and what is the exact-vs-fuzzy share? *(deps: ER)*
 - Have companies undergone acquisitions or rebrandings that break matching? *(deps: ER)*
 
 ### E3. Data quality & completeness (Tier 1)
 
-- What percentage of awards have valid NAICS codes, and what is the fallback usage rate? *(deps: —)*
+- What percentage of awards have valid NAICS codes, and what is the fallback usage rate? — [../specs/naics-enricher-consolidation/](../specs/naics-enricher-consolidation/). *(deps: —)*
 - How many awards lack UEI/DUNS identifiers? *(deps: —)*
-- What is the data-freshness lag for SBIR.gov, USAspending, USPTO, and BEA I-O sources? *(deps: —)*
+- What is the data-freshness lag for SBIR.gov, USAspending, USPTO, and BEA I-O sources? — [../specs/iterative_api_enrichment/](../specs/iterative_api_enrichment/). *(deps: —)*
 - Which awards have missing or null critical fields (amount, dates, recipient)? *(deps: —)*
 
 ### E4. Data imputation (Tier 2–3) *(spec merged via PR #277; implementation not yet started)*
@@ -250,7 +250,7 @@ placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
 ### E5. External data source evaluation (Tier 2) *(branch: claude/procurement-data-sources-eval)*
 
 - Does SAM.gov Entity Extracts materially improve UEI backfill recall? — `specs/procurement-data-sources-eval/` *(branch)*. *(deps: ER)*
-- Does the SAM.gov Opportunities API replace agency-page scraping for solicitation ceilings and periods of performance? *(deps: E3)*
+- Does the SAM.gov Opportunities API replace agency-page scraping for solicitation ceilings and periods of performance? — [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/). *(deps: E3)*
 - Does FSCPSC NAICS prediction beat our abstract-nearest-neighbor baseline? *(deps: IMP)*
 - Does the PSC Selection Tool provide the NAICS ↔ PSC crosswalk needed for topic-derived NAICS? *(deps: IMP)*
 - Do DIIG CSIS lookup tables feed our NAICS hierarchy or agency normalization? *(deps: —)*
@@ -258,7 +258,7 @@ placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
 
 ### E6. Continuous monitoring & rolling analytics (Tier 4, capstone)
 
-- What are current-quarter SBIR metrics and trends (weekly snapshots)? — [research-plan-alignment.md](research-plan-alignment.md). Fills the gap between point-in-time NASEM reviews [L1][L3][L4][L5]. *(deps: E1–E5 + A–D pipelines)*
+- What are current-quarter SBIR metrics and trends (weekly snapshots)? — [research-plan-alignment.md](research-plan-alignment.md), [../specs/weekly-awards-report-refactor/](../specs/weekly-awards-report-refactor/). Fills the gap between point-in-time NASEM reviews [L1][L3][L4][L5]. *(deps: E1–E5 + A–D pipelines)*
 - How have transition rates, patent output, and fiscal returns changed quarter-over-quarter? *(deps: all)*
 - Which agencies are under-performing on transitions vs. historical baseline? *(deps: all)*
 
@@ -270,7 +270,7 @@ This area treats the SBIR awardee as a **firm with a capital history**, not as a
 
 ### F1. Descriptive (Tier 1)
 
-- What is the Form D [L23] private-placement fundraising profile of SBIR awardees? *(PR #286 merged)* *(deps: ER, SEC EDGAR)*
+- What is the Form D [L23] private-placement fundraising profile of SBIR awardees? *(PR #286 merged)* — [../specs/form-d-pipeline/](../specs/form-d-pipeline/). *(deps: ER, SEC EDGAR)*
 - What is the debt-vs-equity composition and offering fill rate of SBIR-firm Form D filings? *(PR #286 merged)* *(deps: ER, SEC EDGAR)*
 - What fraction of SBIR awardees show secured-debt activity (UCC-1 filings), and what mix of equipment finance, depository-bank lending, and venture debt do those filings represent by lender? UCC-1 complements Form D's equity view — [../specs/ucc1-financing-analysis/](../specs/ucc1-financing-analysis/) *(PRs #303 / #305 merged, CA-only pilot found equipment + community-bank patterns and an absence of venture-debt lenders in the CA channel)*. *(deps: ER, UCC-1)*
 - Unified capital-event timeline: federal awards, private placements, M&A, and patent events on a single firm history *(PR #307 merged)*. *(deps: ER, SEC EDGAR, UCC-1, M&A signals)*
@@ -281,12 +281,12 @@ This area treats the SBIR awardee as a **firm with a capital history**, not as a
 
 - Among acquirers of SBIR firms, what share are life-sciences consolidators (Bruker, Ligand, Thermo Fisher) vs. defense primes vs. financial sponsors? What fraction of acquirers are serial (3+ SBIR-firm targets)? *(deps: ER, M&A signals)*
 - Do Form D filers and non-filers differ on transition, patent, and exit outcomes — controlling for vintage, agency, and CET area? *(PR #314)* *(deps: ER, ID, CET, SEC EDGAR)*
-- What is the SBIR ↔ M&A-event match rate by fiscal year, and how is coverage trending? *(PR #313)* *(deps: ER, M&A signals)*
+- What is the SBIR ↔ M&A-event match rate by fiscal year, and how is coverage trending? *(PR #313)* — [../specs/sbir_ma_match_rate_by_fy/](../specs/sbir_ma_match_rate_by_fy/). *(deps: ER, M&A signals)*
 - How does SBIR-firm capital structure benchmark against the NVCA Yearbook [L25] cohort of comparable-stage VC-backed startups? *(deps: ER, SEC EDGAR)*
 
 ### F3. Inferential (Tier 3)
 
-- What is the **private-to-SBIR leverage ratio** (private capital raised ÷ SBIR funding) by agency, vintage, and firm size? The private-side mirror to NASEM's 4:1 DoD non-SBIR-federal leverage [L1]. *(deps: ER, ID, SEC EDGAR)*
+- What is the **private-to-SBIR leverage ratio** (private capital raised ÷ SBIR funding) by agency, vintage, and firm size? The private-side mirror to NASEM's 4:1 DoD non-SBIR-federal leverage [L1] — [../specs/form-d-pipeline/](../specs/form-d-pipeline/), [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/). *(deps: ER, ID, SEC EDGAR)*
 - For Phase II awardees of any agency, do follow-on funding and exit outcomes match the published private-capital-backed-startup baselines from the NVCA Yearbook [L25]? *(PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, terminology changed from "VC" to "private capital")* *(deps: ER, SEC EDGAR)*
 - Does SBIR funding crowd in or crowd out subsequent private capital? **Target: reproduce or extend Howell's finding that an early-stage DOE SBIR grant roughly doubles the probability of subsequent VC** [L11]. Compare against Kortum & Lerner [L24] on VC's contribution to innovation. *(deps: ER, ID, SEC EDGAR)*
 - Does the Lerner [L10] finding — SBIR growth effects concentrated in VC-rich zip codes — still hold post-2010 and across all eleven agencies? *(deps: ER, ID, SEC EDGAR)*

--- a/specs/REQUIREMENTS_TEMPLATE.md
+++ b/specs/REQUIREMENTS_TEMPLATE.md
@@ -1,0 +1,97 @@
+# [Feature Name] — Requirements
+
+> **Status:** [Not yet started | In progress | Partially implemented | Complete]
+> Anchors inventory question(s) **[RQ IDs]** in [docs/research-questions.md](../docs/research-questions.md).
+
+**Research question anchor:** [e.g., A3 — DoD leverage ratio]
+**Answers for:** [audiences from the RQ inventory — e.g., policy analysts, SBIR program managers]
+**Complexity tier:** [Descriptive | Relational | Inferential | Predictive]
+
+---
+
+## Done when
+
+> [A concrete, first-person statement of the output — not what the system does, but what
+> an analyst can say or show as a result. Example:
+>
+> "An analyst can state: 'NASEM reports 4:1. Our pipeline yields [X]:1 using [method].
+> The difference is attributable to [Y]. Here is the stratification by vintage and CET area.'"
+>
+> If the output is a report, name the report. If it is a graph query, show the query shape.
+> If it is a briefing, describe the claim the briefing can make.]
+
+---
+
+## Background
+
+[2–4 sentences: what is the problem, why can't it be answered today, what data makes it
+tractable. Cite the relevant RQ section. Do not repeat the glossary or the requirements.]
+
+## Glossary
+
+[Optional. Define only terms that are ambiguous in context or that have project-specific
+meanings. Omit standard terms like "award" or "agency".]
+
+---
+
+## Requirements
+
+### Requirement 1 — [Short name]
+
+**User story:** As a [actor from taxonomy below], I want [outcome], so that [downstream
+decision or use — not "so that I can see X" but "so that I can brief/publish/flag X"].
+
+#### Acceptance Criteria
+
+1. WHEN [triggering condition], THE System SHALL [observable behavior or output].
+2. WHEN [condition], THE System SHALL [behavior].
+3. ...
+
+---
+
+### Requirement 2 — [Short name]
+
+**User story:** As a [actor], I want [outcome], so that [downstream use].
+
+#### Acceptance Criteria
+
+1. WHEN [condition], THE System SHALL [behavior].
+2. ...
+
+---
+
+<!-- Add more requirements as needed. Each requirement should be independently testable. -->
+
+---
+
+## Dependencies
+
+- [Upstream spec or existing component] — [EXISTS | IN PROGRESS | BLOCKED]
+- ...
+
+---
+
+<!--
+ACTOR TAXONOMY — use these labels (or close variants) in user stories:
+
+  policy analyst              preparing a congressional or OMB briefing; needs citable,
+                              benchmark-anchored figures (A3, D2, F3 leverage questions)
+
+  SBIR program manager        SBA / NIH / DoD / NSF program office staff evaluating
+                              portfolio performance and statutory compliance (B-area,
+                              commercialization-benchmark, E-area questions)
+
+  defense industrial base     DoD acquisition / OSTP / HASC/SASC staff assessing DIB
+  analyst                     resilience, concentration, and choke-point risk (Section A
+                              vulnerability questions)
+
+  entrepreneurial finance     NVCA / Kauffman / NBER researchers and VC/PE analysts
+  researcher                  benchmarking SBIR-firm capital formation (F-area questions)
+
+  pipeline engineer           Internal developer maintaining the ETL pipeline
+                              (infrastructure specs: imputation, graph labels, NAICS
+                              enricher consolidation, iterative refresh). Use this actor
+                              only when the feature has no direct research-output facing.
+
+Avoid: "data analyst", "user", "developer" as stand-alone actors in research-output specs.
+-->

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -1,5 +1,32 @@
 # SBIR vs. Private-Capital Comparison — Requirements (agency-parameterized; NSF as initial target)
 
+> **Status:** Phase 1 not yet started; Phase 2 gated on PR #286 merging.
+> Supports inventory questions **F3** (private-capital comparison), **B2** (commercialization outcomes), **B3** (transition rates) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** F3 / B2 / B3 — SBIR vs. private-capital cohort comparison (NSF initial target)
+**Answers for:** entrepreneurial finance researchers, SBIR program managers, policy analysts
+**Complexity tier:** Relational → Inferential (Tier 2–3)
+
+---
+
+## Done when
+
+> **Phase 1:** A policy analyst can state: "NVCA reports seed→A graduation at ~30%. NSF Phase I→II graduation is [X]% on cohort [vintage range, n=Y]. The difference is attributable to [Z]." Produces the exact reconciliation pattern of `leverage-ratio-analysis`.
+>
+> **Phase 2:** An entrepreneurial finance researcher can state: "On vintage [X], NAICS-2 [Y], state [Z]: NSF Phase II awardees transitioned to federal contract at [A]% within 5 years; matched non-SBIR Form D issuers transitioned at [B]%. Selection-bias and matching caveats: [see threats-to-validity section]."
+
+---
+
+## User Stories
+
+**As a policy analyst benchmarking NSF's SBIR program against published venture-capital performance metrics,**
+I want Phase I→II graduation rates, 5-year survival proxies, and M&A exit rates computed for the NSF cohort and placed alongside NVCA/Howell/Lerner baselines with a reconciliation narrative, so that I can report how NSF SBIR performs relative to seed-stage private capital in a form suitable for OSTP or congressional briefings.
+
+**As an entrepreneurial finance researcher studying whether SBIR awardees outperform comparable private-capital-financed firms,**
+I want a covariate-matched control cohort of non-SBIR Form D issuers with outcome deltas computed against the NSF SBIR cohort, so that I can assess whether the SBIR treatment effect on commercialization holds after controlling for vintage, NAICS sector, and firm geography.
+
+---
+
 Research-questions tags: **B2/B3** (commercialization), **A4** (private-capital signals),
 **[L21]** (ITIF "America's Seed Fund"), **[L10]** (Lerner), **[L11]** (Howell), **[L23]** (Form D).
 

--- a/specs/archive/completed-features/transition_detection/requirements.md
+++ b/specs/archive/completed-features/transition_detection/requirements.md
@@ -1,4 +1,14 @@
-# Requirements Document
+# Requirements — SBIR Transition Detection (Archive)
+
+> **Status:** Implemented and merged (October 30, 2025). Current live spec stub:
+> [`specs/transition-detection/requirements.md`](../../../transition-detection/requirements.md).
+> Supports inventory questions **B2** and **B3** in
+> [docs/research-questions.md](../../../../docs/research-questions.md).
+
+**Research question anchor:** B2 (did SBIR research result in a federal contract?),
+B3 (Phase II→III latency, survival probability, transition effectiveness)
+
+---
 
 ## Introduction
 

--- a/specs/commercialization-benchmark/requirements.md
+++ b/specs/commercialization-benchmark/requirements.md
@@ -1,0 +1,105 @@
+# Requirements — §638(qq)(3) Commercialization Benchmark
+
+> **Status:** Implemented on `main`. CLI: `scripts/run_benchmark.py`. Models:
+> `sbir_etl/models/benchmark_models.py`. Evaluator:
+> `packages/sbir-ml/sbir_ml/transition/analysis/benchmark_evaluator.py`.
+> Tests: `tests/unit/test_benchmark_evaluator.py`.
+> Supports inventory question **B3** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** B3 — which Phase II awardees subject to §638(qq)(3)
+Increased Performance Standards meet the statutory Commercialization Benchmark?
+**Answers for:** SBA program oversight analysts, GAO compliance reviewers, policy analysts
+**Complexity tier:** Inferential (Tier 3)
+
+---
+
+## Done when
+
+> An SBA program oversight analyst can run `poetry run benchmark evaluate` against a
+> cohort of Phase II awardees subject to §638(qq)(3) and receive per-firm compliance
+> status (`MEETS` / `DOES_NOT_MEET` / `INSUFFICIENT_DATA`) with the underlying
+> components (FPDS contract dollars, SEC Form D investment, FABS grant dollars) shown
+> separately, and aggregate pass/fail rates by agency and cohort FY.
+
+---
+
+## Introduction
+
+Pub. L. 117-183 (SBIR/STTR Extension Act of 2022) §638(qq)(3) established Increased
+Performance Standards for firms receiving multiple Phase II awards. This feature
+evaluates whether subject firms meet the statutory Commercialization Benchmark:
+(sales + private investment over the 10-FY covered period) ÷ SBIR funding ≥ the
+specified statutory ratio. The pipeline draws on three data sources — FPDS federal
+contract obligations, SEC Form D private placements, and FABS grant records — to
+construct per-firm numerator components, then applies the statutory formula.
+
+---
+
+## User Stories
+
+**As an SBA program officer,** I want per-firm §638(qq)(3) compliance status computed
+from FPDS, Form D, and FABS data, so that I can identify which firms meet the statutory
+Commercialization Benchmark before applying increased performance standards.
+
+**As a GAO analyst reviewing SBIR program effectiveness,** I want aggregate pass/fail
+rates by agency and cohort year, so that I can report on program-wide commercialization
+outcomes under the SBIR/STTR Extension Act of 2022.
+
+**As a policy analyst benchmarking against GAO-24-106398,** I want the pipeline's
+coverage rate (share of subject firms with sufficient data to evaluate) stated alongside
+the compliance rate, so that figures cited in congressional reports carry an explicit
+denominator-coverage qualifier.
+
+---
+
+## Requirements
+
+### Requirement 1 — Per-firm benchmark evaluation
+
+**User Story:** As an SBA program officer, I want per-firm compliance status
+for each Phase II awardee in the subject cohort, so that I can identify
+firms approaching or below the statutory threshold.
+
+#### Acceptance Criteria
+
+1. THE System SHALL evaluate each subject firm using the statutory formula:
+   (FPDS contract obligations + Form D investment + FABS grants over the
+   10-FY covered period) ÷ total Phase II SBIR funding received.
+2. THE System SHALL classify each firm as `MEETS`, `DOES_NOT_MEET`, or
+   `INSUFFICIENT_DATA` based on the computed ratio and data availability.
+3. THE System SHALL expose the three component values (contract dollars, Form D
+   dollars, FABS dollars) separately in the output so analysts can attribute
+   benchmark performance to specific data channels.
+4. WHEN a firm lacks sufficient data to evaluate (e.g., no FPDS match and no
+   Form D filing), THE System SHALL classify it `INSUFFICIENT_DATA` and
+   record which component is missing.
+
+### Requirement 2 — Aggregate reporting by agency and cohort
+
+**User Story:** As a GAO analyst, I want aggregate compliance rates by
+awarding agency and first-Phase-II fiscal year, so that agency-level
+program effectiveness can be compared against the statutory intent.
+
+#### Acceptance Criteria
+
+1. THE System SHALL produce a summary table of `MEETS` / `DOES_NOT_MEET` /
+   `INSUFFICIENT_DATA` counts and percentages by awarding agency.
+2. THE System SHALL produce a cohort-by-year breakdown using the firm's first
+   Phase II award fiscal year as the cohort anchor.
+3. WHEN any cell contains fewer than 10 firms, THE System SHALL suppress the
+   rate and note the suppression reason.
+
+### Requirement 3 — CLI interface
+
+**User Story:** As a pipeline engineer, I want a CLI command for running the
+benchmark evaluation so that it can be integrated into CI pipelines and
+called from Dagster jobs.
+
+#### Acceptance Criteria
+
+1. THE System SHALL expose `poetry run benchmark evaluate [--agency <name>]
+   [--cohort-fy <year>] [--output <path>]` as the primary evaluation interface.
+2. THE System SHALL expose `poetry run benchmark sensitivity` to compute
+   compliance rates under alternative statutory ratio assumptions.
+3. THE System SHALL expose `poetry run benchmark company <firm_id>` for
+   per-firm audit output with full component breakdown.

--- a/specs/company-categorization/requirements.md
+++ b/specs/company-categorization/requirements.md
@@ -1,8 +1,25 @@
-# Requirements Document
+# Company Categorization — Requirements
 
-## Introduction
+> **Status:** 77% complete.
+> Anchors inventory question **B1** in [docs/research-questions.md](../../docs/research-questions.md).
 
-This feature implements a classification system to categorize SBIR companies as Product, Service, or Mixed firms based on their complete federal contract portfolio from USAspending. The system identifies SBIR award recipients, retrieves their full contract history from USAspending, and classifies their business orientation based on contract characteristics. The classification uses a minimal set of data fields (PSC, Contract Type, Pricing, Award Description, SBIR Phase) and applies rule-based logic at both the award level and company level to determine business orientation with confidence scoring.
+**Research question anchor:** B1 — product / service / mixed-mode firm classification
+**Answers for:** SBIR program managers, policy analysts (§638(qq)(3) compliance review)
+**Complexity tier:** Descriptive (Tier 1)
+
+---
+
+## Done when
+
+> An analyst can state: "Of the N SBIR companies in the pipeline, X% are product-leaning,
+> Y% service-leaning, Z% mixed, with high-confidence classifications covering NN% of
+> award dollars. Product-leaning firms show a [higher / lower] Phase II→III transition
+> rate relative to service-leaning firms."
+>
+> The output must be queryable by CET area, agency, and confidence tier so that
+> orientation can be used as a covariate in transition and benchmark analyses.
+
+---
 
 ## Glossary
 
@@ -20,11 +37,17 @@ This feature implements a classification system to categorize SBIR companies as 
 - **Confidence Level**: Classification reliability based on number of awards (Low: <2, Medium: 2-5, High: >5)
 - **PSC Family**: The first character or digit grouping of a PSC code
 
+---
+
 ## Requirements
 
 ### Requirement 1
 
-**User Story:** As a data analyst, I want to retrieve the complete federal contract portfolio for each SBIR company from USAspending, so that I can classify their business orientation based on their full revenue profile rather than just SBIR awards.
+**User Story:** As an SBIR program manager evaluating firm commercialization history,
+I want to retrieve the complete federal contract portfolio for each SBIR company from
+USAspending, so that classification reflects the firm's full federal revenue profile —
+not just SBIR awards — and can support §638(qq)(3) benchmark evaluation and
+transition-effectiveness comparisons.
 
 #### Acceptance Criteria
 
@@ -36,7 +59,10 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 2
 
-**User Story:** As a data analyst, I want to classify individual federal contracts as Product, Service, or R&D based on minimal data fields, so that I can understand the nature of each contract.
+**User Story:** As a pipeline engineer building award-level classification logic, I want
+to classify individual federal contracts as Product, Service, or R&D from PSC and
+contract-type fields alone, so that company-level orientation rests on a consistent,
+auditable per-award classification that does not require manual review.
 
 #### Acceptance Criteria
 
@@ -48,7 +74,10 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 3
 
-**User Story:** As a data analyst, I want to apply description-based inference to award classification, so that I can improve classification accuracy when explicit indicators suggest product orientation.
+**User Story:** As a pipeline engineer improving classification signal coverage, I want
+to apply description-based keyword inference when PSC signals are ambiguous, so that
+prototype, hardware, and device awards are correctly labeled rather than defaulting to
+service classification.
 
 #### Acceptance Criteria
 
@@ -60,7 +89,10 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 4
 
-**User Story:** As a data analyst, I want to adjust award classification for SBIR-specific characteristics, so that I can account for the research-oriented nature of SBIR Phase I and Phase II awards.
+**User Story:** As a pipeline engineer preserving the integrity of SBIR-phase signals,
+I want to override award classification for Phase I and II awards, so that early-stage
+R&D contracts do not inflate a firm's product count and misrepresent its commercial
+orientation.
 
 #### Acceptance Criteria
 
@@ -72,7 +104,10 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 5
 
-**User Story:** As a data analyst, I want to aggregate award classifications at the company level, so that I can determine each company's overall business orientation.
+**User Story:** As an SBIR program manager comparing firm orientations across the
+portfolio, I want award classifications rolled up to a company-level product / service /
+mixed label, so that I can correlate orientation with transition rates and exit outcomes
+and identify whether product-leaning firms systematically outperform service-leaning ones.
 
 #### Acceptance Criteria
 
@@ -84,7 +119,9 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 6
 
-**User Story:** As a data analyst, I want to assign confidence levels to company classifications, so that I can assess the reliability of each classification based on portfolio size.
+**User Story:** As a policy analyst preparing a briefing, I want confidence levels
+assigned to company classifications, so that thin-portfolio results are clearly marked
+and not cited alongside high-confidence findings in published reports.
 
 #### Acceptance Criteria
 
@@ -96,7 +133,9 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 7
 
-**User Story:** As a data analyst, I want to apply override rules for edge cases, so that I can prevent misclassification of companies with unusual portfolio characteristics.
+**User Story:** As a pipeline engineer preventing misclassification of edge-case firms,
+I want override rules for highly diversified portfolios, so that firms spanning many PSC
+families are not misleadingly labeled by a narrow-category majority.
 
 #### Acceptance Criteria
 
@@ -108,7 +147,9 @@ This feature implements a classification system to categorize SBIR companies as 
 
 ### Requirement 8
 
-**User Story:** As a data analyst, I want to generate classification output with complete metadata, so that I can audit and validate the classification results.
+**User Story:** As a pipeline engineer maintaining classification transparency, I want
+full metadata emitted with each company classification, so that any result can be traced
+back to its source awards, PSC families, and override reasons for audit or validation.
 
 #### Acceptance Criteria
 

--- a/specs/cross-agency-taxonomy/design.md
+++ b/specs/cross-agency-taxonomy/design.md
@@ -1,0 +1,78 @@
+# Cross-Agency Technology Taxonomy — Design
+
+## Architecture
+
+The analytical tools are already built. The design work is limited to wiring them
+into a Dagster pipeline and defining the output schema that downstream assets consume.
+
+```
+packages/sbir-analytics/sbir_analytics/tools/mission_a/
+  ├── compute_portfolio_metrics.py   HHI per CET area, company count, geo concentration
+  ├── cluster_topics.py              semantic clustering of award topics
+  ├── detect_gaps.py                 whitespace detection vs. CET spine
+  └── extract_topics.py             topic extraction from award text
+
+packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py
+  └── classifies awards → (cet_area, confidence)
+```
+
+### Data Flow
+
+```
+SBIR.gov corpus (full, all 11 agencies)
+    ↓
+CET classifier (sbir-ml)
+    ↓  award_id → cet_area, confidence  [Parquet artifact]
+    ↓
+AgencyTaxonomyAnalyzer
+  ├── per-agency CET share table  (award count + dollar weight)
+  ├── cross-agency Jaccard overlap matrix
+  ├── HHI per CET area  (from compute_portfolio_metrics.py)
+  ├── gap/whitespace detection  (from detect_gaps.py)
+  └── fiscal-year trend table  (agency × cet_area × year)
+    ↓
+ReportBuilder
+    ↓
+reports/cross-agency-taxonomy/
+  ├── taxonomy_YYYYMMDD.md          human-readable summary
+  ├── taxonomy_YYYYMMDD.json        full structured output
+  ├── classification.parquet        award-level CET assignments
+  ├── overlap_matrix.json           pairwise Jaccard scores
+  ├── concentration.json            per-CET-area HHI
+  └── trends.json                   agency × cet_area × year shares
+```
+
+### Dagster Asset Structure
+
+Three asset nodes, each independently materializable:
+
+1. **`cet_classification_corpus`** — runs the CET classifier over the full corpus;
+   outputs `classification.parquet`. Downstream of the weekly SBIR corpus refresh asset.
+   Triggers only when new awards are present (checked via award count comparison).
+
+2. **`cross_agency_taxonomy_metrics`** — runs AgencyTaxonomyAnalyzer over the
+   classification Parquet; outputs the overlap matrix, concentration JSON, and trends
+   table. Downstream of `cet_classification_corpus`.
+
+3. **`cross_agency_taxonomy_report`** — runs ReportBuilder; outputs the dated markdown
+   and JSON report. Downstream of `cross_agency_taxonomy_metrics`. This is the terminal
+   asset the reporting dashboard or weekly email would consume.
+
+### CET Taxonomy Version Pinning
+
+The canonical taxonomy is `config/cet/taxonomy.yaml` (21 areas, `NSTC-2025Q1`).
+The classification Parquet artifact SHALL carry a `taxonomy_version` metadata field.
+When the taxonomy YAML changes, existing Parquet artifacts are stale and must be
+re-materialized. The Dagster asset should check for taxonomy-version mismatch on
+each run and force re-classification if a mismatch is detected.
+
+### Note on the Two Divergent CET Code Taxonomies
+
+Two code-level taxonomies are not yet reconciled to the canonical 21-area spine
+(documented in `docs/research-questions.md` Maintenance section):
+- 10-area set in transition-system code (`docs/transition/cet-integration.md`)
+- 19-area set in `sbir_etl/utils/reporting/analyzers/cet_analyzer.py`
+
+This spec uses only the canonical 21-area classifier. Do not use `cet_analyzer.py`
+as the classification source. Reconciling the divergent taxonomies is a separate
+scope item with test/precision-benchmark risk.

--- a/specs/cross-agency-taxonomy/requirements.md
+++ b/specs/cross-agency-taxonomy/requirements.md
@@ -1,31 +1,141 @@
 # Cross-Agency Technology Taxonomy — Requirements
 
-> **Status:** Partially implemented as of June 2026 — `packages/sbir-analytics/sbir_analytics/tools/mission_a/` already covers portfolio metrics (`compute_portfolio_metrics.py`: HHI per CET area, cross-agency company count, geographic concentration), semantic clustering (`cluster_topics.py`), gap detection (`detect_gaps.py`), and topic extraction (`extract_topics.py`). What's still missing is the dedicated end-to-end Dagster pipeline / reporting asset that this spec covers — wiring the tools into a scheduled cross-agency view per inventory questions **C1a–c** in [docs/research-questions.md](../../docs/research-questions.md). The CET classifier (C1d) is also already implemented at `packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`.
+> **Status:** Partially implemented as of June 2026 — analytical tools in
+> `packages/sbir-analytics/sbir_analytics/tools/mission_a/` already compute HHI per CET
+> area, cross-agency company count, geographic concentration, semantic clustering, gap
+> detection, and topic extraction. The CET classifier is live at
+> `packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`. What remains is a Dagster
+> pipeline / reporting asset wiring these tools into a scheduled, cross-agency view.
+> Anchors inventory questions **C1a–c** in [docs/research-questions.md](../../docs/research-questions.md).
 
-Research Plan Milestone: **M3 — Cross-Agency Technology Taxonomy**
+**Research question anchor:** C1 — federal SBIR portfolio composition across all 11 agencies (descriptive tier)
+**Answers for:** SBIR program managers, OSTP analysts, agency R&D directors
+**Complexity tier:** Descriptive (Tier 1) → Relational (Tier 2) for overlap and trend
+
+---
+
+## Done when
+
+> An analyst can open a single report and state:
+> "Across all 11 SBIR agencies, [CET area X] is the most-funded technology area
+> ($Y in SBIR awards, N% of total). Agencies A and B both fund [CET area Z] — with
+> [X%] portfolio overlap. No agency funds [CET area W] above the noise threshold,
+> a potential coverage gap. DoD's technology mix has shifted from [area P] toward
+> [area Q] over the last five fiscal years."
+>
+> The report must be producible by re-running a Dagster asset, not by manually
+> assembling tool outputs.
+
+---
 
 ## Background
 
-No unified view exists of what the federal SBIR portfolio is buying across all 11 agencies.
-NASEM studies are siloed by committee mandate. This spec deploys the CET classifier
-across the full SBIR.gov corpus to produce that cross-agency view.
+No unified view exists of what the 11-agency federal SBIR portfolio funds technologically.
+NASEM reviews are siloed by agency and committee mandate — there is no cross-agency
+synthesis. The CET classifier and portfolio-metrics tools exist and already run in
+isolation; this spec wires them into a single scheduled pipeline that applies the
+CET spine consistently across all agencies and produces a cross-agency view that no
+NASEM report provides.
+
+---
 
 ## Requirements
 
-1. **SHALL** classify all SBIR.gov awards using the CET technology taxonomy
-2. **SHALL** produce agency-level technology allocation breakdowns (% of awards per CET area per agency)
-3. **SHALL** identify cross-agency overlap (same technology areas funded by multiple agencies)
-4. **SHALL** identify concentration risk (technology areas dominated by a single agency)
-5. **SHOULD** produce a single visualization showing SBIR technology allocation across all 11 agencies
-6. **SHOULD** support temporal analysis (how technology mix shifts over time per agency)
+### Requirement 1 — Full-corpus CET classification
 
-## Gate Condition
+**User story:** As an SBIR program manager briefing an interagency audience, I want
+all SBIR awards classified against the canonical 21-area CET taxonomy in a single
+pass, so that every agency's portfolio is described in a common vocabulary and
+cross-agency comparisons rest on consistent labels rather than agency-specific framing.
 
-A single visualization showing SBIR technology allocation across all 11 agencies.
+#### Acceptance Criteria
+
+1. WHEN running the classification pipeline, THE System SHALL apply the CET classifier
+   (`packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`) to the full SBIR.gov
+   corpus, producing a per-award `cet_area` assignment and a calibrated confidence
+   score.
+2. WHEN storing classification results, THE System SHALL write a Parquet artifact
+   with columns `award_id`, `agency`, `cet_area`, and `confidence` so that downstream
+   analysis can filter by confidence threshold without re-running the classifier.
+3. WHEN the classified corpus is materialized, THE System SHALL emit coverage metrics:
+   % of awards classified at confidence ≥ 0.5, multi-label distribution, and
+   unclassified count by agency.
+4. WHEN the CET taxonomy changes (i.e., `config/cet/taxonomy.yaml` is updated from
+   the canonical 21-area spine), THE System SHALL re-classify the full corpus and
+   flag the taxonomy version in the artifact metadata.
+
+---
+
+### Requirement 2 — Cross-agency overlap and concentration
+
+**User story:** As an OSTP analyst identifying coordination opportunities and
+concentration risk across the federal SBIR portfolio, I want a cross-agency
+technology-overlap matrix and an HHI-based concentration measure per CET area, so
+that I can flag areas funded redundantly by multiple agencies and areas dominated
+by a single-agency funder.
+
+#### Acceptance Criteria
+
+1. WHEN computing cross-agency overlap, THE System SHALL produce a pairwise
+   Jaccard similarity matrix over each agency pair's CET-area portfolios (by award
+   dollar share per CET area).
+2. WHEN computing concentration per CET area, THE System SHALL use the existing
+   `compute_portfolio_metrics.py` HHI computation, with HHI > 6000 flagged as
+   high-concentration (single-agency dominance).
+3. WHEN identifying coverage gaps, THE System SHALL use `detect_gaps.py` to surface
+   CET areas with total SBIR funding below [configurable threshold] across all
+   agencies, which represent whitespace relative to the CET spine.
+4. WHEN emitting the overlap and concentration results, THE System SHALL include
+   both award-count and award-dollar weighting so that large-dollar concentration
+   is distinguishable from high-volume but low-dollar overlap.
+
+---
+
+### Requirement 3 — Technology-mix trend by agency
+
+**User story:** As an SBIR program manager tracking portfolio shifts, I want each
+agency's CET-area allocation expressed as a time series by fiscal year, so that
+I can detect emerging priorities and fading investment areas before a NASEM review
+cycle surfaces them.
+
+#### Acceptance Criteria
+
+1. WHEN computing technology-mix trends, THE System SHALL compute each agency's
+   CET-area share (% of award dollars) per fiscal year, producing a
+   `(agency, cet_area, fiscal_year, share)` table.
+2. WHEN a CET area's share shifts by more than 10 percentage points within a single
+   agency over a three-year window, THE System SHALL flag it as a significant trend
+   in the report summary.
+3. WHEN an agency has fewer than 20 awards in a given fiscal year, THE System SHALL
+   suppress that year's trend point for that agency to prevent noise from sparse
+   recent vintages.
+
+---
+
+### Requirement 4 — Scheduled Dagster asset
+
+**User story:** As a pipeline engineer maintaining the cross-agency view, I want the
+classification and reporting steps wired into a Dagster asset with a scheduled
+refresh, so that the cross-agency taxonomy report stays current as new SBIR awards
+are ingested without requiring manual re-runs.
+
+#### Acceptance Criteria
+
+1. WHEN the Dagster asset is defined, THE System SHALL declare the full-corpus
+   classification Parquet, the overlap matrix, and the trend table as distinct
+   asset outputs so they can be materialized and inspected independently.
+2. WHEN the SBIR.gov award corpus is refreshed (weekly asset in the existing
+   pipeline), THE System SHALL trigger a downstream re-classification run if the
+   new corpus contains awards not present in the existing classification Parquet.
+3. WHEN the reporting asset runs, THE System SHALL write output to
+   `reports/cross-agency-taxonomy/` as a markdown summary and companion JSON,
+   date-stamped to the corpus snapshot used.
+
+---
 
 ## Dependencies
 
-- CET classifier (`src/transition/features/cet_analyzer.py`) — EXISTS
-- Topic extraction (`src/tools/mission_a/extract_topics.py`) — EXISTS
-- ModernBert embeddings (`specs/modernbert_analysis_layer/`) — 30% complete (enhances but not required)
-- Full SBIR.gov award corpus — needs verification of data freshness
+- CET classifier (`packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`) — EXISTS
+- Portfolio-metrics tools (`packages/sbir-analytics/sbir_analytics/tools/mission_a/`) — EXISTS
+- Full SBIR.gov award corpus — EXISTS (verify freshness before scheduling)
+- ModernBERT embeddings (`specs/modernbert_analysis_layer/`) — enhances clustering but not required

--- a/specs/data-imputation/requirements.md
+++ b/specs/data-imputation/requirements.md
@@ -1,5 +1,25 @@
 # Data Imputation — Requirements
 
+> **Status:** Spec merged via PR #277 — implementation not yet started as of June 2026.
+> Anchors inventory question **E4** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** E4 — missing-field recovery (award_date ~50% absent; UEI/DUNS gaps)
+**Answers for:** pipeline engineers, SBIR program managers (downstream data consumers)
+**Complexity tier:** Descriptive / foundational (Tier 1–2)
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "The effective `award_date` completeness rate rises
+> from ~50% (raw) to ≥90% (effective) after imputation. Every imputed value carries
+> a method name, confidence tier (high / medium / low), and a raw field backup.
+> The phase-transition precision benchmark remains ≥85% when imputed values are
+> included. An SBIR program manager can filter any analysis to raw-only or
+> imputed-OK with a single boolean column per field."
+
+---
+
 ## Introduction
 
 The SBIR.gov bulk download is the canonical source of SBIR/STTR award records for this
@@ -46,8 +66,9 @@ choose whether to include imputed values.
 
 ### Requirement 1 — Non-destructive imputation
 
-**User Story:** As a data consumer, I want imputed values to never overwrite raw source
-data, so that I can always recover the original and audit downstream claims.
+**User Story:** As an SBIR program manager or downstream analyst relying on pipeline
+output, I want imputed values to never overwrite raw source data, so that I can always
+recover the original value and audit any claim that cites an imputed field.
 
 #### Acceptance Criteria
 
@@ -62,8 +83,10 @@ data, so that I can always recover the original and audit downstream claims.
 
 ### Requirement 2 — Provenance and auditability
 
-**User Story:** As an analyst, I want to filter imputed values in or out per-field, so
-that I can run analyses at different confidence levels without re-deriving imputations.
+**User Story:** As an SBIR program manager running portfolio analysis, I want to filter
+imputed values in or out per field, so that I can run the same analysis at different
+confidence levels — raw-only for audits, imputed-included for trend reporting — without
+re-deriving imputations each time.
 
 #### Acceptance Criteria
 

--- a/specs/fiscal-tax-impact-v2.md
+++ b/specs/fiscal-tax-impact-v2.md
@@ -5,6 +5,28 @@
 **Branch:** `research/open-source-tax-impact-modeling`
 **Research:** `docs/research/open-source-tax-impact-modeling.md`
 
+**Research question anchor:** D2 — jurisdiction-separated fiscal tax impact from SBIR spending
+**Answers for:** policy analysts, pipeline engineers
+**Complexity tier:** Descriptive (Tier 1)
+
+---
+
+## Done when
+
+> A policy analyst preparing a Treasury/OMB report can state: "Federal income, payroll, and corporate tax receipts from SBIR spending, plus state and local estimates, are separated by jurisdiction type. Per-dollar SBIR return estimates are within 20% of published IMPLAN benchmarks. Rates are sourced from BEA NIPA tables, not hardcoded."
+
+---
+
+## User Stories
+
+**As a policy analyst preparing a fiscal impact report for Treasury or OMB,**
+I want SBIR spending translated into jurisdiction-separated tax receipt estimates (federal income, payroll, corporate; state; local) using BEA NIPA-derived rates, so that I can cite defensible, data-grounded numbers rather than a hardcoded flat rate when estimating the public-finance return on SBIR investment.
+
+**As a pipeline engineer maintaining the BEA NIPA rate logic,**
+I want state-level and national tax rates refreshed from published BEA and Tax Foundation data rather than hardcoded constants, so that the pipeline remains accurate as rates change without requiring a code change per tax year.
+
+---
+
 ## Goal
 
 Replace the current hardcoded effective tax rates in `FiscalTaxEstimator` with

--- a/specs/form-d-pipeline/requirements.md
+++ b/specs/form-d-pipeline/requirements.md
@@ -1,0 +1,116 @@
+# Requirements — Form D Private Capital Pipeline
+
+> **Status:** Implemented on `main`. PR #286 merged. Methodology commit `f65abb89`.
+> Canonical analysis: [`docs/research/sbir-form-d-fundraising-analysis.md`](../../docs/research/sbir-form-d-fundraising-analysis.md).
+> Supports inventory questions **F1** and **F3** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** F1 (Form D fundraising profile of SBIR awardees), F3 (private-to-SBIR leverage ratio)
+**Answers for:** entrepreneurial finance researchers, defense industrial base analysts
+**Complexity tier:** Descriptive (Tier 1) / Inferential (Tier 3)
+
+---
+
+## Done when
+
+> An entrepreneurial finance researcher can state: "3,640 high-confidence SBIR-firm
+> Form D matches (PI name score ≥ 0.7 OR ZIP match). Private-to-SBIR leverage ratio:
+> $1.82x (95% bootstrap CI [1.65, 2.02]) using total SBIR program spending as the
+> denominator; $9.48x [8.26, 10.85] per matched firm. Two-signal tiering documented
+> in `docs/research/sbir-form-d-fundraising-analysis.md`."
+
+---
+
+## Introduction
+
+This pipeline matches SBIR awardees to their SEC Form D (Regulation D) private-placement
+filings and computes the private-to-SBIR leverage ratio — the private capital raised per
+dollar of SBIR funding received. It is the private-capital mirror to NASEM's 4:1
+DoD-contract leverage ratio.
+
+**Matching methodology:** Company name fuzzy matching with two independent confirmation
+signals — PI-to-Form-D-executive name score (≥ 0.7 = high) and ZIP code overlap. Either
+signal alone qualifies a match as high-confidence. State overlap only = medium confidence.
+Pooled Investment Fund vehicles and other structurally incompatible industry groups are
+excluded.
+
+**Key findings (methodology commit `f65abb89`):**
+- 3,640 high-confidence matches across 219K SBIR awards
+- High-tier leverage: $1.82x [1.65, 2.02] (total-program denominator)
+- Per-firm leverage: $9.48x [8.26, 10.85] (matched-firm denominator)
+- HHS/NIH companies use ZIP matching as the primary confirmation signal (PI often
+  doesn't appear as a Form D officer)
+
+---
+
+## User Stories
+
+**As an entrepreneurial finance researcher,** I want SBIR awardees matched to their
+SEC Form D private-placement filings, so that I can compute private-to-SBIR leverage
+ratios by agency, vintage, and firm size and benchmark them against the NVCA Yearbook
+cohort.
+
+**As a defense industrial base analyst,** I want Form D matches broken out by awarding
+agency and CET area, so that I can identify which technology domains attract the highest
+private co-investment alongside federal SBIR funding and flag areas where private capital
+is absent.
+
+---
+
+## Requirements
+
+### Requirement 1 — SBIR-to-Form-D matching
+
+**User Story:** As an entrepreneurial finance researcher, I want SBIR awardee records
+matched to Form D filings using a two-signal confidence model, so that matches are
+high-precision without unnecessarily excluding companies where PI names don't appear
+on SEC filings (e.g., HHS/NIH academic PIs).
+
+#### Acceptance Criteria
+
+1. THE System SHALL match SBIR companies to Form D filings using company name fuzzy
+   matching as the primary filter.
+2. THE System SHALL assign confidence tier `HIGH` when person_score ≥ 0.7 OR the
+   SBIR ZIP code matches the Form D issuer ZIP code.
+3. THE System SHALL assign confidence tier `MEDIUM` when neither person nor address
+   matches but the SBIR state matches the Form D state.
+4. THE System SHALL assign confidence tier `LOW` for all remaining name matches and
+   exclude the LOW tier from leverage ratio computation.
+5. THE System SHALL exclude Form D filings in structurally incompatible industry groups
+   (Pooled Investment Fund, Insurance, Restaurants, Retailing, and related categories)
+   before computing leverage ratios.
+
+### Requirement 2 — Leverage ratio computation
+
+**User Story:** As an entrepreneurial finance researcher, I want private-to-SBIR
+leverage ratios computed at both the program level and the per-matched-firm level,
+so that both interpretations (program-wide ROI framing and per-firm leverage framing)
+are available for citation.
+
+#### Acceptance Criteria
+
+1. THE System SHALL compute the program-level leverage ratio as:
+   sum(Form D `totalAmountSold` for HIGH-tier matches) ÷ sum(SBIR `Award Amount`)
+   across the full SBIR award universe.
+2. THE System SHALL compute the per-firm leverage ratio as:
+   sum(Form D `totalAmountSold` for HIGH-tier matches) ÷ sum(SBIR `Award Amount`
+   for firms with at least one HIGH-tier Form D match).
+3. THE System SHALL compute bootstrap confidence intervals (≥ 1,000 iterations,
+   firm-level percentile bootstrap) for both ratio variants.
+4. THE System SHALL stratify leverage ratios by awarding agency, first-award fiscal
+   year, and CET area when sample sizes permit (minimum cell size 10 firms).
+
+### Requirement 3 — Capital-event timeline integration
+
+**User Story:** As a defense industrial base analyst, I want Form D events on the
+unified capital-event timeline alongside federal awards, M&A events, and patent grants,
+so that I can read a firm's full capital history in one query.
+
+#### Acceptance Criteria
+
+1. THE System SHALL load each HIGH-tier Form D match as a `RAISED` or
+   `PRIVATE_PLACEMENT` event node in the Neo4j graph, linked to the matched
+   `Organization` node.
+2. THE System SHALL include `offering_date`, `total_amount_sold`, `security_type`,
+   `confidence_tier`, and `cik` on each event node.
+3. THE System SHALL support incremental updates: re-running the pipeline SHALL add
+   new Form D filings without duplicating existing events.

--- a/specs/iterative_api_enrichment/requirements.md
+++ b/specs/iterative_api_enrichment/requirements.md
@@ -1,6 +1,6 @@
 # Requirements — Iterative API Enrichment Refresh
 
-> **Status:** Not yet started.
+> **Status:** Partially implemented — USAspending iterative enrichment is live (`packages/sbir-analytics/sbir_analytics/assets/usaspending_iterative_enrichment.py`); other sources (SAM.gov, NIH RePORTER, PatentsView) pending.
 > Supports inventory question **E3** (enrichment freshness infrastructure) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** E3 — incremental enrichment refresh to keep company, award, and patent metadata current
@@ -11,7 +11,7 @@
 
 ## Done when
 
-> A pipeline engineer can state: "The `iterative_enrichment_refresh_job` Dagster job runs nightly after bulk enrichment succeeds, processing only stale or failed records by source. Per-source freshness metrics are visible in `enrichment_events`. A targeted refresh can be triggered via `poetry run refresh_enrichment --source <name> --window <start>:<end>`."
+> A pipeline engineer can state: "The `iterative_enrichment_refresh_job` Dagster job runs nightly after bulk enrichment succeeds, processing only stale or failed records by source. Per-source freshness state is tracked in `data/derived/enrichment_freshness.parquet` and `data/state/enrichment_refresh_state.json`. A targeted refresh can be triggered via `poetry run refresh_enrichment --source <name> --window <start>:<end>`."
 
 ---
 
@@ -58,7 +58,7 @@ This specification implements an iterative API enrichment refresh loop to keep c
 
 1. THE System SHALL implement a Dagster job and sensor that activates after bulk enrichment asset materialization succeeds and runs on a configurable schedule (default: nightly).
 2. THE System SHALL track per-record enrichment state via `last_attempt_at` and `last_success_at` timestamps so that only stale or failed records are queued for refresh.
-3. THE System SHALL be configurable via `config.enrichment.*` per-source toggles and schedule parameters without code changes.
+3. THE System SHALL be configurable via `PipelineConfig.enrichment_refresh` (e.g., `config.enrichment_refresh.usaspending.*`) per-source toggles and schedule parameters without code changes.
 
 ### Requirement 2 — Per-source partitioned processing
 
@@ -76,6 +76,6 @@ This specification implements an iterative API enrichment refresh loop to keep c
 
 #### Acceptance Criteria
 
-1. THE System SHALL emit per-source enrichment events to `enrichment_events` recording attempt count, last success timestamp, and staleness window.
+1. THE System SHALL persist per-source enrichment state to `data/derived/enrichment_freshness.parquet` and `data/state/enrichment_refresh_state.json`, recording attempt count, last success timestamp, and staleness window per source.
 2. THE System SHALL alert (via Dagster asset check or log warning) when any source's last successful enrichment exceeds its configured SLA window.
 3. THE System SHALL support a `--window` CLI flag (`poetry run refresh_enrichment --source <name> --window <start>:<end>`) for manual targeted refreshes of specific date ranges.

--- a/specs/iterative_api_enrichment/requirements.md
+++ b/specs/iterative_api_enrichment/requirements.md
@@ -38,8 +38,9 @@ This specification implements an iterative API enrichment refresh loop to keep c
 - **iterative_enrichment_refresh_job**: Code component or file: iterative_enrichment_refresh_job
 - **last_attempt_at**: Code component or file: last_attempt_at
 - **last_success_at**: Code component or file: last_success_at
-- **config.enrichment.***: Code component or file: config.enrichment.*
-- **enrichment_events**: Code component or file: enrichment_events
+- **PipelineConfig.enrichment_refresh**: Code component or file: sbir_etl/config/schemas/pipeline.py — the actual config namespace for iterative-refresh settings (e.g., `config.enrichment_refresh.usaspending.*`).
+- **data/derived/enrichment_freshness.parquet**: Code component or file: the Parquet ledger where per-source freshness metrics are persisted.
+- **data/state/enrichment_refresh_state.json**: Code component or file: the JSON state file tracking per-source last-attempt / last-success timestamps.
 - **poetry run refresh_enrichment --source sam_gov --window 2023-10-01:2023-10-07**: Code component or file: poetry run refresh_enrichment --source sam_gov --window 2023-10-01:2023-10-07
 - **docs/enrichment/iterative-refresh.md**: Code component or file: docs/enrichment/iterative-refresh.md
 - **Iterative enrichment scheduler**: Key concept: Iterative enrichment scheduler
@@ -72,7 +73,7 @@ This specification implements an iterative API enrichment refresh loop to keep c
 
 ### Requirement 3 — Freshness telemetry and SLA monitoring
 
-**User Story:** As a pipeline engineer responsible for data quality SLAs, I want per-source freshness metrics logged to `enrichment_events` and surfaced as staleness alerts, so that I can identify which enrichment sources have drifted beyond acceptable windows and trigger targeted remediation without a full re-enrichment run.
+**User Story:** As a pipeline engineer responsible for data quality SLAs, I want per-source freshness metrics persisted to `data/derived/enrichment_freshness.parquet` (with state in `data/state/enrichment_refresh_state.json`) and surfaced as staleness alerts, so that I can identify which enrichment sources have drifted beyond acceptable windows and trigger targeted remediation without a full re-enrichment run.
 
 #### Acceptance Criteria
 

--- a/specs/iterative_api_enrichment/requirements.md
+++ b/specs/iterative_api_enrichment/requirements.md
@@ -1,8 +1,23 @@
-# Requirements Document
+# Requirements — Iterative API Enrichment Refresh
+
+> **Status:** Not yet started.
+> Supports inventory question **E3** (enrichment freshness infrastructure) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** E3 — incremental enrichment refresh to keep company, award, and patent metadata current
+**Answers for:** pipeline engineers
+**Complexity tier:** Foundational infrastructure
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "The `iterative_enrichment_refresh_job` Dagster job runs nightly after bulk enrichment succeeds, processing only stale or failed records by source. Per-source freshness metrics are visible in `enrichment_events`. A targeted refresh can be triggered via `poetry run refresh_enrichment --source <name> --window <start>:<end>`."
+
+---
 
 ## Introduction
 
-This specification implements Add Iterative API Enrichment Refresh Loop.
+This specification implements an iterative API enrichment refresh loop to keep company, award, and patent metadata current.
 
 - The current enrichment stage performs a heavy, mostly one-off merge after SBIR bulk ingestion, so company, award, and patent metadata start to drift as soon as external systems publish corrections or new records.
 - The external sources we already rely on (SBIR.gov awards API, USAspending v2, SAM.gov entity data, NIH RePORTER, PatentsView, plus the other APIs called out across docs/config) publish updated snapshots daily to monthly; without an iterative refresh we miss compliance actions, debarments, UEI/DUNS changes, new transitions, and patent grants that happen after the initial load.
@@ -35,38 +50,32 @@ This specification implements Add Iterative API Enrichment Refresh Loop.
 
 ## Requirements
 
-### Requirement 1
+### Requirement 1 — Scheduled incremental refresh loop
 
-**User Story:** As a developer, I want add iterative api enrichment refresh loop, so that - the current enrichment stage performs a heavy, mostly one-off merge after sbir bulk ingestion, so company, award, and patent metadata start to drift as soon as external systems publish corrections or new records.
-
-#### Acceptance Criteria
-
-1. THE System SHALL implement iterative api enrichment refresh loop
-2. THE System SHALL validate the implementation of iterative api enrichment refresh loop
-
-### Requirement 2
-
-**User Story:** As a developer, I want **Iterative enrichment scheduler**, so that support the enhanced functionality described in the proposal.
+**User Story:** As a pipeline engineer maintaining data freshness, I want a Dagster job (`iterative_enrichment_refresh_job`) and sensor that activates once bulk enrichment assets have succeeded and runs on a nightly rolling schedule, so that the pipeline incrementally refreshes only records changed since the last run rather than re-running a full enrichment against all awards.
 
 #### Acceptance Criteria
 
-1. THE System SHALL support **iterative enrichment scheduler**
-2. THE System SHALL ensure proper operation of **iterative enrichment scheduler**
+1. THE System SHALL implement a Dagster job and sensor that activates after bulk enrichment asset materialization succeeds and runs on a configurable schedule (default: nightly).
+2. THE System SHALL track per-record enrichment state via `last_attempt_at` and `last_success_at` timestamps so that only stale or failed records are queued for refresh.
+3. THE System SHALL be configurable via `config.enrichment.*` per-source toggles and schedule parameters without code changes.
 
-### Requirement 3
+### Requirement 2 — Per-source partitioned processing
 
-**User Story:** As a developer, I want Add a Dagster job (`iterative_enrichment_refresh_job`) plus sensor that activates once bulk enrichment assets have succeeded and then runs on a rolling schedule (nightly by default), so that support the enhanced functionality described in the proposal.
-
-#### Acceptance Criteria
-
-1. THE System SHALL implement a dagster job (`iterative_enrichment_refresh_job`) plus sensor that activates once bulk enrichment assets have succeeded and then runs on a rolling schedule (nightly by default)
-2. THE System SHALL validate the implementation of a dagster job (`iterative_enrichment_refresh_job`) plus sensor that activates once bulk enrichment assets have succeeded and then runs on a rolling schedule (nightly by default)
-
-### Requirement 4
-
-**User Story:** As a developer, I want Partition work by API/source and record cohort (e.g., UEI batches for SAM.gov, award years for USAspending) so each run respects rate limits and can be retried independently, so that support the enhanced functionality described in the proposal.
+**User Story:** As a pipeline engineer managing external API quotas, I want enrichment work partitioned by source and record cohort (e.g., UEI batches for SAM.gov, award-year slices for USAspending), so that each refresh run respects per-source rate limits and individual partition failures can be retried independently without re-processing the full corpus.
 
 #### Acceptance Criteria
 
-1. THE System SHALL support partition work by api/source and record cohort (e.g., uei batches for sam.gov, award years for usaspending) so each run respects rate limits and can be retried independently
-2. THE System SHALL ensure proper operation of partition work by api/source and record cohort (e.g., uei batches for sam.gov, award years for usaspending) so each run respects rate limits and can be retried independently
+1. THE System SHALL partition each refresh run by source (SAM.gov, USAspending, NIH RePORTER, PatentsView) and record cohort (e.g., UEI batches, award-year windows).
+2. THE System SHALL respect per-source rate limits using the same retry and back-off semantics as the existing `SAMGovAPIClient`.
+3. THE System SHALL make each partition independently retryable; a single-partition failure SHALL NOT abort the remaining partitions.
+
+### Requirement 3 — Freshness telemetry and SLA monitoring
+
+**User Story:** As a pipeline engineer responsible for data quality SLAs, I want per-source freshness metrics logged to `enrichment_events` and surfaced as staleness alerts, so that I can identify which enrichment sources have drifted beyond acceptable windows and trigger targeted remediation without a full re-enrichment run.
+
+#### Acceptance Criteria
+
+1. THE System SHALL emit per-source enrichment events to `enrichment_events` recording attempt count, last success timestamp, and staleness window.
+2. THE System SHALL alert (via Dagster asset check or log warning) when any source's last successful enrichment exceeds its configured SLA window.
+3. THE System SHALL support a `--window` CLI flag (`poetry run refresh_enrichment --source <name> --window <start>:<end>`) for manual targeted refreshes of specific date ranges.

--- a/specs/leverage-ratio-analysis/requirements.md
+++ b/specs/leverage-ratio-analysis/requirements.md
@@ -1,10 +1,14 @@
-# Leverage Ratio Analysis — Requirements
+# Follow-on Funding Multiplier Analysis — Requirements
 
 > **Status:** Not yet started — zero implementation code as of June 2026.
 > Anchors inventory question **A3** in [docs/research-questions.md](../../docs/research-questions.md).
 > Prerequisites (entity resolution, SBIR identification, USAspending enrichment) are all live on `main`.
+>
+> NASEM's reviews of DoD SBIR call this quantity the *leverage ratio*. This codebase
+> uses *follow-on funding multiplier* for the same calculation to avoid the debt
+> connotation that "leverage" carries in finance.
 
-**Research question anchor:** A3 — DoD leverage ratio (inferential tier)
+**Research question anchor:** A3 — DoD follow-on funding multiplier (inferential tier)
 **Answers for:** policy analysts (congressional briefings, OMB), SBIR program managers
 **Complexity tier:** Inferential (Tier 3)
 
@@ -27,16 +31,17 @@ NASEM reports a ~4:1 ratio of non-SBIR DoD obligations to SBIR/STTR obligations 
 DoD SBIR firms (2012–2020) [L1][L2], computed manually on a quadrennial review cycle.
 USAspending shows that a firm received a SBIR Phase II award and later won a non-SBIR
 DoD contract — but it does not flag the relationship. Our entity resolution + FPDS
-pipeline automates this linkage at scale, enabling a continuously-updateable leverage
-computation and stratifications NASEM does not publish (by CET area, firm experience,
-and time trend).
+pipeline automates this linkage at scale, enabling a continuously-updateable follow-on
+funding multiplier computation and stratifications NASEM does not publish (by CET
+area, firm experience, and time trend).
 
 ---
 
 ## Glossary
 
-- **Leverage ratio** — Non-SBIR DoD obligations ÷ SBIR/STTR obligations for the set of
-  firms that received at least one SBIR/STTR award in the measurement window.
+- **Follow-on funding multiplier** (a.k.a. NASEM's *leverage ratio*) — Non-SBIR DoD
+  obligations ÷ SBIR/STTR obligations for the set of firms that received at least one
+  SBIR/STTR award in the measurement window.
 - **Cohort** — The set of SBIR/STTR awardees grouped by their first-award fiscal year.
 - **Experienced firm** — A firm with more than one prior SBIR award at the time of the
   award being measured.
@@ -47,18 +52,18 @@ and time trend).
 
 ## Requirements
 
-### Requirement 1 — Aggregate ratio computation
+### Requirement 1 — Aggregate multiplier computation
 
 **User story:** As a policy analyst preparing a congressional briefing, I want an
-aggregate DoD leverage ratio computed from our pipeline, so that I can benchmark it
-against NASEM's 4:1 figure and state either a confirmation or a characterized
-divergence before an HASC or SASC audience.
+aggregate DoD follow-on funding multiplier computed from our pipeline, so that I can
+benchmark it against NASEM's 4:1 figure and state either a confirmation or a
+characterized divergence before an HASC or SASC audience.
 
 #### Acceptance Criteria
 
 1. WHEN the pipeline runs over the SBIR firm universe, THE System SHALL compute the
-   aggregate leverage ratio as: sum(non-SBIR DoD obligations) / sum(SBIR/STTR
-   obligations) across all resolved firms.
+   aggregate follow-on funding multiplier as: sum(non-SBIR DoD obligations) /
+   sum(SBIR/STTR obligations) across all resolved firms.
 2. WHEN separating SBIR from non-SBIR obligations, THE System SHALL use FPDS
    product-or-service codes and contract-type flags (not just the SBIR.gov award list)
    to classify each obligation.
@@ -73,10 +78,10 @@ divergence before an HASC or SASC audience.
 
 ### Requirement 2 — Cohort stratification
 
-**User story:** As an SBIR program manager, I want the leverage ratio broken out by
-award vintage, firm size, technology area, and firm experience, so that I can identify
-which cohorts and technology clusters generate the highest follow-on DoD investment and
-target program support accordingly.
+**User story:** As an SBIR program manager, I want the follow-on funding multiplier
+broken out by award vintage, firm size, technology area, and firm experience, so that
+I can identify which cohorts and technology clusters generate the highest follow-on
+DoD investment and target program support accordingly.
 
 #### Acceptance Criteria
 
@@ -112,15 +117,16 @@ data-source differences rather than leaving it unexplained.
    window, FPDS Phase III undercount, ER coverage) account for the gap.
 3. WHEN producing the reconciliation report, THE System SHALL emit both a JSON artifact
    (for programmatic consumption) and a markdown summary (for human review), to the
-   `reports/leverage-ratio/` directory.
+   `reports/follow-on-multiplier/` directory.
 
 ---
 
 ### Requirement 4 — Civilian-agency extension
 
 **User story:** As an SBIR program manager at a civilian agency, I want the same
-leverage ratio computed for DOE so that my agency can benchmark its follow-on
-investment generation against DoD and against the Myers & Lanahan DOE baseline [L9][L5].
+follow-on funding multiplier computed for DOE so that my agency can benchmark its
+follow-on investment generation against DoD and against the Myers & Lanahan DOE
+baseline [L9][L5].
 
 #### Acceptance Criteria
 
@@ -136,10 +142,10 @@ investment generation against DoD and against the Myers & Lanahan DOE baseline [
 
 ### Requirement 5 — Time-series trend
 
-**User story:** As a policy analyst tracking program-level trends, I want the leverage
-ratio expressed as a time series by fiscal year, so that I can show whether DoD's
-follow-on investment in SBIR firms is growing, shrinking, or stable — a question NASEM's
-quadrennial reviews cannot answer.
+**User story:** As a policy analyst tracking program-level trends, I want the
+follow-on funding multiplier expressed as a time series by fiscal year, so that I can
+show whether DoD's follow-on investment in SBIR firms is growing, shrinking, or
+stable — a question NASEM's quadrennial reviews cannot answer.
 
 #### Acceptance Criteria
 

--- a/specs/leverage-ratio-analysis/requirements.md
+++ b/specs/leverage-ratio-analysis/requirements.md
@@ -1,39 +1,161 @@
 # Leverage Ratio Analysis — Requirements
 
-> **Status:** Not yet started — spec is design-only, zero implementation code as of June 2026. Anchors inventory question **A3** in [docs/research-questions.md](../../docs/research-questions.md). Prerequisites (entity resolution, SBIR identification, USAspending enrichment) are all live on `main`.
+> **Status:** Not yet started — zero implementation code as of June 2026.
+> Anchors inventory question **A3** in [docs/research-questions.md](../../docs/research-questions.md).
+> Prerequisites (entity resolution, SBIR identification, USAspending enrichment) are all live on `main`.
 
-Research Plan Milestone: **M1 — DOD Leverage Ratio Replication**
+**Research question anchor:** A3 — DoD leverage ratio (inferential tier)
+**Answers for:** policy analysts (congressional briefings, OMB), SBIR program managers
+**Complexity tier:** Inferential (Tier 3)
+
+---
+
+## Done when
+
+> An analyst can state: "NASEM reports 4:1. Our pipeline yields [X]:1 using [method].
+> The difference is attributable to [Y]."
+>
+> The reconciliation matters more than matching the number. A well-characterized
+> divergence (different time window, different SBIR-vs-non-SBIR coding, incomplete FPDS
+> Phase III tagging) is a valid and publishable result. An unexplained match is not.
+
+---
 
 ## Background
 
-**Outcomes-layer linkage: Award → Follow-on Contract.**
+NASEM reports a ~4:1 ratio of non-SBIR DoD obligations to SBIR/STTR obligations for
+DoD SBIR firms (2012–2020) [L1][L2], computed manually on a quadrennial review cycle.
+USAspending shows that a firm received a SBIR Phase II award and later won a non-SBIR
+DoD contract — but it does not flag the relationship. Our entity resolution + FPDS
+pipeline automates this linkage at scale, enabling a continuously-updateable leverage
+computation and stratifications NASEM does not publish (by CET area, firm experience,
+and time trend).
 
-USAspending can show that Firm X received SBIR Phase II and later won a non-SBIR
-DOD contract. But it doesn't flag the relationship. Our entity resolution + FPDS
-pipeline automates this linkage at scale, enabling the leverage ratio computation
-that NASEM performs manually on a quadrennial cycle.
+---
 
-NASEM reports a 4:1 non-SBIR-to-SBIR funding ratio for DOD SBIR/STTR firms.
-This spec implements the analytics to reproduce, reconcile, and extend that finding.
+## Glossary
+
+- **Leverage ratio** — Non-SBIR DoD obligations ÷ SBIR/STTR obligations for the set of
+  firms that received at least one SBIR/STTR award in the measurement window.
+- **Cohort** — The set of SBIR/STTR awardees grouped by their first-award fiscal year.
+- **Experienced firm** — A firm with more than one prior SBIR award at the time of the
+  award being measured.
+- **NASEM benchmark** — The 4:1 aggregate ratio reported in [L1] for DoD SBIR firms,
+  2012–2020.
+
+---
 
 ## Requirements
 
-1. **SHALL** compute aggregate leverage ratio (non-SBIR DOD obligations / SBIR/STTR obligations) for DOD SBIR firms
-2. **SHALL** stratify ratios by: award vintage (cohort year), firm size, technology area, experienced vs. new firm
-3. **SHALL** produce a reconciliation narrative comparing pipeline result to NASEM's 4:1 benchmark
-4. **SHALL** compute the same ratio for at least one civilian agency (DOE preferred)
-5. **SHOULD** decompose the ratio as a time series (is it growing or shrinking?)
-6. **SHOULD** compute technology-area breakdown showing which clusters generate highest follow-on leverage
-7. **SHALL** report match rates and entity resolution coverage as sensitivity metadata
+### Requirement 1 — Aggregate ratio computation
 
-## Gate Condition
+**User story:** As a policy analyst preparing a congressional briefing, I want an
+aggregate DoD leverage ratio computed from our pipeline, so that I can benchmark it
+against NASEM's 4:1 figure and state either a confirmation or a characterized
+divergence before an HASC or SASC audience.
 
-Can state: "NASEM reports 4:1. Our pipeline yields [X]:1 using [method]. The difference is attributable to [Y]."
-The reconciliation matters more than the match.
+#### Acceptance Criteria
+
+1. WHEN the pipeline runs over the SBIR firm universe, THE System SHALL compute the
+   aggregate leverage ratio as: sum(non-SBIR DoD obligations) / sum(SBIR/STTR
+   obligations) across all resolved firms.
+2. WHEN separating SBIR from non-SBIR obligations, THE System SHALL use FPDS
+   product-or-service codes and contract-type flags (not just the SBIR.gov award list)
+   to classify each obligation.
+3. WHEN the aggregate ratio is computed, THE System SHALL also compute a firm-level
+   distribution (median, 25th/75th percentile, share of firms with ratio > 1) so that
+   the aggregate is not mistaken for the typical firm experience.
+4. WHEN reporting entity-resolution coverage, THE System SHALL state the share of SBIR
+   award dollars that successfully matched to FPDS vendor records, so that the ratio
+   carries an explicit denominator-coverage qualifier.
+
+---
+
+### Requirement 2 — Cohort stratification
+
+**User story:** As an SBIR program manager, I want the leverage ratio broken out by
+award vintage, firm size, technology area, and firm experience, so that I can identify
+which cohorts and technology clusters generate the highest follow-on DoD investment and
+target program support accordingly.
+
+#### Acceptance Criteria
+
+1. WHEN stratifying by award vintage, THE System SHALL group firms by first-SBIR-award
+   fiscal year and compute the ratio per cohort.
+2. WHEN stratifying by firm size, THE System SHALL use SAM.gov employee or revenue
+   buckets and emit a ratio per bucket.
+3. WHEN stratifying by technology area, THE System SHALL use CET classifier output
+   (`packages/sbir-ml/`) and emit a ratio per CET area.
+4. WHEN stratifying by firm experience, THE System SHALL split firms into
+   first-time awardee vs. repeat awardee (≥2 prior SBIR awards) and compute the ratio
+   for each group.
+5. WHEN any stratification cell contains fewer than 10 firms, THE System SHALL suppress
+   the ratio and note the suppression reason, to prevent unreliable small-cell figures
+   from appearing in published output.
+
+---
+
+### Requirement 3 — NASEM reconciliation
+
+**User story:** As a policy analyst preparing a publishable methodology comparison, I
+want the pipeline's ratio accompanied by a structured reconciliation against NASEM's
+4:1, so that I can explain any divergence in terms of methodology, time window, or
+data-source differences rather than leaving it unexplained.
+
+#### Acceptance Criteria
+
+1. WHEN the aggregate ratio is computed, THE System SHALL produce a reconciliation
+   report documenting: measurement time window, SBIR identification method, FPDS
+   inclusion/exclusion rules, and entity-resolution match rate.
+2. WHEN the pipeline ratio diverges from NASEM's 4:1 by more than 0.5 in either
+   direction, THE System SHALL identify which methodology differences (e.g., time
+   window, FPDS Phase III undercount, ER coverage) account for the gap.
+3. WHEN producing the reconciliation report, THE System SHALL emit both a JSON artifact
+   (for programmatic consumption) and a markdown summary (for human review), to the
+   `reports/leverage-ratio/` directory.
+
+---
+
+### Requirement 4 — Civilian-agency extension
+
+**User story:** As an SBIR program manager at a civilian agency, I want the same
+leverage ratio computed for DOE so that my agency can benchmark its follow-on
+investment generation against DoD and against the Myers & Lanahan DOE baseline [L9][L5].
+
+#### Acceptance Criteria
+
+1. WHEN running the civilian-agency computation, THE System SHALL support DOE as the
+   first civilian-agency target, using both FPDS contracts and USAspending grants
+   (DOE uses both instrument types).
+2. WHEN emitting civilian-agency results, THE System SHALL produce a side-by-side
+   comparison table (DoD vs. DOE) in the same report format as Requirement 3.
+3. WHEN the DOE ratio is computed, THE System SHALL note which NASEM DOE review [L5]
+   and Myers & Lanahan [L9] figures are the relevant external benchmarks.
+
+---
+
+### Requirement 5 — Time-series trend
+
+**User story:** As a policy analyst tracking program-level trends, I want the leverage
+ratio expressed as a time series by fiscal year, so that I can show whether DoD's
+follow-on investment in SBIR firms is growing, shrinking, or stable — a question NASEM's
+quadrennial reviews cannot answer.
+
+#### Acceptance Criteria
+
+1. WHEN computing the time series, THE System SHALL emit the aggregate ratio for each
+   fiscal year in the data window, using a rolling 3-year trailing cohort to smooth
+   vintage effects.
+2. WHEN a fiscal year has fewer than 50 resolved firms, THE System SHALL flag that
+   year's ratio as low-confidence.
+3. WHEN the trend direction is determinable (monotone for ≥5 consecutive years), THE
+   System SHALL note it in the markdown report.
+
+---
 
 ## Dependencies
 
-- FPDS contract data (`src/tools/phase0/extract_fpds_contracts.py`) — EXISTS
-- Entity resolution (`src/tools/phase0/resolve_entities.py`) — EXISTS
+- FPDS contract data (`scripts/data/extract_fpds_contracts.py`) — EXISTS
+- Entity resolution (`sbir_etl/enrichers/`) — EXISTS
+- CET classifier (`packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`) — EXISTS
 - Company categorization (`specs/company-categorization/`) — 77% complete
-- CET classifier (`src/transition/features/cet_analyzer.py`) — EXISTS (for tech-area stratification)

--- a/specs/leverage-ratio-analysis/requirements.md
+++ b/specs/leverage-ratio-analysis/requirements.md
@@ -155,7 +155,7 @@ quadrennial reviews cannot answer.
 
 ## Dependencies
 
-- FPDS contract data (`scripts/data/extract_fpds_contracts.py`) — EXISTS
+- FPDS contract data (`packages/sbir-analytics/sbir_analytics/tools/phase0/extract_fpds_contracts.py`) — EXISTS
 - Entity resolution (`sbir_etl/enrichers/`) — EXISTS
 - CET classifier (`packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`) — EXISTS
 - Company categorization (`specs/company-categorization/`) — 77% complete

--- a/specs/load-contract-nodes/requirements.md
+++ b/specs/load-contract-nodes/requirements.md
@@ -1,5 +1,27 @@
 # Requirements: Make `RESULTED_IN` resolve (CONTRACT FinancialTransaction nodes)
 
+> **Status:** Not yet started.
+> Supports inventory question **A3** (SBIR → follow-on contract linkage) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** A3 — SBIR award → follow-on federal contract linkage
+**Answers for:** defense industrial base analysts, pipeline engineers
+**Complexity tier:** Foundational infrastructure
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "On a seeded graph, `RESULTED_IN` returns non-empty rows. `TransitionPathwayQueries.award_to_transition_to_contract` returns results. CONTRACT nodes are created idempotently (MERGE on `transaction_id`); no `:FinancialTransaction` nodes are duplicated."
+
+---
+
+## User Story
+
+**As a defense industrial base analyst tracking the SBIR-to-contract pipeline,**
+I want the `RESULTED_IN` graph edge to be structurally resolvable, so that I can query the "SBIR award → follow-on federal contract" pathway and measure how often SBIR awards lead to follow-on procurement once seed contract data is loaded.
+
+---
+
 > **Revised after scope-guard (verdict: TRIM).** Original draft proposed a
 > transformer + new `loaded_contracts` asset + RECIPIENT_OF/FUNDED_BY edges +
 > sequencing. Scope-guard (verified) showed that's over-built for the goal and that

--- a/specs/merger_acquisition_detection/requirements.md
+++ b/specs/merger_acquisition_detection/requirements.md
@@ -1,4 +1,6 @@
-# Requirements
+# Requirements — M&A Detection
 
-Implemented and merged. See research question A4 in
-[`../../docs/research-questions.md`](../../docs/research-questions.md).
+> **Status:** Implemented and merged. Candidate for archiving to `specs/archive/completed-features/`.
+> See research question **A4** in [docs/research-questions.md](../../docs/research-questions.md).
+
+Implementation is complete. See `sbir_etl/enrichers/sec_edgar/`, `scripts/data/detect_sbir_ma_events.py`, and `data/sbir_ma_events.jsonl` for the delivered artifacts. Published findings in `docs/research/sbir-ma-exit-analysis.md`.

--- a/specs/modernbert_analysis_layer/requirements.md
+++ b/specs/modernbert_analysis_layer/requirements.md
@@ -1,4 +1,19 @@
-# Requirements Document
+# Requirements — ModernBert Analysis Layer
+
+> **Status:** Not yet started. Requirements 5–7 (Bayesian MoE routing) are flagged for scope review before implementation.
+> Supports inventory question **C2** (patent–award semantic similarity) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** C2 — patent–award semantic similarity via ModernBert embeddings
+**Answers for:** pipeline engineers, defense industrial base analysts
+**Complexity tier:** Relational (Tier 2)
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "Querying `SIMILAR_TO` edges in Neo4j returns the top-N SBIR awards most semantically similar to a given patent. Embedding coverage is ≥95% for awards and ≥98% for patents. The CET cohesion check passes. Requirements 5–7 (Bayesian MoE routing) are deferred pending scope review."
+
+---
 
 ## Introduction
 
@@ -33,7 +48,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 1
 
-**User Story:** As a data scientist, I want to compute dense embeddings for patents and awards using ModernBert, so that I can perform semantic analysis and similarity matching across the SBIR ecosystem.
+**User Story:** As a pipeline engineer building the semantic similarity layer, I want to compute dense embeddings for patents and awards using ModernBert, so that downstream assets can perform semantic analysis and similarity matching across the SBIR ecosystem.
 
 #### Acceptance Criteria
 
@@ -45,7 +60,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 2
 
-**User Story:** As a researcher, I want to identify semantic similarity between awards and patents, so that I can discover potential technology transfer relationships and prior art connections.
+**User Story:** As an R&D policy researcher, I want to identify semantic similarity between awards and patents, so that I can discover potential technology transfer relationships and prior art connections across the SBIR corpus.
 
 #### Acceptance Criteria
 
@@ -57,7 +72,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 3
 
-**User Story:** As a system administrator, I want quality validation for the ModernBert analysis pipeline, so that I can ensure data quality and system reliability.
+**User Story:** As a pipeline engineer responsible for data quality, I want quality validation gates for the ModernBert analysis pipeline, so that embedding coverage and cohesion thresholds are enforced before downstream assets consume similarity data.
 
 #### Acceptance Criteria
 
@@ -69,7 +84,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 4
 
-**User Story:** As a graph database user, I want semantic similarity relationships loaded into Neo4j, so that I can query and visualize award-patent connections alongside existing graph data.
+**User Story:** As a defense industrial base analyst, I want semantic similarity relationships loaded into Neo4j, so that I can query award-patent connections alongside transition and CET graph data to surface technology transfer signals.
 
 #### Acceptance Criteria
 
@@ -81,7 +96,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 5
 
-**User Story:** As a policy researcher, I want Bayesian MoE classification routing for CET/CPC categories, so that I can quickly categorize patents and SBIR awards into technology domains with calibrated uncertainty before detailed analysis.
+**User Story:** As an R&D policy researcher, I want Bayesian MoE classification routing for CET/CPC categories, so that I can quickly categorize patents and SBIR awards into technology domains with calibrated uncertainty before detailed analysis.
 
 #### Acceptance Criteria
 
@@ -93,7 +108,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 6
 
-**User Story:** As a researcher, I want Bayesian MoE similarity computation routing, so that I can get robust semantic similarity measures within and across technology categories with uncertainty quantification.
+**User Story:** As an R&D policy researcher, I want Bayesian MoE similarity computation routing, so that I can get robust semantic similarity measures within and across technology categories with uncertainty quantification.
 
 #### Acceptance Criteria
 
@@ -105,7 +120,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 7
 
-**User Story:** As a technology analyst, I want Bayesian MoE embedding generation routing, so that patents and SBIR awards can be processed by specialized embedding experts optimized for their identified technology domains.
+**User Story:** As an R&D policy researcher, I want Bayesian MoE embedding generation routing, so that patents and SBIR awards can be processed by specialized embedding experts optimized for their identified technology domains.
 
 #### Acceptance Criteria
 
@@ -117,7 +132,7 @@ The system will use Hugging Face's hosted Inference API by default (no local GPU
 
 ### Requirement 8
 
-**User Story:** As a developer, I want the ModernBert analysis layer to be strictly additive, so that existing CET classification and pipeline functionality remains unchanged.
+**User Story:** As a pipeline engineer, I want the ModernBert analysis layer to be strictly additive, so that existing CET classification and pipeline functionality remains unchanged and the feature can be enabled or disabled without affecting other assets.
 
 #### Acceptance Criteria
 

--- a/specs/naics-enricher-consolidation/requirements.md
+++ b/specs/naics-enricher-consolidation/requirements.md
@@ -1,5 +1,23 @@
 # Requirements — NAICS Enricher Consolidation
 
+> **Status:** Not yet started.
+> Supports inventory questions **D1 / E3** (NAICS coverage and fiscal-impact infrastructure)
+> in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** D1 / E3 — NAICS code coverage and NAICS→BEA sector mapping
+**Answers for:** pipeline engineers
+**Complexity tier:** Foundational infrastructure
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "`grep -r 'Backward-compat re-export' sbir_etl/` returns
+> zero hits. There is exactly one public class for NAICS→BEA mapping. All pre-existing
+> NAICS tests pass and the golden-file comparison against `naics_to_bea` output is clean."
+
+---
+
 ## Purpose
 
 Reduce the current NAICS enricher surface

--- a/specs/ot-consortium-subaward-attribution/requirements.md
+++ b/specs/ot-consortium-subaward-attribution/requirements.md
@@ -1,8 +1,29 @@
 # Requirements — OT Consortium Sub-Award Attribution (FFATA/FSRS)
 
-**Status:** spec only — not implemented. Follow-on to the OT consortium
-verification-tiering module (`sbir_etl/ot_consortium/`, see
-`docs/ot-consortium/tiers.md`).
+> **Status:** Spec only — not implemented. Follow-on to the OT consortium verification-tiering module.
+> Supports inventory question **A2** (OT consortium attribution) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** A2 — OT consortium sub-award attribution and T2→T1 recovery via FSRS
+**Answers for:** DoD acquisition analysts, SBIR program managers
+**Complexity tier:** Relational (Tier 2)
+
+---
+
+## Done when
+
+> A DoD acquisition analyst can state: "Of [N] T2 (rollup-only) OT consortium records, [X] were upgraded to T1 via sub-award UEI match. The recovered amount is $[Y] ([Z]% of the T2 pool). `recovered_from_rollup_usd` and `recovered_from_rollup_count` are surfaced in the magnitude report alongside the existing verified total."
+
+---
+
+## User Stories
+
+**As a DoD acquisition analyst measuring how much SBIR-adjacent OT consortium spending is attributable to specific firms,**
+I want T2 (rollup-only) records upgraded to T1 when FSRS sub-award data provides a UEI-keyed attribution, so that obligated dollars previously hidden in CMF rollups can be linked to individual SBIR-eligible firms for transition-rate and concentration analysis.
+
+**As an SBIR program manager reviewing firm-level federal contract history,**
+I want the magnitude report to expose how much formerly unverifiable T2 spending was recovered to T1 via sub-award UEI match, so that I can understand the lower bound of OT-consortium activity that was previously invisible in firm-level obligation totals.
+
+---
 
 ## Problem
 

--- a/specs/patent-cost-spillover/design.md
+++ b/specs/patent-cost-spillover/design.md
@@ -1,0 +1,84 @@
+# Patent Cost and Spillover Analysis — Design
+
+## Architecture
+
+Builds on the existing patent-award linkage pipeline. New analytical code lives in
+`packages/sbir-analytics/sbir_analytics/tools/mission_b/` (knowledge-output metrics
+are an innovation/commercialization outcome, consistent with the mission_b namespace).
+
+### Precondition: USPTO citation ingestion
+
+The existing USPTO pipeline ingests patent grant data but **does not yet ingest patent
+citation pairs** (citing_patent → cited_patent). The `PatentCitation` model exists in the
+graph schema but citations are not yet loaded as graph relationships
+(`docs/research-questions.md` A2 note). Citation ingestion is a hard prerequisite for
+Requirement 2 (spillover) and must be completed before Phase 2 of this spec begins.
+Phase 1 (marginal cost) has no citation dependency and can proceed independently.
+
+### Data Flow
+
+```
+SBIR awards (SBIR.gov)
+    ↓
+patent-award linkage (sbir_etl/transformers/patent_transformer.py)
+    ↓ patent_id → award_id pairs
+PatentCostCalculator
+    ↓ marginal cost per agency / CET / vintage
+    ↓
+    ←── USPTO citation pairs (precondition ingestion)
+CitationNetworkBuilder
+    ↓ directed citation graph (SBIR-labeled nodes)
+SpilloverCalculator
+    ↓ inbound/outbound multipliers per agency
+    ↓
+NASEMReconciler
+    ↓
+reports/patent-spillover/
+    ├── cost_by_agency.json
+    ├── spillover_by_agency.json
+    ├── stratified/
+    │   ├── by_cet_area.json
+    │   ├── by_firm_size.json
+    │   └── by_vintage.json
+    └── reconciliation/
+        ├── reconciliation.json
+        └── reconciliation.md
+```
+
+### Key Components
+
+**`PatentCostCalculator`** (`patent_cost_analysis.py`)
+Inputs: patent-award linkage table, SBIR award amounts.
+Outputs: marginal-cost-per-patent DataFrame by agency, CET area, firm size, and vintage.
+Suppresses cells with <20 linked patents; reports match-rate metadata alongside every
+figure.
+
+**`CitationNetworkBuilder`** (`citation_network.py`)
+Inputs: USPTO citing → cited pairs (after precondition ingestion), patent-award linkage.
+Outputs: directed citation graph with SBIR/non-SBIR node labels, serialized as an
+adjacency list for SpilloverCalculator (not loaded into Neo4j in this spec — separate
+concern).
+
+**`SpilloverCalculator`**
+Inputs: citation graph from CitationNetworkBuilder.
+Outputs: inbound spillover multiplier (non-SBIR → SBIR citations / SBIR patent count),
+U.S.-retained fraction, per-agency and per-CET breakdowns. Documents citation-window
+cutoff in every output artifact.
+
+**`NASEMReconciler`**
+Stores benchmark constants (NIH ~$1.5M, DOE ~3×, ~60% U.S.-retained).
+Produces structured reconciliation comparing pipeline output to each benchmark, with
+methodology-difference attribution. Emits JSON + markdown.
+
+### Output Format
+
+All analytical output lands in `reports/patent-spillover/`. Dagster asset wrappers
+(Phase 5 in tasks.md) read from this directory and expose the artifacts as materializations.
+Human-readable markdown summaries are co-emitted alongside every JSON artifact for
+direct review without tooling.
+
+### Implementation Phase Ordering
+
+Phase 1 (marginal cost) is independent of citation ingestion and can start immediately.
+Phase 2 (citation network) requires the citation-ingestion precondition. Track the
+precondition as a separate prerequisite task in tasks.md before beginning Phase 2.

--- a/specs/patent-cost-spillover/requirements.md
+++ b/specs/patent-cost-spillover/requirements.md
@@ -1,41 +1,149 @@
 # Patent Cost and Spillover Analysis — Requirements
 
-> **Status:** Not yet started — spec is design-only, zero implementation code as of June 2026. Anchors inventory questions **C3a–c** in [docs/research-questions.md](../../docs/research-questions.md). Target benchmark: Myers & Lanahan AER 2022 (~3× DOE spillover, ~60% US-retained).
+> **Status:** Not yet started — zero implementation code as of June 2026.
+> Anchors inventory questions **C3a–c** in [docs/research-questions.md](../../docs/research-questions.md).
+> Target benchmarks: NIH ~$1.5M marginal cost per patent; Myers & Lanahan AER 2022 ~3× DOE
+> spillover, ~60% U.S.-retained [L9][L5].
 
-Research Plan Milestone: **M2 — Patent Linkage and Spillover Pipeline**
+**Research question anchor:** C3 — marginal cost per patent and spillover multiplier (inferential tier)
+**Answers for:** R&D policy researchers, OSTP analysts, agency R&D directors
+**Complexity tier:** Inferential (Tier 3)
+
+---
+
+## Done when
+
+> An analyst can state: "NIH produces one linked patent per ~$1.5M in SBIR funding.
+> Our pipeline yields [X] per $1M for NIH and [Y] for DOE, using [method]. DOE patents
+> attract [Z]× non-SBIR citations — [above / below / consistent with] Myers & Lanahan's
+> ~3× spillover figure. The difference is attributable to [methodology / time window /
+> citation-lag window]."
+>
+> As with the leverage ratio, a characterized divergence from the benchmark is a valid
+> result. An unexplained match is not.
+
+---
 
 ## Background
 
-**Outcomes-layer linkages: Award → Patent + Award → Outcome Through Primes.**
+USAspending has no patent field. USPTO government-interest statements carry
+grant/contract numbers but are not joined back to award databases. The existing USPTO
+pipeline performs that join, producing a `patent_id → award_id` linkage at scale. This
+spec builds the analytical layer on top of that linkage: marginal knowledge-production
+cost per agency, and a citation-network-based spillover multiplier that measures how far
+SBIR-generated IP propagates into the broader innovation ecosystem.
 
-USAspending has no patent field. USPTO government interest statements contain
-grant/contract numbers but aren't joined back to award databases. Our USPTO
-pipeline performs this join. When SBIR tech enters a prime contractor's system
-via subcontract, FPDS can't see it — patent citation networks trace IP flow
-where procurement data cannot.
+NASEM treats patent output as a count variable. No NASEM study computes marginal cost
+per patent across agencies or a spillover multiplier beyond the DOE analysis in [L5]
+(which draws on [L9]). Both metrics are answerable now with existing pipeline components.
 
-NASEM treats IP output as a count variable. This spec builds the analytical layer
-on top of the existing patent-award linkage pipeline to compute marginal cost per patent,
-trace citation networks for knowledge transfer, and replicate DOE spillover methodology.
+---
 
 ## Requirements
 
-1. **SHALL** compute marginal cost per patent by agency (award $ / linked patent count)
-2. **SHALL** build citation network from USPTO citation data for SBIR-linked patents
-3. **SHALL** compute spillover multiplier (citations from non-SBIR patents to SBIR patents)
-4. **SHALL** replicate NIH ~$1.5M marginal cost benchmark and DOE 3x spillover multiplier
-5. **SHOULD** extend both metrics across all agencies
-6. **SHOULD** stratify by technology area, firm size, and award vintage
+### Requirement 1 — Marginal cost per patent by agency
 
-## Gate Condition
+**User story:** As an R&D policy researcher benchmarking federal knowledge-production
+efficiency, I want the ratio of SBIR award dollars to linked patents computed per agency,
+so that I can compare agencies on a cost-per-knowledge-unit basis and position the result
+against NIH's published ~$1.5M figure.
 
-Reproduce NIH's ~$1.5M marginal cost per patent AND DOE's 3x spillover multiplier.
-Then extend both across all agencies.
+#### Acceptance Criteria
+
+1. WHEN computing marginal cost per patent, THE System SHALL divide total SBIR award
+   dollars by linked-patent count for each agency, both at the aggregate level and as a
+   firm-level distribution (median, 25th/75th percentile).
+2. WHEN an agency has fewer than 20 linked patents in the measurement window, THE System
+   SHALL suppress the per-agency figure and note the suppression reason, to prevent
+   small-cell estimates from appearing alongside reliable agency figures.
+3. WHEN reporting marginal cost, THE System SHALL also report the patent-award match rate
+   (linked patents / total SBIR patents per agency) so that coverage gaps are visible.
+4. WHEN the pipeline figure diverges from NIH's ~$1.5M benchmark, THE System SHALL
+   document the time window, linkage method, and any patent-type filters used, so that
+   the difference can be attributed rather than left unexplained.
+5. WHEN stratifying by technology area, THE System SHALL use CET classifier output to
+   emit a marginal cost figure per CET area for agencies with sufficient coverage.
+
+---
+
+### Requirement 2 — Citation network and spillover multiplier
+
+**User story:** As an OSTP analyst assessing the diffusion of federally funded innovation,
+I want the ratio of non-SBIR citations to SBIR patents computed as a spillover multiplier,
+so that I can state how many downstream inventions build on each SBIR-originated patent and
+compare that figure to Myers & Lanahan's ~3× DOE finding [L9].
+
+#### Acceptance Criteria
+
+1. WHEN building the citation network, THE System SHALL ingest USPTO citing-patent →
+   cited-patent pairs for all patents linked to SBIR awards.
+2. WHEN classifying citations, THE System SHALL label each citation as one of:
+   SBIR→SBIR, non-SBIR→SBIR (inbound spillover), or SBIR→non-SBIR (outbound), using
+   the patent-award linkage to determine SBIR status.
+3. WHEN computing the spillover multiplier, THE System SHALL calculate: inbound
+   non-SBIR citations to SBIR patents / SBIR-linked patent count, at both the
+   aggregate level and per agency.
+4. WHEN computing the U.S.-retained fraction, THE System SHALL use USPTO assignee
+   country codes to distinguish U.S.-retained from internationally assigned citations,
+   targeting the ~60% U.S.-retained finding from [L9].
+5. WHEN the citation data has a lag window (USPTO citation records typically lag
+   grant date by 12–24 months), THE System SHALL document the citation-window cutoff
+   used and its effect on the multiplier, so the figure is not compared naively to
+   studies using different windows.
+
+---
+
+### Requirement 3 — NASEM / Myers & Lanahan reconciliation
+
+**User story:** As a policy analyst preparing a publishable methodology note, I want
+the pipeline's cost and spillover figures accompanied by a structured reconciliation
+against the NIH $1.5M and DOE 3× benchmarks, so that any divergence can be attributed
+to methodology rather than left as an unexplained discrepancy that would undermine
+credibility.
+
+#### Acceptance Criteria
+
+1. WHEN the aggregate figures are computed, THE System SHALL produce a reconciliation
+   report documenting: measurement time window, patent-award linkage method, citation
+   cutoff date, and entity-resolution match rate.
+2. WHEN the marginal-cost figure diverges from NIH's ~$1.5M by more than 50%, THE
+   System SHALL identify at least one methodology difference (linkage coverage, award
+   denominator scope, patent-type filter) that accounts for the gap.
+3. WHEN the spillover multiplier diverges from Myers & Lanahan's ~3× by more than
+   1.0×, THE System SHALL identify which methodological difference (citation window,
+   SBIR patent definition, U.S./international scope) accounts for the gap.
+4. WHEN emitting the reconciliation, THE System SHALL produce both a JSON artifact
+   and a markdown summary to `reports/patent-spillover/reconciliation/`.
+
+---
+
+### Requirement 4 — Cross-agency and stratified extension
+
+**User story:** As an SBIR program manager or OSTP analyst comparing knowledge-output
+profiles across the portfolio, I want both metrics broken out by technology area, firm
+size, and award vintage, so that I can identify which CET areas and investment profiles
+produce the highest knowledge output per dollar and which show low spillover — suggesting
+IP retention rather than diffusion into the broader ecosystem.
+
+#### Acceptance Criteria
+
+1. WHEN stratifying by CET area, THE System SHALL emit marginal cost per patent and
+   spillover multiplier for each of the 21 canonical CET areas in `config/cet/taxonomy.yaml`,
+   suppressing cells with fewer than 10 linked patents.
+2. WHEN stratifying by firm size, THE System SHALL use the same size buckets as the
+   leverage-ratio analysis (SAM.gov employee or revenue tiers) for consistency.
+3. WHEN stratifying by award vintage, THE System SHALL group by first-SBIR-award
+   fiscal year and emit both metrics per cohort.
+4. WHEN emitting stratified output, THE System SHALL include the linked-patent count
+   and citation count per cell so that readers can assess statistical reliability.
+
+---
 
 ## Dependencies
 
-- Patent-award linkage (`src/transformers/patent_transformer.py`) — EXISTS
+- Patent-award linkage (`sbir_etl/transformers/patent_transformer.py`) — EXISTS
 - USPTO extraction pipeline — EXISTS
-- USPTO Lambda downloads (`specs/uspto-lambda-downloads/`) — 90% complete
+- USPTO Lambda downloads (`specs/archive/completed-features/uspto-lambda-downloads/`) — COMPLETE
+- CET classifier (`packages/sbir-ml/sbir_ml/ml/models/cet_classifier.py`) — EXISTS
 - Entity resolution — EXISTS
-- Leverage ratio analysis (M1) — for shared entity universe
+- USPTO citation data ingestion — **PRECONDITION; not yet implemented** (see design.md)

--- a/specs/phase-3-solicitation-alerts/requirements.md
+++ b/specs/phase-3-solicitation-alerts/requirements.md
@@ -1,5 +1,33 @@
 # Phase III Solicitation & Award Candidate Alerts — Requirements
 
+> **Status:** Not yet started.
+> Supports inventory questions **B2 / B3 / B4 / E1 / E6 / E5** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** B2 / B3 / B4 / E1 / E6 / E5 — Phase III identification, solicitation alerting, and FPDS data-gap measurement
+**Answers for:** SBIR program managers, GAO/SBA oversight analysts, pipeline engineers
+**Complexity tier:** Relational (Tier 2)
+
+---
+
+## Done when
+
+> For FY [N], the pipeline identified [X] HIGH-confidence `RETROSPECTIVE` candidates (Phase III contracts not coded as such in FPDS); a hand-audited 100-row sample shows [P]% true-positive rate (≥85% target). The pipeline surfaced [Y] `DIRECTED` and [Z] `FOLLOWON` candidates; outputs written to `data/processed/phase_iii_candidates.parquet` and evidence to `data/processed/phase_iii_evidence.ndjson`. The `agencies_with_zero_phase_iii` list shrank by [Δ] agencies relative to the pre-`RETROSPECTIVE` baseline.
+
+---
+
+## User Stories
+
+**As an SBIR program manager tracking whether prior awardees receive follow-on contracts,**
+I want sole-source and directed-award notices from SAM.gov surfaced as `DIRECTED` Phase III candidates linked to prior awards, so that I can identify opportunities my agency's awardees are likely eligible for under the Phase III sole-source authority.
+
+**As a GAO/SBA oversight analyst measuring Phase III undercount in FPDS,**
+I want a scored list of `RETROSPECTIVE` candidates — contracts that fit Phase III criteria but are not coded as such in FPDS — with ≥85% precision on a hand-audited sample, so that I can quantify the Phase III data-quality gap cited in GAO-24-107036 and report how many agencies previously showed zero Phase III activity.
+
+**As a pipeline engineer maintaining the Phase III detection asset,**
+I want a CI backtest that fails when `RETROSPECTIVE` HIGH precision drops below 0.85, so that any change to scoring logic is immediately validated against the DoD-coded Phase III ground truth before it reaches production.
+
+---
+
 Research-question anchors: **B2, B3, B4, E1, E6**, and the open evaluation in
 **E5** ("Does the SAM.gov Opportunities API replace agency-page scraping?").
 Narrows the Phase III undercount flagged as a threat-to-validity in
@@ -136,7 +164,7 @@ cadence, and precision targets.
    solicitation is not statutory Phase III and must not be described as
    such.
 
-## Gate condition
+## Done when (reference)
 
 The spec is done when we can state:
 

--- a/specs/sbir-cohort-design/requirements.md
+++ b/specs/sbir-cohort-design/requirements.md
@@ -1,5 +1,6 @@
-# Requirements
+# Requirements — SBIR Cohort Design
 
-Implemented and merged. See research area F (capital formation &
-entrepreneurial finance) in
-[`../../docs/research-questions.md`](../../docs/research-questions.md).
+> **Status:** Implemented and merged. Candidate for archiving to `specs/archive/completed-features/`.
+> See research area **F** (capital formation & entrepreneurial finance) in [docs/research-questions.md](../../docs/research-questions.md).
+
+Implementation is complete. Cohort design logic lives in the Form D and M&A exit analysis pipeline; see `docs/research/sbir-form-d-fundraising-analysis.md` and `docs/research/sbir-ma-exit-analysis.md` for findings.

--- a/specs/sbir-identification/requirements.md
+++ b/specs/sbir-identification/requirements.md
@@ -1,0 +1,104 @@
+# Requirements — SBIR/STTR Award Identification
+
+> **Status:** Implemented on `main`. Classifier: `sbir_etl/extractors/sbir_classifier.py`.
+> Methodology: [`docs/sbir-identification-methodology.md`](../../docs/sbir-identification-methodology.md).
+> Supports inventory question **E1** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** E1 — which federal awards are SBIR/STTR vs. non-SBIR, and with what confidence?
+**Answers for:** pipeline engineers, SBA oversight analysts
+**Complexity tier:** Foundational infrastructure (Tier 1–2)
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "Every award record in the pipeline carries a
+> `sbir_confidence` score (0.5–1.0) and `sbir_method` tag
+> (`fpds_research_field` / `aln_match` / `description_parse`). FPDS-research-field
+> identifications score 1.0; ALN matches 0.8–1.0; description-parse matches 0.5–0.7.
+> False-positive rates for shared-ALN programs (e.g., NIH ~20% non-SBIR via ALN 47.084)
+> are documented and tested. The methodology is in `docs/sbir-identification-methodology.md`."
+
+---
+
+## Introduction
+
+The SBIR/STTR identification classifier is the foundational layer for all downstream
+analytics. It determines which records in USAspending / FPDS / FABS are SBIR or STTR
+awards, assigning confidence scores based on the strength of the identifying signal.
+
+Three independent signals are used in priority order:
+
+1. **FPDS `research` field** — FAR 35.106 research type codes; when present, score 1.0.
+2. **Assistance Listing Number (ALN)** — OMB Circular A-133 ALNs designated for SBIR/STTR; score 0.8–1.0 depending on ALN exclusivity (some ALNs, like NIH's 47.084, are shared with non-SBIR grants, reducing confidence).
+3. **Description parsing** — abstract / title keyword extraction when neither FPDS nor ALN signals are available; score 0.5–0.7.
+
+All confidence scores and method tags are persisted to the graph and available for
+downstream filtering.
+
+---
+
+## User Stories
+
+**As a pipeline engineer,** I want every federal award record tagged with an
+`sbir_confidence` score and `sbir_method` tag, so that downstream analytics (transition
+detection, fiscal impact, leverage ratios) can filter to high-confidence SBIR awards
+without manual review.
+
+**As an SBA oversight analyst,** I want the identification methodology's false-positive
+rate documented by data source (FPDS vs. ALN vs. description), so that I can characterize
+the accuracy of SBIR program metrics derived from this pipeline in reports to Congress.
+
+---
+
+## Requirements
+
+### Requirement 1 — Three-tier confidence classification
+
+**User Story:** As a pipeline engineer, I want each award classified by the strongest
+available SBIR identification signal, so that high-confidence records can be separated
+from uncertain ones without discarding borderline awards entirely.
+
+#### Acceptance Criteria
+
+1. THE System SHALL classify awards using three tiers in priority order:
+   (a) FPDS `research` field present and set to SBIR/STTR → `fpds_research_field`,
+   confidence 1.0;
+   (b) ALN matches a designated SBIR/STTR ALN → `aln_match`, confidence 0.8–1.0
+   depending on ALN exclusivity;
+   (c) Abstract or title contains SBIR/STTR keywords → `description_parse`,
+   confidence 0.5–0.7.
+2. THE System SHALL attach `sbir_confidence` (float 0.0–1.0) and `sbir_method`
+   (enum string) to every processed award record.
+3. WHEN an award matches multiple tiers, THE System SHALL use the highest-confidence
+   signal and record only that method tag.
+
+### Requirement 2 — Shared-ALN false-positive handling
+
+**User Story:** As a pipeline engineer, I want shared-ALN programs (where one ALN
+covers both SBIR and non-SBIR grants) handled with reduced confidence, so that
+false-positive SBIR identifications do not inflate program metrics.
+
+#### Acceptance Criteria
+
+1. THE System SHALL maintain a configured list of shared ALNs (e.g., NIH ALN 47.084)
+   with their estimated SBIR share and associated confidence penalty.
+2. WHEN an award's ALN is on the shared list, THE System SHALL assign a reduced
+   confidence score (below 1.0) and flag the record as `shared_aln`.
+3. THE System SHALL expose the shared-ALN false-positive rate by ALN in the
+   methodology documentation (`docs/sbir-identification-methodology.md`).
+
+### Requirement 3 — SBIR.gov reconciliation
+
+**User Story:** As an SBA oversight analyst, I want the pipeline's SBIR award count
+reconciled against SBIR.gov, so that discrepancies between USAspending FPDS data and
+the authoritative SBA program database are characterized and documented.
+
+#### Acceptance Criteria
+
+1. THE System SHALL compare pipeline-identified SBIR award counts against SBIR.gov
+   bulk award records by agency and fiscal year.
+2. THE System SHALL report the reconciliation match rate (share of SBIR.gov records
+   also found in the pipeline) and the unmatched count per agency.
+3. WHEN the reconciliation match rate falls below 95% for any agency-year cell,
+   THE System SHALL log a warning identifying the gap.

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -1,5 +1,30 @@
 # Requirements: SBIR M&A Match Rate by Fiscal Year
 
+> **Status:** Not yet started.
+> Supports inventory question **F2** (M&A exit rate by vintage) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** F2 — SBIR-awardee M&A match rate by fiscal year
+**Answers for:** entrepreneurial finance researchers, policy analysts
+**Complexity tier:** Descriptive (Tier 1)
+
+---
+
+## Done when
+
+> An entrepreneurial finance researcher can state: "The FY2015–2024 aggregate high+medium M&A match rate for SBIR awardees is [X]% (95% Wilson CI: [Y–Z]%), based on [N] distinct firms. The FY-by-FY breakdown shows [trend]. Item-2.01-only sub-rate is [P]% (reported as methodological footnote, not the headline number)."
+
+---
+
+## User Stories
+
+**As an entrepreneurial finance researcher comparing SBIR-firm exit outcomes to venture-backed norms,**
+I want the SBIR M&A match rate broken down by fiscal year and confidence tier, so that I can report how acquisition frequency has changed over time and compare it to published VC exit-rate benchmarks alongside the leverage-ratio and private-capital comparison analyses.
+
+**As a policy analyst preparing a brief on SBIR program outcomes,**
+I want a reproducible firm-level M&A attribution table with signal provenance and explicit caveats, so that I can cite defensible exit-rate numbers without overstating precision from low-confidence signals like Item-2.01-only filings or Exhibit-21-only attributions.
+
+---
+
 ## Question of record
 
 What is the SBIR-awardee → M&A-event match rate for FY2015–2024,

--- a/specs/transition-detection/requirements.md
+++ b/specs/transition-detection/requirements.md
@@ -1,0 +1,101 @@
+# Requirements — SBIR Transition Detection
+
+> **Status:** Implemented and merged (October 30, 2025). Full requirements and design in
+> [`specs/archive/completed-features/transition_detection/`](../archive/completed-features/transition_detection/).
+> Supports inventory questions **B2** and **B3** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** B2 (did SBIR research result in a federal contract?), B3 (Phase II→III latency, survival probability, transition effectiveness)
+**Answers for:** SBIR program managers, policy analysts
+**Complexity tier:** Relational (Tier 2) / Inferential (Tier 3)
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "The Neo4j graph contains `RESULTED_IN` edges scored
+> by a 6-signal scorer (agency continuity 0.25, timing proximity 0.20, competition type
+> 0.20, patent signal 0.15, CET alignment 0.10, vendor match 0.10). Confidence bands:
+> HIGH ≥ 0.85, LIKELY ≥ 0.65, POSSIBLE < 0.65. Precision ≥ 85% at HIGH band; recall
+> ≥ 70% overall. Detection throughput ≥ 15,000 records/min. Algorithm documented in
+> `docs/transition/detection-algorithm.md`."
+
+---
+
+## Introduction
+
+This feature detects technology transitions from SBIR awards to follow-on federal
+contracts, measuring program commercialization effectiveness at scale. The system uses
+multi-signal scoring — vendor matching, agency continuity, timing proximity, competition
+type, patent filing signals, and CET alignment — to produce calibrated confidence scores
+for each award-to-contract link. Evidence bundles for all HIGH and LIKELY detections
+provide full audit trails.
+
+**Implementation location:** `packages/sbir-analytics/sbir_analytics/assets/transition/`
+and `sbir_etl/transition/`. Algorithm described in `docs/transition/detection-algorithm.md`.
+Archived spec: `specs/archive/completed-features/transition_detection/`.
+
+---
+
+## User Stories
+
+**As an SBIR program manager,** I want to see which Phase II awards led to follow-on
+federal contracts, so that I can measure transition effectiveness by agency, technology
+area, and award vintage and identify which cohorts or CET areas are underperforming.
+
+**As a pipeline engineer,** I want each transition detection to include an evidence
+bundle (matched vendor, score breakdown by signal, timeline) and a confidence band
+(HIGH / LIKELY / POSSIBLE), so that individual detections can be audited and the
+precision benchmark (≥85% at HIGH) can be verified against holdout samples.
+
+---
+
+## Requirements
+
+### Requirement 1 — Multi-signal transition scoring
+
+**User Story:** As an SBIR program manager, I want transition likelihood scored using
+six independent signals, so that HIGH-confidence detections are reliable enough to cite
+in program evaluations without manual review.
+
+#### Acceptance Criteria
+
+1. THE System SHALL score each award-to-contract candidate pair using six signals:
+   agency continuity (weight 0.25), timing proximity (0.20), competition type (0.20),
+   patent signal (0.15), CET alignment (0.10), and vendor match (0.10).
+2. THE System SHALL classify detections as HIGH (≥ 0.85), LIKELY (≥ 0.65), or POSSIBLE
+   (< 0.65) based on the composite score.
+3. THE System SHALL achieve precision ≥ 85% at the HIGH confidence band and recall
+   ≥ 70% overall, validated against the precision benchmark test suite in
+   `tests/unit/test_transition_scorer.py`.
+4. THE System SHALL generate evidence bundles for all detections with score ≥ 0.60,
+   recording per-signal contributions and matched entity identifiers.
+
+### Requirement 2 — Vendor resolution for cross-dataset matching
+
+**User Story:** As a data analyst, I want SBIR recipients matched to federal contract
+vendors using a priority cascade (UEI → CAGE → DUNS → fuzzy name), so that transitions
+are not missed due to identifier inconsistencies across SBIR.gov, FPDS, and USAspending.
+
+#### Acceptance Criteria
+
+1. THE System SHALL match vendors using UEI (confidence 0.99), CAGE, DUNS, and fuzzy
+   name matching (minimum threshold 0.85) in priority order.
+2. THE System SHALL achieve vendor match rate ≥ 90% for SBIR recipients present in
+   FPDS contract data.
+3. THE System SHALL record the match method and confidence for each resolution so
+   downstream consumers can filter by identifier type.
+
+### Requirement 3 — Graph integration
+
+**User Story:** As a defense industrial base analyst, I want transition detections
+stored as `RESULTED_IN` edges in Neo4j, so that I can query award-to-contract
+relationships alongside CET, patent, and entity nodes in a single graph traversal.
+
+#### Acceptance Criteria
+
+1. THE System SHALL persist each detected transition as a `RESULTED_IN` edge between
+   the `Award` node and the `Contract` node, carrying `score`, `confidence_band`,
+   `signals`, and `detected_at` properties.
+2. THE System SHALL use MERGE operations to avoid duplicate edges on re-runs.
+3. THE System SHALL support a dry-run mode that reports match counts without committing
+   graph writes.

--- a/specs/ucc1-financing-analysis/requirements.md
+++ b/specs/ucc1-financing-analysis/requirements.md
@@ -1,13 +1,22 @@
 # UCC-1 Financing Analysis — Requirements
 
-**Research questions:** A4 (private capital signals, foreign-acquisition risk,
-M&A exit detection), B3 (Phase II → III latency)
+> **Status:** Pilot complete — PRs #303 / #305 merged. CA-only pilot found
+> equipment-finance and community-bank lender patterns and an absence of venture-debt
+> lenders in the CA-organized channel. See
+> [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md)
+> for findings. Anchors inventory question **F1** (UCC-1 sub-question) in
+> [docs/research-questions.md](../../docs/research-questions.md).
 
-**Status:** Pilot scope, **narrowed after Phase 0** to CA-only against the
-CA-organized subset of the Form D cohort. The original DE+CA scope was not
-achievable on free data — see
-[docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md)
-for the Phase 0 findings.
+**Research question anchor:** F1 — secured-debt composition of SBIR firms; A4 — foreign-lender signal
+**Answers for:** entrepreneurial finance researchers, defense industrial base analysts
+**Complexity tier:** Descriptive (Tier 1)
+
+---
+
+## Done when
+
+> *See [Gate Condition](#done-when-pilot-gate-condition) below for the specific
+> quantified statement this pilot was designed to produce.*
 
 ## Background
 
@@ -35,6 +44,20 @@ This spec scopes a **CA-only pilot** answering:
    fraction took secured debt and from whom?*
 2. *Does UCC-3 termination timing line up with known M&A events for that
    subset, making it a usable corroborating / earlier signal?*
+
+## User Stories
+
+**As an entrepreneurial finance researcher benchmarking SBIR-firm capital structure,**
+I want to know what fraction of CA-organized SBIR firms took secured debt and from which
+lender types, so that I can complete the capital-structure picture that Form D's equity
+view leaves out and compare it to VC-backed startup norms.
+
+**As a defense industrial base analyst tracking foreign-capital exposure,**
+I want foreign secured parties flagged in the UCC-1 dataset, so that I can surface
+potential national-security signals (foreign-lender relationships at SBIR firms)
+consistent with the A4 foreign-acquisition-risk question.
+
+---
 
 ## Requirements
 
@@ -72,7 +95,7 @@ This spec scopes a **CA-only pilot** answering:
     IP-collateral parsing, or Neo4j loading in the pilot. Those are
     explicitly out of scope; revisit after pilot results.
 
-## Gate Condition
+## Done when (pilot gate condition)
 
 Can state, on completion:
 

--- a/specs/unify-company-into-organization/requirements.md
+++ b/specs/unify-company-into-organization/requirements.md
@@ -1,4 +1,19 @@
-# Requirements Document
+# Requirements — Unify :Company onto :Organization (Phase 2)
+
+> **Status:** Not yet started. Stacks on Phase 1 (PR #379).
+> Phase 2 of graph label unification. Supports inventory question **E2** (graph schema correctness) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** E2 — graph label unification (Phase 2: :Company → :Organization)
+**Answers for:** pipeline engineers
+**Complexity tier:** Foundational infrastructure
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "`grep ':Company' packages/sbir-graph/` returns zero hits in live loader source (migrations and tests excepted). Categorization and SEC EDGAR enrichment properties appear on `:Organization{uei}` nodes. Migration `007` ran with no property loss; orphaned `:Company` nodes without a matching `:Organization` are logged and left in place."
+
+---
 
 ## Introduction
 

--- a/specs/unify-graph-node-labels/requirements.md
+++ b/specs/unify-graph-node-labels/requirements.md
@@ -1,4 +1,19 @@
-# Requirements Document
+# Requirements — Unify :Award onto :FinancialTransaction (Phase 1)
+
+> **Status:** Implemented — PR #379 merged.
+> Phase 1 of graph label unification. Supports inventory question **E2** (graph schema correctness) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** E2 — graph label unification (Phase 1: :Award → :FinancialTransaction)
+**Answers for:** pipeline engineers
+**Complexity tier:** Foundational infrastructure (completed)
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "Zero `:Award` nodes remain in the graph. `APPLICABLE_TO` and `GENERATED_FROM` edges land on `:FinancialTransaction`. `pathway_queries.py` returns equivalent results against `:FinancialTransaction` as it previously did against `:Award`. Migration `006_*` is idempotent with a working `downgrade()`."
+
+---
 
 ## Introduction
 

--- a/specs/weekly-awards-report-refactor/requirements.md
+++ b/specs/weekly-awards-report-refactor/requirements.md
@@ -1,5 +1,20 @@
 # Requirements — Weekly Awards Report Refactor
 
+> **Status:** Not yet started.
+> Supports inventory question **E6** (weekly report maintainability) in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** E6 — weekly awards report pipeline maintainability
+**Answers for:** pipeline engineers
+**Complexity tier:** Foundational infrastructure
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "`scripts/data/weekly_awards_report.py` is ≤200 lines. Every enrichment and rendering function lives in `sbir_etl/reporting/weekly/` with ≥70% line coverage. A golden-file test against a recorded pre-refactor output passes with zero diff (modulo timestamp)."
+
+---
+
 ## Purpose
 
 Break up `scripts/data/weekly_awards_report.py` (2,807 lines, 44 top-level


### PR DESCRIPTION
Introduces specs/REQUIREMENTS_TEMPLATE.md as the canonical pattern for all
requirements files: Done-when gate condition up front, actor taxonomy drawn
from the RQ inventory audience labels, RQ anchor in the header, and WHEN/SHALL
acceptance criteria unchanged.

Refactors specs/leverage-ratio-analysis/requirements.md as the first concrete
application: replaces the flat SHALL list with five user stories (aggregate
ratio, cohort stratification, NASEM reconciliation, civilian-agency extension,
time-series trend), each with a named actor from the policy-analyst /
program-manager taxonomy and a "so that" clause that names the downstream
decision the output enables.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Uf6DkRWXkQ3LB5krcrcSRA