### PR TITLE
style: ruff format sbir_neo4j_loading and matching

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
@@ -111,7 +111,6 @@ _BOOL_FIELDS_WITH_UNKNOWN = (
 # ---------------------------------------------------------------------------
 
 
-
 def _company_id_for_award(award: Award) -> str | None:
     """Return UEI / DUNS-prefixed / NAME-prefixed identifier (in that priority)."""
     if award.company_uei:
@@ -119,7 +118,9 @@ def _company_id_for_award(award: Award) -> str | None:
     if award.company_duns:
         return f"DUNS:{award.company_duns}"
     if award.company_name:
-        normalized = normalize_name(award.company_name, remove_suffixes=True, apply_abbreviations=True)
+        normalized = normalize_name(
+            award.company_name, remove_suffixes=True, apply_abbreviations=True
+        )
         if normalized:
             return f"NAME:{normalized}"
     return None
@@ -560,7 +561,9 @@ def neo4j_sbir_awards(
                 award_nodes.append(_transaction_props(award))
                 award_objects.append(award)
 
-                normalized_name = normalize_name(award.company_name or "", remove_suffixes=True, apply_abbreviations=True)
+                normalized_name = normalize_name(
+                    award.company_name or "", remove_suffixes=True, apply_abbreviations=True
+                )
                 company_id, id_type, name_only_fallback = _resolve_canonical_company(
                     award, canonical_map, normalized_name
                 )

--- a/sbir_etl/enrichers/matching.py
+++ b/sbir_etl/enrichers/matching.py
@@ -26,14 +26,24 @@ except ImportError:  # pragma: no cover
 
 
 # Business-entity suffix tokens removed during name normalization.
-SUFFIX_TOKENS: frozenset[str] = frozenset({
-    "inc", "incorporated",
-    "llc", "l.l.c", "l l c",
-    "ltd", "limited",
-    "corp", "corporation", "co",
-    "lp", "llp",
-    "company", "the",
-})
+SUFFIX_TOKENS: frozenset[str] = frozenset(
+    {
+        "inc",
+        "incorporated",
+        "llc",
+        "l.l.c",
+        "l l c",
+        "ltd",
+        "limited",
+        "corp",
+        "corporation",
+        "co",
+        "lp",
+        "llp",
+        "company",
+        "the",
+    }
+)
 
 # Enhanced abbreviation dictionary for company name normalization
 ENHANCED_ABBREVIATIONS = {


### PR DESCRIPTION
## Summary

Both files were merged to main with format issues (likely via admin-merge in #392 and/or #393) that block CI's \`ruff format --check\` step on subsequent PRs.

Pure formatting, no logic changes.

\`\`\`
uvx ruff format packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py sbir_etl/enrichers/matching.py
2 files reformatted
\`\`\`

Unblocks #394 (Phase III universe + size enrichment).