### PR TITLE
Add cleanup inventory and repository hygiene guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Run MyPy type checker
         run: uv run python -m mypy sbir_etl
 
-      - name: Reject removed source-root references
+      - name: Run repository hygiene guards
         run: uv run python scripts/ci/check_removed_src_references.py
 
   package-type-checks:

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -24,6 +24,7 @@ This directory contains guides and documentation for developers working on the S
 
 - [Exception Handling](exception-handling.md) - Custom exception hierarchy and patterns
 - [Logging Standards](logging-standards.md) - When to use logger vs console.print
+- [Cleanup Inventory](cleanup-inventory.md) - Current simplification, stale-content, and CI/test drift inventory
 
 ## Workflow
 

--- a/docs/development/cleanup-inventory.md
+++ b/docs/development/cleanup-inventory.md
@@ -1,0 +1,158 @@
+---
+Type: Reference
+Owner: devops@project
+Last-Reviewed: 2026-07-07
+Status: active
+---
+
+# Cleanup Inventory
+
+This inventory tracks codebase simplification work: live specs, stale docs,
+archived scripts, test drift, and CI drift. It is not a feature spec. Use it as
+the starting point for cleanup PRs, and use
+[`docs/research-questions.md`](../research-questions.md) as the scope gate.
+
+## Cleanup Rules
+
+Keep a file, test, or workflow when it satisfies at least one condition:
+
+- It directly supports a live research question or output product.
+- It is part of the current ETL, Dagster, ML, Neo4j, data-refresh, or CI path.
+- It is needed for reproducibility of a published analysis.
+- It is historical context under an explicit archive directory.
+
+Otherwise, update it, archive it, or delete it. Do not keep stale content merely
+because it may become useful later.
+
+## Current Shape
+
+Snapshot from the July 2026 cleanup review:
+
+| Area | Current signal | Cleanup implication |
+| --- | --- | --- |
+| Python source and tests | ~206k Python LOC across `sbir_etl/`, `packages/`, `scripts/`, and `tests/` | Prioritize large modules and duplicate test setup only after low-risk stale cleanup. |
+| Tests | 214 unit test modules, 3 slow test modules, plus integration/e2e/validation suites | Test taxonomy must be simpler and documented in one place. |
+| Docs/specs | 108 docs Markdown files and 103 spec files | Live docs need link/path audits; archive docs can remain historical. |
+| Scripts | `scripts/archive/` contains ~12k Python LOC; `scripts/data/` contains ~3.7k LOC | Archive scripts need a clear reactivation policy. |
+| CI | Six workflows plus nine composite actions | Workflows share repeated setup, Python path, AWS, and summary logic. |
+
+## Live Spec Inventory
+
+Status strings below come from spec files where available; task counts came from
+`specs/*/tasks.md`. `specs/status.md` is the current top-level status registry.
+"Cleanup action" is the next simplification decision, not a feature
+implementation commitment.
+
+| Spec | Current signal | Cleanup action |
+| --- | --- | --- |
+| `agency-private-capital-comparison` | Phase 1 implemented; 7 done, 13 pending | Keep Phase 2 gated until private-capital cohort comparison is selected. |
+| `company-categorization` | Requirements say 77% complete; 32 done, 8 pending | Update old `src/` paths; decide whether Neo4j loader work is still live. |
+| `cross-agency-taxonomy` | Gated backlog; 0 done, 16 pending | Promote only when M3 cross-agency taxonomy reporting is selected. |
+| `data-imputation` | Gated backlog; implementation not started; 30 pending | Defer unless missing-field recovery becomes the next data-quality priority. |
+| `follow-on-multiplier-validation` | Design-only spec, no task file | Either add tasks and make active, or leave as design note. |
+| `iterative_api_enrichment` | USAspending refresh live; 18 done, 2 pending | Split Phase 2 source expansion into a new spec or archive Phase 1 as complete. |
+| `modernbert_analysis_layer` | Maintenance; core embeddings/similarity implemented | Keep Neo4j, quality, and Bayesian work as scoped follow-ups. |
+| `naics-enricher-consolidation` | Maintenance cleanup; 11 done, 5 pending | Close obsolete audit/golden-file tasks as superseded; finish docs cleanup. |
+| `ot-consortium-subaward-attribution` | Gated backlog; 17 pending | Keep gated on coverage probe; do not implement before T0 decision. |
+| `patent-cost-spillover` | Gated backlog; 23 pending | Defer unless C3 patent-cost analysis is the next research priority. |
+| `phase-3-solicitation-alerts` | Maintenance; S1 shipped, S2/S3 backlog | Avoid adding another ingestion path until SAM.gov Opportunities is prioritized. |
+| `sbir_ma_match_rate_by_fy` | Gated backlog; 19 pending | Keep only if it will produce a near-term analysis artifact. |
+| `state-local-tax-rates` | Maintenance; hardcoded provider exists | Good low-risk cleanup: make rates data-driven when fiscal v2 resumes. |
+| `ucc1-financing-analysis` | Archive candidate; 24 done, 14 deferred | Archive completed pilot; move deferred lifecycle/lender work to a follow-up only if active. |
+| `weekly-awards-report-refactor` | Maintenance; 12 done, 4 pending | Finish injection/coverage cleanup; drop alias cleanup only if still meaningful. |
+| `fiscal-tax-impact-v2.md` | Gated backlog | Keep inactive until fiscal-model refresh is selected. |
+
+## Stale Content Signals
+
+These are concrete drift examples found during the review:
+
+- `src/` references remain in active docs/specs even though the repo now uses
+  `sbir_etl/` and `packages/`.
+- Poetry commands appear in validation docs and active specs, while the repo
+  uses `uv`.
+- `black` appears in the Makefile and docs, while current formatting standard is
+  Ruff.
+- `pytest-shard` is installed and documented, but current CI workflows do not
+  run shard matrices.
+- Steering quick-reference Cypher still uses legacy `:Company` / `:Award`
+  examples while schema docs describe `:Organization` /
+  `:FinancialTransaction`.
+- `.pre-commit-config.yaml` comments reference a nonexistent
+  `.github/workflows/static-analysis.yml`.
+- `docs/research-questions.md` says `docs/commercialization-benchmark-methodology.md`
+  is not committed, but the file is present in the repo.
+
+Recommended treatment:
+
+- Live docs/specs: update or delete stale references.
+- `docs/archive/` and `specs/archive/`: preserve historical text unless it is
+  misleadingly linked from current docs.
+- Historical ADRs: keep old paths when the old path is the point of the ADR.
+
+## Scripts Archive Policy
+
+Default policy for `scripts/archive/`:
+
+- Archived scripts are not current operational entrypoints.
+- Active code, CI, and Makefile targets should not import or call archived
+  scripts.
+- Archived scripts should not be extended for new features.
+- If an archived script is needed again, move it to the appropriate live
+  directory, update docs, and add focused tests.
+- Tests under `tests/unit/scripts/archive/` need an explicit reason to remain;
+  otherwise they should move with the reactivated script or be deleted with the
+  archived behavior.
+
+Deletion rule:
+
+- Delete archived scripts only when no active doc/spec cites them as provenance
+  and they are not needed to reproduce a published result.
+
+## Test And CI Drift
+
+Current drift to resolve:
+
+| Area | Drift | Preferred fix |
+| --- | --- | --- |
+| Test taxonomy | Docs describe `pytest -m fast`; CI uses `tests/unit/ -m "not slow and not integration"` | Pick one definition and update docs/CI together. |
+| Validation scripts | Some operator CLIs live under `tests/validation/test_*.py` with zero pytest tests | Rename CLIs or keep explicit exceptions in the integrity guard. |
+| Sharding | `pytest-shard` is installed and documented but unused | Reintroduce sharding intentionally or remove the dependency/docs. |
+| Setup | Workflows mix composite setup, direct `pip install`, and `uv pip install` | Route normal Python setup through one action; allow documented tool bootstraps only. |
+| Dagster jobs | Workflows repeat `PYTHONPATH` and `dagster job execute` summary blocks | Create a reusable script/action for Dagster job execution and summaries. |
+| CI typo | `data-refresh.yml` summary job has a checkout step named "Configure AWS credentials" | Fix naming/step intent while simplifying the summary job. |
+| Test safeguards | Integrity guard focuses on integration/e2e/validation empty suites | Add marker/tier drift checks only after taxonomy is settled. |
+
+## Proposed Cleanup Checks
+
+Add these checks incrementally after the first stale-content cleanup PR:
+
+1. Live-doc path audit:
+   - scan `docs/steering/`, `docs/development/`, `docs/testing/`, top-level
+     `docs/*.md`, and top-level `specs/*`
+   - ignore `docs/archive/`, `specs/archive/`, and ADRs by default
+   - flag old `src/` executable paths, Poetry commands, Black commands, and
+     missing local links
+
+2. Spec status audit:
+   - compare `Status:` text with task counts
+   - flag specs with no tasks unless they are explicitly design-only
+   - flag active specs with no research-question anchor
+
+3. Archive import guard:
+   - fail if live code, CI, or Makefile references `scripts/archive/`
+   - allow docs and archived specs to cite archive paths
+
+4. Runtime-artifact guard:
+   - fail if tracked files include `__pycache__`, `.pyc`, `.pytest_cache`, or
+     generated report artifacts
+
+## First Cleanup PRs
+
+Suggested order:
+
+1. Fix low-risk command/doc drift: Makefile Ruff formatting, invalid ML extras,
+   pre-commit comments, CI sharding docs, and validation CLI command examples.
+2. Update spec statuses and archive/defer clearly stale specs.
+3. Add the live-doc path audit.
+4. Add the archive import guard.
+5. Tackle code simplification modules after docs/tests/CI stop moving underfoot.

