### PR TITLE
feat: restricted-entity screening lists ingestion (A1/A2)

### DIFF
--- a/specs/restricted-entity-screening/requirements.md
+++ b/specs/restricted-entity-screening/requirements.md
@@ -35,18 +35,21 @@ Ingesting all eight lists and building a `RestrictedEntityScreener` enables the 
 FOCI exposure question to be answered for the full awardee universe, not just the
 disclosed/structured ownership subset.
 
-**The eight lists (all publicly downloadable):**
+**The eight lists (all publicly downloadable), aligned with Pub. L. 119-83, sec. 2
+(codified at 15 U.S.C. § 638(g)(16)(D) and (o)(20)(D)):**
 
-| List | Authority | Format |
-|------|-----------|--------|
-| UFLPA Entity List | CBP / DHS | CSV |
-| NS-CMIC List (Non-SDN Chinese Military-Industrial Complex) | OFAC / Treasury | CSV |
-| Section 889 Prohibition List | GSA / FCC | CSV |
-| 1260H List | DoD | CSV / PDF |
-| Military End-User (MEU) List | BIS / Commerce | CSV |
-| BIS Entity List | BIS / Commerce | CSV |
-| FCC Covered List | FCC | JSON |
-| CBP WRO/Findings List | CBP / DHS | CSV |
+| List (statutory label) | Maintainer / authority | Format | Notes |
+|------|-----------|--------|-------|
+| UFLPA Entity List | CBP / DHS | CSV | |
+| NS-CMIC List (Non-SDN Chinese Military-Industrial Complex) | OFAC / Treasury | CSV | |
+| Section 889 Prohibition List | **Department of Defense** | CSV | Statute names the DoD-maintained prohibition list; do not route implementers to GSA/FCC endpoints |
+| 1260H List | DoD | CSV / PDF | |
+| Military End-User (MEU) List | BIS / Commerce | CSV | |
+| BIS Entity List | BIS / Commerce | CSV | |
+| FCC List of Equipment and Services | FCC | JSON | Statutory label; not the informal "Covered List" shorthand alone |
+| CBP WRO/Findings List | CBP / DHS | CSV | |
+
+**Statutory source:** [Pub. L. 119-83 (2026)](https://www.govinfo.gov/content/pkg/PLAW-119publ83/pdf/PLAW-119publ83.pdf), Small Business Innovation and Economic Security Act, sec. 2.
 
 ---
 
@@ -70,6 +73,9 @@ enrichment run without manual intervention.
 
 1. THE System SHALL implement a downloader for each of the eight lists, fetching from
    their authoritative government sources on a configurable schedule (default: weekly).
+   Each downloader SHALL record the canonical source URL, update cadence, identifier
+   fields available, alias handling, and whether matches are entity-level vs.
+   person/ownership-level in the manifest.
 2. THE System SHALL normalize each list to a common schema:
    `entity_name`, `entity_aliases`, `country`, `list_name`, `list_authority`,
    `effective_date`, `source_url`, `raw_id`.

--- a/specs/restricted-entity-screening/requirements.md
+++ b/specs/restricted-entity-screening/requirements.md
@@ -1,0 +1,113 @@
+# Requirements — Restricted-Entity Screening Lists Ingestion
+
+> **Status:** Not yet started. Current FOCI exposure coverage is "SEC-filer subset
+> only." Full screening requires ingesting the eight lists mandated by Pub. L. 119-83.
+> Anchors inventory questions **A1** (FOCI exposure share per CET area) and **A2**
+> (adversary-affiliation screening) in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** A1 — foreign ownership / control (FOCI) exposure share per CET area (A-CP4); A2 — adversary-affiliation screening of awardees and key personnel
+**Answers for:** DoD acquisition leadership, OSTP, congressional defense committees
+**Complexity tier:** Foundational data acquisition
+
+---
+
+## Done when
+
+> A DoD acquisition analyst can state: "All eight Pub. L. 119-83 restricted-entity
+> lists are ingested and normalized in `data/reference/restricted_entities/`. The
+> `RestrictedEntityScreener` checks any SBIR awardee name or UEI against all eight
+> lists in a single pass and returns a match report with list name, match confidence,
+> and entity detail. Lists are refreshed weekly. FOCI exposure share per CET area is
+> computable as a Dagster asset."
+
+---
+
+## Introduction
+
+Pub. L. 119-83 (SBIR/STTR reauthorization, signed April 13, 2026) mandates
+risk-based due-diligence screening against eight restricted-entity lists for SBIR/STTR
+applicants. The pipeline currently detects FOCI exposure only for the SEC-filer subset
+(via EDGAR Exhibit 21 / 8-K ownership disclosures), which misses private SBIR firms
+— the majority of the awardee population.
+
+Ingesting all eight lists and building a `RestrictedEntityScreener` enables the A1
+FOCI exposure question to be answered for the full awardee universe, not just the
+disclosed/structured ownership subset.
+
+**The eight lists (all publicly downloadable):**
+
+| List | Authority | Format |
+|------|-----------|--------|
+| UFLPA Entity List | CBP / DHS | CSV |
+| NS-CMIC List (Non-SDN Chinese Military-Industrial Complex) | OFAC / Treasury | CSV |
+| Section 889 Prohibition List | GSA / FCC | CSV |
+| 1260H List | DoD | CSV / PDF |
+| Military End-User (MEU) List | BIS / Commerce | CSV |
+| BIS Entity List | BIS / Commerce | CSV |
+| FCC Covered List | FCC | JSON |
+| CBP WRO/Findings List | CBP / DHS | CSV |
+
+---
+
+## User Stories
+
+**As a DoD acquisition analyst,** I want every SBIR awardee screened against all
+eight Pub. L. 119-83 restricted-entity lists, so that I can produce the FOCI exposure
+share per CET area required by the statute's risk-based due-diligence framework.
+
+**As a pipeline engineer,** I want the eight lists normalized to a common schema and
+refreshed weekly, so that new additions to any list are reflected in the next
+enrichment run without manual intervention.
+
+---
+
+## Requirements
+
+### Requirement 1 — List ingestion and normalization
+
+#### Acceptance Criteria
+
+1. THE System SHALL implement a downloader for each of the eight lists, fetching from
+   their authoritative government sources on a configurable schedule (default: weekly).
+2. THE System SHALL normalize each list to a common schema:
+   `entity_name`, `entity_aliases`, `country`, `list_name`, `list_authority`,
+   `effective_date`, `source_url`, `raw_id`.
+3. THE System SHALL persist each list to
+   `data/reference/restricted_entities/<list_name>.parquet` and maintain a
+   `data/reference/restricted_entities/manifest.json` recording the last-fetched
+   timestamp and record count per list.
+4. WHEN a list source URL returns a non-200 status, THE System SHALL retain the prior
+   version and emit an alert so the staleness does not go undetected.
+
+### Requirement 2 — RestrictedEntityScreener
+
+#### Acceptance Criteria
+
+1. THE `RestrictedEntityScreener` SHALL accept an entity name, UEI, or CAGE code and
+   return a list of matches across all eight lists, including list name, match
+   confidence (exact / fuzzy / alias), and matched entity detail.
+2. THE screener SHALL use exact match on UEI/CAGE where available, and fuzzy name
+   matching (threshold ≥ 0.85, same as `SAMGovAPIClient`) for name-only checks.
+3. THE screener SHALL complete a single-entity check in < 500ms for the full
+   eight-list corpus.
+4. THE screener SHALL expose a batch mode for screening the full SBIR awardee
+   universe in one pass, with results written to
+   `data/derived/restricted_entity_matches.parquet`.
+
+### Requirement 3 — FOCI exposure Dagster asset
+
+#### Acceptance Criteria
+
+1. THE System SHALL implement a `foci_exposure_by_cet` Dagster asset in the
+   `industrial_base` asset group that:
+   - Joins `restricted_entity_matches` to SBIR awards via entity resolution
+   - Computes share of awardees and award dollars per CET area with at least one
+     list match
+   - Emits the result to `reports/foci-exposure/foci_exposure_<period>.parquet`
+2. THE asset SHALL distinguish between the eight lists in its output so that
+   consumers can filter to specific statutory concerns (e.g., UFLPA for Xinjiang
+   supply-chain exposure vs. NS-CMIC for military-industrial complex).
+3. ALL match results SHALL carry the caveat that this is a LOWER-BOUND proxy —
+   structured lists detect only disclosed/public entity relationships, not private
+   beneficial ownership.


### PR DESCRIPTION
## Summary

Spec for ingesting all eight Pub. L. 119-83 restricted-entity lists (UFLPA, NS-CMIC, Section 889, 1260H, Military End-User, BIS Entity, FCC Covered, CBP WRO/Findings), normalizing to a common schema, and building a `RestrictedEntityScreener`. Enables the A1 FOCI exposure share per CET area (A-CP4) to be computed for the full SBIR awardee universe — not just the SEC-filer subset currently covered via EDGAR.

**RQ anchors:** A1 (FOCI exposure share, A-CP4), A2 (adversary-affiliation screening)

## What's in this PR

- `specs/restricted-entity-screening/requirements.md` — spec covering list downloaders + normalization schema, `RestrictedEntityScreener` (exact + fuzzy match, batch mode), and `foci_exposure_by_cet` Dagster asset in the `industrial_base` group

## Dependencies / sequencing

- All eight lists are publicly downloadable from government sources (CBP, OFAC, GSA, DoD, BIS, FCC)
- No dependency on other in-flight specs
- Note: all match results carry the LOWER-BOUND proxy caveat — structured lists detect disclosed/public entity relationships only, not private beneficial ownership

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf6DkRWXkQ3LB5krcrcSRA)_