### PR TITLE
feat: UCC-1 national coverage — 50-state expansion (F1/A-CP9)

### DIFF
--- a/specs/ucc1-national-coverage/requirements.md
+++ b/specs/ucc1-national-coverage/requirements.md
@@ -1,11 +1,23 @@
 # Requirements — UCC-1 National Coverage (50-State Expansion)
 
-> **Status:** Not yet started. California pilot is live (PRs #303 / #305, extractor
-> at `scripts/data/ucc/ca_extractor.py`). CA pilot findings: equipment finance +
-> community-bank lending patterns; absence of venture-debt lenders in the CA channel.
-> Anchors inventory questions **F1** (secured-debt activity, debt-vs-equity composition)
-> and **A-CP9** (UCC-1 financial-distress signal for choke-point firms) in
-> [docs/research-questions.md](../../docs/research-questions.md).
+> **Status:** Not yet started — but a significant CA pilot implementation exists.
+> `scripts/data/ucc/` contains the full pilot framework: `schema.py` (typed dicts
+> `UCCFiling`, `UCCLifecycle`, `UCCMatch`, `ClassifiedSecuredParty`; enums
+> `FilingType`, `UCCStatus`), `ca_extractor.py` (reference extractor),
+> `matcher.py` (fuzzy debtor-side matching), `_common.py` (data path helpers
+> with `SBIR_DATA_DIR` env override), and `cohort_state_filter.py`.
+> **The task is to build a per-state extractor framework on top of these
+> existing components** rather than from scratch.
+>
+> **CA pilot scope note:** Delaware was explicitly abandoned — no free public
+> UCC search portal. The CA pilot ran against 70 of 3,639 cohort firms and
+> was stopped by Imperva anti-bot protections; `curl_cffi` was used for
+> JS-challenge bypass. These are known constraints the national expansion must
+> account for per-state.
+>
+> Anchors inventory questions **F1** (secured-debt activity, debt-vs-equity
+> composition) and **A-CP9** (UCC-1 financial-distress signal for choke-point
+> firms) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** F1 — what fraction of SBIR awardees show secured-debt activity, and what mix of equipment finance, depository-bank lending, and venture debt? A-CP9 — do UCC-1 lapse/lien-churn patterns flag financial distress among choke-point firms?
 **Answers for:** entrepreneurial finance researchers, defense industrial base analysts, pipeline engineers
@@ -16,12 +28,14 @@
 ## Done when
 
 > A pipeline engineer can state: "UCC-1 financing statement extractors exist for all
-> 50 states, extending the CA pilot pattern. Each state's SOS portal has a documented
-> extractor with rate limits, session-handling, and anti-bot notes. Extracted filings
-> are normalized to `data/derived/ucc1_filings.parquet` with a `state_fips` column
-> and refreshed on a per-state configurable cadence. National coverage enables the
-> F1 debt-vs-equity question to be answered for the full SBIR awardee universe, not
-> just California-incorporated firms."
+> 50 states (Delaware excluded — no free public portal), extending the CA pilot
+> pattern in `scripts/data/ucc/ca_extractor.py`. Each state's SOS portal has a
+> documented extractor with rate limits, session-handling, and anti-bot notes. The
+> `UCC1StateExtractor` base class and registry sit alongside the existing `schema.py`
+> typed dicts, which are reused unchanged. Extracted filings are normalized to
+> `data/derived/ucc1_filings.parquet` with a `state_fips` column and refreshed on a
+> per-state configurable cadence. National coverage enables the F1 debt-vs-equity
+> question for the full SBIR awardee universe, not just California-incorporated firms."
 
 ---
 
@@ -34,15 +48,30 @@ a firm's secured-debt capital structure that is invisible in SEC filings (privat
 firms don't file 8-K or Form D for debt).
 
 The CA pilot (`scripts/data/ucc/ca_extractor.py`, `specs/ucc1-financing-analysis/`)