--- a/docs/follow-on-multiplier-analysis.md
+++ b/docs/follow-on-multiplier-analysis.md
@@ -4,7 +4,10 @@
 
 ## Specification validation and requirement map
 
-Validation was completed before implementation against `specs/archive/completed-features/follow-on-multiplier-analysis/requirements.md`. The specification's old `src/tools/mission_b` paths do not match the current package layout, so implementation follows the repository's current analytics convention under `packages/sbir-analytics/sbir_analytics/assets/`.
+Validation was completed before implementation against `specs/archive/completed-features/follow-on-multiplier-analysis/requirements.md`.
+That archived specification used a legacy analytics path that no longer matches
+the current package layout, so implementation follows the repository's current
+analytics convention under `packages/sbir-analytics/sbir_analytics/assets/`.
 
 | Requirement | Existing data / identifier | Implementation | Test |
 |---|---|---|---|

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -1,10 +1,12 @@
 # Specification System Documentation
 
-This document centralizes information about the specification systems used in the SBIR ETL project, including the active specifications and the archived OpenSpec content.
+This document centralizes information about the specification systems used in
+the SBIR ETL project, including top-level specs, their status registry, and the
+archived OpenSpec content.
 
 ## Table of Contents
 
-1. [Specifications (Active)](#1-specifications-active)
+1. [Specifications](#1-specifications)
     * [Purpose](#purpose)
     * [Location](#location)
     * [Usage](#usage)
@@ -18,11 +20,16 @@ This document centralizes information about the specification systems used in th
 
 ---
 
-## 1. Specifications (Active)
+## 1. Specifications
 
 ### Purpose
 
-Specifications are the **active and authoritative source of truth** for all development work in the SBIR ETL project. They are used for:
+Specifications are the source of truth for planned and in-progress development
+work in the SBIR ETL project. Not every top-level spec is an active
+implementation target; some are gated, deferred, or archive candidates. Check
+[`specs/status.md`](../../specs/status.md) before starting work from a spec.
+
+They are used for:
 
 * **Planning**: Defining new features, capabilities, and project phases.
 * **Architecture**: Documenting design decisions, architectural patterns, and system components.

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -703,8 +703,8 @@ async def enrich_company(
       2. Filing mentions — search for the company in other filers' filings
          (M&A, ownership, partnership signals).
 
-    Form D is off by default — use `scripts/archive/data/fetch_form_d_index.py` for bulk Form D
-    matching from EDGAR quarterly index files instead of EFTS.
+    Form D is off by default; bulk Form D matching should run from the maintained
+    capital-events pipeline rather than from this single-company EFTS entry point.
     """
     profile = CompanyEdgarProfile(
         company_name=company_name,

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -12,9 +12,11 @@ from urllib.parse import unquote
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 AUTOMATION_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/")
-ARCHIVE_GUARD_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/")
 SCANNED_FILES = {"Makefile", ".pre-commit-config.yaml"}
 EXCLUDED_HISTORICAL_DOCUMENTS = {"docs/decisions/ADR-002-etl-library-extraction.md"}
+EXCLUDED_SCAN_FILES = {
+    "tests/unit/scripts/test_repository_hygiene.py",
+}
 REMOVED_SRC_PATTERNS = (
     re.compile(r"--cov=src(?:\b|/)"),
     re.compile(r"\bsrc\.definitions(?:_ml)?\b"),
@@ -39,7 +41,9 @@ LIVE_DOC_STALE_PATTERNS = (
         "Poetry command in live docs",
     ),
     (
-        re.compile(r"(?:^|[\s`'\"])(?:python\s+-m\s+)?black(?:[\s`'\"]|$)"),
+        re.compile(
+            r"(?:^|[\s'\"(=:/])(?:python\s+-m\s+)?black\s+(?:--|[A-Za-z0-9_.-]+)"
+        ),
         "Black command in live docs",
     ),
 )
@@ -90,7 +94,9 @@ def _relative_to_repository(path: Path, root: Path = REPOSITORY_ROOT) -> str:
 
 
 def _is_automation_file(relative: str) -> bool:
-    if relative in EXCLUDED_HISTORICAL_DOCUMENTS or relative == __file_relative__():
+    if relative in EXCLUDED_HISTORICAL_DOCUMENTS or relative in EXCLUDED_SCAN_FILES:
+        return False
+    if relative == __file_relative__():
         return False
     return relative in SCANNED_FILES or relative.startswith(AUTOMATION_PREFIXES)
 
@@ -108,11 +114,11 @@ def _is_live_doc_file(relative: str) -> bool:
 
 
 def _is_archive_guard_file(relative: str) -> bool:
-    if relative == __file_relative__():
+    if relative in EXCLUDED_SCAN_FILES or relative == __file_relative__():
         return False
     if relative.startswith(("scripts/archive/", "tests/unit/scripts/archive/")):
         return False
-    return relative in SCANNED_FILES or relative.startswith(ARCHIVE_GUARD_PREFIXES)
+    return relative in SCANNED_FILES or relative.startswith(AUTOMATION_PREFIXES)
 
 
 def _read_text_lines(path: Path) -> list[str] | None:

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -1,26 +1,76 @@
 #!/usr/bin/env python3
-"""Reject executable automation references to the removed ``src/`` source root."""
+"""Repository hygiene checks for stale paths and archive dependencies."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import re
 import subprocess
 from pathlib import Path
+from urllib.parse import unquote
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
-SCANNED_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/")
+AUTOMATION_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/")
+ARCHIVE_GUARD_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/")
 SCANNED_FILES = {"Makefile", ".pre-commit-config.yaml"}
 EXCLUDED_HISTORICAL_DOCUMENTS = {"docs/decisions/ADR-002-etl-library-extraction.md"}
-PATTERNS = (
+REMOVED_SRC_PATTERNS = (
     re.compile(r"--cov=src(?:\b|/)"),
     re.compile(r"\bsrc\.definitions(?:_ml)?\b"),
     re.compile(r"(?:^|[\s'\"(=:/])src/[A-Za-z0-9_.*?/-]+"),
 )
+LIVE_DOC_DIR_PREFIXES = ("docs/steering/", "docs/development/", "docs/testing/")
+LIVE_DOC_STALE_PATTERNS = (
+    (
+        re.compile(r"--cov=src(?:\b|/)"),
+        "removed source-root coverage target",
+    ),
+    (
+        re.compile(r"\bsrc\.[A-Za-z0-9_.]+\b"),
+        "removed source-root Python module path",
+    ),
+    (
+        re.compile(r"(?:^|[\s'\"(=:/`])src/[A-Za-z0-9_][A-Za-z0-9_.*?/-]*"),
+        "removed source-root file path",
+    ),
+    (
+        re.compile(r"\bpoetry\s+run\b"),
+        "Poetry command in live docs",
+    ),
+    (
+        re.compile(r"(?:^|[\s`'\"])(?:python\s+-m\s+)?black(?:[\s`'\"]|$)"),
+        "Black command in live docs",
+    ),
+)
+ARCHIVE_REFERENCE_PATTERNS = (
+    re.compile(r"scripts/archive(?:/|\b)"),
+    re.compile(r"scripts\.archive(?:\.|\b)"),
+)
+MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]+\]\(([^)]+)\)")
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A repository hygiene violation with enough context for CI output."""
+
+    path: str
+    line_number: int
+    message: str
+    line: str
+
+    def format(self) -> str:
+        """Format a violation for stable, grep-friendly CI logs."""
+        return f"{self.path}:{self.line_number}: {self.message}: {self.line.strip()}"
 
 
 def tracked_automation_files() -> list[Path]:
     """Return tracked automation files covered by the source-root policy."""
+    return [path for path in tracked_files() if _is_automation_file(_relative_to_repository(path))]
+
+
+def tracked_files() -> list[Path]:
+    """Return tracked repository files."""
     result = subprocess.run(
         ["git", "ls-files"],
         cwd=REPOSITORY_ROOT,
@@ -28,39 +78,194 @@ def tracked_automation_files() -> list[Path]:
         capture_output=True,
         text=True,
     )
-    paths = []
-    for relative in result.stdout.splitlines():
-        if relative in EXCLUDED_HISTORICAL_DOCUMENTS or relative == __file_relative__():
-            continue
-        if relative in SCANNED_FILES or relative.startswith(SCANNED_PREFIXES):
-            paths.append(REPOSITORY_ROOT / relative)
-    return paths
+    return [REPOSITORY_ROOT / relative for relative in result.stdout.splitlines()]
 
 
 def __file_relative__() -> str:
     return str(Path(__file__).resolve().relative_to(REPOSITORY_ROOT))
 
 
-def main() -> int:
-    """Report removed source-root references and return a failing status when found."""
-    violations: list[str] = []
-    for path in tracked_automation_files():
-        try:
-            lines = path.read_text(encoding="utf-8").splitlines()
-        except UnicodeDecodeError:
-            continue
-        for line_number, line in enumerate(lines, 1):
-            if any(pattern.search(line) for pattern in PATTERNS):
-                violations.append(
-                    f"{path.relative_to(REPOSITORY_ROOT)}:{line_number}: {line.strip()}"
-                )
+def _relative_to_repository(path: Path, root: Path = REPOSITORY_ROOT) -> str:
+    return path.resolve().relative_to(root).as_posix()
 
-    if violations:
-        print("Executable references to the removed src/ source root were found:")
-        print("\n".join(violations))
+
+def _is_automation_file(relative: str) -> bool:
+    if relative in EXCLUDED_HISTORICAL_DOCUMENTS or relative == __file_relative__():
+        return False
+    return relative in SCANNED_FILES or relative.startswith(AUTOMATION_PREFIXES)
+
+
+def _is_live_doc_file(relative: str) -> bool:
+    if not relative.endswith(".md"):
+        return False
+    if relative.startswith(("docs/archive/", "specs/archive/")):
+        return False
+    if relative.startswith(LIVE_DOC_DIR_PREFIXES):
+        return True
+    if relative.startswith("docs/") and relative.count("/") == 1:
+        return True
+    return relative.startswith("specs/")
+
+
+def _is_archive_guard_file(relative: str) -> bool:
+    if relative == __file_relative__():
+        return False
+    if relative.startswith(("scripts/archive/", "tests/unit/scripts/archive/")):
+        return False
+    return relative in SCANNED_FILES or relative.startswith(ARCHIVE_GUARD_PREFIXES)
+
+
+def _read_text_lines(path: Path) -> list[str] | None:
+    try:
+        return path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return None
+
+
+def _scan_line_patterns(
+    paths: list[Path],
+    *,
+    root: Path,
+    patterns: tuple[tuple[re.Pattern[str], str], ...],
+) -> list[Violation]:
+    violations: list[Violation] = []
+    for path in paths:
+        lines = _read_text_lines(path)
+        if lines is None:
+            continue
+        relative = _relative_to_repository(path, root)
+        for line_number, line in enumerate(lines, 1):
+            for pattern, message in patterns:
+                if pattern.search(line):
+                    violations.append(Violation(relative, line_number, message, line))
+                    break
+    return violations
+
+
+def scan_removed_src_references(
+    paths: list[Path], *, root: Path = REPOSITORY_ROOT
+) -> list[Violation]:
+    """Find removed ``src`` root references in executable automation."""
+    return _scan_line_patterns(
+        paths,
+        root=root,
+        patterns=tuple(
+            (pattern, "removed src source-root reference") for pattern in REMOVED_SRC_PATTERNS
+        ),
+    )
+
+
+def scan_live_doc_stale_content(
+    paths: list[Path], *, root: Path = REPOSITORY_ROOT
+) -> list[Violation]:
+    """Find stale executable paths and commands in live docs/specs."""
+    live_docs = [path for path in paths if _is_live_doc_file(_relative_to_repository(path, root))]
+    return _scan_line_patterns(live_docs, root=root, patterns=LIVE_DOC_STALE_PATTERNS)
+
+
+def scan_archive_references(paths: list[Path], *, root: Path = REPOSITORY_ROOT) -> list[Violation]:
+    """Find live-code references to archived scripts."""
+    guard_files = [
+        path for path in paths if _is_archive_guard_file(_relative_to_repository(path, root))
+    ]
+    return _scan_line_patterns(
+        guard_files,
+        root=root,
+        patterns=tuple(
+            (pattern, "live code references scripts/archive")
+            for pattern in ARCHIVE_REFERENCE_PATTERNS
+        ),
+    )
+
+
+def _extract_markdown_link_target(raw_target: str) -> str:
+    target = raw_target.strip()
+    if target.startswith("<") and ">" in target:
+        return target[1:].split(">", 1)[0]
+    return target.split(maxsplit=1)[0]
+
+
+def _is_external_or_anchor_link(target: str) -> bool:
+    lower = target.lower()
+    return (
+        not target
+        or target.startswith("#")
+        or lower.startswith(("http://", "https://", "mailto:", "tel:", "app://"))
+    )
+
+
+def _resolve_markdown_target(source_path: Path, target: str, root: Path) -> Path | None:
+    normalized = unquote(target).split("#", 1)[0].split("?", 1)[0]
+    if not normalized:
+        return None
+    if normalized.startswith("/"):
+        return root / normalized.lstrip("/")
+    return source_path.parent / normalized
+
+
+def scan_missing_live_doc_links(
+    paths: list[Path], *, root: Path = REPOSITORY_ROOT
+) -> list[Violation]:
+    """Find local Markdown links in live docs/specs that point nowhere."""
+    violations: list[Violation] = []
+    live_docs = [path for path in paths if _is_live_doc_file(_relative_to_repository(path, root))]
+    for path in live_docs:
+        lines = _read_text_lines(path)
+        if lines is None:
+            continue
+        relative = _relative_to_repository(path, root)
+        for line_number, line in enumerate(lines, 1):
+            for match in MARKDOWN_LINK_RE.finditer(line):
+                target = _extract_markdown_link_target(match.group(1))
+                if _is_external_or_anchor_link(target):
+                    continue
+                resolved = _resolve_markdown_target(path, target, root)
+                if resolved is not None and not resolved.exists():
+                    violations.append(
+                        Violation(
+                            relative, line_number, f"missing local Markdown link {target}", line
+                        )
+                    )
+    return violations
+
+
+def _print_section(title: str, violations: list[Violation]) -> None:
+    if not violations:
+        return
+    print(title)
+    print("\n".join(violation.format() for violation in violations))
+
+
+def main() -> int:
+    """Report repository hygiene violations and return a failing status when found."""
+    paths = tracked_files()
+    violations_by_section = [
+        (
+            "Executable references to the removed src/ source root were found:",
+            scan_removed_src_references(
+                [path for path in paths if _is_automation_file(_relative_to_repository(path))]
+            ),
+        ),
+        (
+            "Stale live-doc paths or commands were found:",
+            scan_live_doc_stale_content(paths),
+        ),
+        (
+            "Missing local Markdown links were found in live docs/specs:",
+            scan_missing_live_doc_links(paths),
+        ),
+        (
+            "Live code references archived scripts:",
+            scan_archive_references(paths),
+        ),
+    ]
+
+    if any(violations for _, violations in violations_by_section):
+        for title, violations in violations_by_section:
+            _print_section(title, violations)
         return 1
 
-    print("No executable references to the removed src/ source root found.")
+    print("Repository hygiene checks passed.")
     return 0
 
 

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -1,6 +1,9 @@
 # SBIR vs. Private-Capital Comparison — Requirements (agency-parameterized; NSF as initial target)
 
-> **Status:** Phase 1 not yet started; Phase 2 gated on PR #286 merging.
+> **Status:** Phase 1 implemented; Phase 2 is a gated backlog item now that the
+> Form D / M&A infrastructure from PR #286 is available. Do not start Phase 2
+> until the private-capital control-cohort comparison is selected as a current
+> research priority.
 > Supports inventory questions **F3** (private-capital comparison), **B2** (commercialization outcomes), **B3** (transition rates) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** F3 / B2 / B3 — SBIR vs. private-capital cohort comparison (NSF initial target)

--- a/specs/company-categorization/design.md
+++ b/specs/company-categorization/design.md
@@ -290,7 +290,8 @@ def aggregate_company_classification(contracts: list[dict], company_uei: str) ->
 
 **Integration Points**:
 
-- Uses existing `DuckDBUSAspendingExtractor` from `src/extractors/usaspending.py`
+- Uses existing `DuckDBUSAspendingExtractor` from
+  `sbir_etl/extractors/usaspending.py`
 - Queries `transaction_normalized` table from USAspending dump
 - Filters by recipient identifiers
 
@@ -691,8 +692,8 @@ def company_categorization_completeness_check(
 ## Related Documents
 
 - Requirements: `specs/company-categorization/requirements.md`
-- USAspending Extractor: `src/extractors/usaspending.py`
-- Award Model: `src/models/award.py`
-- Company Model: `src/models/company.py`
+- USAspending Extractor: `sbir_etl/extractors/usaspending.py`
+- Award Model: `sbir_etl/models/award.py`
+- Company Model: `sbir_etl/models/company.py`
 - Enrichment Patterns: `docs/steering/enrichment-patterns.md`
 - Pipeline Orchestration: `docs/steering/pipeline-orchestration.md`

--- a/specs/company-categorization/tasks.md
+++ b/specs/company-categorization/tasks.md
@@ -8,11 +8,11 @@ This implementation plan tracks the remaining work for the company categorizatio
 
 **Completed:**
 
-- ✅ Data models (`src/models/categorization.py`)
-- ✅ Contract classifier (`src/transformers/company_categorization.py`)
-- ✅ Company aggregator (`src/transformers/company_categorization.py`)
-- ✅ USAspending contract retrieval (`src/enrichers/company_categorization.py`)
-- ✅ Dagster asset (`src/assets/company_categorization.py`)
+- ✅ Data models (`sbir_etl/models/categorization.py`)
+- ✅ Contract classifier (`sbir_etl/transformers/company_categorization.py`)
+- ✅ Company aggregator (`sbir_etl/transformers/company_categorization.py`)
+- ✅ USAspending contract retrieval (`sbir_etl/enrichers/company_categorization.py`)
+- ✅ Dagster asset (`packages/sbir-analytics/sbir_analytics/assets/company_categorization.py`)
 - ✅ Asset checks for quality validation
 
 **Remaining:**
@@ -26,15 +26,15 @@ This implementation plan tracks the remaining work for the company categorizatio
 ## Implementation Tasks
 
 - [x] 1. Create data models for contract and company classifications
-  - Create `ContractClassification` Pydantic model in `src/models/`
-  - Create `CompanyClassification` Pydantic model in `src/models/`
+  - Create `ContractClassification` Pydantic model in `sbir_etl/models/categorization.py`
+  - Create `CompanyClassification` Pydantic model in `sbir_etl/models/categorization.py`
   - Add field validators for classification values and confidence scores
   - Add model serialization methods for DataFrame conversion
   - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
-  - _Status: Completed in `src/models/categorization.py`_
+  - _Status: Completed in `sbir_etl/models/categorization.py`_
 
 - [x] 2. Implement contract classifier module
-  - [x] 2.1 Create `src/transformers/company_categorization.py` module
+  - [x] 2.1 Create `sbir_etl/transformers/company_categorization.py` module
     - Implement `classify_contract()` function with PSC-based rules
     - Implement contract type override logic (CPFF, Cost-Type, T&M → Service)
     - Implement description inference logic (prototype, hardware, device → Product)
@@ -106,7 +106,7 @@ This implementation plan tracks the remaining work for the company categorizatio
 
 - [x] 4. Implement USAspending contract retrieval
   - [x] 4.1 Create contract retrieval function
-    - Implement `retrieve_company_contracts()` function in `src/enrichers/company_categorization.py`
+    - Implement `retrieve_company_contracts()` function in `sbir_etl/enrichers/company_categorization.py`
     - Query USAspending by UEI using existing `DuckDBUSAspendingExtractor`
     - Query USAspending by DUNS if UEI query returns no results
     - Query USAspending by CAGE if DUNS query returns no results
@@ -130,13 +130,14 @@ This implementation plan tracks the remaining work for the company categorizatio
 
 - [x] 5. Create Dagster asset for company categorization
   - [x] 5.1 Implement main categorization asset
-    - Create `enriched_sbir_companies_with_categorization` asset in `src/assets/`
+    - Create `enriched_sbir_companies_with_categorization` asset in
+      `packages/sbir-analytics/sbir_analytics/assets/company_categorization.py`
     - Depend on `validated_sbir_awards` asset
     - Load configuration from `get_config()`
     - Initialize `DuckDBUSAspendingExtractor` with database path
     - Extract unique companies from validated SBIR awards
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
-    - _Status: Completed in `src/assets/company_categorization.py`_
+    - _Status: Completed in `packages/sbir-analytics/sbir_analytics/assets/company_categorization.py`_
 
   - [x] 5.2 Implement batch processing loop
     - Iterate through companies in batches
@@ -175,13 +176,15 @@ This implementation plan tracks the remaining work for the company categorizatio
 
 - [x] 7. Add configuration schema
   - [x] 7.1 Create configuration model
-    - Add `CompanyCategorization` config schema to `src/config/schemas.py`
+    - Add `CompanyCategorization` config schema to `sbir_etl/config/schemas/data.py`
     - Define threshold parameters (product_leaning_pct: 51, service_leaning_pct: 51, psc_family_diversity: 6)
     - Define confidence level parameters (low_max_awards: 2, medium_max_awards: 5)
     - Define processing parameters (batch_size: 100, parallel_workers: 4)
     - Define USAspending query parameters (table_name, timeout, retries)
     - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5, 6.1, 6.2, 6.3, 6.4, 6.5, 7.1, 7.2, 7.3, 7.4, 7.5_
-    - _Status: Implemented in `src/config/schemas/runtime.py` as `CompanyCategorizationConfig`. Schema defaults corrected from 60% to 51% threshold._
+    - _Status: Implemented in `sbir_etl/config/schemas/data.py` as
+      `CompanyCategorizationConfig`. Schema defaults corrected from 60% to 51%
+      threshold._
 
   - [x] 7.2 Add default configuration
     - Add `company_categorization` section to `config/base.yaml`
@@ -193,7 +196,8 @@ This implementation plan tracks the remaining work for the company categorizatio
 
 - [ ] 8. Implement Neo4j loader
   - [ ] 8.1 Create CompanyCategorizationLoader class
-    - Create `CompanyCategorizationLoader` in `src/loaders/neo4j/`
+    - Create `CompanyCategorizationLoader` in
+      `packages/sbir-graph/sbir_graph/loaders/neo4j/categorization.py`
     - Implement `load_categorizations()` method for batch loading
     - Update existing Company nodes with categorization properties
     - Handle missing companies gracefully (log warnings)
@@ -275,7 +279,9 @@ This implementation plan tracks the remaining work for the company categorizatio
     - Document `aggregate_company_classification()` function with examples
     - Document `retrieve_company_contracts()` function with examples
     - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5, 2.1, 2.2, 2.3, 2.4, 2.5, 5.1, 5.2, 5.3, 5.4, 5.5_
-    - _Status: Comprehensive docstrings already exist in `src/transformers/company_categorization.py` and `src/enrichers/company_categorization.py`_
+    - _Status: Comprehensive docstrings already exist in
+      `sbir_etl/transformers/company_categorization.py` and
+      `sbir_etl/enrichers/company_categorization.py`_
 
   - [ ]* 10.2 Create usage guide
     - Document how to run categorization asset in Dagster UI

--- a/specs/cross-agency-taxonomy/tasks.md
+++ b/specs/cross-agency-taxonomy/tasks.md
@@ -1,6 +1,10 @@
 # Cross-Agency Technology Taxonomy — Tasks
 
-> **Status (2026-07-02):** Not started. CET classifier infrastructure exists (`packages/sbir-analytics/sbir_analytics/assets/cet/`), but the cross-agency analyzer and full-corpus batch run described here are not implemented.
+> **Status (2026-07-07):** Gated backlog. Prerequisite CET classifier and
+> mission-a analysis tools exist, but none of this spec's listed tasks are
+> complete: no full-corpus batch run, cross-agency report, visualization output,
+> or scheduled Dagster asset exists yet. Promote only when M3 cross-agency
+> taxonomy reporting is selected as the next research priority.
 
 ## Phase 1: Full Corpus Classification
 

--- a/specs/data-imputation/requirements.md
+++ b/specs/data-imputation/requirements.md
@@ -1,6 +1,7 @@
 # Data Imputation — Requirements
 
-> **Status:** Spec merged via PR #277 — implementation not yet started as of June 2026.
+> **Status:** Gated backlog — spec merged via PR #277; implementation not yet
+> started as of July 2026.
 > Anchors inventory question **E4** in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** E4 — missing-field recovery (award_date ~50% absent; UEI/DUNS gaps)

--- a/specs/iterative_api_enrichment/requirements.md
+++ b/specs/iterative_api_enrichment/requirements.md
@@ -11,7 +11,7 @@
 
 ## Done when
 
-> A pipeline engineer can state: "The `iterative_enrichment_refresh_job` Dagster job runs nightly after bulk enrichment succeeds, processing only stale or failed records by source. Per-source freshness state is tracked in `data/derived/enrichment_freshness.parquet` and `data/state/enrichment_refresh_state.json`. A targeted refresh can be triggered via `poetry run refresh_enrichment --source <name> --window <start>:<end>`."
+> A pipeline engineer can state: "The `iterative_enrichment_refresh_job` Dagster job runs nightly after bulk enrichment succeeds, processing only stale or failed records by source. Per-source freshness state is tracked in `data/derived/enrichment_freshness.parquet` and `data/state/enrichment_refresh_state.json`. A targeted refresh can be triggered via `uv run refresh_enrichment --source <name> --window <start>:<end>`."
 
 ---
 
@@ -41,7 +41,7 @@ This specification implements an iterative API enrichment refresh loop to keep c
 - **PipelineConfig.enrichment_refresh**: Code component or file: sbir_etl/config/schemas/pipeline.py — the actual config namespace for iterative-refresh settings (e.g., `config.enrichment_refresh.usaspending.*`).
 - **data/derived/enrichment_freshness.parquet**: Code component or file: the Parquet ledger where per-source freshness metrics are persisted.
 - **data/state/enrichment_refresh_state.json**: Code component or file: the JSON state file tracking per-source last-attempt / last-success timestamps.
-- **poetry run refresh_enrichment --source sam_gov --window 2023-10-01:2023-10-07**: Code component or file: poetry run refresh_enrichment --source sam_gov --window 2023-10-01:2023-10-07
+- **uv run refresh_enrichment --source sam_gov --window 2023-10-01:2023-10-07**: Code component or file: uv run refresh_enrichment --source sam_gov --window 2023-10-01:2023-10-07
 - **docs/enrichment/iterative-refresh.md**: Code component or file: docs/enrichment/iterative-refresh.md
 - **Iterative enrichment scheduler**: Key concept: Iterative enrichment scheduler
 - **Per-source refresh policies**: Key concept: Per-source refresh policies
@@ -79,4 +79,4 @@ This specification implements an iterative API enrichment refresh loop to keep c
 
 1. THE System SHALL persist per-source enrichment state to `data/derived/enrichment_freshness.parquet` and `data/state/enrichment_refresh_state.json`, recording attempt count, last success timestamp, and staleness window per source.
 2. THE System SHALL alert (via Dagster asset check or log warning) when any source's last successful enrichment exceeds its configured SLA window.
-3. THE System SHALL support a `--window` CLI flag (`poetry run refresh_enrichment --source <name> --window <start>:<end>`) for manual targeted refreshes of specific date ranges.
+3. THE System SHALL support a `--window` CLI flag (`uv run refresh_enrichment --source <name> --window <start>:<end>`) for manual targeted refreshes of specific date ranges.

--- a/specs/modernbert_analysis_layer/requirements.md
+++ b/specs/modernbert_analysis_layer/requirements.md
@@ -1,6 +1,10 @@
 # Requirements — ModernBert Analysis Layer
 
-> **Status:** Not yet started. Requirements 5–7 (Bayesian MoE routing) are flagged for scope review before implementation.
+> **Status:** Partially implemented. Core ModernBert client, embedding assets,
+> similarity output, config, and client-level tests exist. Neo4j `SIMILAR_TO`
+> loading, quality/cohesion metrics, fuller asset checks, and Dagster integration
+> tests remain open. Requirements 5–7 (Bayesian MoE routing) are deferred pending
+> explicit scope review.
 > Supports inventory question **C2** (patent–award semantic similarity) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** C2 — patent–award semantic similarity via ModernBert embeddings

--- a/specs/naics-enricher-consolidation/requirements.md
+++ b/specs/naics-enricher-consolidation/requirements.md
@@ -1,6 +1,9 @@
 # Requirements — NAICS Enricher Consolidation
 
-> **Status:** Not yet started.
+> **Status:** Largely complete. Shim deletion, canonical mapper consolidation,
+> strategy registration, and Ruff/mypy verification are done. Remaining work is
+> documentation cleanup and deciding whether obsolete audit/golden-file tasks
+> should be closed as superseded rather than re-created.
 > Supports inventory questions **D1 / E3** (NAICS coverage and fiscal-impact infrastructure)
 > in [docs/research-questions.md](../../docs/research-questions.md).
 

--- a/specs/ot-consortium-subaward-attribution/requirements.md
+++ b/specs/ot-consortium-subaward-attribution/requirements.md
@@ -1,6 +1,7 @@
 # Requirements — OT Consortium Sub-Award Attribution (FFATA/FSRS)
 
-> **Status:** Spec only — not implemented. Follow-on to the OT consortium verification-tiering module.
+> **Status:** Gated backlog — not implemented. Run the T0 coverage probe before
+> promoting beyond the OT consortium verification-tiering follow-up.
 > Supports inventory question **A2** (OT consortium attribution) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** A2 — OT consortium sub-award attribution and T2→T1 recovery via FSRS
@@ -75,5 +76,5 @@ this gives us exactly what the rollup destroys:
 - Magnitude report exposes `recovered_from_rollup_usd` /
   `recovered_from_rollup_count`: obligated $ and records moved T2→T1 via
   sub-awards, reported alongside (not folded into) the existing verified total.
-- Unit tests for each case above; ≥85% coverage on new code; ruff/black/mypy
-  clean.
+- Unit tests for each case above; >=85% coverage on new code; Ruff formatting,
+  Ruff lint, and mypy clean.

--- a/specs/ot-consortium-subaward-attribution/tasks.md
+++ b/specs/ot-consortium-subaward-attribution/tasks.md
@@ -62,7 +62,7 @@
 
 - [ ] **T5.1** Update `docs/ot-consortium/tiers.md`: document route (c), the
       amount-override semantics, and the "absence is not contradiction" caveat.
-- [ ] **T5.2** Full gate: ≥85% coverage on new code; ruff/black/mypy clean;
-      existing OT + transition suites green.
+- [ ] **T5.2** Full gate: >=85% coverage on new code; Ruff formatting, Ruff
+      lint, and mypy clean; existing OT + transition suites green.
 - [ ] **T5.3** Sanity run on a real CMF prime (e.g. an ATI/NSTXL PIID) to confirm
       sub-award rows resolve and the recovered-$ line is non-zero where expected.

--- a/specs/patent-cost-spillover/requirements.md
+++ b/specs/patent-cost-spillover/requirements.md
@@ -1,6 +1,7 @@
 # Patent Cost and Spillover Analysis — Requirements
 
-> **Status:** Not yet started — zero implementation code as of June 2026.
+> **Status:** Gated backlog — zero cost/citation/spillover analytical-layer
+> implementation as of July 2026.
 > Anchors inventory questions **C3a–c** in [docs/research-questions.md](../../docs/research-questions.md).
 > Target benchmarks: NIH ~$1.5M marginal cost per patent; Myers & Lanahan AER 2022 ~3× DOE
 > spillover, ~60% U.S.-retained [L9][L5].

--- a/specs/phase-3-solicitation-alerts/requirements.md
+++ b/specs/phase-3-solicitation-alerts/requirements.md
@@ -1,6 +1,8 @@
 # Phase III Solicitation & Award Candidate Alerts — Requirements
 
-> **Status:** Not yet started.
+> **Status:** Partially implemented. S1 retrospective reclassification shipped
+> in PRs #394, #410, and #412; S2/S3 SAM.gov Opportunities candidate paths and
+> final documentation/sign-off remain backlog.
 > Supports inventory questions **B2 / B3 / B4 / E1 / E6 / E5** in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** B2 / B3 / B4 / E1 / E6 / E5 — Phase III identification, solicitation alerting, and FPDS data-gap measurement

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -1,6 +1,7 @@
 # Requirements: SBIR M&A Match Rate by Fiscal Year
 
-> **Status:** Not yet started.
+> **Status:** Gated backlog — analysis-only spec, not yet implemented. Start
+> only when FY match-rate reporting is requested.
 > Supports inventory question **F2** (M&A exit rate by vintage) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** F2 — SBIR-awardee M&A match rate by fiscal year

--- a/specs/state-local-tax-rates/requirements.md
+++ b/specs/state-local-tax-rates/requirements.md
@@ -1,14 +1,14 @@
 # Requirements — State & Local Tax Rate Reference Data
 
-> **Status:** Not yet started — but significant existing implementation.
+> **Status:** Maintenance backlog — significant existing implementation remains
+> hardcoded.
 > `sbir_etl/transformers/fiscal/state_rates.py` already contains all 50 states
 > with hardcoded 2024 Tax Foundation / Census ASGF rates and a `StateRateProvider`
 > class. **The task is to make those rates data-driven** (loaded from a refreshable
 > CSV) rather than hardcoded constants. The `StateTaxRates` dataclass and
 > `StateRateProvider` interface stay unchanged.
 >
-> Required by **Phase 3** of [../fiscal-tax-impact-v2.md](../fiscal-tax-impact-v2.md) and
-> **Requirement 3** of [../fiscal-sensitivity-reconciliation/](../fiscal-sensitivity-reconciliation/).
+> Required by **Phase 3** of [../fiscal-tax-impact-v2.md](../fiscal-tax-impact-v2.md).
 > Anchors inventory questions **D2** and **D3** in
 > [docs/research-questions.md](../../docs/research-questions.md).
 
@@ -23,7 +23,7 @@
 > A pipeline engineer can state: "`data/reference/tax/state_effective_rates.csv`
 > contains the same rates as `state_rates.py`'s `_STATE_RATES_2024` dict — but
 > refreshed from Tax Foundation and Census ASGF source files, not hardcoded. Running
-> `poetry run refresh-state-rates` downloads the latest Tax Foundation tables and
+> `uv run refresh-state-rates` downloads the latest Tax Foundation tables and
 > updates the CSV. `StateRateProvider` loads from the CSV when a path is supplied,
 > falls back to the hardcoded dict otherwise. Existing tests pass unchanged."
 
@@ -97,7 +97,7 @@ without reading source code.
 
 #### Acceptance Criteria
 
-1. THE System SHALL implement `poetry run refresh-state-rates` that downloads the
+1. THE System SHALL implement `uv run refresh-state-rates` that downloads the
    latest Tax Foundation "State Individual Income Tax Rates" and "State and Local
    Sales Tax Rates" tables, appends a new fiscal-year row for each state, and
    writes the updated CSV.

--- a/specs/status.md
+++ b/specs/status.md
@@ -1,0 +1,81 @@
+# Specification Status Registry
+
+Reviewed: 2026-07-07
+
+This registry is the cleanup checkpoint for top-level specs. It does not replace
+the requirements, design, or tasks files; it records whether a spec is a current
+implementation target, a gated backlog item, a deferred design, or an archive
+candidate. Use `docs/research-questions.md` as the scope gate before promoting
+any gated or deferred spec back into active work.
+
+## Status Categories
+
+- **Active:** current implementation or cleanup work can proceed from the spec.
+- **Maintenance:** core behavior is mostly implemented; remaining work is test,
+  documentation, or small cleanup.
+- **Gated backlog:** valid research question, but do not implement until the
+  named prerequisite or priority decision is satisfied.
+- **Deferred:** keep for historical or future context; do not implement as part
+  of normal cleanup work.
+- **Archive candidate:** move under `specs/archive/` after any live docs are
+  updated to point at the archived path.
+
+## Top-Level Specs
+
+- **`agency-private-capital-comparison` — Gated backlog.** Phase 1 is
+  implemented. Phase 2 depends on prioritizing the Form D / private-capital
+  control-cohort comparison.
+- **`company-categorization` — Maintenance.** About 80% complete. Evaluate the
+  remaining Neo4j loader and docs against the current `:Organization` graph
+  schema before implementation.
+- **`cross-agency-taxonomy` — Gated backlog.** M3 research target. Prerequisite
+  classifier/tools exist, but this spec's batch run, report, and Dagster wiring
+  are not implemented.
+- **`data-imputation` — Gated backlog.** Foundational E4 work, but zero
+  implementation. Start only when missing-field recovery becomes the next
+  data-quality priority.
+- **`follow-on-multiplier-validation` — Active.** Design-only follow-up to the
+  completed multiplier asset. Still called out as an immediate research-plan
+  gap.
+- **`iterative_api_enrichment` — Maintenance.** USAspending refresh is live.
+  Remaining source expansion should be split or scheduled intentionally.
+- **`modernbert_analysis_layer` — Maintenance.** Core embeddings and similarity
+  are implemented. Neo4j loading, quality metrics, and Bayesian routing remain
+  scoped follow-ups.
+- **`naics-enricher-consolidation` — Maintenance.** Consolidation is largely
+  complete. Remaining obsolete audit/golden-file tasks should not be revived as
+  written.
+- **`ot-consortium-subaward-attribution` — Gated backlog.** Valid A2 research
+  question, but the T0 coverage probe must run before implementation.
+- **`patent-cost-spillover` — Gated backlog.** M2 analytical layer remains
+  missing. Implement only when patent cost/spillover becomes the selected
+  sprint.
+- **`phase-3-solicitation-alerts` — Maintenance.** Retrospective S1 work is
+  implemented. SAM.gov Opportunities S2/S3 paths remain backlog.
+- **`sbir_ma_match_rate_by_fy` — Gated backlog.** Analysis-only F2 follow-up on
+  completed M&A detection. Start only when FY match-rate reporting is requested.
+- **`state-local-tax-rates` — Maintenance.** Existing hardcoded 2024 provider
+  works. Remaining work is data-file/provenance cleanup for fiscal v2.
+- **`ucc1-financing-analysis` — Archive candidate.** CA-only pilot is complete
+  and extension is explicitly deferred by the research memo.
+- **`weekly-awards-report-refactor` — Maintenance.** Monolith is already split
+  into weekly reporting modules. Remaining work is injection, coverage, and
+  alias cleanup.
+- **`fiscal-tax-impact-v2.md` — Gated backlog.** Valid D2 methodology upgrade.
+  Leave inactive until fiscal-model refresh is selected.
+
+## Archive Candidates
+
+`ucc1-financing-analysis` is the only top-level archive candidate from this
+review. Before moving it:
+
+1. Update `docs/research-questions.md` and `docs/research/sbir-ucc1-pilot.md`
+   links to the archived path.
+2. Add a completion record summarizing PRs #303 / #305, the CA-only pilot result,
+   and the stop/defer rationale.
+3. Move the spec under `specs/archive/completed-features/` if treating the pilot
+   as complete, or `specs/archive/superseded/` if treating the extension plan as
+   dropped.
+
+No other top-level spec should be archived from this review because each still
+anchors a live research question or an active maintenance cleanup.

--- a/tests/unit/scripts/test_repository_hygiene.py
+++ b/tests/unit/scripts/test_repository_hygiene.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+
+from scripts.ci import check_removed_src_references as hygiene
+
+
+def _write(root: Path, relative: str, text: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_live_doc_stale_content_scans_live_docs_only(tmp_path: Path):
+    live_doc = _write(
+        tmp_path,
+        "docs/development/example.md",
+        "Run `poetry run old-task` and inspect `src/assets/example.py`.\n",
+    )
+    archive_doc = _write(
+        tmp_path,
+        "docs/archive/example.md",
+        "Run `poetry run old-task` and inspect `src/assets/example.py`.\n",
+    )
+
+    violations = hygiene.scan_live_doc_stale_content([live_doc, archive_doc], root=tmp_path)
+
+    assert [violation.message for violation in violations] == [
+        "removed source-root file path",
+    ]
+
+
+def test_live_doc_link_audit_resolves_relative_links(tmp_path: Path):
+    source = _write(
+        tmp_path,
+        "docs/development/example.md",
+        "[good](../target.md)\n[missing](../missing.md)\n[external](https://example.com)\n",
+    )
+    target = _write(tmp_path, "docs/target.md", "ok\n")
+
+    violations = hygiene.scan_missing_live_doc_links([source, target], root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].message == "missing local Markdown link ../missing.md"
+    assert violations[0].path == "docs/development/example.md"
+
+
+def test_archive_guard_ignores_archive_scripts_and_flags_live_references(tmp_path: Path):
+    live_code = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "HELPER = 'scripts/archive/data/old.py'\n",
+    )
+    archive_script = _write(
+        tmp_path,
+        "scripts/archive/data/old.py",
+        "HELPER = 'scripts/archive/data/old.py'\n",
+    )
+    archive_test = _write(
+        tmp_path,
+        "tests/unit/scripts/archive/test_old.py",
+        "from scripts.archive.data import old\n",
+    )
+
+    violations = hygiene.scan_archive_references(
+        [live_code, archive_script, archive_test],
+        root=tmp_path,
+    )
+
+    assert len(violations) == 1
+    assert violations[0].path == "sbir_etl/example.py"
+
+
+def test_removed_src_guard_scans_automation_paths(tmp_path: Path):
+    workflow = _write(
+        tmp_path,
+        ".github/workflows/ci.yml",
+        "run: uv run dagster job execute -f src.definitions\n",
+    )
+
+    violations = hygiene.scan_removed_src_references([workflow], root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].message == "removed src source-root reference"


### PR DESCRIPTION
## Summary

- Add a cleanup inventory and top-level spec status registry to make simplification work explicit.
- Reconcile stale spec status banners and outdated path/command examples in live docs/specs.
- Extend the existing CI source-root guard into repository hygiene checks for live-doc stale content, missing local Markdown links, and live-code references to `scripts/archive`.
- Add focused unit coverage for the new repository hygiene scanner.

## Why

The codebase had a mix of active specs, deferred specs, stale `src/` paths, old Poetry/Black references, and archived script references. This PR makes the cleanup state visible and adds CI coverage so the drift does not quietly return.

## Validation

- `uv run pytest tests/unit/scripts/test_repository_hygiene.py -v`
- `uv run ruff check scripts/ci/check_removed_src_references.py tests/unit/scripts/test_repository_hygiene.py`
- `uv run ruff format --check scripts/ci/check_removed_src_references.py tests/unit/scripts/test_repository_hygiene.py`
- `uv run python scripts/ci/check_removed_src_references.py`
- `git diff --cached --check`

## Notes

This branch intentionally excludes unrelated local `agency_private_capital` worktree files.