### PR TITLE
Implement agency private capital Phase 2

### DIFF
--- a/docs/research/agency-private-capital-phase2-form-d.md
+++ b/docs/research/agency-private-capital-phase2-form-d.md
@@ -1,0 +1,53 @@
+# Agency Private-Capital Phase 2 Form D Methodology
+
+Phase 2 compares a configured agency's SBIR awardees that have high-confidence
+Form D matches with non-SBIR Form D issuers. It supports research questions
+F3, B2, and B3 by producing a descriptive matched-cohort artifact, not a causal
+treatment estimate.
+
+## Inputs
+
+- `data/form_d_details.jsonl`: SBIR-company Form D matches from the SEC EDGAR
+  pipeline. Phase 2 keeps high-tier matches and excludes industry groups already
+  flagged as structurally incompatible with operating-company SBIR raises.
+- `data/form_d_control_universe.jsonl`: broader Form D issuer universe for
+  non-SBIR controls. Issuers with CIKs already resolved to any SBIR company are
+  dropped before matching.
+- `data/sbir_ma_events.jsonl`: curated M&A event signals. Missing files produce
+  unavailable metrics rather than zero-valued outcomes.
+
+## Matching
+
+The v1 matcher uses coarsened-exact matching on:
+
+- filing or award vintage year
+- Form D industry group
+- issuer state
+
+This intentionally avoids propensity scoring until the control side has richer
+firm-level covariates. The asset publishes matched-pair rows and a
+`match_balance.json` file with cohort sizes, match rate, per-stratum counts, and
+an agency-scoped Form D leverage cross-check.
+
+## Outputs
+
+The Dagster asset
+`agency_private_capital_form_d_matched_comparison` writes to
+`data/processed/agency_private_capital/<agency>/`:
+
+- `agency_vs_form_d_comparison.parquet`
+- `agency_vs_form_d_matched_pairs.parquet`
+- `agency_vs_form_d_comparison.md`
+- `match_balance.json`
+- `threats_to_validity.json`
+
+The markdown report includes outcome rows for federal-contract presence, patent
+presence, and M&A exit rate. Metrics whose event inputs are not materialized are
+marked unavailable.
+
+## Interpretation
+
+The comparison is descriptive. Required threats-to-validity entries cover SAFE
+and convertible undercount, late-stage Form D inclusion, issuer-reported
+industry noise, CIK-resolution recall limits, selection bias, and timing leakage
+from excluding any issuer ever matched to SBIR.

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/__init__.py
@@ -1,4 +1,4 @@
-"""SBIR vs. published-VC-baseline comparison (agency-parameterized, Phase 1).
+"""SBIR vs. private-capital comparisons (agency-parameterized).
 
 Produces a descriptive comparison artifact: SBIR cohort outcome rates for
 the configured funding agency alongside published seed-VC / small-business-
@@ -7,29 +7,55 @@ NSF is the initial implementation target and the default agency. Mirrors
 the posture of ``specs/archive/completed-features/follow-on-multiplier-analysis``: reconciliation matters
 more than the match.
 
-Outputs (under ``data/processed/agency_private_capital/<agency_lower>/``):
+Phase 1 outputs (under ``data/processed/agency_private_capital/<agency_lower>/``):
     - ``agency_cohort_outcomes.parquet``
     - ``agency_vs_published_baselines.md``
     - ``agency_baseline_comparison.json``
