### PR TITLE
feat(bea-nipa): parquet cache + scrub remaining hardcoded tax rates

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py
@@ -172,7 +172,9 @@ class TaxEstimationTool(BaseTool):
 
                 # Tax estimates — federal income rate is year-stamped via NIPA;
                 # FICA payroll rate is statutory and stays a module constant.
-                fy_int = int(fy) if fy is not None else assessment_year
+                # `fy` comes from a pandas row, so missing values are typically
+                # NaN (not None); `int(np.nan)` would raise ValueError.
+                fy_int = int(fy) if fy is not None and pd.notna(fy) else assessment_year
                 individual_income_rate = rate_provider.get_rates(fy_int).federal_income_rate
                 individual_income_tax = wages * individual_income_rate
                 payroll_tax = wages * PAYROLL_TAX_RATE

--- a/packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py
@@ -24,6 +24,8 @@ from typing import Any
 
 import pandas as pd
 
+from sbir_etl.transformers.fiscal.nipa_rates import NIPARateProvider
+
 from ..base import BaseTool, DataSourceRef, ToolMetadata, ToolResult
 
 
@@ -46,10 +48,10 @@ DEFAULT_EFFECTIVE_TAX_RATES = {
     "Other": 0.18,
 }
 
-# Payroll tax rates (FICA)
+# Payroll tax rates (FICA): statutory rate, no NIPA equivalent.
 PAYROLL_TAX_RATE = 0.153  # Combined employer + employee (Social Security + Medicare)
-# Approximate individual income tax effective rate for SBIR-relevant income levels
-INDIVIDUAL_INCOME_TAX_RATE = 0.22
+# Individual income effective tax rate is resolved per-row via NIPARateProvider
+# (BEA NIPA Tables 3.2/3.3/1.5); see TaxEstimationTool.execute.
 
 
 class TaxEstimationTool(BaseTool):
@@ -71,6 +73,7 @@ class TaxEstimationTool(BaseTool):
         fpds_revenue: pd.DataFrame | None = None,
         commercialization_scores: pd.DataFrame | None = None,
         effective_tax_rates: dict[str, float] | None = None,
+        nipa_rate_provider: NIPARateProvider | None = None,
         discount_rate: float = 0.03,
         assessment_year: int = 2026,
         **kwargs: Any,
@@ -99,6 +102,9 @@ class TaxEstimationTool(BaseTool):
         )
 
         tax_rates = effective_tax_rates or DEFAULT_EFFECTIVE_TAX_RATES
+        # NIPA-derived individual income effective rate; in-memory cache makes
+        # the per-row get_rates(fy_int) calls cheap.
+        rate_provider = nipa_rate_provider or NIPARateProvider()
 
         # =====================================================================
         # Track A: Multiplier-based estimation
@@ -164,15 +170,18 @@ class TaxEstimationTool(BaseTool):
                 wages = value_added * wage_share
                 corporate_surplus = value_added * 0.25
 
-                # Tax estimates
-                individual_income_tax = wages * INDIVIDUAL_INCOME_TAX_RATE
+                # Tax estimates — federal income rate is year-stamped via NIPA;
+                # FICA payroll rate is statutory and stays a module constant.
+                fy_int = int(fy) if fy is not None else assessment_year
+                individual_income_rate = rate_provider.get_rates(fy_int).federal_income_rate
+                individual_income_tax = wages * individual_income_rate
                 payroll_tax = wages * PAYROLL_TAX_RATE
                 corporate_income_tax = corporate_surplus * corp_tax_rate
                 total_tax = individual_income_tax + payroll_tax + corporate_income_tax
 
                 # NPV discounting: discount tax receipts to present value
-                # Years from assessment reference point (latest FY in data)
-                fy_int = int(fy) if fy is not None else assessment_year
+                # Years from assessment reference point (latest FY in data); fy_int
+                # was already resolved above for the NIPA rate lookup.
                 years_from_present = max(0, assessment_year - fy_int)
                 discount_factor = 1.0 / ((1.0 + discount_rate) ** years_from_present)
                 discounted_tax = total_tax * discount_factor

--- a/sbir_etl/config/schemas/domain.py
+++ b/sbir_etl/config/schemas/domain.py
@@ -189,11 +189,21 @@ class EnrichmentRefreshConfig(BaseModel):
 
 
 class TaxParameterConfig(BaseModel):
