### PR TITLE
docs(specs): rewrite #404 NVCA spec — correct F2/F3 anchors, defer impl

### DIFF
--- a/specs/nvca-yearbook-benchmarks/requirements.md
+++ b/specs/nvca-yearbook-benchmarks/requirements.md
@@ -1,108 +1,183 @@
 # Requirements — NVCA Yearbook Benchmark Reference Data
 
-> **Status:** Not yet started. The `agency_private_capital_baseline_comparison` Dagster
-> asset (PR #321, group `agency_private_capital`) currently uses internal baselines.
-> NVCA Yearbook figures are needed for the publishable comparison in
-> `specs/acquirer-concentration/` (Requirement 3) and the F3 NVCA-baseline comparison.
-> Anchors inventory questions **F2** and **F3** in
-> [docs/research-questions.md](../../docs/research-questions.md).
+> **Status:** **Partially implemented; spec was mis-framed on first pass.** A
+> 2026-06-29 audit (paralleling #400 and #402) found that
+> `agency_private_capital/baselines.py` already provides a fully-functional
+> `PublishedBaseline` + `PublishedBaselineRegistry` registry that loads from
+> `config/agency_private_capital/published_baselines.yaml`. **One NVCA Yearbook
+> entry is already wired in** (`nvca_seed_to_series_a`, 0.33 graduation rate
+> paired with the `phase_i_to_ii_graduation` SBIR cohort metric). `reconcile.py`
+> consumes the registry and emits paired SBIR-vs-baseline reconciliation rows.
+>
+> The audit also found the original spec was *mis-anchored against F3*. The
+> canonical F3 question in [docs/research-questions.md](../../docs/research-questions.md):289
+> is the **private-to-SBIR leverage ratio** (private capital raised ÷ SBIR
+> funding) mirroring NASEM's 4:1 DoD figure [L1] — not the
+> median-deal-size / exit-count figures the original spec listed. NVCA Yearbook
+> data feeds the F2 cohort-outcome comparison; the F3 anchor metric is
+> a leverage-ratio computation.
+>
+> This rewrite reframes the work scope honestly, defers source-access-dependent
+> data acquisition to a clearly-marked follow-up, and corrects the F2/F3
+> anchoring.
 
-**Research question anchor:** F2 — how does SBIR-firm capital structure benchmark against the NVCA Yearbook cohort? F3 — do follow-on funding and exit outcomes match published private-capital-backed-startup baselines?
+**Research question anchor:** F2 — SBIR-firm capital structure vs. NVCA Yearbook cohort outcome metrics; F3 — private-to-SBIR leverage ratio with NASEM 4:1 DoD figure as the canonical published comparator
 **Answers for:** entrepreneurial finance researchers, NVCA / Kauffman-style investment researchers
-**Complexity tier:** Foundational data acquisition
+**Complexity tier:** Data acquisition + paired cohort-metric implementation
 
 ---
 
 ## Done when
 
-> An entrepreneurial finance researcher can state: "NVCA Yearbook benchmark figures
-> for seed and early-stage companies (median deal size, round type distribution,
-> fill rate, exit rate, M&A rate) are available in
-> `data/reference/nvca/nvca_yearbook_benchmarks.csv` for years 2009–2024, with
-> source citations. The `agency_private_capital_baseline_comparison` asset uses these
-> as the non-SBIR comparison cohort."
+> An entrepreneurial finance researcher can state: "The
+> `published_baselines.yaml` registry contains NVCA Yearbook public-summary
+> figures paired with implemented SBIR cohort metrics in
+> `outcomes.py` — every baseline is reportable via `reconcile.py` against a
+> real SBIR-side numerator. The F3 private-to-SBIR leverage ratio is
+> computed and compared against NASEM 4:1 [L1]."
 
 ---
 
-## Introduction
+## Current state (what's already shipped)
 
-The F3 research questions require benchmarking SBIR-firm capital raises (via Form D)
-against what comparable private-capital-backed startups raise. The NVCA Yearbook [L25]
-is the industry-standard source for VC fundraising, deployment, deal stage and size,
-and exit activity. It is published annually by the National Venture Capital Association
-and PITCHBOOK.
+`packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/` has:
 
-NVCA publishes selected summary statistics publicly (press releases, annual report
-highlights); detailed deal-level data requires an NVCA/PITCHBOOK subscription. This
-spec covers both paths: (a) manual transcription of public summary figures sufficient
-for headline comparisons, and (b) a structured placeholder for licensed data if the
-detailed cohort comparison is needed.
+- **`baselines.py`** — `PublishedBaseline` dataclass with all needed fields
+  (id, cohort_metric, label, kind ∈ {rate, effect_size, framing},
+  point_estimate, as_of, population, citation, citation_url, notes,
+  effect_description). `PublishedBaselineRegistry.load(yaml_path)` reads from
+  YAML. Frozen dataclasses; tested.
+- **`published_baselines.yaml`** — 5 entries today: `nvca_seed_to_series_a`,
+  `bls_bed_5yr_survival`, `lerner_growth_effect`, `howell_followon_vc`,
+  `itif_seed_fund_framing`. All paired against the **three** cohort metrics
+  `outcomes.py` produces today: `phase_i_to_ii_graduation`,
+  `phase_ii_to_federal_contract_transition`, `five_year_survival_proxy`.
+- **`reconcile.py`** — iterates the registry, joins to outcomes on
+  `cohort_metric == metric`, emits one row per (metric, baseline) pair with a
+  curated `_ATTRIBUTION` narrative explaining the cohort-vs-baseline
+  divergence.
 
-**Caveat:** The SBIR Form D cohort includes all Reg D offerings (angel, seed,
-institutional non-VC, debt, convertible). The NVCA Yearbook measures VC deals only.
-The comparison must carry an explicit "different instruments" qualifier — consistent
-with the caveat in `specs/acquirer-concentration/` Requirement 3.
+The infrastructure works. The gap is **which** additional baselines + paired
+SBIR-side cohort metrics are worth adding.
+
+---
+
+## What's wrong with the original spec
+
+The original spec asked for `data/reference/nvca/nvca_yearbook_benchmarks.csv`
+populated with median deal size, exit counts, M&A/IPO rates 2009–present.
+Three problems:
+
+1. **CSV duplicates the YAML pattern.** Existing baselines are YAML with
+   multi-line `notes:`, structured citations, and string-typed kind enums —
+   YAML is the right format for hand-curated baseline metadata. CSV would
+   require restructuring or duplicating storage.
+
+2. **Each new baseline needs a paired SBIR-side cohort metric in
+   `outcomes.py`.** `reconcile.py` only emits records for metrics that exist
+   on both sides. Adding "median seed deal size" as a baseline does nothing
+   until `median_form_d_round_size_phase_ii` (or similar) is also implemented.
+   Original spec didn't acknowledge the paired-work requirement.
+
+3. **F3 anchor is mis-stated.** F3's canonical metric per
+   `docs/research-questions.md:289` is the private-to-SBIR leverage ratio,
+   not deal sizes. NVCA Yearbook data feeds F2's cohort-outcome comparison,
+   not F3's leverage-ratio question. Original spec conflated the two.
 
 ---
 
 ## User Stories
 
-**As an entrepreneurial finance researcher,** I want NVCA Yearbook benchmark figures
-in a machine-readable reference file, so that the `agency_private_capital_baseline_comparison`
-asset can produce a side-by-side table without manual spreadsheet lookup each time
-a report is generated.
+**As an entrepreneurial finance researcher,** I want each NVCA Yearbook
+baseline in `published_baselines.yaml` to be paired with a real SBIR-side
+cohort metric in `outcomes.py`, so the reconciliation report never produces
+empty rows — every comparison is a genuine cohort-vs-baseline number.
 
-**As a policy analyst citing SBIR vs. VC outcomes in a congressional briefing,** I
-want the NVCA source year and page number attached to each benchmark figure, so that
-the comparison is auditable and a staff researcher can verify the figures independently.
+**As a policy analyst citing F3 private-to-SBIR leverage,** I want the
+NASEM 4:1 DoD figure [L1] in the baseline registry paired with a computed
+`private_to_sbir_leverage_ratio` metric, so the report has the right F3
+anchor — not a deal-size analogue that the public reader won't recognize.
 
 ---
 
 ## Requirements
 
-### Requirement 1 — Public summary figure transcription
+### Requirement 1 — NVCA Yearbook public-figure expansion (**source-access-dependent**)
+
+> **Implementation gate:** This requirement is blocked on someone with NVCA
+> Yearbook PDF access transcribing verified figures. Do not add YAML entries
+> with unverified numbers — the existing 5 baselines all carry primary-source
+> citations (`citation_url`); new entries must too.
 
 #### Acceptance Criteria
 
-1. THE System SHALL populate `data/reference/nvca/nvca_yearbook_benchmarks.csv`
-   with the following figures from publicly available NVCA Yearbook editions for
-   years 2009–present:
-   - Median seed deal size ($M)
-   - Median early-stage deal size ($M)
-   - Share of deals by stage (seed / early / late / growth)
-   - National M&A exit count and median exit valuation
-   - National IPO exit count and median offering size
-2. EACH row SHALL include: `year`, `metric_name`, `value`, `unit`, `stage`,
-   `source_edition`, `source_page_or_url`, `access_date`.
-3. THE System SHALL include a `data/reference/nvca/README.md` documenting the
-   transcription process, the difference between public summary figures vs.
-   PITCHBOOK licensed data, and the instrument-type caveat (Form D ≠ VC-only).
+1. THE System SHALL append additional `kind: rate` NVCA Yearbook entries to
+   `published_baselines.yaml`, each with `as_of`, `population`, `citation`
+   (e.g. "NVCA (2024). NVCA Yearbook 2024, p. NN"), and `citation_url`.
+2. EACH new NVCA entry SHALL be paired with a `cohort_metric` value that is
+   **already implemented** in `outcomes.py`, or paired with a new metric
+   added under Requirement 2.
+3. The existing entry `nvca_seed_to_series_a` SHALL stay; if a more recent
+   NVCA Yearbook edition is cited, add a new entry with the newer
+   `as_of` rather than overwriting (lets `reconcile.py` show the temporal
+   robustness of the comparison).
 
-### Requirement 2 — Licensed data placeholder
+### Requirement 2 — Paired SBIR-side cohort metrics
 
 #### Acceptance Criteria
 
-1. THE System SHALL define a `data/reference/nvca/licensed/` directory structure
-   and a schema specification (`licensed_schema.md`) for PITCHBOOK-exported deal
-   data, so that licensed data can be dropped in and immediately consumed by the
-   comparison asset without code changes.
-2. THE `agency_private_capital_baseline_comparison` asset SHALL detect whether the
-   licensed directory is populated and upgrade its comparison from summary-figure
-   to deal-level if so, logging which mode is active.
-3. WHEN only public summary figures are available, THE asset SHALL emit a
-   `comparison_precision = "summary_figures"` metadata flag on its output to
-   signal that the comparison is approximate.
+1. EACH new baseline added under Requirement 1 SHALL be paired with a
+   matching `outcomes.py` cohort metric — either an existing one
+   (`phase_i_to_ii_graduation`, `phase_ii_to_federal_contract_transition`,
+   `five_year_survival_proxy`) or a newly added metric that
+   `agency_private_capital_outcomes` emits.
+2. WHEN adding a new cohort metric, THE System SHALL also add a
+   corresponding `_ATTRIBUTION` entry in `reconcile.py` explaining the
+   plausible-cause framing for the SBIR-vs-baseline divergence, matching
+   the existing five attribution narratives.
+3. THE registry-loading and `reconcile.py` tests SHALL stay green; new tests
+   SHALL cover any newly added cohort metric.
 
-### Requirement 3 — Integration with comparison asset
+### Requirement 3 — F3 leverage-ratio baseline (NASEM 4:1)
 
 #### Acceptance Criteria
 
-1. THE `agency_private_capital_baseline_comparison` asset (group `agency_private_capital`)
-   SHALL be updated to load NVCA benchmark figures from
-   `data/reference/nvca/nvca_yearbook_benchmarks.csv` rather than any hardcoded
-   internal baseline.
-2. THE asset SHALL produce a side-by-side table: SBIR-firm Form D metrics (from
-   `specs/form-d-pipeline/`) vs. NVCA Yearbook metrics for the matched year range,
-   with the instrument-type caveat prominently noted.
-3. THE asset SHALL stratify the SBIR side by funding agency (HHS / DoD / NSF / DOE)
-   since capital structure differs materially across these populations.
+1. THE System SHALL add a `nasem_dod_leverage_ratio` baseline entry to
+   `published_baselines.yaml` paired with a new cohort metric
+   `private_to_sbir_leverage_ratio` (NASEM 4:1 DoD figure per [L1]).
+2. THE System SHALL implement `private_to_sbir_leverage_ratio` in
+   `outcomes.py` per Requirement 2, drawing on the existing
+   Form-D-pipeline data (private capital raised) ÷ SBIR funding amounts
+   (already in cohort). Stratified by agency, vintage bucket, and firm
+   size per the F3 anchor language.
+
+---
+
+## Out of scope / deferred
+
+- **Original spec's CSV at `data/reference/nvca/nvca_yearbook_benchmarks.csv`.**
+  Existing YAML registry is the canonical storage; introducing a competing
+  CSV pattern fragments the comparison surface. If a future use case
+  genuinely requires a flat CSV export, write it as a *derived view* of the
+  YAML registry, not as the source of truth.
+- **Original spec's `licensed/` directory + PITCHBOOK schema.** Punt until a
+  PITCHBOOK subscription is actually acquired and the integration is
+  prioritized. Designing the directory layout in advance is speculative.
+- **`comparison_precision` metadata flag.** The current `kind` enum
+  ({rate, effect_size, framing}) already encodes baseline precision;
+  adding another flag is duplicate information.
+- **Per-agency `agency_private_capital_baseline_comparison` stratification.**
+  Already supported by `agency_parametrized` shape of the asset; not the
+  data-acquisition layer's responsibility.
+
+---
+
+## Notes on this rewrite
+
+The audit-then-rewrite pattern (cf. #400, #402) produced a small,
+verifiable-fix PR in both prior cases. For #404, the genuine gap is
+*data acquisition + paired metric implementation*, both of which require
+verifiable source figures and substantial code work — neither of which fits
+in a single audit-rewrite PR. This rewrite ships the **corrected spec
+alone**; implementation lands in a follow-up that has NVCA Yearbook source
+access and can implement the paired `outcomes.py` metrics.

--- a/specs/nvca-yearbook-benchmarks/requirements.md
+++ b/specs/nvca-yearbook-benchmarks/requirements.md
@@ -49,9 +49,10 @@
   YAML. Frozen dataclasses; tested.
 - **`published_baselines.yaml`** — 5 entries today: `nvca_seed_to_series_a`,
   `bls_bed_5yr_survival`, `lerner_growth_effect`, `howell_followon_vc`,
-  `itif_seed_fund_framing`. All paired against the **three** cohort metrics
+  `itif_seed_fund_framing`. All paired against the **four** cohort metrics
   `outcomes.py` produces today: `phase_i_to_ii_graduation`,
-  `phase_ii_to_federal_contract_transition`, `five_year_survival_proxy`.
+  `phase_ii_to_federal_contract_transition`, `five_year_survival_proxy`,
+  `ma_exit_rate`.
 - **`reconcile.py`** — iterates the registry, joins to outcomes on
   `cohort_metric == metric`, emits one row per (metric, baseline) pair with a
   curated `_ATTRIBUTION` narrative explaining the cohort-vs-baseline
@@ -74,10 +75,14 @@ Three problems:
    require restructuring or duplicating storage.
 
 2. **Each new baseline needs a paired SBIR-side cohort metric in
-   `outcomes.py`.** `reconcile.py` only emits records for metrics that exist
-   on both sides. Adding "median seed deal size" as a baseline does nothing
-   until `median_form_d_round_size_phase_ii` (or similar) is also implemented.
-   Original spec didn't acknowledge the paired-work requirement.
+   `outcomes.py`.** When a baseline's `cohort_metric` has no matching rows
+   in outcomes, `reconcile.py` emits an "empty" record (`cohort_available=False`,
+   numeric fields `None`) rather than skipping the pair — useful for surfacing
+   gaps but the comparison row carries no SBIR-side numerator. Adding
+   "median seed deal size" as a baseline produces only empty rows until
+   `median_form_d_round_size_phase_ii` (or similar) is implemented in
+   `outcomes.py`. Original spec didn't acknowledge the paired-work
+   requirement.
 
 3. **F3 anchor is mis-stated.** F3's canonical metric per
    `docs/research-questions.md:289` is the private-to-SBIR leverage ratio,
@@ -112,8 +117,9 @@ anchor — not a deal-size analogue that the public reader won't recognize.
 #### Acceptance Criteria
 
 1. THE System SHALL append additional `kind: rate` NVCA Yearbook entries to
-   `published_baselines.yaml`, each with `as_of`, `population`, `citation`
-   (e.g. "NVCA (2024). NVCA Yearbook 2024, p. NN"), and `citation_url`.
+   `config/agency_private_capital/published_baselines.yaml`, each with
+   `as_of`, `population`, `citation` (e.g. "NVCA (2024). NVCA Yearbook 2024,
+   p. NN"), and `citation_url`.
 2. EACH new NVCA entry SHALL be paired with a `cohort_metric` value that is
    **already implemented** in `outcomes.py`, or paired with a new metric
    added under Requirement 2.
@@ -129,7 +135,7 @@ anchor — not a deal-size analogue that the public reader won't recognize.
 1. EACH new baseline added under Requirement 1 SHALL be paired with a
    matching `outcomes.py` cohort metric — either an existing one
    (`phase_i_to_ii_graduation`, `phase_ii_to_federal_contract_transition`,
-   `five_year_survival_proxy`) or a newly added metric that
+   `five_year_survival_proxy`, `ma_exit_rate`) or a newly added metric that
    `agency_private_capital_outcomes` emits.
 2. WHEN adding a new cohort metric, THE System SHALL also add a
    corresponding `_ATTRIBUTION` entry in `reconcile.py` explaining the

--- a/specs/nvca-yearbook-benchmarks/requirements.md
+++ b/specs/nvca-yearbook-benchmarks/requirements.md
@@ -1,0 +1,108 @@
+# Requirements — NVCA Yearbook Benchmark Reference Data
+
+> **Status:** Not yet started. The `agency_private_capital_baseline_comparison` Dagster
+> asset (PR #321, group `agency_private_capital`) currently uses internal baselines.
+> NVCA Yearbook figures are needed for the publishable comparison in
+> `specs/acquirer-concentration/` (Requirement 3) and the F3 NVCA-baseline comparison.
+> Anchors inventory questions **F2** and **F3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** F2 — how does SBIR-firm capital structure benchmark against the NVCA Yearbook cohort? F3 — do follow-on funding and exit outcomes match published private-capital-backed-startup baselines?
+**Answers for:** entrepreneurial finance researchers, NVCA / Kauffman-style investment researchers
+**Complexity tier:** Foundational data acquisition
+
+---
+
+## Done when
+
+> An entrepreneurial finance researcher can state: "NVCA Yearbook benchmark figures
+> for seed and early-stage companies (median deal size, round type distribution,
+> fill rate, exit rate, M&A rate) are available in
+> `data/reference/nvca/nvca_yearbook_benchmarks.csv` for years 2009–2024, with
+> source citations. The `agency_private_capital_baseline_comparison` asset uses these
+> as the non-SBIR comparison cohort."
+
+---
+
+## Introduction
+
+The F3 research questions require benchmarking SBIR-firm capital raises (via Form D)
+against what comparable private-capital-backed startups raise. The NVCA Yearbook [L25]
+is the industry-standard source for VC fundraising, deployment, deal stage and size,
+and exit activity. It is published annually by the National Venture Capital Association
+and PITCHBOOK.
+
+NVCA publishes selected summary statistics publicly (press releases, annual report
+highlights); detailed deal-level data requires an NVCA/PITCHBOOK subscription. This
+spec covers both paths: (a) manual transcription of public summary figures sufficient
+for headline comparisons, and (b) a structured placeholder for licensed data if the
+detailed cohort comparison is needed.
+
+**Caveat:** The SBIR Form D cohort includes all Reg D offerings (angel, seed,
+institutional non-VC, debt, convertible). The NVCA Yearbook measures VC deals only.
+The comparison must carry an explicit "different instruments" qualifier — consistent
+with the caveat in `specs/acquirer-concentration/` Requirement 3.
+
+---
+
+## User Stories
+
+**As an entrepreneurial finance researcher,** I want NVCA Yearbook benchmark figures
+in a machine-readable reference file, so that the `agency_private_capital_baseline_comparison`
+asset can produce a side-by-side table without manual spreadsheet lookup each time
+a report is generated.
+
+**As a policy analyst citing SBIR vs. VC outcomes in a congressional briefing,** I
+want the NVCA source year and page number attached to each benchmark figure, so that
+the comparison is auditable and a staff researcher can verify the figures independently.
+
+---
+
+## Requirements
+
+### Requirement 1 — Public summary figure transcription
+
+#### Acceptance Criteria
+
+1. THE System SHALL populate `data/reference/nvca/nvca_yearbook_benchmarks.csv`
+   with the following figures from publicly available NVCA Yearbook editions for
+   years 2009–present:
+   - Median seed deal size ($M)
+   - Median early-stage deal size ($M)
+   - Share of deals by stage (seed / early / late / growth)
+   - National M&A exit count and median exit valuation
+   - National IPO exit count and median offering size
+2. EACH row SHALL include: `year`, `metric_name`, `value`, `unit`, `stage`,
+   `source_edition`, `source_page_or_url`, `access_date`.
+3. THE System SHALL include a `data/reference/nvca/README.md` documenting the
+   transcription process, the difference between public summary figures vs.
+   PITCHBOOK licensed data, and the instrument-type caveat (Form D ≠ VC-only).
+
+### Requirement 2 — Licensed data placeholder
+
+#### Acceptance Criteria
+
+1. THE System SHALL define a `data/reference/nvca/licensed/` directory structure
+   and a schema specification (`licensed_schema.md`) for PITCHBOOK-exported deal
+   data, so that licensed data can be dropped in and immediately consumed by the
+   comparison asset without code changes.
+2. THE `agency_private_capital_baseline_comparison` asset SHALL detect whether the
+   licensed directory is populated and upgrade its comparison from summary-figure
+   to deal-level if so, logging which mode is active.
+3. WHEN only public summary figures are available, THE asset SHALL emit a
+   `comparison_precision = "summary_figures"` metadata flag on its output to
+   signal that the comparison is approximate.
+
+### Requirement 3 — Integration with comparison asset
+
+#### Acceptance Criteria
+
+1. THE `agency_private_capital_baseline_comparison` asset (group `agency_private_capital`)
+   SHALL be updated to load NVCA benchmark figures from
+   `data/reference/nvca/nvca_yearbook_benchmarks.csv` rather than any hardcoded
+   internal baseline.
+2. THE asset SHALL produce a side-by-side table: SBIR-firm Form D metrics (from
+   `specs/form-d-pipeline/`) vs. NVCA Yearbook metrics for the matched year range,
+   with the instrument-type caveat prominently noted.
+3. THE asset SHALL stratify the SBIR side by funding agency (HHS / DoD / NSF / DOE)
+   since capital structure differs materially across these populations.

--- a/specs/nvca-yearbook-benchmarks/tasks.md
+++ b/specs/nvca-yearbook-benchmarks/tasks.md
@@ -1,0 +1,56 @@
+# NVCA Yearbook Benchmark Reference Data — Tasks
+
+> **Status:** **All tasks deferred — blocked on NVCA Yearbook source access.**
+> This PR ships only the corrected spec (see `requirements.md`); implementation
+> lands in a follow-up once a contributor with NVCA Yearbook PDF access can
+> transcribe verified figures. Mark tasks complete only after the gating
+> source-access step is satisfied.
+
+## Phase 1: Source access (blocking)
+
+- [ ] 1.1 (deferred / blocked-on-NVCA-access) Verify NVCA Yearbook data source
+  access — confirm which edition(s) are available, page numbers for the
+  public-summary cohort-outcome figures, and a stable `citation_url` for each.
+
+## Phase 2: Baseline registry expansion
+
+- [ ] 2.1 (deferred / blocked-on-NVCA-access) Add NVCA Yearbook baseline entries
+  to `config/agency_private_capital/published_baselines.yaml` per Requirement 1
+  — each with `as_of`, `population`, `citation`, `citation_url`, and a
+  `cohort_metric` already implemented in `outcomes.py`
+  (`phase_i_to_ii_graduation`, `phase_ii_to_federal_contract_transition`,
+  `five_year_survival_proxy`, `ma_exit_rate`) or paired with a new metric
+  added under task 3.1.
+- [ ] 2.2 (deferred / blocked-on-NVCA-access) Preserve the existing
+  `nvca_seed_to_series_a` entry; for newer Yearbook editions, add a new entry
+  with the newer `as_of` rather than overwriting.
+
+## Phase 3: Reconciliation wiring
+
+- [ ] 3.1 (deferred / blocked-on-NVCA-access) For each new baseline whose
+  `cohort_metric` is not already in `outcomes.py`, implement the matching
+  SBIR-side cohort metric and update
+  `agency_private_capital_outcomes` to emit it.
+- [ ] 3.2 (deferred / blocked-on-NVCA-access) Add a corresponding `_ATTRIBUTION`
+  entry in `packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/reconcile.py`
+  for each new (metric, baseline) pair, matching the existing five attribution
+  narratives.
+- [ ] 3.3 (deferred / blocked-on-NVCA-access) Add the corresponding `_CAVEAT`
+  entry in `reconcile.py` for each new pair.
+
+## Phase 4: F3 leverage-ratio baseline (NASEM 4:1)
+
+- [ ] 4.1 (deferred / blocked-on-implementation-decision) Add a
+  `nasem_dod_leverage_ratio` baseline entry to
+  `config/agency_private_capital/published_baselines.yaml` per Requirement 3.
+- [ ] 4.2 (deferred / blocked-on-implementation-decision) Implement
+  `private_to_sbir_leverage_ratio` in `outcomes.py`, stratified by agency,
+  vintage bucket, and firm size per the F3 anchor language.
+
+## Phase 5: Testing
+
+- [ ] 5.1 (deferred / blocked-on-NVCA-access) Integration tests covering each
+  newly added (baseline, cohort_metric) pair through
+  `agency_private_capital_baseline_comparison`.
+- [ ] 5.2 (deferred / blocked-on-NVCA-access) Confirm existing
+  registry-loading and `reconcile.py` tests stay green after additions.


### PR DESCRIPTION
## Summary

> **What changed since this PR was opened:** A 2026-06-29 audit (same playbook as #400 / #402) found that the original spec was mis-framed in three ways. Unlike #400 / #402, the genuine gap can't be closed in a single rewrite PR — it needs verifiable NVCA Yearbook source-PDF access plus paired SBIR-side cohort-metric implementation in `outcomes.py`. This PR ships **the corrected spec only**; implementation lands in a follow-up.

## The three problems the audit found

### 1. Infrastructure already exists
`packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/baselines.py` provides a fully-functional `PublishedBaseline` dataclass + `PublishedBaselineRegistry.load(yaml_path)` loader. `reconcile.py` consumes the registry and emits one row per (SBIR-cohort-metric, baseline) pair with a curated `_ATTRIBUTION` narrative. **One NVCA entry is already wired** in `config/agency_private_capital/published_baselines.yaml`:
```yaml
- id: nvca_seed_to_series_a
  cohort_metric: phase_i_to_ii_graduation
  kind: rate
  point_estimate: 0.33
  citation: "NVCA (2023). NVCA Yearbook 2023..."
```

### 2. CSV proposal duplicates the YAML pattern
The existing baseline storage is YAML, structured for multi-line `notes:`, string-typed `kind:` enums, and rich citation metadata. Introducing a competing `data/reference/nvca/nvca_yearbook_benchmarks.csv` fragments storage.

### 3. F3 anchor was mis-stated
`docs/research-questions.md:289` names the F3 anchor as the **private-to-SBIR leverage ratio** (private capital raised ÷ SBIR funding), mirroring NASEM's 4:1 DoD figure [L1]. NVCA Yearbook deal sizes / exit counts feed F2's cohort-outcome comparison, not F3. The original spec conflated the two.

## What the rewrite delivers

| Original Requirement | Rewritten Requirement |
|---|---|
| Populate CSV with median deal size / exit counts | **Req 1** — Append NVCA Yearbook entries to the existing YAML registry, gated on verifiable primary-source citations |
| (Missing) | **Req 2** — Each new baseline needs a paired SBIR-side cohort metric in `outcomes.py` and a matching `_ATTRIBUTION` narrative in `reconcile.py` — explicit paired-work requirement |
| (Missing) | **Req 3** — F3 anchor done correctly: add `nasem_dod_leverage_ratio` baseline + implement `private_to_sbir_leverage_ratio` cohort metric stratified by agency, vintage, firm size |
| Licensed `PITCHBOOK` directory + schema | **Deferred** — speculative until subscription acquired |
| `comparison_precision` metadata flag | **Deferred** — `kind:` enum already encodes precision |

## Why no code change in this PR

For #400 (BEA NIPA hardening) and #402 (CSV-backed state rates), the audit turned up "infrastructure complete, data file missing" gaps that fit a single PR. **#404 is structurally different**: every new baseline requires (a) verified NVCA Yearbook source figures (PDF transcription, primary-source `citation_url`, page numbers) AND (b) a paired SBIR-side cohort metric implementation in `outcomes.py`. Honest scope says don't fabricate either half here.

## Test plan

- [x] Spec-only PR — no code change; no test impact.
- [x] Verified that `PublishedBaselineRegistry.load` + `reconcile.py` work today against the 5 existing baselines (covered by existing tests in `tests/unit/transformers/`).
- [x] Implementation follow-up will own tests for the new cohort metric and YAML entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)