+
+Phase 2 outputs:
+    - ``agency_vs_form_d_comparison.parquet``
+    - ``agency_vs_form_d_matched_pairs.parquet``
+    - ``agency_vs_form_d_comparison.md``
+    - ``threats_to_validity.json``
 """
 
 from .asset import AgencyPrivateCapitalConfig, agency_private_capital_baseline_comparison
 from .baselines import PublishedBaseline, PublishedBaselineRegistry
 from .cohort import AgencyCohortBuilder, NSFCohortBuilder, vintage_bucket
+from .control_cohort import (
+    AgencyAwardeeFilter,
+    PrivateCapitalControlCohortBuilder,
+    agency_leverage_cross_check,
+)
+from .form_d_matched_asset import (
+    AgencyPrivateCapitalPhase2Config,
+    agency_private_capital_form_d_matched_comparison,
+)
+from .matching import CohortMatcher
 from .outcomes import OutcomeMetricsCalculator, wilson_interval
+from .phase2_outcomes import MatchedCohortOutcomes
 from .reconcile import ReconciliationNarrative, ReconciliationRecord
+from .threats import ThreatsToValidity
 
 
 __all__ = [
     "AgencyCohortBuilder",
+    "AgencyAwardeeFilter",
     "AgencyPrivateCapitalConfig",
+    "AgencyPrivateCapitalPhase2Config",
+    "CohortMatcher",
+    "MatchedCohortOutcomes",
     "NSFCohortBuilder",
     "OutcomeMetricsCalculator",
+    "PrivateCapitalControlCohortBuilder",
     "PublishedBaseline",
     "PublishedBaselineRegistry",
     "ReconciliationNarrative",
     "ReconciliationRecord",
+    "ThreatsToValidity",
+    "agency_leverage_cross_check",
     "agency_private_capital_baseline_comparison",
+    "agency_private_capital_form_d_matched_comparison",
     "vintage_bucket",
     "wilson_interval",
 ]

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/control_cohort.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/control_cohort.py
@@ -1,0 +1,227 @@
+"""Cohort construction for agency-vs-private-capital Phase 2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from .cohort import AgencyCohortBuilder
+from .form_d_inputs import normalize_name
+
+
+def agency_leverage_cross_check(
+    agency_code: str,
+    awards: pd.DataFrame,
+    treated: pd.DataFrame,
+) -> dict[str, float | int | None | str]:
+    """Compare matched Form D capital to the full agency SBIR award denominator."""
+
+    agency_awards = AgencyCohortBuilder(agency_code=agency_code).build(awards)
+    amount_col = "award_amount" if "award_amount" in agency_awards.columns else "Award Amount"
+    agency_program_total = (
+        float(agency_awards[amount_col].map(award_amount).sum())
+        if amount_col in agency_awards.columns
+        else 0.0
+    )
+    matched_sbir_total = _sum_numeric(treated, "agency_sbir_amount")
+    matched_form_d_total = _sum_numeric(treated, "total_form_d_raised")
+    return {
+        "agency_code": agency_code,
+        "agency_award_rows": int(len(agency_awards)),
+        "matched_treated_firms": int(len(treated)),
+        "agency_program_sbir_amount": agency_program_total,
+        "matched_agency_sbir_amount": matched_sbir_total,
+        "matched_form_d_raised": matched_form_d_total,
+        "form_d_to_agency_program_ratio": _ratio(matched_form_d_total, agency_program_total),
+        "form_d_to_matched_sbir_ratio": _ratio(matched_form_d_total, matched_sbir_total),
+    }
+
+
+def award_amount(value: object) -> float:
+    """Parse SBIR award amount strings defensively."""
+
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return 0.0
+    try:
+        return float(str(value).replace("$", "").replace(",", "").strip())
+    except ValueError:
+        return 0.0
+
+
+def award_year(row: pd.Series) -> int | None:
+    """Return award year from common normalized or SBIR.gov-style columns."""
+
+    for key in ("award_year", "Award Year"):
+        value = row.get(key)
+        if value is not None and not (isinstance(value, float) and pd.isna(value)):
+            try:
+                return int(str(value).strip())
+            except ValueError:
+                pass
+    for key in ("award_date", "Proposal Award Date"):
+        value = row.get(key)
+        if value is None or (isinstance(value, float) and pd.isna(value)):
+            continue
+        parsed = pd.to_datetime(value, errors="coerce")
+        if pd.notna(parsed):
+            return int(parsed.year)
+    return None
+
+
+def company_name(row: pd.Series) -> str:
+    for key in ("company_name", "Company"):
+        value = row.get(key)
+        if value is not None and not (isinstance(value, float) and pd.isna(value)):
+            return str(value).strip()
+    return ""
+
+
+def state_code(row: pd.Series) -> str:
+    for key in ("state", "State"):
+        value = row.get(key)
+        if value is not None and not (isinstance(value, float) and pd.isna(value)):
+            return str(value).strip().upper()[:2]
+    return ""
+
+
+@dataclass(frozen=True)
+class AgencyAwardeeFilter:
+    """Build the treated agency cohort intersected with high-tier Form D matches."""
+
+    agency_code: str = "NSF"
+
+    def build(self, awards: pd.DataFrame, form_d_matches: pd.DataFrame) -> pd.DataFrame:
+        agency_awards = AgencyCohortBuilder(agency_code=self.agency_code).build(awards)
+        if agency_awards.empty or form_d_matches.empty:
+            return _treated_frame([])
+
+        agency_awards = agency_awards.copy()
+        agency_awards["company_key"] = agency_awards.apply(
+            lambda row: normalize_name(company_name(row)), axis=1
+        )
+        agency_awards["_award_year"] = agency_awards.apply(award_year, axis=1)
+        amount_col = "award_amount" if "award_amount" in agency_awards.columns else "Award Amount"
+        if amount_col in agency_awards.columns:
+            amount_values = agency_awards[amount_col]
+        else:
+            amount_values = pd.Series(0.0, index=agency_awards.index)
+        agency_awards["_award_amount"] = amount_values.map(award_amount)
+        agency_awards["_state"] = agency_awards.apply(state_code, axis=1)
+
+        award_summary = (
+            agency_awards.groupby("company_key", dropna=False)
+            .agg(
+                company_name=("company_name", "first")
+                if "company_name" in agency_awards.columns
+                else ("Company", "first"),
+                agency_first_award_year=("_award_year", "min"),
+                agency_sbir_amount=("_award_amount", "sum"),
+                agency_award_count=("_award_amount", "size"),
+                state=("_state", "first"),
+            )
+            .reset_index()
+        )
+        merged = award_summary.merge(
+            form_d_matches,
+            on="company_key",
+            how="inner",
+            suffixes=("_agency", "_form_d"),
+        )
+        if merged.empty:
+            return _treated_frame([])
+
+        rows: list[dict[str, Any]] = []
+        for _, row in merged.iterrows():
+            vintage_year = row.get("agency_first_award_year")
+            rows.append(
+                {
+                    "cohort": "agency_sbir",
+                    "company_name": row.get("company_name_agency") or row.get("company_name"),
+                    "company_key": row["company_key"],
+                    "form_d_cik": row["form_d_cik"],
+                    "vintage_year": int(vintage_year) if pd.notna(vintage_year) else None,
+                    "state": row.get("state_form_d") or row.get("state") or "",
+                    "industry_group": row.get("industry_group") or "Unknown",
+                    "first_form_d_year": row.get("first_form_d_year"),
+                    "total_form_d_raised": row.get("total_form_d_raised", 0.0),
+                    "agency_sbir_amount": row.get("agency_sbir_amount", 0.0),
+                    "agency_award_count": row.get("agency_award_count", 0),
+                }
+            )
+        return _treated_frame(rows)
+
+
+@dataclass(frozen=True)
+class PrivateCapitalControlCohortBuilder:
+    """Build non-SBIR Form D controls from the broader Form D universe."""
+
+    def build(self, form_d_universe: pd.DataFrame) -> pd.DataFrame:
+        if form_d_universe.empty:
+            return _control_frame([])
+        rows: list[dict[str, Any]] = []
+        for _, row in form_d_universe.iterrows():
+            vintage_year = row.get("first_form_d_year")
+            rows.append(
+                {
+                    "cohort": "form_d_control",
+                    "issuer_name": row.get("issuer_name") or row.get("company_name"),
+                    "issuer_key": row.get("issuer_key") or row.get("company_key"),
+                    "form_d_cik": row.get("form_d_cik"),
+                    "vintage_year": int(vintage_year) if pd.notna(vintage_year) else None,
+                    "state": row.get("state") or "",
+                    "industry_group": row.get("industry_group") or "Unknown",
+                    "first_form_d_year": row.get("first_form_d_year"),
+                    "total_form_d_raised": row.get("total_form_d_raised", 0.0),
+                    "offering_count": row.get("offering_count", 0),
+                }
+            )
+        return _control_frame(rows)
+
+
+def _treated_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "cohort",
+            "company_name",
+            "company_key",
+            "form_d_cik",
+            "vintage_year",
+            "state",
+            "industry_group",
+            "first_form_d_year",
+            "total_form_d_raised",
+            "agency_sbir_amount",
+            "agency_award_count",
+        ],
+    )
+
+
+def _control_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "cohort",
+            "issuer_name",
+            "issuer_key",
+            "form_d_cik",
+            "vintage_year",
+            "state",
+            "industry_group",
+            "first_form_d_year",
+            "total_form_d_raised",
+            "offering_count",
+        ],
+    )
+
+
+def _sum_numeric(frame: pd.DataFrame, column: str) -> float:
+    if frame.empty or column not in frame.columns:
+        return 0.0
+    return float(pd.to_numeric(frame[column], errors="coerce").fillna(0).sum())
+
+
+def _ratio(numerator: float, denominator: float) -> float | None:
+    return numerator / denominator if denominator else None

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
@@ -90,7 +90,14 @@ def load_form_d_control_universe(
         if not _keep_row(row, tier_filter=None, year_min=year_min, year_max=year_max):
             continue
         rows.append(row)
-    return _frame(rows)
+    frame = _frame(rows)
+    if frame.empty:
+        return frame
+    return (
+        frame.sort_values(["first_form_d_year", "company_key"], na_position="last")
+        .drop_duplicates(subset=["form_d_cik"], keep="first")
+        .reset_index(drop=True)
+    )
 
 
 def _iter_company_form_d_rows(

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
@@ -1,0 +1,244 @@
+"""Input adapters for agency-vs-Form-D matched cohort analysis.
+
+The production Form D research artifacts are JSONL files, but their exact
+shape has changed across analysis passes. These helpers normalize the two
+shapes Phase 2 needs:
+
+- SBIR-matched Form D details (`form_d_details.jsonl`)
+- broader Form D issuer universe used for non-SBIR controls
+
+Both outputs are ordinary DataFrames so matching and tests stay simple.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from sbir_etl.enrichers.sec_edgar.form_d_scoring import EXCLUDED_INDUSTRY_GROUPS
+
+
+DEFAULT_FORM_D_MATCHES_PATH = Path("data/form_d_details.jsonl")
+DEFAULT_FORM_D_CONTROL_UNIVERSE_PATH = Path("data/form_d_control_universe.jsonl")
+
+
+def normalize_name(value: object) -> str:
+    """Return the normalized join key used by the existing Form D analyses."""
+
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    return " ".join(str(value).strip().upper().split())
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read JSONL records, skipping blank and invalid lines."""
+
+    records: list[dict[str, Any]] = []
+    if not path.exists():
+        return records
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return records
+
+
+def load_form_d_matches(
+    path: Path,
+    *,
+    tier_filter: set[str] | None = None,
+    year_min: int | None = None,
+    year_max: int | None = None,
+) -> pd.DataFrame:
+    """Normalize SBIR-matched Form D records to one row per matched company."""
+
+    rows = [
+        row
+        for row in _iter_company_form_d_rows(read_jsonl(path), matched_to_sbir=True)
+        if _keep_row(row, tier_filter=tier_filter, year_min=year_min, year_max=year_max)
+    ]
+    return _frame(rows)
+
+
+def load_form_d_control_universe(
+    path: Path,
+    *,
+    sbir_ciks: set[str],
+    year_min: int | None = None,
+    year_max: int | None = None,
+) -> pd.DataFrame:
+    """Normalize non-SBIR Form D controls to one row per issuer CIK.
+
+    The control universe is expected to be broader than SBIR matches. Any CIK
+    already present in the SBIR matched set is removed before matching.
+    """
+
+    rows: list[dict[str, Any]] = []
+    for row in _iter_company_form_d_rows(read_jsonl(path), matched_to_sbir=False):
+        cik = str(row.get("form_d_cik") or "").lstrip("0")
+        if not cik or cik in sbir_ciks:
+            continue
+        if not _keep_row(row, tier_filter=None, year_min=year_min, year_max=year_max):
+            continue
+        rows.append(row)
+    return _frame(rows)
+
+
+def _iter_company_form_d_rows(
+    records: Iterable[dict[str, Any]],
+    *,
+    matched_to_sbir: bool,
+) -> Iterable[dict[str, Any]]:
+    for rec in records:
+        company_name = rec.get("company_name") or rec.get("issuer_name") or rec.get("entity_name")
+        cik = rec.get("form_d_cik") or rec.get("cik")
+        tier = (rec.get("match_confidence") or {}).get("tier")
+        offerings = rec.get("offerings")
+        if not isinstance(offerings, list):
+            offerings = [_offering_from_flat_record(rec)]
+
+        kept_offerings = [
+            offering
+            for offering in offerings
+            if offering
+            and (offering.get("industry_group") or "") not in EXCLUDED_INDUSTRY_GROUPS
+        ]
+        if not kept_offerings:
+            continue
+
+        first = _first_offering(kept_offerings)
+        filing_years = sorted(
+            year
+            for year in (_year(o.get("filing_date") or o.get("date_filed")) for o in kept_offerings)
+            if year is not None
+        )
+        total_sold = _sum_float(o.get("total_amount_sold") for o in kept_offerings)
+        total_offered = _sum_float(o.get("total_offering_amount") for o in kept_offerings)
+
+        issuer_name = (
+            first.get("entity_name")
+            or first.get("issuer_name")
+            or rec.get("issuer_name")
+            or rec.get("entity_name")
+            or company_name
+        )
+        state = first.get("state") or rec.get("state")
+        industry_group = first.get("industry_group") or rec.get("industry_group")
+        security_types = sorted(
+            {
+                str(t).lower()
+                for offering in kept_offerings
+                for t in (offering.get("securities_types") or [])
+                if t
+            }
+        )
+
+        yield {
+            "company_name": company_name,
+            "company_key": normalize_name(company_name),
+            "issuer_name": issuer_name,
+            "issuer_key": normalize_name(issuer_name),
+            "form_d_cik": str(cik or first.get("cik") or "").lstrip("0"),
+            "tier": tier,
+            "matched_to_sbir": matched_to_sbir,
+            "state": _state_code(state),
+            "industry_group": industry_group or "Unknown",
+            "first_form_d_date": first.get("filing_date") or first.get("date_filed") or "",
+            "first_form_d_year": filing_years[0] if filing_years else None,
+            "offering_count": len(kept_offerings),
+            "total_form_d_raised": total_sold,
+            "total_form_d_offered": total_offered,
+            "security_types": security_types,
+        }
+
+
+def _offering_from_flat_record(rec: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "cik": rec.get("cik") or rec.get("form_d_cik"),
+        "entity_name": rec.get("entity_name") or rec.get("issuer_name") or rec.get("company_name"),
+        "filing_date": rec.get("filing_date") or rec.get("date_filed"),
+        "state": rec.get("state"),
+        "industry_group": rec.get("industry_group"),
+        "securities_types": rec.get("securities_types") or [],
+        "total_amount_sold": rec.get("total_amount_sold") or rec.get("total_raised"),
+        "total_offering_amount": rec.get("total_offering_amount"),
+    }
+
+
+def _first_offering(offerings: list[dict[str, Any]]) -> dict[str, Any]:
+    def key(offering: dict[str, Any]) -> str:
+        return str(offering.get("filing_date") or offering.get("date_filed") or "9999-99-99")
+
+    return sorted(offerings, key=key)[0]
+
+
+def _year(value: object) -> int | None:
+    if value is None:
+        return None
+    s = str(value)
+    return int(s[:4]) if len(s) >= 4 and s[:4].isdigit() else None
+
+
+def _sum_float(values: Iterable[object]) -> float:
+    total = 0.0
+    for value in values:
+        if value is None:
+            continue
+        try:
+            total += float(value)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def _state_code(value: object) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+    return str(value).strip().upper()[:2]
+
+
+def _keep_row(
+    row: dict[str, Any],
+    *,
+    tier_filter: set[str] | None,
+    year_min: int | None,
+    year_max: int | None,
+) -> bool:
+    if tier_filter is not None and row.get("tier") not in tier_filter:
+        return False
+    year = row.get("first_form_d_year")
+    if year is not None and year_min is not None and int(year) < year_min:
+        return False
+    if year is not None and year_max is not None and int(year) > year_max:
+        return False
+    return bool(row.get("form_d_cik") and row.get("company_key"))
+
+
+def _frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    columns = [
+        "company_name",
+        "company_key",
+        "issuer_name",
+        "issuer_key",
+        "form_d_cik",
+        "tier",
+        "matched_to_sbir",
+        "state",
+        "industry_group",
+        "first_form_d_date",
+        "first_form_d_year",
+        "offering_count",
+        "total_form_d_raised",
+        "total_form_d_offered",
+        "security_types",
+    ]
+    return pd.DataFrame(rows, columns=columns)

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
@@ -109,8 +109,7 @@ def _iter_company_form_d_rows(
         kept_offerings = [
             offering
             for offering in offerings
-            if offering
-            and (offering.get("industry_group") or "") not in EXCLUDED_INDUSTRY_GROUPS
+            if offering and (offering.get("industry_group") or "") not in EXCLUDED_INDUSTRY_GROUPS
         ]
         if not kept_offerings:
             continue
@@ -191,13 +190,20 @@ def _year(value: object) -> int | None:
 def _sum_float(values: Iterable[object]) -> float:
     total = 0.0
     for value in values:
-        if value is None:
+        parsed = _float_or_none(value)
+        if parsed is None:
             continue
-        try:
-            total += float(value)
-        except (TypeError, ValueError):
-            continue
+        total += parsed
     return total
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    try:
+        return float(str(value))
+    except ValueError:
+        return None
 
 
 def _state_code(value: object) -> str:

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_matched_asset.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_matched_asset.py
@@ -18,8 +18,8 @@ from .form_d_inputs import (
     load_form_d_control_universe,
     load_form_d_matches,
 )
-from .matching import CohortMatcher
-from .phase2_outcomes import MatchedCohortOutcomes, keys_from_ma_events
+from .matching import CohortMatcher, _pairs_frame
+from .phase2_outcomes import MatchedCohortOutcomes, _outcome_frame, keys_from_ma_events
 from .threats import ThreatsToValidity
 
 
@@ -77,9 +77,8 @@ def agency_private_capital_form_d_matched_comparison(
         md_path.write_text(
             _missing_inputs_markdown(config.agency_code, missing_inputs), encoding="utf-8"
         )
-        empty = pd.DataFrame()
-        empty.to_parquet(comparison_path, index=False)
-        empty.to_parquet(pairs_path, index=False)
+        _outcome_frame([]).to_parquet(comparison_path, index=False)
+        _pairs_frame([]).to_parquet(pairs_path, index=False)
         balance_path.write_text(
             json.dumps({"status": "missing_inputs", "missing_inputs": missing_inputs}, indent=2),
             encoding="utf-8",

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_matched_asset.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_matched_asset.py
@@ -1,0 +1,241 @@
+"""Dagster asset for Phase 2 agency-vs-Form-D matched cohort analysis."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+from dagster import AssetExecutionContext, Config, MetadataValue, Output, asset
+
+from .control_cohort import (
+    AgencyAwardeeFilter,
+    PrivateCapitalControlCohortBuilder,
+    agency_leverage_cross_check,
+)
+from .form_d_inputs import (
+    DEFAULT_FORM_D_CONTROL_UNIVERSE_PATH,
+    DEFAULT_FORM_D_MATCHES_PATH,
+    load_form_d_control_universe,
+    load_form_d_matches,
+)
+from .matching import CohortMatcher
+from .phase2_outcomes import MatchedCohortOutcomes, keys_from_ma_events
+from .threats import ThreatsToValidity
+
+
+DEFAULT_OUTPUT_ROOT = Path("data/processed/agency_private_capital")
+DEFAULT_MA_EVENTS_PATH = Path("data/sbir_ma_events.jsonl")
+
+
+class AgencyPrivateCapitalPhase2Config(Config):
+    """Run config for the Phase 2 matched Form D comparison."""
+
+    agency_code: str = "NSF"
+    form_d_matches_path: str = str(DEFAULT_FORM_D_MATCHES_PATH)
+    form_d_control_universe_path: str = str(DEFAULT_FORM_D_CONTROL_UNIVERSE_PATH)
+    ma_events_path: str = str(DEFAULT_MA_EVENTS_PATH)
+    controls_per_treated: int = 3
+    year_min: int = 2009
+    year_max: int = 2024
+    output_dir: str | None = None
+
+
+@asset(
+    name="agency_private_capital_form_d_matched_comparison",
+    group_name="agency_private_capital",
+    compute_kind="pandas",
+    description=(
+        "Phase 2 Form D matched-control comparison for a configured SBIR agency. "
+        "Builds agency Form D awardee cohort, non-SBIR Form D controls, coarsened-"
+        "exact matches, outcome rows, balance metadata, and threats-to-validity gate."
+    ),
+)
+def agency_private_capital_form_d_matched_comparison(
+    context: AssetExecutionContext,
+    config: AgencyPrivateCapitalPhase2Config,
+    enriched_sbir_awards: pd.DataFrame,
+) -> Output[str]:
+    output_dir = (
+        Path(config.output_dir)
+        if config.output_dir
+        else DEFAULT_OUTPUT_ROOT / config.agency_code.lower()
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    comparison_path = output_dir / "agency_vs_form_d_comparison.parquet"
+    pairs_path = output_dir / "agency_vs_form_d_matched_pairs.parquet"
+    md_path = output_dir / "agency_vs_form_d_comparison.md"
+    threats_path = output_dir / "threats_to_validity.json"
+    balance_path = output_dir / "match_balance.json"
+
+    form_d_matches_path = Path(config.form_d_matches_path)
+    control_path = Path(config.form_d_control_universe_path)
+    missing_inputs = [
+        str(path)
+        for path in (form_d_matches_path, control_path)
+        if not path.exists()
+    ]
+    if missing_inputs:
+        threats_payload = ThreatsToValidity().write(threats_path)
+        md_path.write_text(_missing_inputs_markdown(config.agency_code, missing_inputs), encoding="utf-8")
+        empty = pd.DataFrame()
+        empty.to_parquet(comparison_path, index=False)
+        empty.to_parquet(pairs_path, index=False)
+        balance_path.write_text(
+            json.dumps({"status": "missing_inputs", "missing_inputs": missing_inputs}, indent=2),
+            encoding="utf-8",
+        )
+        return Output(
+            str(md_path),
+            metadata={
+                "status": "missing_inputs",
+                "missing_inputs": MetadataValue.json(missing_inputs),
+                "threats_passed": bool(threats_payload["passed"]),
+            },
+        )
+
+    form_d_matches = load_form_d_matches(
+        form_d_matches_path,
+        tier_filter={"high"},
+        year_min=config.year_min,
+        year_max=config.year_max,
+    )
+    sbir_ciks = set(form_d_matches["form_d_cik"].dropna().astype(str))
+    controls_universe = load_form_d_control_universe(
+        control_path,
+        sbir_ciks=sbir_ciks,
+        year_min=config.year_min,
+        year_max=config.year_max,
+    )
+    treated = AgencyAwardeeFilter(agency_code=config.agency_code).build(
+        enriched_sbir_awards, form_d_matches
+    )
+    controls = PrivateCapitalControlCohortBuilder().build(controls_universe)
+    pairs, balance = CohortMatcher(controls_per_treated=config.controls_per_treated).match(
+        treated, controls
+    )
+    balance["agency_leverage_cross_check"] = agency_leverage_cross_check(
+        config.agency_code,
+        enriched_sbir_awards,
+        treated,
+    )
+    ma_keys = keys_from_ma_events(config.ma_events_path)
+    outcomes = MatchedCohortOutcomes(ma_event_keys=ma_keys).compute(pairs)
+    threats_payload = ThreatsToValidity().write(threats_path)
+
+    pairs.to_parquet(pairs_path, index=False)
+    outcomes.to_parquet(comparison_path, index=False)
+    balance_path.write_text(json.dumps(balance, indent=2, default=str), encoding="utf-8")
+    md_path.write_text(
+        _comparison_markdown(
+            agency_code=config.agency_code,
+            outcomes=outcomes,
+            balance=balance,
+            threats_passed=bool(threats_payload["passed"]),
+        ),
+        encoding="utf-8",
+    )
+
+    context.log.info(
+        "Phase 2 agency private-capital matched comparison complete",
+        extra={"agency_code": config.agency_code, "balance": balance},
+    )
+    return Output(
+        str(md_path),
+        metadata={
+            "status": "complete",
+            "agency_code": config.agency_code,
+            "treated_count": int(balance["treated_count"]),
+            "control_count": int(balance["control_count"]),
+            "matched_treated_count": int(balance["matched_treated_count"]),
+            "match_rate": MetadataValue.float(float(balance["match_rate"])),
+            "comparison_path": str(comparison_path),
+            "pairs_path": str(pairs_path),
+            "threats_path": str(threats_path),
+            "threats_passed": bool(threats_payload["passed"]),
+        },
+    )
+
+
+def _missing_inputs_markdown(agency_code: str, missing_inputs: list[str]) -> str:
+    lines = [
+        f"# {agency_code} SBIR vs. Form D Matched Controls",
+        "",
+        "Phase 2 did not run because required input artifacts are missing.",
+        "",
+        "| Missing input |",
+        "| --- |",
+    ]
+    lines.extend(f"| `{path}` |" for path in missing_inputs)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _comparison_markdown(
+    *,
+    agency_code: str,
+    outcomes: pd.DataFrame,
+    balance: dict[str, Any],
+    threats_passed: bool,
+) -> str:
+    leverage = balance.get("agency_leverage_cross_check", {})
+    lines = [
+        f"# {agency_code} SBIR vs. Form D Matched Controls",
+        "",
+        "Descriptive comparison only. Coarsened-exact matching uses filing/award vintage, "
+        "Form D industry group, and state.",
+        "",
+        "## Match Balance",
+        "",
+        f"- Treated firms: {balance['treated_count']}",
+        f"- Control issuers: {balance['control_count']}",
+        f"- Matched treated firms: {balance['matched_treated_count']}",
+        f"- Unmatched treated firms: {balance['unmatched_treated_count']}",
+        f"- Match rate: {balance['match_rate']:.1%}",
+        "",
+        "## Agency Leverage Cross-Check",
+        "",
+        f"- Agency SBIR denominator: {_money(leverage.get('agency_program_sbir_amount'))}",
+        f"- Matched agency SBIR amount: {_money(leverage.get('matched_agency_sbir_amount'))}",
+        f"- Matched Form D raised: {_money(leverage.get('matched_form_d_raised'))}",
+        "- Form D / agency SBIR denominator: "
+        f"{_multiple(leverage.get('form_d_to_agency_program_ratio'))}",
+        "- Form D / matched SBIR amount: "
+        f"{_multiple(leverage.get('form_d_to_matched_sbir_ratio'))}",
+        "",
+        "## Outcome Rows",
+        "",
+        "| Cohort | Metric | Rate | n | Available |",
+        "| --- | --- | ---: | ---: | --- |",
+    ]
+    if outcomes.empty:
+        lines.append("| n/a | n/a | n/a | 0 | false |")
+    else:
+        for _, row in outcomes.iterrows():
+            rate = row.get("rate")
+            rate_text = "n/a" if pd.isna(rate) else f"{float(rate):.1%}"
+            lines.append(
+                f"| {row['cohort']} | {row['metric']} | {rate_text} | "
+                f"{int(row['denominator'])} | {bool(row['available'])} |"
+            )
+    lines.extend(
+        [
+            "",
+            "## Threats Gate",
+            "",
+            "Passed." if threats_passed else "Failed. Headline interpretation is suppressed.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _money(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "n/a"
+    return f"${float(value):,.0f}"
+
+
+def _multiple(value: object) -> str:
+    if value is None or pd.isna(value):
+        return "n/a"
+    return f"{float(value):.2f}x"

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_matched_asset.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_matched_asset.py
@@ -70,13 +70,13 @@ def agency_private_capital_form_d_matched_comparison(
     form_d_matches_path = Path(config.form_d_matches_path)
     control_path = Path(config.form_d_control_universe_path)
     missing_inputs = [
-        str(path)
-        for path in (form_d_matches_path, control_path)
-        if not path.exists()
+        str(path) for path in (form_d_matches_path, control_path) if not path.exists()
     ]
     if missing_inputs:
         threats_payload = ThreatsToValidity().write(threats_path)
-        md_path.write_text(_missing_inputs_markdown(config.agency_code, missing_inputs), encoding="utf-8")
+        md_path.write_text(
+            _missing_inputs_markdown(config.agency_code, missing_inputs), encoding="utf-8"
+        )
         empty = pd.DataFrame()
         empty.to_parquet(comparison_path, index=False)
         empty.to_parquet(pairs_path, index=False)
@@ -230,12 +230,23 @@ def _comparison_markdown(
 
 
 def _money(value: object) -> str:
-    if value is None or pd.isna(value):
+    parsed = _float_or_none(value)
+    if parsed is None:
         return "n/a"
-    return f"${float(value):,.0f}"
+    return f"${parsed:,.0f}"
 
 
 def _multiple(value: object) -> str:
-    if value is None or pd.isna(value):
+    parsed = _float_or_none(value)
+    if parsed is None:
         return "n/a"
-    return f"{float(value):.2f}x"
+    return f"{parsed:.2f}x"
+
+
+def _float_or_none(value: object) -> float | None:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return None
+    try:
+        return float(str(value))
+    except ValueError:
+        return None

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/matching.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/matching.py
@@ -51,7 +51,9 @@ class CohortMatcher:
                         "control_total_form_d_raised": control_row.get("total_form_d_raised"),
                     }
                 )
-        return _pairs_frame(pairs), self._balance(treated, controls, matched_treated=matched_treated)
+        return _pairs_frame(pairs), self._balance(
+            treated, controls, matched_treated=matched_treated
+        )
 
     def _balance(
         self,

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/matching.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/matching.py
@@ -1,0 +1,120 @@
+"""Coarsened-exact matching for Phase 2 private-capital controls."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+
+MATCH_COLUMNS = ("vintage_year", "industry_group", "state")
+
+
+@dataclass(frozen=True)
+class CohortMatcher:
+    """Match each treated agency Form D firm to up to `controls_per_treated` controls."""
+
+    controls_per_treated: int = 3
+    match_columns: tuple[str, ...] = MATCH_COLUMNS
+
+    def match(self, treated: pd.DataFrame, controls: pd.DataFrame) -> tuple[pd.DataFrame, dict]:
+        if treated.empty or controls.empty:
+            return _pairs_frame([]), self._balance(treated, controls, matched_treated=set())
+
+        control_buckets: dict[tuple[Any, ...], list[dict]] = {}
+        for _, row in controls.sort_values(["form_d_cik"]).iterrows():
+            key = tuple(row.get(col) for col in self.match_columns)
+            control_buckets.setdefault(key, []).append(row.to_dict())
+
+        pairs: list[dict[str, Any]] = []
+        matched_treated: set[str] = set()
+        for _, treated_row in treated.sort_values(["company_key"]).iterrows():
+            key = tuple(treated_row.get(col) for col in self.match_columns)
+            candidates = control_buckets.get(key, [])[: self.controls_per_treated]
+            if not candidates:
+                continue
+            matched_treated.add(str(treated_row.get("company_key")))
+            for control_row in candidates:
+                pairs.append(
+                    {
+                        "treated_company_name": treated_row.get("company_name"),
+                        "treated_company_key": treated_row.get("company_key"),
+                        "treated_form_d_cik": treated_row.get("form_d_cik"),
+                        "control_issuer_name": control_row.get("issuer_name"),
+                        "control_issuer_key": control_row.get("issuer_key"),
+                        "control_form_d_cik": control_row.get("form_d_cik"),
+                        "vintage_year": treated_row.get("vintage_year"),
+                        "industry_group": treated_row.get("industry_group"),
+                        "state": treated_row.get("state"),
+                        "treated_total_form_d_raised": treated_row.get("total_form_d_raised"),
+                        "control_total_form_d_raised": control_row.get("total_form_d_raised"),
+                    }
+                )
+        return _pairs_frame(pairs), self._balance(treated, controls, matched_treated=matched_treated)
+
+    def _balance(
+        self,
+        treated: pd.DataFrame,
+        controls: pd.DataFrame,
+        *,
+        matched_treated: set[str],
+    ) -> dict:
+        strata = []
+        if not treated.empty:
+            treated_counts = (
+                treated.groupby(list(self.match_columns), dropna=False)
+                .size()
+                .reset_index(name="treated_count")
+            )
+        else:
+            treated_counts = pd.DataFrame(columns=[*self.match_columns, "treated_count"])
+        if not controls.empty:
+            control_counts = (
+                controls.groupby(list(self.match_columns), dropna=False)
+                .size()
+                .reset_index(name="control_count")
+            )
+        else:
+            control_counts = pd.DataFrame(columns=[*self.match_columns, "control_count"])
+        merged = treated_counts.merge(
+            control_counts, on=list(self.match_columns), how="outer"
+        ).fillna(0)
+        for _, row in merged.iterrows():
+            strata.append(
+                {
+                    **{col: row[col] for col in self.match_columns},
+                    "treated_count": int(row["treated_count"]),
+                    "control_count": int(row["control_count"]),
+                }
+            )
+        n_treated = int(len(treated))
+        return {
+            "match_columns": list(self.match_columns),
+            "controls_per_treated": self.controls_per_treated,
+            "treated_count": n_treated,
+            "control_count": int(len(controls)),
+            "matched_treated_count": len(matched_treated),
+            "unmatched_treated_count": n_treated - len(matched_treated),
+            "match_rate": (len(matched_treated) / n_treated) if n_treated else 0.0,
+            "strata": strata,
+        }
+
+
+def _pairs_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "treated_company_name",
+            "treated_company_key",
+            "treated_form_d_cik",
+            "control_issuer_name",
+            "control_issuer_key",
+            "control_form_d_cik",
+            "vintage_year",
+            "industry_group",
+            "state",
+            "treated_total_form_d_raised",
+            "control_total_form_d_raised",
+        ],
+    )

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/phase2_outcomes.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/phase2_outcomes.py
@@ -1,0 +1,167 @@
+"""Outcome calculations for matched agency-vs-Form-D control cohorts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from .outcomes import wilson_interval
+
+
+def keys_from_ma_events(path: str | None) -> set[str] | None:
+    """Load M&A event keys from JSONL, supporting company-name and CIK fields."""
+
+    if not path:
+        return None
+    from pathlib import Path
+
+    import json
+
+    p = Path(path)
+    if not p.exists():
+        return None
+    keys: set[str] = set()
+    with p.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = row.get("company_name") or row.get("issuer_name") or row.get("entity_name")
+            if name:
+                keys.add(f"name:{str(name).strip().lower()}")
+            cik = row.get("form_d_cik") or row.get("cik") or row.get("target_cik")
+            if cik:
+                keys.add(f"cik:{str(cik).lstrip('0')}")
+    return keys
+
+
+@dataclass(frozen=True)
+class MatchedCohortOutcomes:
+    """Compute outcome rates on treated and matched-control cohorts.
+
+    Event sets are optional because real FPDS/PATLINK control joins are not
+    always materialized. Missing sets produce `available=False` rows instead
+    of silently reporting zero.
+    """
+
+    federal_contract_keys: set[str] | None = None
+    patent_keys: set[str] | None = None
+    ma_event_keys: set[str] | None = None
+
+    def compute(self, pairs: pd.DataFrame) -> pd.DataFrame:
+        if pairs.empty:
+            return _outcome_frame([])
+        rows: list[dict[str, Any]] = []
+        rows.extend(
+            self._metric(
+                pairs,
+                metric="federal_contract_presence",
+                keys=self.federal_contract_keys,
+            )
+        )
+        rows.extend(self._metric(pairs, metric="patent_presence", keys=self.patent_keys))
+        rows.extend(self._metric(pairs, metric="ma_exit_rate", keys=self.ma_event_keys))
+        return _outcome_frame(rows)
+
+    def _metric(
+        self,
+        pairs: pd.DataFrame,
+        *,
+        metric: str,
+        keys: set[str] | None,
+    ) -> list[dict[str, Any]]:
+        treated = pairs.drop_duplicates("treated_company_key")
+        controls = pairs.drop_duplicates("control_form_d_cik")
+        return [
+            self._row(
+                cohort="agency_sbir",
+                metric=metric,
+                candidate_keys=_treated_keys(treated),
+                keys=keys,
+            ),
+            self._row(
+                cohort="form_d_control",
+                metric=metric,
+                candidate_keys=_control_keys(controls),
+                keys=keys,
+            ),
+        ]
+
+    def _row(
+        self,
+        *,
+        cohort: str,
+        metric: str,
+        candidate_keys: dict[str, set[str]],
+        keys: set[str] | None,
+    ) -> dict[str, Any]:
+        denominator = len(candidate_keys)
+        if keys is None:
+            return {
+                "cohort": cohort,
+                "metric": metric,
+                "numerator": 0,
+                "denominator": denominator,
+                "rate": float("nan"),
+                "ci_low": float("nan"),
+                "ci_high": float("nan"),
+                "available": False,
+            }
+        numerator = sum(1 for key_set in candidate_keys.values() if key_set & keys)
+        wi = wilson_interval(numerator, denominator)
+        return {
+            "cohort": cohort,
+            "metric": metric,
+            "numerator": wi["numerator"],
+            "denominator": wi["denominator"],
+            "rate": wi["rate"],
+            "ci_low": wi["ci_low"],
+            "ci_high": wi["ci_high"],
+            "available": True,
+        }
+
+
+def _treated_keys(rows: pd.DataFrame) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for _, row in rows.iterrows():
+        key = str(row.get("treated_company_key") or "")
+        keys = {f"name:{str(row.get('treated_company_name')).strip().lower()}"}
+        cik = row.get("treated_form_d_cik")
+        if cik:
+            keys.add(f"cik:{str(cik).lstrip('0')}")
+        out[key] = keys
+    return out
+
+
+def _control_keys(rows: pd.DataFrame) -> dict[str, set[str]]:
+    out: dict[str, set[str]] = {}
+    for _, row in rows.iterrows():
+        key = str(row.get("control_form_d_cik") or row.get("control_issuer_key") or "")
+        keys = {f"name:{str(row.get('control_issuer_name')).strip().lower()}"}
+        cik = row.get("control_form_d_cik")
+        if cik:
+            keys.add(f"cik:{str(cik).lstrip('0')}")
+        out[key] = keys
+    return out
+
+
+def _outcome_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=[
+            "cohort",
+            "metric",
+            "numerator",
+            "denominator",
+            "rate",
+            "ci_low",
+            "ci_high",
+            "available",
+        ],
+    )

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/threats.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/threats.py
@@ -1,0 +1,116 @@
+"""Threats-to-validity gate for Phase 2 matched cohort reporting."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+REQUIRED_THREATS = (
+    "safe_convertible_undercount",
+    "late_stage_form_d_inclusion",
+    "naics_self_report_noise",
+    "cik_resolution_recall_floor",
+    "selection_bias",
+    "control_cohort_timing_leak",
+)
+
+
+@dataclass(frozen=True)
+class ThreatEntry:
+    id: str
+    label: str
+    description: str
+    mitigation: str
+    as_of: str
+
+
+class ThreatsToValidity:
+    """Validate that all required caveats are present before reporting headlines."""
+
+    def __init__(self, entries: list[ThreatEntry] | None = None) -> None:
+        self.entries = entries if entries is not None else default_threat_entries()
+
+    def validate(self) -> dict:
+        present = {entry.id for entry in self.entries}
+        missing = [threat for threat in REQUIRED_THREATS if threat not in present]
+        return {
+            "passed": not missing,
+            "required": list(REQUIRED_THREATS),
+            "missing": missing,
+            "entries": [asdict(entry) for entry in self.entries],
+        }
+
+    def write(self, path: Path) -> dict:
+        payload = self.validate()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+
+def default_threat_entries() -> list[ThreatEntry]:
+    as_of = datetime.now(UTC).date().isoformat()
+    return [
+        ThreatEntry(
+            id="safe_convertible_undercount",
+            label="SAFE / convertible undercount",
+            description=(
+                "Form D is incomplete for some early-stage instruments and does not fully "
+                "capture non-filed SAFEs, bootstrapping, bank debt, revenue, or grants."
+            ),
+            mitigation="Report Form-D-detected private capital only; avoid total financing claims.",
+            as_of=as_of,
+        ),
+        ThreatEntry(
+            id="late_stage_form_d_inclusion",
+            label="Late-stage Form D inclusion",
+            description=(
+                "The control universe includes Form D issuers across stages, not only seed-stage "
+                "or pre-seed venture-backed firms."
+            ),
+            mitigation="Match on filing vintage and decompose by offering size/security type.",
+            as_of=as_of,
+        ),
+        ThreatEntry(
+            id="naics_self_report_noise",
+            label="Industry self-report noise",
+            description=(
+                "Current v1 matching uses Form D industry_group when NAICS-2 is unavailable; "
+                "issuer-reported industry can be coarser than award-derived NAICS."
+            ),
+            mitigation="Publish balance tables and treat industry controls as coarse strata.",
+            as_of=as_of,
+        ),
+        ThreatEntry(
+            id="cik_resolution_recall_floor",
+            label="CIK recall floor",
+            description=(
+                "Only firms with resolved EDGAR/Form D signals enter the matched analysis, so "
+                "private-capital non-filers and unresolved CIKs are outside the estimand."
+            ),
+            mitigation="Report CIK/form-D coverage alongside every headline table.",
+            as_of=as_of,
+        ),
+        ThreatEntry(
+            id="selection_bias",
+            label="Technical-merit vs lawyer-access selection bias",
+            description=(
+                "SBIR awardees are selected on agency technical merit and proposal quality; "
+                "Form D controls self-select on private-market readiness and filing access."
+            ),
+            mitigation="Frame as descriptive comparison, not a causal SBIR treatment effect.",
+            as_of=as_of,
+        ),
+        ThreatEntry(
+            id="control_cohort_timing_leak",
+            label="Control-cohort timing leak",
+            description=(
+                "Dropping any issuer ever matched to SBIR prevents obvious contamination but can "
+                "also exclude firms whose SBIR exposure happens after the control filing."
+            ),
+            mitigation="Document exclusion rule; defer time-varying treatment design to v2.",
+            as_of=as_of,
+        ),
+    ]

--- a/tests/integration/agency_private_capital/test_phase2_pipeline.py
+++ b/tests/integration/agency_private_capital/test_phase2_pipeline.py
@@ -1,0 +1,96 @@
+"""Integration test for Phase 2 agency-vs-Form-D matched cohort flow."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.agency_private_capital.control_cohort import (
+    AgencyAwardeeFilter,
+    PrivateCapitalControlCohortBuilder,
+)
+from sbir_analytics.assets.agency_private_capital.form_d_inputs import (
+    load_form_d_control_universe,
+    load_form_d_matches,
+)
+from sbir_analytics.assets.agency_private_capital.matching import CohortMatcher
+from sbir_analytics.assets.agency_private_capital.phase2_outcomes import MatchedCohortOutcomes
+from sbir_analytics.assets.agency_private_capital.threats import ThreatsToValidity
+
+
+pytestmark = pytest.mark.integration
+
+
+def _write_jsonl(path, rows):
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def test_phase2_pipeline_produces_pairs_outcomes_and_threats(tmp_path) -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2020,
+                "award_amount": "1000000",
+                "company_name": "Acme Corp",
+                "state": "CA",
+            }
+        ]
+    )
+    matches_path = tmp_path / "form_d_details.jsonl"
+    _write_jsonl(
+        matches_path,
+        [
+            {
+                "company_name": "Acme Corp",
+                "form_d_cik": "0000123",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {
+                        "entity_name": "ACME CORP",
+                        "filing_date": "2021-03-01",
+                        "state": "CA",
+                        "industry_group": "Other Technology",
+                        "total_amount_sold": 5_000_000,
+                    }
+                ],
+            }
+        ],
+    )
+    control_path = tmp_path / "controls.jsonl"
+    _write_jsonl(
+        control_path,
+        [
+            {
+                "issuer_name": "Control One",
+                "cik": "0000999",
+                "filing_date": "2020-01-01",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_amount_sold": 2_000_000,
+            }
+        ],
+    )
+
+    matches = load_form_d_matches(matches_path, tier_filter={"high"}, year_min=2009, year_max=2024)
+    controls_universe = load_form_d_control_universe(
+        control_path, sbir_ciks={"123"}, year_min=2009, year_max=2024
+    )
+    treated = AgencyAwardeeFilter(agency_code="NSF").build(awards, matches)
+    controls = PrivateCapitalControlCohortBuilder().build(controls_universe)
+    pairs, balance = CohortMatcher().match(treated, controls)
+    outcomes = MatchedCohortOutcomes(ma_event_keys={"name:acme corp"}).compute(pairs)
+    threats = ThreatsToValidity().validate()
+
+    assert len(pairs) == 1
+    assert balance["match_rate"] == pytest.approx(1.0)
+    ma_treated = outcomes[
+        (outcomes["cohort"] == "agency_sbir") & (outcomes["metric"] == "ma_exit_rate")
+    ].iloc[0]
+    assert ma_treated["numerator"] == 1
+    assert threats["passed"] is True

--- a/tests/unit/agency_private_capital/test_form_d_inputs.py
+++ b/tests/unit/agency_private_capital/test_form_d_inputs.py
@@ -1,0 +1,111 @@
+"""Tests for Phase 2 Form D input normalization."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sbir_analytics.assets.agency_private_capital.form_d_inputs import (
+    load_form_d_control_universe,
+    load_form_d_matches,
+    normalize_name,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _write_jsonl(path, rows):
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def test_normalize_name_uppercases_and_squashes_whitespace() -> None:
+    assert normalize_name("  Acme   Corp ") == "ACME CORP"
+
+
+def test_load_form_d_matches_keeps_high_non_excluded_offerings(tmp_path) -> None:
+    path = tmp_path / "form_d_details.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "company_name": "Acme Corp",
+                "form_d_cik": "0000123",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {
+                        "entity_name": "ACME CORP",
+                        "filing_date": "2021-03-01",
+                        "state": "CA",
+                        "industry_group": "Other Technology",
+                        "total_amount_sold": 1_000_000,
+                        "total_offering_amount": 2_000_000,
+                        "securities_types": ["Equity"],
+                    },
+                    {
+                        "entity_name": "ACME FUND",
+                        "filing_date": "2021-04-01",
+                        "state": "CA",
+                        "industry_group": "Pooled Investment Fund",
+                        "total_amount_sold": 9_000_000,
+                    },
+                ],
+            },
+            {
+                "company_name": "Low Match",
+                "form_d_cik": "0000456",
+                "match_confidence": {"tier": "low"},
+                "offerings": [
+                    {
+                        "filing_date": "2021-01-01",
+                        "state": "MA",
+                        "industry_group": "Other Technology",
+                        "total_amount_sold": 500,
+                    }
+                ],
+            },
+        ],
+    )
+
+    df = load_form_d_matches(path, tier_filter={"high"}, year_min=2009, year_max=2024)
+
+    assert len(df) == 1
+    row = df.iloc[0]
+    assert row["company_key"] == "ACME CORP"
+    assert row["form_d_cik"] == "123"
+    assert row["total_form_d_raised"] == 1_000_000
+    assert row["first_form_d_year"] == 2021
+
+
+def test_load_form_d_control_universe_excludes_sbir_ciks(tmp_path) -> None:
+    path = tmp_path / "controls.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "issuer_name": "Control One",
+                "cik": "0000999",
+                "filing_date": "2020-01-01",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_amount_sold": 2_000_000,
+            },
+            {
+                "issuer_name": "Already SBIR",
+                "cik": "0000123",
+                "filing_date": "2020-01-01",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_amount_sold": 3_000_000,
+            },
+        ],
+    )
+
+    df = load_form_d_control_universe(path, sbir_ciks={"123"}, year_min=2009, year_max=2024)
+
+    assert len(df) == 1
+    assert df.iloc[0]["issuer_key"] == "CONTROL ONE"
+    assert df.iloc[0]["form_d_cik"] == "999"