-scraped California bizfileOnline using `curl_cffi` to bypass anti-bot protections and
-found equipment finance + community-bank lending patterns in the CA SBIR population.
+scraped California bizfileOnline using `curl_cffi` to bypass Imperva/JS-challenge
+anti-bot protections. Findings: equipment finance + community-bank lending patterns in
+the CA SBIR population; absence of venture-debt lenders in the CA channel. The pilot
+stopped at 70 of 3,639 cohort firms when anti-bot rate limits were hit.
+
+**Existing framework (do not rewrite):**
+
+| File | Role |
+|------|------|
+| `scripts/data/ucc/schema.py` | `UCCFiling`, `UCCLifecycle`, `UCCMatch`, `ClassifiedSecuredParty` typed dicts; `FilingType`, `UCCStatus` enums |
+| `scripts/data/ucc/ca_extractor.py` | Reference extractor — becomes the first `UCC1StateExtractor` subclass |
+| `scripts/data/ucc/matcher.py` | Fuzzy debtor-side matching (Jaro-Winkler + address + person-name rejection) |
+| `scripts/data/ucc/_common.py` | `data_dir()` / `data_path()` helpers; respects `SBIR_DATA_DIR` env var |
+| `scripts/data/ucc/cohort_state_filter.py` | Cohort firm filtering by state |
+
 Extending to all 50 states requires a per-state extractor — each state Secretary of
 State portal has a different HTML structure, session model, and rate-limit policy.
+Delaware has no free public portal and is excluded.
 
 **Scope note:** Each state SOS portal is a distinct integration effort. This spec
-scopes the national framework and the first-five-state expansion. Remaining states
+scopes the national framework and the first five-state expansion. Remaining states
 should be tackled in batches, prioritized by SBIR awardee concentration (TX, VA, MA,
-CO, MD are the top non-CA states by SBIR award volume).
+CO, MD are the top non-CA states by SBIR award volume). Anti-bot mitigations
+(Imperva, CAPTCHA, JS challenges) must be documented per state.
 
 ---
 
