### PR TITLE
fix(docker): include data/reference in CI image for container tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,10 +27,13 @@ env/
 *~
 .editorconfig
 
-# Data files (large, not needed in image)
-data/
+# Data files (large, not needed in image) — keep versioned reference tables
+data/*
+!data/reference/
+!data/reference/**
 reports/
 *.csv
+!data/reference/**
 *.parquet
 *.db
 *.duckdb

--- a/.gitignore
+++ b/.gitignore
@@ -141,12 +141,10 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# Data files
-/data/
-!data/reference/*.csv
-!data/reference/*.xlsx
-!data/reference/*.xls
-!data/reference/*.txt
+# Data files (runtime artifacts); keep versioned reference tables under data/reference/
+/data/*
+!/data/reference/
+!/data/reference/**
 logs/
 *.db
 *.duckdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY packages/sbir-graph/sbir_graph/ /app/sbir_graph/
 COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY scripts/ /app/scripts/
 COPY config/ /app/config/
+COPY data/reference/ /app/data/reference/
 COPY migrations/ /app/migrations/
 COPY pyproject.toml /app/
 

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -34,6 +34,7 @@ COPY packages/sbir-analytics/sbir_analytics/ /app/sbir_analytics/
 COPY packages/sbir-graph/sbir_graph/ /app/sbir_graph/
 COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY config/ /app/config/
+COPY data/reference/ /app/data/reference/
 COPY scripts/ /app/scripts/
 COPY migrations/ /app/migrations/
 COPY pyproject.toml /app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -284,6 +284,7 @@ services:
     working_dir: /app
     volumes:
       - ./data/raw/uspto:/app/data/raw/uspto:rw
+      - ./data/reference:/app/data/reference:ro
       - ./tests/fixtures:/app/test-data:ro
       # Tests live outside the production image; mount them so `pytest -m fast`
       # in the ci profile command (above) finds tests/. Without this, pytest


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

After merging #424 and #429, **Container Build and Test** failed on `main` with three test failures inside the Docker image:

1. `test_seed_registry_loads` — `data/reference/cmf_registry.csv` not found
2. `test_default_csv_file_exists_and_covers_51_states` — `data/reference/tax/state_effective_rates.csv` not found
3. `test_csv_loaded_rates_match_hardcoded_baseline` — same missing CSV

Unit tests passed in the normal CI job because they run on the host checkout. The container CI image only copied application code and mounted `data/raw/uspto`, not the versioned reference tables under `data/reference/`.

## Fix

- **Dockerfile / Dockerfile.full**: `COPY data/reference/ /app/data/reference/` so reference CSVs ship in the image
- **docker-compose.yml** (ci `app` service): mount `./data/reference` read-only as a belt-and-suspenders fallback
- **.gitignore**: simplify to `/data/*` with `!/data/reference/**` so nested reference paths (e.g. `data/reference/tax/`) stay trackable

## Verification

- Reference files are tracked in git (`cmf_registry.csv`, `naics_to_bea.csv`, `tax/state_effective_rates.csv`)
- Container Build and Test should pass on this PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f56e6-f355-7d58-b3cd-09397f4cd371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f56e6-f355-7d58-b3cd-09397f4cd371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

