### PR TITLE
fix: unbreak main CI — ruff-format drift + SAM.gov asset test mock

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
@@ -111,7 +111,6 @@ _BOOL_FIELDS_WITH_UNKNOWN = (
 # ---------------------------------------------------------------------------
 
 
-
 def _company_id_for_award(award: Award) -> str | None:
     """Return UEI / DUNS-prefixed / NAME-prefixed identifier (in that priority)."""
     if award.company_uei:
@@ -119,7 +118,9 @@ def _company_id_for_award(award: Award) -> str | None:
     if award.company_duns:
         return f"DUNS:{award.company_duns}"
     if award.company_name:
-        normalized = normalize_name(award.company_name, remove_suffixes=True, apply_abbreviations=True)
+        normalized = normalize_name(
+            award.company_name, remove_suffixes=True, apply_abbreviations=True
+        )
         if normalized:
             return f"NAME:{normalized}"
     return None
@@ -560,7 +561,9 @@ def neo4j_sbir_awards(
                 award_nodes.append(_transaction_props(award))
                 award_objects.append(award)
 
-                normalized_name = normalize_name(award.company_name or "", remove_suffixes=True, apply_abbreviations=True)
+                normalized_name = normalize_name(
+                    award.company_name or "", remove_suffixes=True, apply_abbreviations=True
+                )
                 company_id, id_type, name_only_fallback = _resolve_canonical_company(
                     award, canonical_map, normalized_name
                 )

--- a/sbir_etl/enrichers/matching.py
+++ b/sbir_etl/enrichers/matching.py
@@ -26,14 +26,24 @@ except ImportError:  # pragma: no cover
 
 
 # Business-entity suffix tokens removed during name normalization.
-SUFFIX_TOKENS: frozenset[str] = frozenset({
-    "inc", "incorporated",
-    "llc", "l.l.c", "l l c",
-    "ltd", "limited",
-    "corp", "corporation", "co",
-    "lp", "llp",
-    "company", "the",
-})
+SUFFIX_TOKENS: frozenset[str] = frozenset(
+    {
+        "inc",
+        "incorporated",
+        "llc",
+        "l.l.c",
+        "l l c",
+        "ltd",
+        "limited",
+        "corp",
+        "corporation",
+        "co",
+        "lp",
+        "llp",
+        "company",
+        "the",
+    }
+)
 
 # Enhanced abbreviation dictionary for company name normalization
 ENHANCED_ABBREVIATIONS = {

--- a/tests/integration/test_sam_gov_integration.py
+++ b/tests/integration/test_sam_gov_integration.py
@@ -133,46 +133,46 @@ class TestSAMGovAssetIntegration:
     """Integration tests for SAM.gov Dagster asset."""
 
     def test_asset_execution_with_local_file(self, sample_sam_gov_parquet):
-        """Test Dagster asset execution with local parquet file."""
+        """Test Dagster asset execution with local parquet file.
+
+        The fixture writes a real parquet at ``tmp_path``, so the asset's
+        tiered-path resolver (`_ingestion_utils._resolve_tiered_path`) finds it
+        directly via ``Path(local).exists()`` — no Path mock needed.
+        """
         from dagster import build_asset_context
 
-        # Mock config
         with patch("sbir_analytics.assets.sam_gov_ingestion.get_config") as mock_config:
             mock_config.return_value.extraction.sam_gov.parquet_path = str(sample_sam_gov_parquet)
             mock_config.return_value.extraction.sam_gov.use_s3_first = False
             mock_config.return_value.s3 = {}
 
-            # Mock Path.exists
-            with patch("sbir_analytics.assets.sam_gov_ingestion.Path") as mock_path:
-                mock_path.return_value.exists.return_value = True
+            # Mock SAMGovExtractor to return our test data
+            with patch(
+                "sbir_analytics.assets.sam_gov_ingestion.SAMGovExtractor"
+            ) as mock_extractor_class:
+                mock_extractor = MagicMock()
+                test_df = pd.read_parquet(sample_sam_gov_parquet)
+                mock_extractor.load_parquet.return_value = test_df
+                mock_extractor_class.return_value = mock_extractor
 
-                # Mock SAMGovExtractor to return our test data
-                with patch(
-                    "sbir_analytics.assets.sam_gov_ingestion.SAMGovExtractor"
-                ) as mock_extractor_class:
-                    mock_extractor = MagicMock()
-                    test_df = pd.read_parquet(sample_sam_gov_parquet)
-                    mock_extractor.load_parquet.return_value = test_df
-                    mock_extractor_class.return_value = mock_extractor
+                # Execute asset with proper context
+                context = build_asset_context()
+                result = raw_sam_gov_entities(context)
 
-                    # Execute asset with proper context
-                    context = build_asset_context()
-                    result = raw_sam_gov_entities(context)
+                # Verify result
+                assert result is not None
+                assert hasattr(result, "value")
+                assert isinstance(result.value, pd.DataFrame)
+                assert len(result.value) == 5
 
-                    # Verify result
-                    assert result is not None
-                    assert hasattr(result, "value")
-                    assert isinstance(result.value, pd.DataFrame)
-                    assert len(result.value) == 5
-
-                    # Verify metadata
-                    assert result.metadata is not None
-                    assert "row_count" in result.metadata
-                    # Metadata values are wrapped in MetadataValue objects
-                    row_count = result.metadata["row_count"]
-                    assert row_count == 5 or (hasattr(row_count, "value") and row_count.value == 5)
-                    assert "num_columns" in result.metadata
-                    assert "key_columns" in result.metadata
+                # Verify metadata
+                assert result.metadata is not None
+                assert "row_count" in result.metadata
+                # Metadata values are wrapped in MetadataValue objects
+                row_count = result.metadata["row_count"]
+                assert row_count == 5 or (hasattr(row_count, "value") and row_count.value == 5)
+                assert "num_columns" in result.metadata
+                assert "key_columns" in result.metadata
 
     def test_asset_error_handling_no_file(self):
         """Test Dagster asset error handling when parquet file is missing."""


### PR DESCRIPTION
## Summary

Two pre-existing failures on `main` falling out of #398's consolidation work. They block every open PR that runs the full CI matrix (currently #395 and #399).

### 1. Ruff format drift in two files #398 touched

- `sbir_etl/enrichers/matching.py` — `SUFFIX_TOKENS` frozenset rewritten one-element-per-line as ruff format wants.
- `packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py` — drop a stray blank line; wrap two long `normalize_name(...)` calls within the line budget.

Pure whitespace. `ruff format --check` clean repo-wide after this.

### 2. `test_asset_execution_with_local_file` mocks the wrong `Path`

The test patched `sbir_analytics.assets.sam_gov_ingestion.Path` so `Path(...).exists()` returned True. After #398 routed path resolution through `_ingestion_utils._resolve_tiered_path`, the helper re-wraps the local path with the real `pathlib.Path`:

```python
if local is not None and Path(local).exists():
```

The test's MagicMock-Path got coerced to a non-existent string path and `.exists()` returned False → asset fell to the API-fallback branch → `ExtractionError: SAM.gov data unavailable...`.

The `sample_sam_gov_parquet` fixture writes a real parquet at `tmp_path`, so the `Path` patch was dead weight even before #398. Removed the patch context manager; the asset's tiered-path resolver now finds the real fixture file directly.

## Test plan

- [x] `pytest tests/integration/test_sam_gov_integration.py -v` → 4/4 pass.
- [x] `pytest tests/integration/ -q` → 135 passed, 41 skipped, no failures.
- [x] `ruff format --check sbir_etl packages/.../sbir_analytics packages/.../sbir_ml packages/.../sbir_graph tests` → clean.
- [x] `ruff check` on changed files → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)