--- a/tests/unit/agency_private_capital/test_form_d_inputs.py
+++ b/tests/unit/agency_private_capital/test_form_d_inputs.py
@@ -109,3 +109,34 @@ def test_load_form_d_control_universe_excludes_sbir_ciks(tmp_path) -> None:
     assert len(df) == 1
     assert df.iloc[0]["issuer_key"] == "CONTROL ONE"
     assert df.iloc[0]["form_d_cik"] == "999"
+
+
+def test_load_form_d_control_universe_dedupes_duplicate_ciks(tmp_path) -> None:
+    path = tmp_path / "controls.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "issuer_name": "Control One",
+                "cik": "0000999",
+                "filing_date": "2020-01-01",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_amount_sold": 2_000_000,
+            },
+            {
+                "issuer_name": "Control One Duplicate",
+                "cik": "0000999",
+                "filing_date": "2021-01-01",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_amount_sold": 3_000_000,
+            },
+        ],
+    )
+
+    df = load_form_d_control_universe(path, sbir_ciks=set(), year_min=2009, year_max=2024)
+
+    assert len(df) == 1
+    assert df.iloc[0]["form_d_cik"] == "999"
+    assert df.iloc[0]["first_form_d_year"] == 2020

--- a/tests/unit/agency_private_capital/test_phase2_matching.py
+++ b/tests/unit/agency_private_capital/test_phase2_matching.py
@@ -1,0 +1,181 @@
+"""Tests for Phase 2 treated/control cohort construction and matching."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.agency_private_capital.control_cohort import (
+    AgencyAwardeeFilter,
+    PrivateCapitalControlCohortBuilder,
+    agency_leverage_cross_check,
+)
+from sbir_analytics.assets.agency_private_capital.matching import CohortMatcher
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_agency_awardee_filter_intersects_agency_awards_with_form_d_matches() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2020,
+                "award_amount": "1000000",
+                "company_name": "Acme Corp",
+                "state": "CA",
+            },
+            {
+                "agency": "Department of Defense",
+                "phase": "Phase II",
+                "award_year": 2020,
+                "award_amount": "1000000",
+                "company_name": "Defense Corp",
+                "state": "CA",
+            },
+        ]
+    )
+    matches = pd.DataFrame(
+        [
+            {
+                "company_name": "Acme Corp",
+                "company_key": "ACME CORP",
+                "form_d_cik": "123",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "first_form_d_year": 2021,
+                "total_form_d_raised": 5_000_000,
+            }
+        ]
+    )
+
+    treated = AgencyAwardeeFilter(agency_code="NSF").build(awards, matches)
+
+    assert len(treated) == 1
+    assert treated.iloc[0]["company_key"] == "ACME CORP"
+    assert treated.iloc[0]["agency_sbir_amount"] == 1_000_000
+    assert treated.iloc[0]["vintage_year"] == 2020
+
+
+def test_private_capital_control_builder_shapes_control_rows() -> None:
+    universe = pd.DataFrame(
+        [
+            {
+                "issuer_name": "Control One",
+                "issuer_key": "CONTROL ONE",
+                "form_d_cik": "999",
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "first_form_d_year": 2020,
+                "total_form_d_raised": 2_000_000,
+                "offering_count": 1,
+            }
+        ]
+    )
+
+    controls = PrivateCapitalControlCohortBuilder().build(universe)
+
+    assert len(controls) == 1
+    assert controls.iloc[0]["cohort"] == "form_d_control"
+    assert controls.iloc[0]["issuer_key"] == "CONTROL ONE"
+
+
+def test_agency_leverage_cross_check_uses_full_agency_award_denominator() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "award_year": 2020,
+                "award_amount": "1000000",
+                "company_name": "Acme Corp",
+            },
+            {
+                "agency": "National Science Foundation",
+                "award_year": 2020,
+                "award_amount": "2000000",
+                "company_name": "Unmatched Corp",
+            },
+            {
+                "agency": "Department of Defense",
+                "award_year": 2020,
+                "award_amount": "9000000",
+                "company_name": "Defense Corp",
+            },
+        ]
+    )
+    treated = pd.DataFrame(
+        [
+            {
+                "company_name": "Acme Corp",
+                "company_key": "ACME CORP",
+                "agency_sbir_amount": 1_000_000,
+                "total_form_d_raised": 6_000_000,
+            }
+        ]
+    )
+
+    summary = agency_leverage_cross_check("NSF", awards, treated)
+
+    assert summary["agency_award_rows"] == 2
+    assert summary["agency_program_sbir_amount"] == 3_000_000
+    assert summary["matched_agency_sbir_amount"] == 1_000_000
+    assert summary["matched_form_d_raised"] == 6_000_000
+    assert summary["form_d_to_agency_program_ratio"] == pytest.approx(2.0)
+    assert summary["form_d_to_matched_sbir_ratio"] == pytest.approx(6.0)
+
+
+def test_cohort_matcher_matches_exact_vintage_industry_state() -> None:
+    treated = pd.DataFrame(
+        [
+            {
+                "company_name": "Acme Corp",
+                "company_key": "ACME CORP",
+                "form_d_cik": "123",
+                "vintage_year": 2020,
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_form_d_raised": 5_000_000,
+            },
+            {
+                "company_name": "Unmatched Corp",
+                "company_key": "UNMATCHED CORP",
+                "form_d_cik": "124",
+                "vintage_year": 2020,
+                "state": "MA",
+                "industry_group": "Biotechnology",
+                "total_form_d_raised": 1_000_000,
+            },
+        ]
+    )
+    controls = pd.DataFrame(
+        [
+            {
+                "issuer_name": "Control One",
+                "issuer_key": "CONTROL ONE",
+                "form_d_cik": "999",
+                "vintage_year": 2020,
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_form_d_raised": 2_000_000,
+            },
+            {
+                "issuer_name": "Control Two",
+                "issuer_key": "CONTROL TWO",
+                "form_d_cik": "998",
+                "vintage_year": 2021,
+                "state": "CA",
+                "industry_group": "Other Technology",
+                "total_form_d_raised": 2_000_000,
+            },
+        ]
+    )
+
+    pairs, balance = CohortMatcher(controls_per_treated=2).match(treated, controls)
+
+    assert len(pairs) == 1
+    assert pairs.iloc[0]["treated_company_key"] == "ACME CORP"
+    assert balance["treated_count"] == 2
+    assert balance["matched_treated_count"] == 1
+    assert balance["unmatched_treated_count"] == 1

--- a/tests/unit/agency_private_capital/test_phase2_outcomes.py
+++ b/tests/unit/agency_private_capital/test_phase2_outcomes.py
@@ -1,0 +1,58 @@
+"""Tests for Phase 2 matched-cohort outcomes."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.agency_private_capital.phase2_outcomes import MatchedCohortOutcomes
+
+
+pytestmark = pytest.mark.fast
+
+
+def _pairs() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "treated_company_name": "Acme Corp",
+                "treated_company_key": "ACME CORP",
+                "treated_form_d_cik": "123",
+                "control_issuer_name": "Control One",
+                "control_issuer_key": "CONTROL ONE",
+                "control_form_d_cik": "999",
+            },
+            {
+                "treated_company_name": "Beta Corp",
+                "treated_company_key": "BETA CORP",
+                "treated_form_d_cik": "124",
+                "control_issuer_name": "Control Two",
+                "control_issuer_key": "CONTROL TWO",
+                "control_form_d_cik": "998",
+            },
+        ]
+    )
+
+
+def test_ma_exit_rate_available_for_treated_and_controls() -> None:
+    outcomes = MatchedCohortOutcomes(
+        ma_event_keys={"name:acme corp", "cik:998"}
+    ).compute(_pairs())
+    rows = {
+        (row["cohort"], row["metric"]): row
+        for _, row in outcomes[outcomes["metric"] == "ma_exit_rate"].iterrows()
+    }
+
+    assert rows[("agency_sbir", "ma_exit_rate")]["numerator"] == 1
+    assert rows[("agency_sbir", "ma_exit_rate")]["denominator"] == 2
+    assert rows[("form_d_control", "ma_exit_rate")]["numerator"] == 1
+    assert rows[("form_d_control", "ma_exit_rate")]["denominator"] == 2
+    assert bool(rows[("form_d_control", "ma_exit_rate")]["available"]) is True
+
+
+def test_missing_event_sets_are_unavailable_not_zero() -> None:
+    outcomes = MatchedCohortOutcomes().compute(_pairs())
+    federal = outcomes[outcomes["metric"] == "federal_contract_presence"]
+    assert not federal.empty
+    assert (federal["available"] == False).all()  # noqa: E712
+    assert federal["rate"].isna().all()