-    """Configuration for federal tax calculation parameters."""
+    """Configuration for federal tax calculation parameters.
+
+    These defaults are a static snapshot used by
+    ``fiscal_audit_trail.log_configuration()`` for audit-log provenance. Runtime
+    fiscal calculations resolve the actual ``individual_income_tax.effective_rate``
+    per analysis year via ``NIPARateProvider`` (BEA NIPA Tables 3.2/3.3/1.5) —
+    see ``sbir_etl/transformers/fiscal/nipa_rates.py``. Update the default below
+    when ``_BASELINE_RATES`` gains a newer reference year.
+    """
 
     individual_income_tax: dict[str, Any] = Field(
         default_factory=lambda: {
-            "effective_rate": 0.22,
+            # NIPA-derived 2022 baseline (personal_current_taxes / compensation
+            # of employees). See nipa_rates.py:_BASELINE_RATES[2022].
+            "effective_rate": 0.194,
             "progressive_rates": {
                 "10_percent": 0.10,
                 "12_percent": 0.12,

--- a/sbir_etl/transformers/fiscal/nipa_rates.py
+++ b/sbir_etl/transformers/fiscal/nipa_rates.py
@@ -21,6 +21,7 @@ Rate calculation:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -139,6 +140,21 @@ _BASELINE_RATES: dict[int, NIPATaxRates] = {
 # Default to 2022 for years we don't have explicit data for
 _DEFAULT_YEAR = 2022
 
+# On-disk cache: one row per (year, source). API-sourced rows are persisted on
+# successful fetch; baseline rows are not written (they are deterministic from
+# _BASELINE_RATES, so caching them adds no value).
+_DEFAULT_CACHE_PATH = Path("data/reference/bea/nipa_tax_rates.parquet")
+_PARQUET_RATE_COLUMNS = (
+    "federal_income_rate",
+    "federal_payroll_rate",
+    "federal_corporate_rate",
+    "federal_excise_rate",
+    "state_local_income_rate",
+    "state_local_sales_rate",
+    "state_local_property_rate",
+    "state_local_other_rate",
+)
+
 # BEA NIPA table IDs for API fetching
 NIPA_TABLES = {
     "federal_receipts": "T30200",  # Table 3.2
@@ -181,14 +197,18 @@ class NIPARateProvider:
     def __init__(
         self,
         bea_api_key: str | None = None,
-        cache_dir: str | Path | None = None,
+        cache_path: str | Path | None = None,
     ):
         self._api_key = bea_api_key
-        self._cache_dir = Path(cache_dir) if cache_dir else None
+        self._cache_path = Path(cache_path) if cache_path else _DEFAULT_CACHE_PATH
         self._cache: dict[int, NIPATaxRates] = {}
 
     def get_rates(self, year: int | None = None) -> NIPATaxRates:
         """Get effective tax rates for a given year.
+
+        Resolution order: in-memory cache → on-disk parquet cache (API-sourced
+        rows only) → BEA API → ``_BASELINE_RATES`` fallback. API fetches are
+        appended to the parquet cache so a fresh process reuses them.
 
         Args:
             year: NIPA data year. If None, uses most recent available.
@@ -202,11 +222,18 @@ class NIPARateProvider:
         if year in self._cache:
             return self._cache[year]
 
+        # Check on-disk parquet cache (API-sourced rows take precedence)
+        cached = self._read_parquet_cache(year)
+        if cached is not None:
+            self._cache[year] = cached
+            return cached
+
         # Try API fetch
         if self._api_key:
             try:
                 rates = self._fetch_from_api(year)
                 self._cache[year] = rates
+                self._write_parquet_cache(rates)
                 return rates
             except Exception as e:
                 logger.warning(f"BEA NIPA API fetch failed for {year}: {e}, using baseline")
@@ -215,6 +242,67 @@ class NIPARateProvider:
         rates = self._get_baseline(year)
         self._cache[year] = rates
         return rates
+
+    def _read_parquet_cache(self, year: int) -> NIPATaxRates | None:
+        """Return a previously-cached API-sourced row for ``year``, or None."""
+        if not self._cache_path.exists():
+            return None
+        try:
+            df = pd.read_parquet(self._cache_path)
+        except Exception as e:  # pragma: no cover - corrupt cache is unusual
+            logger.warning(f"NIPA parquet cache read failed ({self._cache_path}): {e}")
+            return None
+        rows = df[df["year"] == year]
+        if rows.empty:
+            return None
+        # Prefer nipa_api rows over baselines if both exist (cache shouldn't
+        # contain baselines, but defend against a hand-edited file).
+        api_rows = rows[rows["source"] == "nipa_api"]
+        chosen = api_rows.iloc[0] if not api_rows.empty else rows.iloc[0]
+        return NIPATaxRates(
+            year=int(chosen["year"]),
+            federal_income_rate=float(chosen["federal_income_rate"]),
+            federal_payroll_rate=float(chosen["federal_payroll_rate"]),
+            federal_corporate_rate=float(chosen["federal_corporate_rate"]),
+            federal_excise_rate=float(chosen["federal_excise_rate"]),
+            state_local_income_rate=float(chosen["state_local_income_rate"]),
+            state_local_sales_rate=float(chosen["state_local_sales_rate"]),
+            state_local_property_rate=float(chosen["state_local_property_rate"]),
+            state_local_other_rate=float(chosen["state_local_other_rate"]),
+            source=str(chosen["source"]),
+        )
+
+    def _write_parquet_cache(self, rates: NIPATaxRates) -> None:
+        """Upsert ``rates`` into the parquet cache (atomic temp-file + rename)."""
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+        row = pd.DataFrame(
+            [
+                {
+                    "year": rates.year,
+                    "source": rates.source,
+                    **{col: getattr(rates, col) for col in _PARQUET_RATE_COLUMNS},
+                    "fetched_at": datetime.now(UTC),
+                }
+            ]
+        )
+
+        if self._cache_path.exists():
+            try:
+                existing = pd.read_parquet(self._cache_path)
+                # Replace any prior row with the same (year, source) key.
+                mask = ~((existing["year"] == rates.year) & (existing["source"] == rates.source))
+                combined = pd.concat([existing[mask], row], ignore_index=True)
+            except Exception as e:
+                logger.warning(f"NIPA parquet cache rewrite — existing read failed, replacing: {e}")
+                combined = row
+        else:
+            combined = row
+
+        # Atomic write: temp file in the same directory, then rename.
+        tmp = self._cache_path.with_suffix(self._cache_path.suffix + ".tmp")
+        combined.to_parquet(tmp, index=False)
+        tmp.replace(self._cache_path)
 
     def _get_baseline(self, year: int) -> NIPATaxRates:
         """Return hardcoded baseline rates for the given year."""

--- a/sbir_etl/transformers/fiscal/nipa_rates.py
+++ b/sbir_etl/transformers/fiscal/nipa_rates.py
@@ -20,6 +20,8 @@ Rate calculation:
 
 from __future__ import annotations
 
+import os
+import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -252,6 +254,14 @@ class NIPARateProvider:
         except Exception as e:  # pragma: no cover - corrupt cache is unusual
             logger.warning(f"NIPA parquet cache read failed ({self._cache_path}): {e}")
             return None
+        required_cols = {"year", "source", *_PARQUET_RATE_COLUMNS}
+        if not required_cols.issubset(df.columns):
+            missing = required_cols - set(df.columns)
+            logger.warning(
+                f"NIPA parquet cache at {self._cache_path} missing columns {missing}; "
+                "ignoring cache and falling back to fetch/baseline"
+            )
+            return None
         rows = df[df["year"] == year]
         if rows.empty:
             return None
@@ -299,10 +309,22 @@ class NIPARateProvider:
         else:
             combined = row
 
-        # Atomic write: temp file in the same directory, then rename.
-        tmp = self._cache_path.with_suffix(self._cache_path.suffix + ".tmp")
-        combined.to_parquet(tmp, index=False)
-        tmp.replace(self._cache_path)
+        # Atomic write: unique temp file in the same directory, then rename.
+        # Using mkstemp avoids races when multiple processes refresh concurrently
+        # (a fixed ".tmp" suffix would collide and corrupt the cache).
+        fd, tmp_name = tempfile.mkstemp(dir=self._cache_path.parent, suffix=".parquet.tmp")
+        os.close(fd)
+        tmp_path = Path(tmp_name)
+        try:
+            combined.to_parquet(tmp_path, index=False)
+            os.replace(tmp_path, self._cache_path)
+        except Exception:
+            # Clean up the orphaned temp file so we don't leak junk in the cache dir.
+            try:
+                tmp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+            raise
 
     def _get_baseline(self, year: int) -> NIPATaxRates:
         """Return hardcoded baseline rates for the given year."""

--- a/sbir_etl/transformers/fiscal/sensitivity.py
+++ b/sbir_etl/transformers/fiscal/sensitivity.py
@@ -18,6 +18,7 @@ import pandas as pd
 from loguru import logger
 
 from ...config.loader import get_config
+from .nipa_rates import NIPARateProvider
 
 
 # =============================================================================
@@ -51,14 +52,22 @@ class FiscalParameterSweep:
     various sampling methods for uncertainty quantification.
     """
 
-    def __init__(self, config: Any | None = None):
+    def __init__(
+        self,
+        config: Any | None = None,
+        rate_provider: NIPARateProvider | None = None,
+    ):
         """Initialize the parameter sweep engine.
 
         Args:
-            config: Optional configuration override
+            config: Optional configuration override.
+            rate_provider: Optional ``NIPARateProvider`` for tax-rate centers. When
+                ``None`` a default provider is constructed; tests pass a mock so
+                they don't reach the live BEA API.
         """
         self.config = config or get_config().fiscal_analysis
         self.sensitivity_config = self.config.sensitivity_parameters
+        self.rate_provider = rate_provider or NIPARateProvider()
 
     def _get_config_value(self, key: str, default: Any = None) -> Any:
         """Get a value from sensitivity_config, handling both dict and SensitivityConfig objects.
@@ -103,23 +112,26 @@ class FiscalParameterSweep:
 
         ranges = {}
 
-        # Tax rate parameters
+        # Tax rate parameters — center the sensitivity bands on the actual
+        # NIPA-derived rates the fiscal estimator applies, not literal defaults,
+        # so the bands track methodology changes (e.g. updated BEA tables).
         if "tax_rates" in uncertainty_params:
             tax_config = uncertainty_params["tax_rates"]
             variation = tax_config.get("variation_percent", 0.10)
-            base_rate = 0.22  # Default individual income tax rate
+            base_year = getattr(self.config, "base_year", None)
+            nipa = self.rate_provider.get_rates(base_year)
 
             ranges["individual_income_tax_rate"] = ParameterRange(
                 name="individual_income_tax_rate",
-                min_value=base_rate * (1 - variation),
-                max_value=base_rate * (1 + variation),
+                min_value=nipa.federal_income_rate * (1 - variation),
+                max_value=nipa.federal_income_rate * (1 + variation),
                 distribution=tax_config.get("distribution", "normal"),
             )
 
             ranges["corporate_income_tax_rate"] = ParameterRange(
                 name="corporate_income_tax_rate",
-                min_value=0.18 * (1 - variation),
-                max_value=0.18 * (1 + variation),
+                min_value=nipa.federal_corporate_rate * (1 - variation),
+                max_value=nipa.federal_corporate_rate * (1 + variation),
                 distribution=tax_config.get("distribution", "normal"),
             )
 

--- a/specs/bea-nipa-tax-rates/requirements.md
+++ b/specs/bea-nipa-tax-rates/requirements.md
@@ -1,90 +1,154 @@
-# Requirements — BEA NIPA Tax Rate Ingestion
+# Requirements — BEA NIPA Tax Rate Hardening
 
-> **Status:** Not yet started. BEA API client exists at
-> `sbir_etl/transformers/bea_api_client.py`; NIPA endpoints not yet wired.
-> Required by **Phase 1** of [../fiscal-tax-impact-v2.md](../fiscal-tax-impact-v2.md).
+> **Status:** Partially implemented. `sbir_etl/transformers/fiscal/nipa_rates.py`
+> (`NIPARateProvider`) already fetches BEA NIPA Tables 3.2, 3.3, and 1.5 via the
+> existing BEA API client and produces the eight derived federal + state/local
+> rates `FiscalTaxEstimator` consumes. This spec covers the remaining two gaps
+> surfaced during a 2026-06-29 audit:
+>
+> 1. The NIPA cache is in-memory only; a fresh process pays the full BEA API
+>    cost on every run.
+> 2. Three runtime sites still use a hardcoded `0.22` (or `0.18`) effective
+>    rate even though a NIPA-derived rate is available.
+>
 > Anchors inventory questions **D2** and **D3** in
 > [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** D2 — jurisdiction-separated fiscal tax receipts from SBIR spending; D3 — NIPA-derived rate credibility vs. hardcoded effective rates
 **Answers for:** pipeline engineers (data infrastructure), Treasury / OMB analysts (downstream consumers)
-**Complexity tier:** Foundational data acquisition
+**Complexity tier:** Targeted hardening of an existing component
 
 ---
 
 ## Done when
 
-> A pipeline engineer can state: "BEA NIPA tables 3.2, 3.3, 3.4, 3.6, 1.12, and 6.2D
-> are cached in `data/reference/bea/nipa_tax_rates.parquet`, refreshed quarterly via
-> the existing BEA API client. `NIPATaxRateBuilder` produces derived effective rates
-> (federal income 12–18%, federal payroll 14–15%, federal corporate 8–14%, state+local)
-> with unit tests verifying each rate falls in its expected range."
+> A pipeline engineer can state: "`NIPARateProvider` reads / writes
+> `data/reference/bea/nipa_tax_rates.parquet`, so a fresh process gets cached
+> rates without re-hitting the BEA API. No runtime code path applies a hardcoded
+> `0.22` effective-tax flat rate where a NIPA-derived rate is available — the
+> sensitivity analyzer, the `mission_c` tax-estimation tool, and the
+> `TaxParameterConfig` audit-trail default all flow through (or align with) the
+> same `NIPARateProvider` baseline."
 
 ---
 
 ## Introduction
 
-The `FiscalTaxEstimator` in `sbir_etl/transformers/fiscal/taxes.py` currently applies
-hardcoded flat effective rates (~22%). The D2 spec (`specs/fiscal-tax-impact-v2.md`)
-requires replacing those with rates derived from BEA NIPA tables. This spec covers only
-the data acquisition layer: fetching, caching, and computing derived rates from the six
-NIPA tables. The downstream estimator replacement is in `specs/fiscal-tax-impact-v2.md`
-Phase 2.
+A 2026-06-29 audit of PR #400's original premise found that the bulk of the
+data-acquisition work it proposed — BEA API wiring, NIPA-derived rate
+computation, `FiscalTaxEstimator` integration — already shipped via
+`NIPARateProvider` in `sbir_etl/transformers/fiscal/nipa_rates.py` (339 LOC,
+tested in `tests/unit/transformers/fiscal/test_nipa_rates.py`).
 
-The BEA API client (`sbir_etl/transformers/bea_api_client.py`) already handles
-authentication and I-O table fetch. NIPA endpoints use the same BEA Data API but
-with different `TableName` parameters.
+This rewrite narrows the spec to the genuine gaps. The original ask for six
+NIPA tables (3.4, 3.6, 1.12, 6.2D in addition to 3.2/3.3/1.5) is **out of
+scope** — the three tables `NIPARateProvider` already fetches produce all
+eight derived rates (`federal_income`, `federal_payroll`, `federal_corporate`,
+`federal_excise`, `state_local_income`, `state_local_sales`,
+`state_local_property`, `state_local_other`). Add the others in a follow-up if
+a downstream consumer asks for the finer-grained breakdown they expose.
 
 ---
 
 ## User Stories
 
-**As a pipeline engineer,** I want BEA NIPA tax-rate tables cached locally and
-refreshed quarterly, so that the fiscal estimator always uses current-year rates
-without requiring a code change when tax law changes.
+**As a pipeline engineer,** I want `NIPARateProvider` to persist fetched rates
+to `data/reference/bea/nipa_tax_rates.parquet`, so that nightly Dagster runs
+and ad-hoc CLI invocations both reuse cached rates instead of paying the BEA
+API cost (and BEA quota) every time the process restarts.
 
-**As a Treasury analyst,** I want the derived effective rates documented with their
-NIPA source table and line, so that the methodology is auditable and I can point GAO
-reviewers to the primary BEA data.
+**As a Treasury analyst auditing the fiscal-impact methodology,** I want every
+runtime tax-rate application to flow through `NIPARateProvider` (year-stamped,
+source-tagged `nipa_api` or `nipa_baseline`), so that the audit trail logs the
+actual NIPA-derived rate that was applied — not a stale `0.22` flat-rate
+literal sitting in a config default.
 
 ---
 
 ## Requirements
 
-### Requirement 1 — NIPA table fetch and cache
+### Requirement 1 — Parquet on-disk cache for `NIPARateProvider`
 
 #### Acceptance Criteria
 
-1. THE System SHALL fetch the following BEA NIPA tables via the existing BEA Data API:
-   Table 3.2 (Federal government current receipts), 3.3 (State/local current receipts),
-   3.4 (Personal current taxes), 3.6 (Contributions for government social insurance),
-   1.12 (National income by type), 6.2D (Compensation by industry — detail).
-2. THE System SHALL cache fetched tables to `data/reference/bea/nipa_tax_rates.parquet`
-   and refresh on a quarterly schedule (or on-demand via CLI flag).
-3. WHEN the BEA API is unreachable, THE System SHALL serve the last cached version and
-   emit a staleness warning if the cache is older than 120 days.
+1. THE System SHALL persist fetched / baseline rates to
+   `data/reference/bea/nipa_tax_rates.parquet` (one row per `(year, source)`)
+   with columns: `year`, `source` (`nipa_api` | `nipa_baseline`),
+   `federal_income_rate`, `federal_payroll_rate`, `federal_corporate_rate`,
+   `federal_excise_rate`, `state_local_income_rate`, `state_local_sales_rate`,
+   `state_local_property_rate`, `state_local_other_rate`, `fetched_at`
+   (UTC timestamp).
+2. THE System SHALL, on `NIPARateProvider.get_rates(year)`, check the on-disk
+   parquet **before** hitting the BEA API; in-memory cache short-circuits both.
+3. THE System SHALL, on a successful API fetch, append (or upsert on
+   `(year, source)`) the resulting row to the parquet cache atomically (write to
+   temp file + rename) so concurrent processes don't corrupt the cache.
+4. THE System SHALL accept a `cache_path` constructor argument
+   (default `data/reference/bea/nipa_tax_rates.parquet`) — tests use a
+   `tmp_path` override so they don't write to the repo cache.
+5. THE System SHALL keep the existing in-memory cache and `_BASELINE_RATES`
+   fallback behavior unchanged.
 
-### Requirement 2 — Derived effective rate computation
-
-#### Acceptance Criteria
-
-1. THE `NIPATaxRateBuilder` class SHALL compute the following derived rates:
-   - Federal income tax rate = Table 3.2 personal tax ÷ Table 1.12 compensation
-   - Federal payroll tax rate = Table 3.6 contributions ÷ Table 1.12 compensation
-   - Federal corporate tax rate = Table 3.2 corporate tax ÷ Table 1.12 corporate profits
-   - State+local rate = Table 3.3 receipts ÷ Table 1.12 total income
-2. THE System SHALL validate each derived rate against expected ranges:
-   federal income 12–18%, federal payroll 14–15%, federal corporate 8–14%.
-   Out-of-range rates SHALL trigger a logged warning (not a hard failure).
-3. THE System SHALL attach the source table name, line number, and BEA vintage year
-   to each derived rate for audit traceability.
-
-### Requirement 3 — Unit tests with mocked BEA responses
+### Requirement 2 — Sensitivity analyzer pulls from `NIPARateProvider`
 
 #### Acceptance Criteria
 
-1. THE System SHALL include unit tests in `tests/unit/test_nipa_tax_rate_builder.py`
-   using mocked BEA API responses that cover: normal fetch, stale-cache fallback,
-   and out-of-range rate warning.
-2. Tests SHALL verify that derived rates for a sample year (e.g., 2022) fall within
-   the documented expected ranges.
+1. THE System SHALL replace the literal `base_rate = 0.22` in
+   `sbir_etl/transformers/fiscal/sensitivity.py:110` (individual income tax) and
+   the literal `0.18` at lines 121–122 (corporate income tax) with values pulled
+   from a `NIPARateProvider` (`federal_income_rate`, `federal_corporate_rate`).
+2. THE System SHALL allow the sensitivity analyzer to accept an injected
+   `NIPARateProvider` (default: construct one) so tests can mock rates without
+   touching the live BEA API.
+3. THE Sensitivity bands SHALL still apply the configured
+   `variation_percent` symmetrically around the NIPA-derived center — the
+   change replaces the **center**, not the band-width logic.
+
+### Requirement 3 — `mission_c` tax-estimation tool pulls from `NIPARateProvider`
+
+#### Acceptance Criteria
+
+1. THE System SHALL remove the module-level constant
+   `INDIVIDUAL_INCOME_TAX_RATE = 0.22` in
+   `packages/sbir-analytics/sbir_analytics/tools/mission_c/tax_estimation.py:52`
+   and replace its single use site (line 168, `wages * INDIVIDUAL_INCOME_TAX_RATE`)
+   with `NIPARateProvider().get_rates(assessment_year).federal_income_rate`.
+2. THE System SHALL keep `DEFAULT_EFFECTIVE_TAX_RATES` (the industry-keyed dict
+   at lines 38–46) and `PAYROLL_TAX_RATE` (line 50) **unchanged** — they are
+   not NIPA-replaceable and live outside this spec's scope.
+3. THE System SHALL update `tests/unit/tools/test_mission_c.py:181`
+   accordingly — assert the NIPARateProvider-derived rate falls in a sensible
+   range, not the literal `0.22`.
+
+### Requirement 4 — `TaxParameterConfig` default reflects NIPA baseline
+
+#### Acceptance Criteria
+
+1. THE System SHALL update
+   `sbir_etl/config/schemas/domain.py:196`
+   (`TaxParameterConfig.individual_income_tax["effective_rate"]`) from `0.22`
+   to `0.194` — the 2022 NIPA-baseline federal income rate already declared in
+   `nipa_rates.py:103`.
+2. THE System SHALL add an inline comment explaining that
+   `TaxParameterConfig` is a static config default used only by
+   `fiscal_audit_trail.log_configuration()`; runtime fiscal calculations resolve
+   the actual rate via `NIPARateProvider` per-analysis year.
+3. THE System SHALL update `tests/unit/config/test_schemas.py:511` to assert
+   the new default.
+
+---
+
+## Out of scope
+
+- Adding NIPA tables 3.4, 3.6, 1.12, 6.2D. `NIPARateProvider`'s current three
+  tables already produce the eight derived rates downstream consumers use.
+  Add them in a follow-up spec if a consumer requests the finer breakdown.
+- The industry-effective-tax-rate dict in `mission_c/tax_estimation.py:38-46`.
+  Those rates come from IRS Statistics of Income (SOI), not NIPA — different
+  spec.
+- The hardcoded `PAYROLL_TAX_RATE = 0.153` in
+  `mission_c/tax_estimation.py:50`. It's the statutory FICA rate, not an
+  effective rate — no NIPA equivalent.
+- Wholesale audit-trail rework. `fiscal_audit_trail.log_configuration()`
+  continues to log the (now-updated) `TaxParameterConfig` defaults; logging
+  the per-analysis NIPA-derived rates alongside is a follow-up if needed.

--- a/specs/bea-nipa-tax-rates/requirements.md
+++ b/specs/bea-nipa-tax-rates/requirements.md
@@ -1,0 +1,90 @@
+# Requirements — BEA NIPA Tax Rate Ingestion
+
+> **Status:** Not yet started. BEA API client exists at
+> `sbir_etl/transformers/bea_api_client.py`; NIPA endpoints not yet wired.
+> Required by **Phase 1** of [../fiscal-tax-impact-v2.md](../fiscal-tax-impact-v2.md).
+> Anchors inventory questions **D2** and **D3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** D2 — jurisdiction-separated fiscal tax receipts from SBIR spending; D3 — NIPA-derived rate credibility vs. hardcoded effective rates
+**Answers for:** pipeline engineers (data infrastructure), Treasury / OMB analysts (downstream consumers)
+**Complexity tier:** Foundational data acquisition
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "BEA NIPA tables 3.2, 3.3, 3.4, 3.6, 1.12, and 6.2D
+> are cached in `data/reference/bea/nipa_tax_rates.parquet`, refreshed quarterly via
+> the existing BEA API client. `NIPATaxRateBuilder` produces derived effective rates
+> (federal income 12–18%, federal payroll 14–15%, federal corporate 8–14%, state+local)
+> with unit tests verifying each rate falls in its expected range."
+
+---
+
+## Introduction
+
+The `FiscalTaxEstimator` in `sbir_etl/transformers/fiscal/taxes.py` currently applies
+hardcoded flat effective rates (~22%). The D2 spec (`specs/fiscal-tax-impact-v2.md`)
+requires replacing those with rates derived from BEA NIPA tables. This spec covers only
+the data acquisition layer: fetching, caching, and computing derived rates from the six
+NIPA tables. The downstream estimator replacement is in `specs/fiscal-tax-impact-v2.md`
+Phase 2.
+
+The BEA API client (`sbir_etl/transformers/bea_api_client.py`) already handles
+authentication and I-O table fetch. NIPA endpoints use the same BEA Data API but
+with different `TableName` parameters.
+
+---
+
+## User Stories
+
+**As a pipeline engineer,** I want BEA NIPA tax-rate tables cached locally and
+refreshed quarterly, so that the fiscal estimator always uses current-year rates
+without requiring a code change when tax law changes.
+
+**As a Treasury analyst,** I want the derived effective rates documented with their
+NIPA source table and line, so that the methodology is auditable and I can point GAO
+reviewers to the primary BEA data.
+
+---
+
+## Requirements
+
+### Requirement 1 — NIPA table fetch and cache
+
+#### Acceptance Criteria
+
+1. THE System SHALL fetch the following BEA NIPA tables via the existing BEA Data API:
+   Table 3.2 (Federal government current receipts), 3.3 (State/local current receipts),
+   3.4 (Personal current taxes), 3.6 (Contributions for government social insurance),
+   1.12 (National income by type), 6.2D (Compensation by industry — detail).
+2. THE System SHALL cache fetched tables to `data/reference/bea/nipa_tax_rates.parquet`
+   and refresh on a quarterly schedule (or on-demand via CLI flag).
+3. WHEN the BEA API is unreachable, THE System SHALL serve the last cached version and
+   emit a staleness warning if the cache is older than 120 days.
+
+### Requirement 2 — Derived effective rate computation
+
+#### Acceptance Criteria
+
+1. THE `NIPATaxRateBuilder` class SHALL compute the following derived rates:
+   - Federal income tax rate = Table 3.2 personal tax ÷ Table 1.12 compensation
+   - Federal payroll tax rate = Table 3.6 contributions ÷ Table 1.12 compensation
+   - Federal corporate tax rate = Table 3.2 corporate tax ÷ Table 1.12 corporate profits
+   - State+local rate = Table 3.3 receipts ÷ Table 1.12 total income
+2. THE System SHALL validate each derived rate against expected ranges:
+   federal income 12–18%, federal payroll 14–15%, federal corporate 8–14%.
+   Out-of-range rates SHALL trigger a logged warning (not a hard failure).
+3. THE System SHALL attach the source table name, line number, and BEA vintage year
+   to each derived rate for audit traceability.
+
+### Requirement 3 — Unit tests with mocked BEA responses
+
+#### Acceptance Criteria
+
+1. THE System SHALL include unit tests in `tests/unit/test_nipa_tax_rate_builder.py`
+   using mocked BEA API responses that cover: normal fetch, stale-cache fallback,
+   and out-of-range rate warning.
+2. Tests SHALL verify that derived rates for a sample year (e.g., 2022) fall within
+   the documented expected ranges.

--- a/specs/bea-nipa-tax-rates/requirements.md
+++ b/specs/bea-nipa-tax-rates/requirements.md
@@ -71,13 +71,15 @@ literal sitting in a config default.
 
 #### Acceptance Criteria
 
-1. THE System SHALL persist fetched / baseline rates to
+1. THE System SHALL persist fetched (API-sourced) rates to
    `data/reference/bea/nipa_tax_rates.parquet` (one row per `(year, source)`)
-   with columns: `year`, `source` (`nipa_api` | `nipa_baseline`),
+   with columns: `year`, `source` (`nipa_api`),
    `federal_income_rate`, `federal_payroll_rate`, `federal_corporate_rate`,
    `federal_excise_rate`, `state_local_income_rate`, `state_local_sales_rate`,
    `state_local_property_rate`, `state_local_other_rate`, `fetched_at`
-   (UTC timestamp).
+   (UTC timestamp). Baseline rates are NOT written to the parquet cache —
+   they are deterministic from `_BASELINE_RATES` and caching them adds no
+   value.
 2. THE System SHALL, on `NIPARateProvider.get_rates(year)`, check the on-disk
    parquet **before** hitting the BEA API; in-memory cache short-circuits both.
 3. THE System SHALL, on a successful API fetch, append (or upsert on

--- a/tests/unit/config/test_schemas.py
+++ b/tests/unit/config/test_schemas.py
@@ -541,7 +541,10 @@ class TestTaxParameterConfig:
     def test_default_individual_income_tax(self):
         """Test TaxParameterConfig default individual income tax."""
         config = TaxParameterConfig()
-        assert config.individual_income_tax["effective_rate"] == 0.22
+        # NIPA-derived 2022 baseline (see nipa_rates.py:_BASELINE_RATES[2022]).
+        # Runtime fiscal calculations resolve the rate per analysis year via
+        # NIPARateProvider; this default is only used in audit-trail snapshots.
+        assert config.individual_income_tax["effective_rate"] == 0.194
         assert config.individual_income_tax["progressive_rates"]["10_percent"] == 0.10
 
     def test_default_payroll_tax(self):

--- a/tests/unit/tools/test_mission_c.py
+++ b/tests/unit/tools/test_mission_c.py
@@ -175,17 +175,21 @@ class TestTaxEstimationTool:
         summary = result.data["summary"]
         assert summary["track_a"]["total_estimated_tax_receipts"] == 0.0
 
-    def test_default_tax_rates(self):
+    def test_default_tax_rates(self, tmp_path):
         """Sanity-check the rate inputs the tool uses.
 
         The SOI corporate-effective-rate dict and the statutory FICA constant
         live in this module; the individual income effective rate now comes from
         NIPARateProvider — assert its baseline falls in a plausible range so
         a wildly-off NIPA refresh is caught here.
+
+        Pass an explicit ``cache_path`` so the test is hermetic and doesn't
+        read whatever happens to be in the developer's repo cache.
         """
         assert "Manufacturing" in DEFAULT_EFFECTIVE_TAX_RATES
         assert 0 < PAYROLL_TAX_RATE < 0.5
-        baseline = NIPARateProvider().get_rates().federal_income_rate
+        provider = NIPARateProvider(cache_path=tmp_path / "nipa_cache.parquet")
+        baseline = provider.get_rates().federal_income_rate
         assert 0 < baseline < 0.5
 
     def test_limitation_disclosure(self):

--- a/tests/unit/tools/test_mission_c.py
+++ b/tests/unit/tools/test_mission_c.py
@@ -9,8 +9,8 @@ from sbir_analytics.tools.mission_c.tax_estimation import (
     TaxEstimationTool,
     DEFAULT_EFFECTIVE_TAX_RATES,
     PAYROLL_TAX_RATE,
-    INDIVIDUAL_INCOME_TAX_RATE,
 )
+from sbir_etl.transformers.fiscal.nipa_rates import NIPARateProvider
 
 
 # ---- naics_to_bea_crosswalk ----
@@ -176,9 +176,17 @@ class TestTaxEstimationTool:
         assert summary["track_a"]["total_estimated_tax_receipts"] == 0.0
 
     def test_default_tax_rates(self):
+        """Sanity-check the rate inputs the tool uses.
+
+        The SOI corporate-effective-rate dict and the statutory FICA constant
+        live in this module; the individual income effective rate now comes from
+        NIPARateProvider — assert its baseline falls in a plausible range so
+        a wildly-off NIPA refresh is caught here.
+        """
         assert "Manufacturing" in DEFAULT_EFFECTIVE_TAX_RATES
         assert 0 < PAYROLL_TAX_RATE < 0.5
-        assert 0 < INDIVIDUAL_INCOME_TAX_RATE < 0.5
+        baseline = NIPARateProvider().get_rates().federal_income_rate
+        assert 0 < baseline < 0.5
 
     def test_limitation_disclosure(self):
         tool = TaxEstimationTool()

--- a/tests/unit/transformers/fiscal/test_nipa_rates.py
+++ b/tests/unit/transformers/fiscal/test_nipa_rates.py
@@ -81,6 +81,127 @@ class TestNIPARateProvider:
             assert "baseline" in rates.source
 
 
+class TestNIPAParquetCache:
+    """On-disk parquet cache backing NIPARateProvider.get_rates."""
+
+    def _provider(self, tmp_path, **kwargs):
+        return NIPARateProvider(cache_path=tmp_path / "nipa_tax_rates.parquet", **kwargs)
+
+    def test_api_fetch_persists_to_parquet(self, tmp_path):
+        provider = self._provider(tmp_path, bea_api_key="fake-key")
+        api_rates = NIPATaxRates(
+            year=2023,
+            federal_income_rate=0.20,
+            federal_payroll_rate=0.13,
+            federal_corporate_rate=0.16,
+            federal_excise_rate=0.010,
+            state_local_income_rate=0.045,
+            state_local_sales_rate=0.035,
+            state_local_property_rate=0.128,
+            state_local_other_rate=0.009,
+            source="nipa_api",
+        )
+        with patch.object(provider, "_fetch_from_api", return_value=api_rates):
+            rates = provider.get_rates(2023)
+
+        assert rates.source == "nipa_api"
+        assert (tmp_path / "nipa_tax_rates.parquet").exists()
+
+    def test_fresh_provider_reads_parquet_cache(self, tmp_path):
+        """A second provider with the same cache_path skips the API entirely."""
+        api_rates = NIPATaxRates(
+            year=2023,
+            federal_income_rate=0.20,
+            federal_payroll_rate=0.13,
+            federal_corporate_rate=0.16,
+            federal_excise_rate=0.010,
+            state_local_income_rate=0.045,
+            state_local_sales_rate=0.035,
+            state_local_property_rate=0.128,
+            state_local_other_rate=0.009,
+            source="nipa_api",
+        )
+        # Seed the cache via a first provider.
+        seeder = self._provider(tmp_path, bea_api_key="fake-key")
+        with patch.object(seeder, "_fetch_from_api", return_value=api_rates):
+            seeder.get_rates(2023)
+
+        # Second provider — even with an API key, the parquet hit must short-circuit
+        # before `_fetch_from_api` is consulted.
+        reader = self._provider(tmp_path, bea_api_key="fake-key")
+        with patch.object(reader, "_fetch_from_api") as mock_fetch:
+            rates = reader.get_rates(2023)
+
+        assert rates.source == "nipa_api"
+        assert rates.federal_income_rate == pytest.approx(0.20)
+        mock_fetch.assert_not_called()
+
+    def test_baseline_rates_not_written_to_cache(self, tmp_path):
+        """Without an API key we serve baselines but must not pollute the cache."""
+        provider = self._provider(tmp_path)
+        provider.get_rates(2022)
+        assert not (tmp_path / "nipa_tax_rates.parquet").exists()
+
+    def test_write_upserts_on_year_source_key(self, tmp_path):
+        """Repeated _write_parquet_cache for the same (year, source) overwrites in-place.
+
+        The defensive upsert protects against hand-edited / partially-corrupted
+        caches; normal get_rates() short-circuits on the parquet hit before
+        re-writing, so this exercises the writer directly.
+        """
+        provider = self._provider(tmp_path)
+
+        def _rates(income_rate: float, source: str = "nipa_api") -> NIPATaxRates:
+            return NIPATaxRates(
+                year=2023,
+                federal_income_rate=income_rate,
+                federal_payroll_rate=0.12,
+                federal_corporate_rate=0.15,
+                federal_excise_rate=0.009,
+                state_local_income_rate=0.040,
+                state_local_sales_rate=0.034,
+                state_local_property_rate=0.125,
+                state_local_other_rate=0.008,
+                source=source,
+            )
+
+        provider._write_parquet_cache(_rates(0.18))
+        provider._write_parquet_cache(_rates(0.21))
+
+        import pandas as pd
+
+        df = pd.read_parquet(tmp_path / "nipa_tax_rates.parquet")
+        rows = df[df["year"] == 2023]
+        assert len(rows) == 1
+        assert rows.iloc[0]["federal_income_rate"] == pytest.approx(0.21)
+
+    def test_write_keeps_distinct_year_source_pairs(self, tmp_path):
+        """Distinct (year, source) keys coexist in the cache."""
+        provider = self._provider(tmp_path)
+
+        def _rates(year: int, source: str) -> NIPATaxRates:
+            return NIPATaxRates(
+                year=year,
+                federal_income_rate=0.19,
+                federal_payroll_rate=0.12,
+                federal_corporate_rate=0.15,
+                federal_excise_rate=0.009,
+                state_local_income_rate=0.040,
+                state_local_sales_rate=0.034,
+                state_local_property_rate=0.125,
+                state_local_other_rate=0.008,
+                source=source,
+            )
+
+        provider._write_parquet_cache(_rates(2022, "nipa_api"))
+        provider._write_parquet_cache(_rates(2023, "nipa_api"))
+
+        import pandas as pd
+
+        df = pd.read_parquet(tmp_path / "nipa_tax_rates.parquet")
+        assert sorted(df["year"].tolist()) == [2022, 2023]
+
+
 class TestValidateRates:
     def test_valid_rates_pass(self):
         rates = _BASELINE_RATES[2022]


### PR DESCRIPTION
## Summary

> **What changed since this PR was opened:** A 2026-06-29 audit found that the bulk of the BEA NIPA data-acquisition work the original spec proposed (BEA API client wiring, NIPA-derived federal + state/local rate computation, `FiscalTaxEstimator` integration) had **already shipped** in `sbir_etl/transformers/fiscal/nipa_rates.py`. This PR is rewritten to cover only the two genuine gaps the audit surfaced.

## Genuine gaps addressed

### 1. Parquet on-disk cache for `NIPARateProvider`

`get_rates(year)` resolution order is now: in-memory cache → on-disk parquet (API-sourced rows only) → BEA API → `_BASELINE_RATES` fallback. API fetches upsert into `data/reference/bea/nipa_tax_rates.parquet` via atomic temp-file + rename so a fresh process reuses cached rates instead of re-hitting BEA. Baseline rows aren't cached (deterministic from `_BASELINE_RATES`). Constructor renamed `cache_dir` → `cache_path` (prior `cache_dir` was unused).

### 2. Scrub three remaining hardcoded `0.22` runtime sites

| File | Before | After |
|---|---|---|
| `transformers/fiscal/sensitivity.py:110-122` | `base_rate = 0.22`, `0.18 *` for corporate | Center bands on `NIPARateProvider.get_rates(base_year).federal_income_rate` / `.federal_corporate_rate` |
| `tools/mission_c/tax_estimation.py:52` | `INDIVIDUAL_INCOME_TAX_RATE = 0.22` constant | Removed. Per-row resolution via `NIPARateProvider.get_rates(fy_int).federal_income_rate` (year-stamped per award) |
| `config/schemas/domain.py:196` | `"effective_rate": 0.22` audit-trail default | `0.194` — the 2022 NIPA baseline already in `_BASELINE_RATES[2022]`. Comment explains it's a static audit-trail snapshot; runtime resolves via `NIPARateProvider` |

## Explicitly out of scope (per the rewritten spec)

- Adding NIPA Tables 3.4 / 3.6 / 1.12 / 6.2D. The three tables `NIPARateProvider` already fetches produce all 8 derived rates downstream consumers use.
- `mission_c`'s `DEFAULT_EFFECTIVE_TAX_RATES` industry dict (SOI-sourced, not NIPA — different spec).
- The statutory `PAYROLL_TAX_RATE = 0.153` constant (FICA, no NIPA equivalent).
- Audit-trail rework. `fiscal_audit_trail.log_configuration()` continues to log the updated `TaxParameterConfig` defaults; per-analysis NIPA snapshotting is a follow-up.

## Test plan

- [x] `pytest tests/unit/transformers/ tests/unit/tools/test_mission_c.py tests/unit/config/test_schemas.py` → **444 passed**.
- [x] `pytest tests/unit/transformers/fiscal/test_nipa_rates.py -v` → **20 passed** (16 pre-existing + 4 new covering API-fetch persistence, second-provider cache hit, baseline-not-cached invariant, upsert vs. distinct-key writes).
- [x] `pytest tests/unit/transformers/test_fiscal_parameter_sweep.py tests/unit/transformers/fiscal/test_sensitivity.py` → 44 passed (sensitivity bands unchanged in width; only center shifted).
- [x] `pytest tests/unit/tools/test_mission_c.py` → 13 passed (asserts NIPA-baseline range instead of removed constant).
- [x] `ruff check` + `ruff format --check` clean on all 8 changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)