@@ -67,14 +96,18 @@ incorporated in California.
 
 1. THE System SHALL define a `UCC1StateExtractor` base class in
    `scripts/data/ucc/base_extractor.py` with the interface: `fetch_filings(debtor_name,
-   state_fips, date_from, date_to)` → raw filing records.
+   state_fips, date_from, date_to)` → `list[UCCFiling]` (using the existing typed dict
+   from `schema.py`).
 2. THE `ca_extractor.py` SHALL be refactored to extend `UCC1StateExtractor` as the
-   reference implementation.
+   reference implementation, preserving existing behavior.
 3. THE System SHALL implement a registry (`scripts/data/ucc/registry.py`) mapping each
    `state_fips` to its extractor class and configuration (base URL, session model,
-   rate limit, anti-bot notes).
+   rate limit, anti-bot notes). Delaware (FIPS 10) SHALL be absent from the registry
+   with a documented comment explaining no free public portal exists.
 4. WHEN an extractor for a state is not yet implemented, THE registry SHALL return a
    `NotImplementedExtractor` that logs a warning rather than silently skipping.
+5. THE base class SHALL document the expected anti-bot pattern per-state (CAPTCHA type,
+   JS challenge, Imperva) so each implementation includes session-handling notes.
 
 ### Requirement 2 — Priority-state extractors (first batch)
 
@@ -84,25 +117,27 @@ incorporated in California.
    awardee concentration after California: Texas, Virginia, Massachusetts, Colorado,
    and Maryland — covering approximately 35% of non-CA SBIR award volume.
 2. EACH extractor SHALL document: the SOS portal URL, session/cookie requirements,
-   known anti-bot measures (CAPTCHA, JS challenges), rate limit (requests/minute),
-   and field mapping for debtor name, secured party name, and collateral description.
+   known anti-bot measures (CAPTCHA, JS challenges, Imperva), rate limit
+   (requests/minute), and field mapping to `UCCFiling` keys.
 3. EACH extractor SHALL be tested against at least one known SBIR awardee in that
-   state (verifiable via the CA-pilot entity resolution pattern).
+   state (verifiable via the CA-pilot entity resolution pattern in `matcher.py`).
 
 ### Requirement 3 — Normalization and storage
 
 #### Acceptance Criteria
 
-1. THE System SHALL normalize all state extractor outputs to a common schema:
-   `state_fips`, `filing_number`, `debtor_name`, `debtor_uei` (if resolved),
-   `secured_party_name`, `secured_party_type` (equipment / bank / venture-debt /
-   unknown), `collateral_desc`, `filing_date`, `lapse_date`, `status`
-   (active / lapsed / terminated), `extracted_at`.
+1. THE System SHALL normalize all state extractor outputs to the existing `UCCFiling`
+   typed dict schema from `schema.py`, adding a `state_fips` column to disambiguate
+   multi-state output. The `ClassifiedSecuredParty` taxonomy
+   (venture_debt / equipment_finance / bank_depository / tax_authority / foreign /
+   other / unknown) SHALL be applied post-extraction using the existing classification
+   logic.
 2. THE System SHALL persist to `data/derived/ucc1_filings.parquet`, partitioned by
    `state_fips`, appending new records and updating existing ones on re-extraction.
-3. THE System SHALL link filings to SBIR awardees via entity resolution
-   (`debtor_uei` backfill using the same UEI → CAGE → DUNS → fuzzy-name cascade as
-   `SAMGovAPIClient`), populating `debtor_uei` where a match is found.
+3. THE System SHALL link filings to SBIR awardees via entity resolution using the
+   existing `matcher.py` Jaro-Winkler + address-overlap + person-name-rejection
+   pipeline, populating `debtor_uei` via UEI → CAGE → DUNS → fuzzy-name cascade
+   consistent with `SAMGovAPIClient`.
 
 ### Requirement 4 — Cadence and scheduling
 
@@ -111,7 +146,8 @@ incorporated in California.
 1. THE System SHALL support per-state configurable refresh cadence (default: monthly)
    via `config/base.yaml` under `enrichment_refresh.ucc1.*`.
 2. THE System SHALL track per-state freshness in `data/state/enrichment_refresh_state.json`
-   alongside other enrichment sources, consistent with `specs/iterative_api_enrichment/`.
-3. WHEN a state portal is unreachable or returns an error on extraction, THE System
-   SHALL retain the prior extract and emit a staleness warning rather than clearing
-   existing records.
+   alongside other enrichment sources, consistent with `specs/iterative_api_enrichment/`,
+   using the `data_path()` helper from `_common.py` for all path resolution.
+3. WHEN a state portal is unreachable or returns an error (including anti-bot blocks),
+   THE System SHALL retain the prior extract and emit a staleness warning rather than
+   clearing existing records.

--- a/specs/ucc1-national-coverage/requirements.md
+++ b/specs/ucc1-national-coverage/requirements.md
@@ -1,4 +1,4 @@
-# Requirements — UCC-1 National Coverage (50-State Expansion)
+# Requirements — UCC-1 National Coverage (49-State Public-Portal Expansion)
 
 > **Status:** Not yet started — but a significant CA pilot implementation exists.
 > `scripts/data/ucc/` contains the full pilot framework: `schema.py` (typed dicts
@@ -28,14 +28,16 @@
 ## Done when
 
 > A pipeline engineer can state: "UCC-1 financing statement extractors exist for all
-> 50 states (Delaware excluded — no free public portal), extending the CA pilot
-> pattern in `scripts/data/ucc/ca_extractor.py`. Each state's SOS portal has a
+> **49 states with free public SOS portals** (Delaware excluded — no free public
+> portal; documented as `state_fips=10 unavailable`). The framework extends the CA
+> pilot pattern in `scripts/data/ucc/ca_extractor.py`. Each state's SOS portal has a
 > documented extractor with rate limits, session-handling, and anti-bot notes. The
 > `UCC1StateExtractor` base class and registry sit alongside the existing `schema.py`
 > typed dicts, which are reused unchanged. Extracted filings are normalized to
 > `data/derived/ucc1_filings.parquet` with a `state_fips` column and refreshed on a
-> per-state configurable cadence. National coverage enables the F1 debt-vs-equity
-> question for the full SBIR awardee universe, not just California-incorporated firms."
+> per-state configurable cadence. National coverage reports carry an explicit
+> Delaware-exclusion caveat and denominator adjustment because UCC jurisdiction follows
+> state of organization, not HQ state."
 
 ---
 
@@ -63,9 +65,12 @@ stopped at 70 of 3,639 cohort firms when anti-bot rate limits were hit.
 | `scripts/data/ucc/_common.py` | `data_dir()` / `data_path()` helpers; respects `SBIR_DATA_DIR` env var |
 | `scripts/data/ucc/cohort_state_filter.py` | Cohort firm filtering by state |
 
-Extending to all 50 states requires a per-state extractor — each state Secretary of
-State portal has a different HTML structure, session model, and rate-limit policy.
-Delaware has no free public portal and is excluded.
+Extending to **49 states with free public portals** requires a per-state extractor —
+each state Secretary of State portal has a different HTML structure, session model,
+and rate-limit policy. **Delaware (state of organization for many private firms) has
+no free public portal and is excluded from coverage.** Downstream F1/A-CP9 reporting
+MUST surface this gap explicitly (coverage denominator excludes DE-organized firms;
+national rates are not complete for DE-incorporated entities).
 
 **Scope note:** Each state SOS portal is a distinct integration effort. This spec
 scopes the national framework and the first five-state expansion. Remaining states
@@ -138,6 +143,9 @@ incorporated in California.
    existing `matcher.py` Jaro-Winkler + address-overlap + person-name-rejection
    pipeline, populating `debtor_uei` via UEI → CAGE → DUNS → fuzzy-name cascade
    consistent with `SAMGovAPIClient`.
+4. THE System SHALL emit coverage metadata (per-state extractor status, Delaware
+   exclusion flag, and DE-organized cohort share) alongside F1/A-CP9 outputs so
+   consumers do not treat 49-state portal coverage as a complete national universe.
 
 ### Requirement 4 — Cadence and scheduling
 

--- a/specs/ucc1-national-coverage/requirements.md
+++ b/specs/ucc1-national-coverage/requirements.md
@@ -1,0 +1,117 @@
+# Requirements — UCC-1 National Coverage (50-State Expansion)
+
+> **Status:** Not yet started. California pilot is live (PRs #303 / #305, extractor
+> at `scripts/data/ucc/ca_extractor.py`). CA pilot findings: equipment finance +
+> community-bank lending patterns; absence of venture-debt lenders in the CA channel.
+> Anchors inventory questions **F1** (secured-debt activity, debt-vs-equity composition)
+> and **A-CP9** (UCC-1 financial-distress signal for choke-point firms) in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** F1 — what fraction of SBIR awardees show secured-debt activity, and what mix of equipment finance, depository-bank lending, and venture debt? A-CP9 — do UCC-1 lapse/lien-churn patterns flag financial distress among choke-point firms?
+**Answers for:** entrepreneurial finance researchers, defense industrial base analysts, pipeline engineers
+**Complexity tier:** Foundational data acquisition
+
+---
+
+## Done when
+
+> A pipeline engineer can state: "UCC-1 financing statement extractors exist for all
+> 50 states, extending the CA pilot pattern. Each state's SOS portal has a documented
+> extractor with rate limits, session-handling, and anti-bot notes. Extracted filings
+> are normalized to `data/derived/ucc1_filings.parquet` with a `state_fips` column
+> and refreshed on a per-state configurable cadence. National coverage enables the
+> F1 debt-vs-equity question to be answered for the full SBIR awardee universe, not
+> just California-incorporated firms."
+
+---
+
+## Introduction
+
+UCC-1 financing statements are filed by secured creditors (equipment lenders, banks,
+venture-debt providers) in the state where a company is organized. Each filing reveals:
+the debtor name, the secured party (lender) name, and collateral type — a window into
+a firm's secured-debt capital structure that is invisible in SEC filings (private
+firms don't file 8-K or Form D for debt).
+
+The CA pilot (`scripts/data/ucc/ca_extractor.py`, `specs/ucc1-financing-analysis/`)
+scraped California bizfileOnline using `curl_cffi` to bypass anti-bot protections and
+found equipment finance + community-bank lending patterns in the CA SBIR population.
+Extending to all 50 states requires a per-state extractor — each state Secretary of
+State portal has a different HTML structure, session model, and rate-limit policy.
+
+**Scope note:** Each state SOS portal is a distinct integration effort. This spec
+scopes the national framework and the first-five-state expansion. Remaining states
+should be tackled in batches, prioritized by SBIR awardee concentration (TX, VA, MA,
+CO, MD are the top non-CA states by SBIR award volume).
+
+---
+
+## User Stories
+
+**As an entrepreneurial finance researcher,** I want UCC-1 coverage extended beyond
+California so that the debt-vs-equity composition question (F1) reflects the full
+national SBIR awardee population rather than a single-state pilot.
+
+**As a defense industrial base analyst,** I want UCC-1 lapse and lien-churn data for
+choke-point firms across all states so that the A-CP9 financial-distress signal is
+computable for the full set of thin-base CET area suppliers, not just those
+incorporated in California.
+
+---
+
+## Requirements
+
+### Requirement 1 — Per-state extractor framework
+
+#### Acceptance Criteria
+
+1. THE System SHALL define a `UCC1StateExtractor` base class in
+   `scripts/data/ucc/base_extractor.py` with the interface: `fetch_filings(debtor_name,
+   state_fips, date_from, date_to)` → raw filing records.
+2. THE `ca_extractor.py` SHALL be refactored to extend `UCC1StateExtractor` as the
+   reference implementation.
+3. THE System SHALL implement a registry (`scripts/data/ucc/registry.py`) mapping each
+   `state_fips` to its extractor class and configuration (base URL, session model,
+   rate limit, anti-bot notes).
+4. WHEN an extractor for a state is not yet implemented, THE registry SHALL return a
+   `NotImplementedExtractor` that logs a warning rather than silently skipping.
+
+### Requirement 2 — Priority-state extractors (first batch)
+
+#### Acceptance Criteria
+
+1. THE System SHALL implement extractors for the five states with the highest SBIR
+   awardee concentration after California: Texas, Virginia, Massachusetts, Colorado,
+   and Maryland — covering approximately 35% of non-CA SBIR award volume.
+2. EACH extractor SHALL document: the SOS portal URL, session/cookie requirements,
+   known anti-bot measures (CAPTCHA, JS challenges), rate limit (requests/minute),
+   and field mapping for debtor name, secured party name, and collateral description.
+3. EACH extractor SHALL be tested against at least one known SBIR awardee in that
+   state (verifiable via the CA-pilot entity resolution pattern).
+
+### Requirement 3 — Normalization and storage
+
+#### Acceptance Criteria
+
+1. THE System SHALL normalize all state extractor outputs to a common schema:
+   `state_fips`, `filing_number`, `debtor_name`, `debtor_uei` (if resolved),
+   `secured_party_name`, `secured_party_type` (equipment / bank / venture-debt /
+   unknown), `collateral_desc`, `filing_date`, `lapse_date`, `status`
+   (active / lapsed / terminated), `extracted_at`.
+2. THE System SHALL persist to `data/derived/ucc1_filings.parquet`, partitioned by
+   `state_fips`, appending new records and updating existing ones on re-extraction.
+3. THE System SHALL link filings to SBIR awardees via entity resolution
+   (`debtor_uei` backfill using the same UEI → CAGE → DUNS → fuzzy-name cascade as
+   `SAMGovAPIClient`), populating `debtor_uei` where a match is found.
+
+### Requirement 4 — Cadence and scheduling
+
+#### Acceptance Criteria
+
+1. THE System SHALL support per-state configurable refresh cadence (default: monthly)
+   via `config/base.yaml` under `enrichment_refresh.ucc1.*`.
+2. THE System SHALL track per-state freshness in `data/state/enrichment_refresh_state.json`
+   alongside other enrichment sources, consistent with `specs/iterative_api_enrichment/`.
+3. WHEN a state portal is unreachable or returns an error on extraction, THE System
+   SHALL retain the prior extract and emit a staleness warning rather than clearing
+   existing records.

--- a/specs/ucc1-national-coverage/tasks.md
+++ b/specs/ucc1-national-coverage/tasks.md
@@ -1,0 +1,34 @@
+# UCC-1 National Coverage — Tasks
+
+> **Status (2026-07-12):** Not started. Builds on the CA pilot in
+> `scripts/data/ucc/` and `specs/ucc1-financing-analysis/`.
+
+## Kill / skip rules (apply before each state batch)
+
+- **Skip permanently:** Delaware (FIPS 10) — no free public portal.
+- **Skip until manual review:** portals with hard CAPTCHA, paywalls, or no public
+  search after a single probe script run.
+- **Stop a state batch** when anti-bot blocks exceed the documented rate limit for
+  two consecutive runs without a documented mitigation path.
+
+## Phase 0 — Framework
+
+- [ ] 0.1 Add `UCC1StateExtractor` base class in `scripts/data/ucc/base_extractor.py`
+- [ ] 0.2 Refactor `ca_extractor.py` to subclass the base extractor without behavior drift
+- [ ] 0.3 Add `registry.py` with FIPS → extractor mapping; register DE as unavailable
+- [ ] 0.4 Add coverage-metadata helper (DE exclusion flag + per-state status)
+
+## Phase 1 — First five non-CA states (TX, VA, MA, CO, MD)
+
+- [ ] 1.1 Texas extractor + portal notes (session model, rate limit, anti-bot)
+- [ ] 1.2 Virginia extractor + portal notes
+- [ ] 1.3 Massachusetts extractor + portal notes
+- [ ] 1.4 Colorado extractor + portal notes
+- [ ] 1.5 Maryland extractor + portal notes
+- [ ] 1.6 Integration test: one known SBIR awardee per state through `matcher.py`
+
+## Phase 2 — Storage and reporting
+
+- [ ] 2.1 Normalize multi-state output to `data/derived/ucc1_filings.parquet`
+- [ ] 2.2 Wire refresh cadence under `config/base.yaml` → `enrichment_refresh.ucc1.*`
+- [ ] 2.3 Document Delaware-exclusion caveat in F1/A-CP9 reporting templates


### PR DESCRIPTION
## Summary

Spec for extending the California UCC-1 pilot (`scripts/data/ucc/ca_extractor.py`, PRs #303/#305) to all 50 states via a `UCC1StateExtractor` base class and per-state registry. Priority first batch: TX, VA, MA, CO, MD (~35% of non-CA SBIR award volume). Normalized output to `data/derived/ucc1_filings.parquet` with `secured_party_type` classification (equipment / bank / venture-debt) and debtor UEI backfill via entity resolution.

**RQ anchors:** F1 (secured-debt activity, debt-vs-equity composition for national SBIR population), A-CP9 (UCC-1 lapse/lien-churn as financial-distress signal for choke-point firms)

## What's in this PR

- `specs/ucc1-national-coverage/requirements.md` — spec covering the extractor framework (`UCC1StateExtractor` base class + registry), 5-state priority batch with per-portal documentation requirements, normalization schema, and per-state monthly cadence in `enrichment_refresh_state.json`

## Dependencies / sequencing

- CA pilot findings (equipment + community-bank patterns; no venture-debt lenders in CA channel) are the baseline; national expansion validates or extends those findings
- Each state SOS portal is a distinct integration: anti-bot measures, session handling, and rate limits vary significantly — budget accordingly (the CA extractor used `curl_cffi` for JS challenge bypass)
- Prioritization: TX, VA, MA, CO, MD covers SBIR-heavy states; remaining 44 states in follow-on batches

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uf6DkRWXkQ3LB5krcrcSRA)_