--- a/tests/unit/agency_private_capital/test_phase2_outcomes.py
+++ b/tests/unit/agency_private_capital/test_phase2_outcomes.py
@@ -35,9 +35,7 @@ def _pairs() -> pd.DataFrame:
 
 
 def test_ma_exit_rate_available_for_treated_and_controls() -> None:
-    outcomes = MatchedCohortOutcomes(
-        ma_event_keys={"name:acme corp", "cik:998"}
-    ).compute(_pairs())
+    outcomes = MatchedCohortOutcomes(ma_event_keys={"name:acme corp", "cik:998"}).compute(_pairs())
     rows = {
         (row["cohort"], row["metric"]): row
         for _, row in outcomes[outcomes["metric"] == "ma_exit_rate"].iterrows()

--- a/tests/unit/agency_private_capital/test_threats.py
+++ b/tests/unit/agency_private_capital/test_threats.py
@@ -1,0 +1,47 @@
+"""Tests for the Phase 2 threats-to-validity gate."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from sbir_analytics.assets.agency_private_capital.threats import (
+    REQUIRED_THREATS,
+    ThreatEntry,
+    ThreatsToValidity,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_default_threats_cover_required_entries() -> None:
+    payload = ThreatsToValidity().validate()
+    assert payload["passed"] is True
+    assert payload["missing"] == []
+    assert {entry["id"] for entry in payload["entries"]} >= set(REQUIRED_THREATS)
+
+
+def test_missing_required_threat_fails_gate() -> None:
+    payload = ThreatsToValidity(
+        entries=[
+            ThreatEntry(
+                id="safe_convertible_undercount",
+                label="SAFE",
+                description="desc",
+                mitigation="mitigate",
+                as_of="2026-07-08",
+            )
+        ]
+    ).validate()
+
+    assert payload["passed"] is False
+    assert "late_stage_form_d_inclusion" in payload["missing"]
+
+
+def test_write_outputs_json(tmp_path) -> None:
+    path = tmp_path / "threats.json"
+    payload = ThreatsToValidity().write(path)
+    loaded = json.loads(path.read_text(encoding="utf-8"))
+    assert loaded == payload


### PR DESCRIPTION
## Summary

Implements Phase 2 of the agency private-capital comparison over Form D artifacts:

- adds Form D JSONL input normalization for SBIR-matched records and non-SBIR control issuers
- builds configured-agency treated cohorts and non-SBIR Form D controls
- adds deterministic coarsened-exact matching on vintage year, industry group, and state
- computes matched-cohort outcome rows with unavailable-state handling for missing event inputs
- emits threats-to-validity and match-balance artifacts, including an agency-scoped leverage cross-check
- documents the Phase 2 methodology and input/output contract

## Impact

The new Dagster asset `agency_private_capital_form_d_matched_comparison` writes Phase 2 comparison artifacts under `data/processed/agency_private_capital/<agency>/` without reimplementing EDGAR/Form D ingest. It is descriptive only and gates interpretation on the required threats-to-validity record.

## Validation

- `uv run ruff check packages/sbir-analytics/sbir_analytics/assets/agency_private_capital tests/unit/agency_private_capital tests/integration/agency_private_capital`
- `uv run --extra stack-dev pytest tests/unit/agency_private_capital tests/integration/agency_private_capital/test_phase2_pipeline.py -n 0`
