### PR TITLE
Add private analytics API and API-first MCP boundary

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,3 +101,10 @@ USPTO_ODP_API_KEY=
 # BEA API Key (required for fiscal analysis I-O tables)
 # Register at https://apps.bea.gov/API/signup/
 BEA_API_KEY=
+# Private analytics API (use a dedicated read-only Neo4j account in deployed environments)
+SBIR_ANALYTICS_API_TOKEN=
+SBIR_ANALYTICS_API_PORT=8000
+SBIR_ANALYTICS_SNAPSHOT_DIR=reports/analytics_snapshots
+SBIR_ANALYTICS_QUERY_TIMEOUT_SECONDS=10
+NEO4J_READ_USER=neo4j
+NEO4J_READ_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@ RUN pip install \
     "rapidfuzz>=3.0.0,<4.0.0" \
     "jellyfish>=1.0.0,<2.0.0" \
     "httpx>=0.27.0,<1.0.0" \
-    "tenacity>=8.2.3,<10.0.0"
+    "tenacity>=8.2.3,<10.0.0" \
+    "fastapi>=0.115.0,<1.0.0" \
+    "uvicorn>=0.30.0,<1.0.0"
 
 # Copy application code
 COPY sbir_etl/ /app/sbir_etl/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,9 +133,12 @@ services:
       <<: *common-environment
       NEO4J_READ_USER: ${NEO4J_READ_USER:-neo4j}
       NEO4J_READ_PASSWORD: ${NEO4J_READ_PASSWORD:-password}
+      # Default empty rather than :? so an unset token cannot break compose
+      # interpolation for other profiles (e.g. the ci `app` service). The API
+      # itself refuses to serve (503) until a non-empty token is provided.
       SBIR_ANALYTICS_API_TOKEN: ${SBIR_ANALYTICS_API_TOKEN:-}
       SBIR_ANALYTICS_SNAPSHOT_DIR: /app/reports/analytics_snapshots
-    command: ["sbir-analytics-api"]
+    command: ["python", "-m", "sbir_analytics.api"]
     volumes:
       - ./reports:/app/reports:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -133,7 +133,7 @@ services:
       <<: *common-environment
       NEO4J_READ_USER: ${NEO4J_READ_USER:-neo4j}
       NEO4J_READ_PASSWORD: ${NEO4J_READ_PASSWORD:-password}
-      SBIR_ANALYTICS_API_TOKEN: ${SBIR_ANALYTICS_API_TOKEN:?set SBIR_ANALYTICS_API_TOKEN}
+      SBIR_ANALYTICS_API_TOKEN: ${SBIR_ANALYTICS_API_TOKEN:-}
       SBIR_ANALYTICS_SNAPSHOT_DIR: /app/reports/analytics_snapshots
     command: ["sbir-analytics-api"]
     volumes:
@@ -144,7 +144,7 @@ services:
       neo4j:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8000/health/live || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8000/health/ready || exit 1"]
       interval: 15s
       timeout: 3s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,40 @@ services:
     <<: *resource-limits
 
   # =============================================================================
+  # Private Read-Only Analytics API
+  # =============================================================================
+  analytics-api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    image: ${IMAGE_NAME:-sbir-analytics}:${IMAGE_TAG:-local}
+    profiles:
+      - dev
+    environment:
+      <<: *common-environment
+      NEO4J_READ_USER: ${NEO4J_READ_USER:-neo4j}
+      NEO4J_READ_PASSWORD: ${NEO4J_READ_PASSWORD:-password}
+      SBIR_ANALYTICS_API_TOKEN: ${SBIR_ANALYTICS_API_TOKEN:?set SBIR_ANALYTICS_API_TOKEN}
+      SBIR_ANALYTICS_SNAPSHOT_DIR: /app/reports/analytics_snapshots
+    command: ["sbir-analytics-api"]
+    volumes:
+      - ./reports:/app/reports:ro
+    ports:
+      - "${SBIR_ANALYTICS_API_PORT:-8000}:8000"
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:8000/health/live || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 5
+    networks:
+      - sbir-network
+    restart: ${ANALYTICS_API_RESTART_POLICY:-unless-stopped}
+
+  # =============================================================================
   # Dagster Webserver Service
   # =============================================================================
   dagster-webserver:

--- a/docs/architecture/private-analytics-api.md
+++ b/docs/architecture/private-analytics-api.md
@@ -1,0 +1,18 @@
+# Private Analytics API
+
+The private API exposes curated, read-only SBIR evidence to analyst applications. It does not
+accept Cypher or trigger Dagster runs. Neo4j-backed endpoints use parameterized queries and a
+read access mode; deployed environments should also provide a database account with read-only
+permissions.
+
+Run locally with `sbir-analytics-api`, then authenticate with
+`Authorization: Bearer $SBIR_ANALYTICS_API_TOKEN`. OpenAPI documentation is available at `/docs`.
+
+The `/v1/snapshots` endpoints read validated JSON files from
+`reports/analytics_snapshots/<analysis-kind>/<period>.json`. Supported kinds are `cet_portfolio`,
+`transition_rate`, and `follow_on_multiplier`. Snapshot producers must preserve the metadata from
+the analytics `ToolResult`: tool and schema versions, source references, warnings, and run ID.
+Comparisons reject snapshots produced by different tools or versions.
+
+MCP should be implemented, if needed, as an adapter over these service methods. It must not gain
+raw graph access or pipeline controls that are absent from the HTTP API.

--- a/docs/architecture/private-analytics-api.md
+++ b/docs/architecture/private-analytics-api.md
@@ -14,5 +14,16 @@ The `/v1/snapshots` endpoints read validated JSON files from
 the analytics `ToolResult`: tool and schema versions, source references, warnings, and run ID.
 Comparisons reject snapshots produced by different tools or versions.
 
+Pipeline code creates snapshots with `snapshot_from_tool_result(...)`, or
+`snapshot_from_result(...)` for deterministic analyses such as the follow-on multiplier that do
+not return `ToolResult`, and persists them atomically with `write_snapshot(...)`. Those writer
+utilities normalize pandas/numpy values and retain explicit provenance. They are deliberately not
+exposed as HTTP endpoints; the API container mounts the snapshot directory read-only.
+
+`/health/live` reports process liveness. `/health/ready` checks Neo4j connectivity and snapshot-store
+access. Neo4j availability errors are returned as a sanitized `503`. API requests emit structured
+audit records with a correlation ID, route template, status, and duration; request headers,
+identifiers, and query strings are not logged.
+
 MCP should be implemented, if needed, as an adapter over these service methods. It must not gain
 raw graph access or pipeline controls that are absent from the HTTP API.

--- a/docs/decisions/ADR-003-api-before-mcp.md
+++ b/docs/decisions/ADR-003-api-before-mcp.md
@@ -1,0 +1,55 @@
+---
+
+Type: Decision
+Owner: data@project
+Last-Reviewed: 2026-07-12
+Status: accepted
+
+---
+
+# ADR-003: Establish APIs Before MCP Adapters
+
+## Context
+
+The repository produces analytical evidence for dashboards, notebooks, partner applications, and
+AI assistants. If each transport implements its own queries or orchestration, business rules,
+authorization, provenance, and safety controls drift. The superseded MCP design also exposed raw
+Cypher and pipeline execution before a stable application interface existed.
+
+## Decision
+
+New externally callable functionality follows this dependency direction:
+
+```text
+domain and analytics code → transport-neutral service → private/versioned API → optional MCP adapter
+```
+
+- Domain calculations and curated data access live outside HTTP and MCP modules.
+- The private API is the first supported transport and defines validation, provenance, errors, and
+  authorization for a capability.
+- An MCP tool may be added only after the underlying service and API contract exist. It delegates
+  to the same service method and cannot gain raw Cypher, filesystem, Dagster, or other privileges
+  absent from the API capability.
+- MCP-specific response shaping and tool descriptions may live in the adapter; analytical logic,
+  queries, and side-effect policy may not.
+- Exceptions require a superseding ADR. Local developer-only diagnostics that are not product
+  functionality are outside this rule.
+
+## Consequences
+
+- Dashboards, notebooks, integrations, and AI assistants receive consistent answers and provenance.
+- MCP remains inexpensive to add because it is a protocol adapter rather than a second backend.
+- API contracts must be designed and tested before an MCP tool ships.
+- Some local-only AI experiments may take longer to productize, but they cannot silently become a
+  privileged production interface.
+
+## Alternatives considered
+
+- **MCP-first:** rejected because it couples domain behavior to one class of clients.
+- **Independent API and MCP implementations:** rejected because query and security behavior drift.
+- **Raw graph gateway:** rejected because it bypasses curated semantics and least privilege.
+
+## Links
+
+- [Private analytics API](../architecture/private-analytics-api.md)
+- Superseded design: `specs/archive/superseded/mcp_interface/`

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -40,6 +40,8 @@ Each ADR follows this structure:
 ## ADR List
 
 - [ADR-001: Allow Negative Obligation Amounts in Federal Contracts](./ADR-001-negative-obligations.md) - Accepted (2025-10-28)
+- [ADR-002: Extract a Standalone ETL Library](./ADR-002-etl-library-extraction.md) - Accepted
+- [ADR-003: Establish APIs Before MCP Adapters](./ADR-003-api-before-mcp.md) - Accepted (2026-07-12)
 
 ## Resources
 

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -14,7 +14,13 @@ dependencies = [
     "sbir-graph",
     # Dagster orchestration
     "dagster>=1.7.0,<2.0.0",
+    # Private analytics API
+    "fastapi>=0.115.0,<1.0.0",
+    "uvicorn>=0.30.0,<1.0.0",
 ]
+
+[project.scripts]
+sbir-analytics-api = "sbir_analytics.api.__main__:main"
 
 [project.optional-dependencies]
 r = ["sbir-etl[r]"]

--- a/packages/sbir-analytics/sbir_analytics/api/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/api/__init__.py
@@ -1,0 +1,5 @@
+"""Private, read-only analytics API."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/packages/sbir-analytics/sbir_analytics/api/__main__.py
+++ b/packages/sbir-analytics/sbir_analytics/api/__main__.py
@@ -1,0 +1,17 @@
+"""CLI entry point for the private analytics API."""
+
+import os
+
+import uvicorn
+
+
+def main() -> None:
+    uvicorn.run(
+        "sbir_analytics.api.app:app",
+        host=os.getenv("SBIR_ANALYTICS_API_HOST", "0.0.0.0"),
+        port=int(os.getenv("SBIR_ANALYTICS_API_PORT", "8000")),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/sbir-analytics/sbir_analytics/api/app.py
+++ b/packages/sbir-analytics/sbir_analytics/api/app.py
@@ -1,0 +1,165 @@
+"""FastAPI transport for the private analytics service."""
+
+import hmac
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Annotated, Any
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Path as ApiPath, Query, Request, status
+from neo4j import GraphDatabase
+
+from .models import AnalyticsResponse, HealthResponse
+from .repository import AnalyticsRepository
+from .service import AnalyticsService
+from .snapshots import (
+    AnalysisKind,
+    FileSnapshotRepository,
+    IncompatibleSnapshotsError,
+    SnapshotNotFoundError,
+    SnapshotStoreError,
+    compare_snapshots,
+)
+
+
+SnapshotPeriod = Annotated[str, ApiPath(pattern=r"^\d{4}(-Q[1-4])?$")]
+
+
+def _service_from_environment() -> AnalyticsService:
+    uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    username = os.getenv("NEO4J_READ_USER", os.getenv("NEO4J_USER", "neo4j"))
+    password = os.getenv("NEO4J_READ_PASSWORD", os.getenv("NEO4J_PASSWORD", ""))
+    database = os.getenv("NEO4J_DATABASE", "neo4j")
+    timeout = float(os.getenv("SBIR_ANALYTICS_QUERY_TIMEOUT_SECONDS", "10"))
+    driver = GraphDatabase.driver(uri, auth=(username, password))
+    return AnalyticsService(AnalyticsRepository(driver, database=database, timeout=timeout))
+
+
+def create_app(
+    service_factory: Callable[[], AnalyticsService] = _service_from_environment,
+    api_token: str | None = None,
+) -> FastAPI:
+    app = FastAPI(
+        title="SBIR Analytics API",
+        version="1.0.0",
+        description="Private, read-only access to curated SBIR/STTR analytical evidence.",
+    )
+
+    snapshot_repository = FileSnapshotRepository(
+        root=Path(os.getenv("SBIR_ANALYTICS_SNAPSHOT_DIR", "reports/analytics_snapshots"))
+    )
+
+    def authenticate(authorization: str | None = Header(default=None)) -> None:
+        expected = api_token if api_token is not None else os.getenv("SBIR_ANALYTICS_API_TOKEN")
+        if not expected:
+            raise HTTPException(
+                status.HTTP_503_SERVICE_UNAVAILABLE, "API authentication is not configured"
+            )
+        supplied = authorization.removeprefix("Bearer ") if authorization else ""
+        if not hmac.compare_digest(supplied, expected):
+            raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid bearer token")
+
+    def service(request: Request) -> AnalyticsService:
+        if not hasattr(request.app.state, "analytics_service"):
+            request.app.state.analytics_service = service_factory()
+        return request.app.state.analytics_service
+
+    bounded_limit = Query(default=100, ge=1, le=500)
+    bounded_offset = Query(default=0, ge=0, le=100_000)
+
+    @app.get("/health/live", response_model=HealthResponse, include_in_schema=False)
+    def live() -> HealthResponse:
+        return HealthResponse(status="ok")
+
+    @app.get("/v1/organizations/{identifier}", response_model=AnalyticsResponse)
+    def organization(
+        identifier: str,
+        analytics: AnalyticsService = Depends(service),
+        _: None = Depends(authenticate),
+    ) -> AnalyticsResponse:
+        return analytics.organization(identifier)
+
+    @app.get("/v1/organizations/{identifier}/awards", response_model=AnalyticsResponse)
+    def awards(
+        identifier: str,
+        limit: int = bounded_limit,
+        offset: int = bounded_offset,
+        analytics: AnalyticsService = Depends(service),
+        _: None = Depends(authenticate),
+    ) -> AnalyticsResponse:
+        return analytics.award_history(identifier, limit, offset)
+
+    @app.get("/v1/analytics/transitions", response_model=AnalyticsResponse)
+    def transitions(
+        agency: str | None = None,
+        fiscal_year: int | None = Query(default=None, ge=1982, le=2100),
+        limit: int = bounded_limit,
+        offset: int = bounded_offset,
+        analytics: AnalyticsService = Depends(service),
+        _: None = Depends(authenticate),
+    ) -> AnalyticsResponse:
+        return analytics.transition_metrics(agency, fiscal_year, limit, offset)
+
+    @app.get("/v1/analytics/cet-concentration", response_model=AnalyticsResponse)
+    def cet_concentration(
+        agency: str | None = None,
+        fiscal_year: int | None = Query(default=None, ge=1982, le=2100),
+        limit: int = bounded_limit,
+        offset: int = bounded_offset,
+        analytics: AnalyticsService = Depends(service),
+        _: None = Depends(authenticate),
+    ) -> AnalyticsResponse:
+        return analytics.cet_concentration(agency, fiscal_year, limit, offset)
+
+    @app.get("/v1/data/freshness", response_model=AnalyticsResponse)
+    def freshness(
+        analytics: AnalyticsService = Depends(service),
+        _: None = Depends(authenticate),
+    ) -> AnalyticsResponse:
+        return analytics.freshness()
+
+    @app.get("/v1/snapshots")
+    def list_snapshots(
+        analysis_kind: AnalysisKind | None = None,
+        _: None = Depends(authenticate),
+    ) -> dict[str, Any]:
+        try:
+            return {"data": snapshot_repository.list(analysis_kind)}
+        except SnapshotStoreError as exc:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
+
+    @app.get("/v1/snapshots/{analysis_kind}/{period}")
+    def get_snapshot(
+        analysis_kind: AnalysisKind,
+        period: SnapshotPeriod,
+        _: None = Depends(authenticate),
+    ) -> Any:
+        try:
+            return snapshot_repository.get(analysis_kind, period)
+        except SnapshotNotFoundError as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+        except SnapshotStoreError as exc:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
+
+    @app.get("/v1/snapshots/{analysis_kind}/{period}/compare/{comparison_period}")
+    def compare_snapshot_periods(
+        analysis_kind: AnalysisKind,
+        period: SnapshotPeriod,
+        comparison_period: SnapshotPeriod,
+        _: None = Depends(authenticate),
+    ) -> dict[str, Any]:
+        try:
+            baseline = snapshot_repository.get(analysis_kind, period)
+            comparison = snapshot_repository.get(analysis_kind, comparison_period)
+            return compare_snapshots(baseline, comparison)
+        except SnapshotNotFoundError as exc:
+            raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
+        except IncompatibleSnapshotsError as exc:
+            raise HTTPException(status.HTTP_409_CONFLICT, str(exc)) from exc
+        except SnapshotStoreError as exc:
+            raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
+
+    return app
+
+
+app = create_app()

--- a/packages/sbir-analytics/sbir_analytics/api/app.py
+++ b/packages/sbir-analytics/sbir_analytics/api/app.py
@@ -1,16 +1,23 @@
 """FastAPI transport for the private analytics service."""
 
 import hmac
+import json
+import logging
 import os
+import time
+import uuid
+from contextlib import asynccontextmanager
 from collections.abc import Callable
 from pathlib import Path
+from threading import Lock
 from typing import Annotated, Any
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Path as ApiPath, Query, Request, status
+from fastapi.responses import JSONResponse
 from neo4j import GraphDatabase
 
-from .models import AnalyticsResponse, HealthResponse
-from .repository import AnalyticsRepository
+from .models import AnalyticsResponse, HealthResponse, ReadinessResponse
+from .repository import AnalyticsBackendUnavailable, AnalyticsRepository
 from .service import AnalyticsService
 from .snapshots import (
     AnalysisKind,
@@ -23,6 +30,7 @@ from .snapshots import (
 
 
 SnapshotPeriod = Annotated[str, ApiPath(pattern=r"^\d{4}(-Q[1-4])?$")]
+audit_logger = logging.getLogger("sbir_analytics.api.audit")
 
 
 def _service_from_environment() -> AnalyticsService:
@@ -38,16 +46,55 @@ def _service_from_environment() -> AnalyticsService:
 def create_app(
     service_factory: Callable[[], AnalyticsService] = _service_from_environment,
     api_token: str | None = None,
+    snapshot_repository: FileSnapshotRepository | None = None,
 ) -> FastAPI:
+    service_lock = Lock()
+
+    @asynccontextmanager
+    async def lifespan(application: FastAPI):
+        yield
+        analytics_service = getattr(application.state, "analytics_service", None)
+        if analytics_service is not None:
+            analytics_service.close()
+
     app = FastAPI(
         title="SBIR Analytics API",
         version="1.0.0",
         description="Private, read-only access to curated SBIR/STTR analytical evidence.",
+        lifespan=lifespan,
     )
 
-    snapshot_repository = FileSnapshotRepository(
-        root=Path(os.getenv("SBIR_ANALYTICS_SNAPSHOT_DIR", "reports/analytics_snapshots"))
+    snapshot_store = snapshot_repository or FileSnapshotRepository(
+        Path(os.getenv("SBIR_ANALYTICS_SNAPSHOT_DIR", "reports/analytics_snapshots"))
     )
+
+    @app.middleware("http")
+    async def audit_request(request: Request, call_next):
+        request_id = uuid.uuid4().hex
+        started = time.monotonic()
+        response = None
+        status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            response.headers["X-Request-ID"] = request_id
+            return response
+        finally:
+            route = request.scope.get("route")
+            route_template = getattr(route, "path", "unmatched")
+            audit_logger.info(
+                json.dumps(
+                    {
+                        "event": "api_request",
+                        "request_id": request_id,
+                        "method": request.method,
+                        "route": route_template,
+                        "status": status_code,
+                        "duration_ms": round((time.monotonic() - started) * 1000, 2),
+                    },
+                    separators=(",", ":"),
+                )
+            )
 
     def authenticate(authorization: str | None = Header(default=None)) -> None:
         expected = api_token if api_token is not None else os.getenv("SBIR_ANALYTICS_API_TOKEN")
@@ -59,10 +106,27 @@ def create_app(
         if not hmac.compare_digest(supplied, expected):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid bearer token")
 
-    def service(request: Request) -> AnalyticsService:
+    def get_service(request: Request) -> AnalyticsService:
         if not hasattr(request.app.state, "analytics_service"):
-            request.app.state.analytics_service = service_factory()
+            with service_lock:
+                if not hasattr(request.app.state, "analytics_service"):
+                    request.app.state.analytics_service = service_factory()
         return request.app.state.analytics_service
+
+    def service(
+        request: Request,
+        _: None = Depends(authenticate),
+    ) -> AnalyticsService:
+        return get_service(request)
+
+    @app.exception_handler(AnalyticsBackendUnavailable)
+    async def backend_unavailable(
+        _request: Request, _exc: AnalyticsBackendUnavailable
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"detail": "Analytics backend is unavailable"},
+        )
 
     bounded_limit = Query(default=100, ge=1, le=500)
     bounded_offset = Query(default=0, ge=0, le=100_000)
@@ -71,11 +135,44 @@ def create_app(
     def live() -> HealthResponse:
         return HealthResponse(status="ok")
 
+    @app.get(
+        "/health/ready",
+        response_model=ReadinessResponse,
+        responses={503: {"model": ReadinessResponse}},
+        include_in_schema=False,
+    )
+    def ready(request: Request):
+        configured_token = (
+            api_token if api_token is not None else os.getenv("SBIR_ANALYTICS_API_TOKEN")
+        )
+        components: dict[str, str] = {
+            "authentication": "ready" if configured_token else "unavailable"
+        }
+        try:
+            get_service(request).verify_connectivity()
+            components["neo4j"] = "ready"
+        except AnalyticsBackendUnavailable:
+            components["neo4j"] = "unavailable"
+
+        try:
+            components["snapshots"] = snapshot_store.readiness()
+        except SnapshotStoreError:
+            components["snapshots"] = "unavailable"
+
+        is_ready = all(value != "unavailable" for value in components.values())
+        payload = ReadinessResponse(
+            status="ready" if is_ready else "unavailable", components=components
+        )
+        if not is_ready:
+            return JSONResponse(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE, content=payload.model_dump()
+            )
+        return payload
+
     @app.get("/v1/organizations/{identifier}", response_model=AnalyticsResponse)
     def organization(
         identifier: str,
         analytics: AnalyticsService = Depends(service),
-        _: None = Depends(authenticate),
     ) -> AnalyticsResponse:
         return analytics.organization(identifier)
 
@@ -85,7 +182,6 @@ def create_app(
         limit: int = bounded_limit,
         offset: int = bounded_offset,
         analytics: AnalyticsService = Depends(service),
-        _: None = Depends(authenticate),
     ) -> AnalyticsResponse:
         return analytics.award_history(identifier, limit, offset)
 
@@ -96,7 +192,6 @@ def create_app(
         limit: int = bounded_limit,
         offset: int = bounded_offset,
         analytics: AnalyticsService = Depends(service),
-        _: None = Depends(authenticate),
     ) -> AnalyticsResponse:
         return analytics.transition_metrics(agency, fiscal_year, limit, offset)
 
@@ -107,14 +202,12 @@ def create_app(
         limit: int = bounded_limit,
         offset: int = bounded_offset,
         analytics: AnalyticsService = Depends(service),
-        _: None = Depends(authenticate),
     ) -> AnalyticsResponse:
         return analytics.cet_concentration(agency, fiscal_year, limit, offset)
 
     @app.get("/v1/data/freshness", response_model=AnalyticsResponse)
     def freshness(
         analytics: AnalyticsService = Depends(service),
-        _: None = Depends(authenticate),
     ) -> AnalyticsResponse:
         return analytics.freshness()
 
@@ -124,7 +217,7 @@ def create_app(
         _: None = Depends(authenticate),
     ) -> dict[str, Any]:
         try:
-            return {"data": snapshot_repository.list(analysis_kind)}
+            return {"data": snapshot_store.list(analysis_kind)}
         except SnapshotStoreError as exc:
             raise HTTPException(status.HTTP_503_SERVICE_UNAVAILABLE, str(exc)) from exc
 
@@ -135,7 +228,7 @@ def create_app(
         _: None = Depends(authenticate),
     ) -> Any:
         try:
-            return snapshot_repository.get(analysis_kind, period)
+            return snapshot_store.get(analysis_kind, period)
         except SnapshotNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc
         except SnapshotStoreError as exc:
@@ -149,8 +242,8 @@ def create_app(
         _: None = Depends(authenticate),
     ) -> dict[str, Any]:
         try:
-            baseline = snapshot_repository.get(analysis_kind, period)
-            comparison = snapshot_repository.get(analysis_kind, comparison_period)
+            baseline = snapshot_store.get(analysis_kind, period)
+            comparison = snapshot_store.get(analysis_kind, comparison_period)
             return compare_snapshots(baseline, comparison)
         except SnapshotNotFoundError as exc:
             raise HTTPException(status.HTTP_404_NOT_FOUND, str(exc)) from exc

--- a/packages/sbir-analytics/sbir_analytics/api/models.py
+++ b/packages/sbir-analytics/sbir_analytics/api/models.py
@@ -1,0 +1,33 @@
+"""Public response models for the private analytics API."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class Provenance(BaseModel):
+    """Metadata needed to reproduce and qualify an analytical result."""
+
+    as_of: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    source: str = "neo4j"
+    methodology_version: str = "v1"
+    pipeline_run_id: str | None = None
+    limitations: list[str] = Field(default_factory=list)
+
+
+class Page(BaseModel):
+    limit: int
+    offset: int
+    returned: int
+
+
+class AnalyticsResponse(BaseModel):
+    data: list[dict[str, Any]]
+    provenance: Provenance
+    page: Page | None = None
+
+
+class HealthResponse(BaseModel):
+    status: str
+    service: str = "sbir-analytics-api"

--- a/packages/sbir-analytics/sbir_analytics/api/models.py
+++ b/packages/sbir-analytics/sbir_analytics/api/models.py
@@ -31,3 +31,7 @@ class AnalyticsResponse(BaseModel):
 class HealthResponse(BaseModel):
     status: str
     service: str = "sbir-analytics-api"
+
+
+class ReadinessResponse(HealthResponse):
+    components: dict[str, str]

--- a/packages/sbir-analytics/sbir_analytics/api/repository.py
+++ b/packages/sbir-analytics/sbir_analytics/api/repository.py
@@ -1,32 +1,40 @@
 """Curated, parameterized Neo4j reads used by every API transport."""
 
-from collections.abc import Mapping
-from typing import Any, Protocol
+from typing import Any
 
-from neo4j import Query
-
-
-class QuerySession(Protocol):
-    def run(self, query: Query | str, parameters: Mapping[str, Any] | None = None): ...
+from neo4j import Driver, Query
+from neo4j.exceptions import AuthError, ServiceUnavailable, SessionExpired, TransientError
 
 
-class SessionProvider(Protocol):
-    def session(self, **kwargs: Any): ...
+class AnalyticsBackendUnavailable(RuntimeError):
+    """The analytics data store cannot currently serve requests."""
 
 
 class AnalyticsRepository:
     """Read-only domain queries; callers cannot supply Cypher."""
 
-    def __init__(self, driver: SessionProvider, database: str = "neo4j", timeout: float = 10.0):
+    def __init__(self, driver: Driver, database: str = "neo4j", timeout: float = 10.0):
         self.driver = driver
         self.database = database
         self.timeout = timeout
 
     def _read(self, cypher: str, **parameters: Any) -> list[dict[str, Any]]:
         query = Query(cypher, timeout=self.timeout)
-        with self.driver.session(database=self.database, default_access_mode="READ") as session:
-            result = session.run(query, parameters)
-            return [dict(record["item"]) for record in result]
+        try:
+            with self.driver.session(database=self.database, default_access_mode="READ") as session:
+                result = session.run(query, parameters)
+                return [dict(record["item"]) for record in result]
+        except (AuthError, ServiceUnavailable, SessionExpired, TransientError) as exc:
+            raise AnalyticsBackendUnavailable("Analytics backend is unavailable") from exc
+
+    def verify_connectivity(self) -> None:
+        try:
+            self.driver.verify_connectivity()
+        except (AuthError, ServiceUnavailable, SessionExpired, TransientError) as exc:
+            raise AnalyticsBackendUnavailable("Analytics backend is unavailable") from exc
+
+    def close(self) -> None:
+        self.driver.close()
 
     def organization(self, identifier: str) -> list[dict[str, Any]]:
         return self._read(

--- a/packages/sbir-analytics/sbir_analytics/api/repository.py
+++ b/packages/sbir-analytics/sbir_analytics/api/repository.py
@@ -1,0 +1,127 @@
+"""Curated, parameterized Neo4j reads used by every API transport."""
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from neo4j import Query
+
+
+class QuerySession(Protocol):
+    def run(self, query: Query | str, parameters: Mapping[str, Any] | None = None): ...
+
+
+class SessionProvider(Protocol):
+    def session(self, **kwargs: Any): ...
+
+
+class AnalyticsRepository:
+    """Read-only domain queries; callers cannot supply Cypher."""
+
+    def __init__(self, driver: SessionProvider, database: str = "neo4j", timeout: float = 10.0):
+        self.driver = driver
+        self.database = database
+        self.timeout = timeout
+
+    def _read(self, cypher: str, **parameters: Any) -> list[dict[str, Any]]:
+        query = Query(cypher, timeout=self.timeout)
+        with self.driver.session(database=self.database, default_access_mode="READ") as session:
+            result = session.run(query, parameters)
+            return [dict(record["item"]) for record in result]
+
+    def organization(self, identifier: str) -> list[dict[str, Any]]:
+        return self._read(
+            """
+            MATCH (o:Organization)
+            WHERE o.organization_id = $identifier OR o.uei = $identifier
+               OR o.duns = $identifier OR o.cage = $identifier
+            RETURN o { .organization_id, .name, .organization_type, .uei, .duns, .cage,
+                       .city, .state, .country, .business_size, .naics_primary,
+                       .transition_total_awards, .transition_total_transitions,
+                       .transition_success_rate, .updated_at } AS item
+            LIMIT 1
+            """,
+            identifier=identifier,
+        )
+
+    def award_history(self, identifier: str, limit: int, offset: int) -> list[dict[str, Any]]:
+        return self._read(
+            """
+            MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})-[:RECIPIENT_OF]->(o)
+            WHERE o.organization_id = $identifier OR o.uei = $identifier
+               OR o.duns = $identifier OR o.cage = $identifier
+            OPTIONAL MATCH (a)-[:TRANSITIONED_TO]->(t:Transition)
+            RETURN a { .award_id, .title, .agency, .agency_name, .phase, .program, .amount,
+                       .transaction_date, .fiscal_year, .naics_code,
+                       transition_count: count(DISTINCT t) } AS item
+            ORDER BY a.transaction_date DESC, a.award_id
+            SKIP $offset LIMIT $limit
+            """,
+            identifier=identifier,
+            limit=limit,
+            offset=offset,
+        )
+
+    def transition_metrics(
+        self, agency: str | None, fiscal_year: int | None, limit: int, offset: int
+    ) -> list[dict[str, Any]]:
+        return self._read(
+            """
+            MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})
+            WHERE ($agency IS NULL OR a.agency = $agency OR a.agency_name = $agency)
+              AND ($fiscal_year IS NULL OR a.fiscal_year = $fiscal_year)
+            OPTIONAL MATCH (a)-[:TRANSITIONED_TO]->(t:Transition)
+            WITH a.agency AS agency, a.agency_name AS agency_name,
+                 count(DISTINCT a) AS awards,
+                 count(DISTINCT CASE WHEN t IS NOT NULL THEN a END) AS transitioned_awards
+            RETURN { agency: agency, agency_name: agency_name, awards: awards,
+                     transitioned_awards: transitioned_awards,
+                     transition_rate: CASE WHEN awards = 0 THEN 0.0
+                       ELSE toFloat(transitioned_awards) / awards END } AS item
+            ORDER BY awards DESC, agency
+            SKIP $offset LIMIT $limit
+            """,
+            agency=agency,
+            fiscal_year=fiscal_year,
+            limit=limit,
+            offset=offset,
+        )
+
+    def cet_concentration(
+        self, agency: str | None, fiscal_year: int | None, limit: int, offset: int
+    ) -> list[dict[str, Any]]:
+        return self._read(
+            """
+            MATCH (a:FinancialTransaction {transaction_type: 'AWARD'})-[:APPLICABLE_TO]->(c:CETArea)
+            MATCH (a)-[:RECIPIENT_OF]->(o:Organization)
+            WHERE ($agency IS NULL OR a.agency = $agency OR a.agency_name = $agency)
+              AND ($fiscal_year IS NULL OR a.fiscal_year = $fiscal_year)
+            WITH c, o, count(DISTINCT a) AS firm_awards, sum(coalesce(a.amount, 0.0)) AS firm_amount
+            WITH c, collect({organization_id: o.organization_id, awards: firm_awards,
+                             amount: firm_amount}) AS firms,
+                 sum(firm_awards) AS awards, sum(firm_amount) AS amount
+            UNWIND firms AS firm
+            WITH c, firms, awards, amount,
+                 sum((toFloat(firm.awards) / awards) * (toFloat(firm.awards) / awards)) AS hhi
+            RETURN { cet_id: c.cet_id, cet_name: c.name, award_count: awards,
+                     award_amount: amount, distinct_awardees: size(firms),
+                     award_count_hhi: hhi } AS item
+            ORDER BY hhi DESC, awards DESC
+            SKIP $offset LIMIT $limit
+            """,
+            agency=agency,
+            fiscal_year=fiscal_year,
+            limit=limit,
+            offset=offset,
+        )
+
+    def freshness(self) -> list[dict[str, Any]]:
+        return self._read(
+            """
+            MATCH (n)
+            WHERE n:FinancialTransaction OR n:Organization OR n:Patent OR n:Transition OR n:CETArea
+            WITH labels(n)[0] AS entity, count(n) AS records,
+                 max(coalesce(n.updated_at, n.detected_at, n.created_at, n.transaction_date)) AS latest
+            RETURN { entity: entity, records: records, latest: toString(latest) } AS item
+            ORDER BY entity
+            """
+        )

--- a/packages/sbir-analytics/sbir_analytics/api/service.py
+++ b/packages/sbir-analytics/sbir_analytics/api/service.py
@@ -29,7 +29,9 @@ class AnalyticsService:
         )
 
     def organization(self, identifier: str) -> AnalyticsResponse:
-        return AnalyticsResponse(data=self.repository.organization(identifier), provenance=self._provenance())
+        return AnalyticsResponse(
+            data=self.repository.organization(identifier), provenance=self._provenance()
+        )
 
     def award_history(self, identifier: str, limit: int, offset: int) -> AnalyticsResponse:
         return self._page(self.repository.award_history, limit, offset, identifier=identifier)
@@ -62,3 +64,9 @@ class AnalyticsService:
 
     def freshness(self) -> AnalyticsResponse:
         return AnalyticsResponse(data=self.repository.freshness(), provenance=self._provenance())
+
+    def verify_connectivity(self) -> None:
+        self.repository.verify_connectivity()
+
+    def close(self) -> None:
+        self.repository.close()

--- a/packages/sbir-analytics/sbir_analytics/api/service.py
+++ b/packages/sbir-analytics/sbir_analytics/api/service.py
@@ -1,0 +1,64 @@
+"""Transport-neutral analytics application service."""
+
+import os
+from collections.abc import Callable
+
+from .models import AnalyticsResponse, Page, Provenance
+from .repository import AnalyticsRepository
+
+
+class AnalyticsService:
+    def __init__(self, repository: AnalyticsRepository):
+        self.repository = repository
+
+    @staticmethod
+    def _provenance(*limitations: str) -> Provenance:
+        return Provenance(
+            pipeline_run_id=os.getenv("SBIR_ANALYTICS_PIPELINE_RUN_ID"),
+            limitations=list(limitations),
+        )
+
+    def _page(
+        self, query: Callable[..., list[dict]], limit: int, offset: int, **filters
+    ) -> AnalyticsResponse:
+        data = query(limit=limit, offset=offset, **filters)
+        return AnalyticsResponse(
+            data=data,
+            provenance=self._provenance(),
+            page=Page(limit=limit, offset=offset, returned=len(data)),
+        )
+
+    def organization(self, identifier: str) -> AnalyticsResponse:
+        return AnalyticsResponse(data=self.repository.organization(identifier), provenance=self._provenance())
+
+    def award_history(self, identifier: str, limit: int, offset: int) -> AnalyticsResponse:
+        return self._page(self.repository.award_history, limit, offset, identifier=identifier)
+
+    def transition_metrics(
+        self, agency: str | None, fiscal_year: int | None, limit: int, offset: int
+    ) -> AnalyticsResponse:
+        response = self._page(
+            self.repository.transition_metrics,
+            limit,
+            offset,
+            agency=agency,
+            fiscal_year=fiscal_year,
+        )
+        response.provenance.limitations.append(
+            "Phase III and transition detection are conservative and may undercount transitions."
+        )
+        return response
+
+    def cet_concentration(
+        self, agency: str | None, fiscal_year: int | None, limit: int, offset: int
+    ) -> AnalyticsResponse:
+        return self._page(
+            self.repository.cet_concentration,
+            limit,
+            offset,
+            agency=agency,
+            fiscal_year=fiscal_year,
+        )
+
+    def freshness(self) -> AnalyticsResponse:
+        return AnalyticsResponse(data=self.repository.freshness(), provenance=self._provenance())

--- a/packages/sbir-analytics/sbir_analytics/api/snapshots.py
+++ b/packages/sbir-analytics/sbir_analytics/api/snapshots.py
@@ -1,0 +1,131 @@
+"""Persisted analytical snapshot contracts and read-only filesystem repository."""
+
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field, ValidationError
+
+
+class AnalysisKind(StrEnum):
+    CET_PORTFOLIO = "cet_portfolio"
+    TRANSITION_RATE = "transition_rate"
+    FOLLOW_ON_MULTIPLIER = "follow_on_multiplier"
+
+
+class SourceReference(BaseModel):
+    name: str
+    url: str
+    version: str | None = None
+    record_count: int | None = None
+    access_method: str | None = None
+
+
+class SnapshotMetadata(BaseModel):
+    tool_name: str
+    tool_version: str
+    schema_version: str = "1"
+    pipeline_run_id: str | None = None
+    data_sources: list[SourceReference] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class AnalyticsSnapshot(BaseModel):
+    analysis_kind: AnalysisKind
+    period: str = Field(pattern=r"^\d{4}(-Q[1-4])?$")
+    as_of: str
+    metadata: SnapshotMetadata
+    result: dict[str, Any] | list[dict[str, Any]]
+
+
+class SnapshotSummary(BaseModel):
+    analysis_kind: AnalysisKind
+    period: str
+    as_of: str
+    tool_name: str
+    tool_version: str
+    schema_version: str
+
+
+class SnapshotNotFoundError(LookupError):
+    pass
+
+
+class IncompatibleSnapshotsError(ValueError):
+    pass
+
+
+class SnapshotStoreError(RuntimeError):
+    pass
+
+
+class FileSnapshotRepository:
+    """Read validated snapshots from ``<root>/<kind>/<period>.json``."""
+
+    def __init__(self, root: Path):
+        self.root = root
+
+    def _path(self, kind: AnalysisKind, period: str) -> Path:
+        return self.root / kind.value / f"{period}.json"
+
+    def get(self, kind: AnalysisKind, period: str) -> AnalyticsSnapshot:
+        path = self._path(kind, period)
+        if not path.is_file():
+            raise SnapshotNotFoundError(f"No {kind.value} snapshot for {period}")
+        try:
+            return AnalyticsSnapshot.model_validate_json(path.read_text(encoding="utf-8"))
+        except (OSError, ValidationError, ValueError) as exc:
+            raise SnapshotStoreError(f"Snapshot could not be read: {path.name}") from exc
+
+    def list(self, kind: AnalysisKind | None = None) -> list[SnapshotSummary]:
+        kinds = [kind] if kind else list(AnalysisKind)
+        summaries: list[SnapshotSummary] = []
+        for selected in kinds:
+            directory = self.root / selected.value
+            if not directory.is_dir():
+                continue
+            for path in directory.glob("*.json"):
+                snapshot = self.get(selected, path.stem)
+                summaries.append(
+                    SnapshotSummary(
+                        analysis_kind=snapshot.analysis_kind,
+                        period=snapshot.period,
+                        as_of=snapshot.as_of,
+                        tool_name=snapshot.metadata.tool_name,
+                        tool_version=snapshot.metadata.tool_version,
+                        schema_version=snapshot.metadata.schema_version,
+                    )
+                )
+        return sorted(summaries, key=lambda item: (item.analysis_kind, item.period))
+
+
+def compare_snapshots(
+    baseline: AnalyticsSnapshot, comparison: AnalyticsSnapshot
+) -> dict[str, Any]:
+    """Compare compatible snapshots without inventing domain-specific formulas."""
+
+    if baseline.analysis_kind != comparison.analysis_kind:
+        raise IncompatibleSnapshotsError("Analysis kinds differ")
+    if baseline.metadata.schema_version != comparison.metadata.schema_version:
+        raise IncompatibleSnapshotsError("Schema versions differ")
+    if baseline.metadata.tool_name != comparison.metadata.tool_name:
+        raise IncompatibleSnapshotsError("Methodologies differ")
+    if baseline.metadata.tool_version != comparison.metadata.tool_version:
+        raise IncompatibleSnapshotsError("Methodology versions differ")
+    if not isinstance(baseline.result, dict) or not isinstance(comparison.result, dict):
+        raise IncompatibleSnapshotsError("Comparison requires object-shaped results")
+
+    deltas: dict[str, float] = {}
+    for key in baseline.result.keys() & comparison.result.keys():
+        before = baseline.result[key]
+        after = comparison.result[key]
+        if isinstance(before, (int, float)) and isinstance(after, (int, float)):
+            deltas[key] = after - before
+    return {
+        "analysis_kind": baseline.analysis_kind,
+        "baseline_period": baseline.period,
+        "comparison_period": comparison.period,
+        "baseline": baseline.result,
+        "comparison": comparison.result,
+        "numeric_deltas": deltas,
+    }

--- a/packages/sbir-analytics/sbir_analytics/api/snapshots.py
+++ b/packages/sbir-analytics/sbir_analytics/api/snapshots.py
@@ -1,10 +1,23 @@
 """Persisted analytical snapshot contracts and read-only filesystem repository."""
 
+import math
+import os
+import re
+import tempfile
+from dataclasses import asdict, is_dataclass
+from datetime import UTC, date, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+import pandas as pd
 from pydantic import BaseModel, Field, ValidationError
+
+from sbir_analytics.tools.base import ToolResult
+
+
+_PERIOD_PATTERN = re.compile(r"^\d{4}(-Q[1-4])?$")
 
 
 class AnalysisKind(StrEnum):
@@ -63,14 +76,43 @@ class FileSnapshotRepository:
     """Read validated snapshots from ``<root>/<kind>/<period>.json``."""
 
     def __init__(self, root: Path):
-        self.root = root
+        self.root = root.resolve()
 
-    def _path(self, kind: AnalysisKind, period: str) -> Path:
-        return self.root / kind.value / f"{period}.json"
+    def _directory(self, kind: AnalysisKind) -> Path:
+        directories = {
+            AnalysisKind.CET_PORTFOLIO: "cet_portfolio",
+            AnalysisKind.TRANSITION_RATE: "transition_rate",
+            AnalysisKind.FOLLOW_ON_MULTIPLIER: "follow_on_multiplier",
+        }
+        return self.root / directories[kind]
+
+    @staticmethod
+    def _validate_period(period: str) -> None:
+        if not _PERIOD_PATTERN.fullmatch(period):
+            raise SnapshotStoreError("Invalid snapshot period")
+
+    def _find_path(self, kind: AnalysisKind, period: str) -> Path | None:
+        """Find a snapshot without using request data as a path expression."""
+
+        self._validate_period(period)
+        directory = self._directory(kind)
+        if not directory.is_dir():
+            return None
+        expected_name = f"{period}.json"
+        try:
+            for candidate in directory.iterdir():
+                if candidate.name != expected_name:
+                    continue
+                resolved = candidate.resolve(strict=True)
+                resolved.relative_to(self.root)
+                return resolved
+        except (OSError, RuntimeError, ValueError) as exc:
+            raise SnapshotStoreError("Snapshot path is not safe") from exc
+        return None
 
     def get(self, kind: AnalysisKind, period: str) -> AnalyticsSnapshot:
-        path = self._path(kind, period)
-        if not path.is_file():
+        path = self._find_path(kind, period)
+        if path is None or not path.is_file():
             raise SnapshotNotFoundError(f"No {kind.value} snapshot for {period}")
         try:
             return AnalyticsSnapshot.model_validate_json(path.read_text(encoding="utf-8"))
@@ -81,7 +123,7 @@ class FileSnapshotRepository:
         kinds = [kind] if kind else list(AnalysisKind)
         summaries: list[SnapshotSummary] = []
         for selected in kinds:
-            directory = self.root / selected.value
+            directory = self._directory(selected)
             if not directory.is_dir():
                 continue
             for path in directory.glob("*.json"):
@@ -98,10 +140,134 @@ class FileSnapshotRepository:
                 )
         return sorted(summaries, key=lambda item: (item.analysis_kind, item.period))
 
+    def readiness(self) -> str:
+        """Report whether the configured read store is safe and accessible."""
 
-def compare_snapshots(
-    baseline: AnalyticsSnapshot, comparison: AnalyticsSnapshot
-) -> dict[str, Any]:
+        try:
+            if self.root.exists() and not self.root.is_dir():
+                raise SnapshotStoreError("Snapshot root is not a directory")
+            return "ready" if self.root.exists() else "empty"
+        except OSError as exc:
+            raise SnapshotStoreError("Snapshot store is unavailable") from exc
+
+
+def _json_safe(value: Any) -> Any:
+    """Normalize analytical results, including pandas/numpy values, for JSON snapshots."""
+
+    if isinstance(value, pd.DataFrame):
+        return [_json_safe(record) for record in value.to_dict(orient="records")]
+    if isinstance(value, (pd.Series, pd.Index, np.ndarray)):
+        return [_json_safe(item) for item in value.tolist()]
+    if isinstance(value, np.generic):
+        return _json_safe(value.item())
+    if value is pd.NA or value is pd.NaT:
+        return None
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return None
+    if isinstance(value, (datetime, date, pd.Timestamp)):
+        return value.isoformat()
+    if is_dataclass(value) and not isinstance(value, type):
+        return _json_safe(asdict(value))
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def snapshot_from_tool_result(
+    analysis_kind: AnalysisKind,
+    period: str,
+    result: ToolResult,
+    *,
+    pipeline_run_id: str | None = None,
+    as_of: datetime | None = None,
+) -> AnalyticsSnapshot:
+    """Convert an existing analytics ``ToolResult`` into the snapshot contract."""
+
+    metadata = result.metadata
+    return snapshot_from_result(
+        analysis_kind,
+        period,
+        result.data,
+        metadata=SnapshotMetadata(
+            tool_name=metadata.tool_name,
+            tool_version=metadata.tool_version,
+            pipeline_run_id=pipeline_run_id,
+            data_sources=[
+                SourceReference.model_validate(source.to_dict()) for source in metadata.data_sources
+            ],
+            warnings=list(metadata.warnings),
+        ),
+        as_of=as_of,
+    )
+
+
+def snapshot_from_result(
+    analysis_kind: AnalysisKind,
+    period: str,
+    result: Any,
+    *,
+    metadata: SnapshotMetadata,
+    as_of: datetime | None = None,
+) -> AnalyticsSnapshot:
+    """Build a snapshot for deterministic results that do not use ``ToolResult``."""
+
+    return AnalyticsSnapshot(
+        analysis_kind=analysis_kind,
+        period=period,
+        as_of=(as_of or datetime.now(UTC)).isoformat(),
+        metadata=metadata,
+        result=_json_safe(result),
+    )
+
+
+def write_snapshot(
+    root: Path,
+    snapshot: AnalyticsSnapshot,
+    *,
+    overwrite: bool = False,
+) -> Path:
+    """Atomically persist a validated snapshot for the read-only API to consume."""
+
+    repository = FileSnapshotRepository(root)
+    repository._validate_period(snapshot.period)
+    directory = repository._directory(snapshot.analysis_kind)
+    directory.mkdir(parents=True, exist_ok=True)
+    directory = directory.resolve(strict=True)
+    try:
+        directory.relative_to(repository.root)
+    except ValueError as exc:
+        raise SnapshotStoreError("Snapshot destination is not safe") from exc
+
+    target = directory / f"{snapshot.period}.json"
+    if target.exists() and not overwrite:
+        raise SnapshotStoreError("Snapshot already exists")
+
+    payload = snapshot.model_dump_json(indent=2)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=directory,
+            prefix=".snapshot-",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+            temporary = Path(handle.name)
+        os.replace(temporary, target)
+    except OSError as exc:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+        raise SnapshotStoreError("Snapshot could not be written") from exc
+    return target
+
+
+def compare_snapshots(baseline: AnalyticsSnapshot, comparison: AnalyticsSnapshot) -> dict[str, Any]:
     """Compare compatible snapshots without inventing domain-specific formulas."""
 
     if baseline.analysis_kind != comparison.analysis_kind:

--- a/specs/ma-discovery-integration/design.md
+++ b/specs/ma-discovery-integration/design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft for review.
 **Date:** 2026-06-26.
-**Relates to:** [`specs/merger_acquisition_detection/`](../merger_acquisition_detection/design.md) (existing Form D + EFTS detection), [`scripts/data/capital_events/sources/ma_events.py`](../../scripts/data/capital_events/sources/ma_events.py) (downstream consumer), local branch `chore/ma-discovery-toolkit` (scaffolded toolkit, never merged) preserved in draft PR [#371](https://github.com/hollomancer/sbir-analytics/pull/371).
+**Relates to:** [`specs/archive/completed-features/merger_acquisition_detection/`](../archive/completed-features/merger_acquisition_detection/design.md) (existing Form D + EFTS detection), [`sbir_etl/capital_events/sources/ma_events.py`](../../sbir_etl/capital_events/sources/ma_events.py) (downstream consumer), local branch `chore/ma-discovery-toolkit` (scaffolded toolkit, never merged) preserved in draft PR [#371](https://github.com/hollomancer/sbir-analytics/pull/371).
 
 ## Why
 
@@ -12,7 +12,7 @@ A web-search-based discovery path can recover some of those, but only if the row
 
 ## The Decision
 
-The capital-events builder at `scripts/data/capital_events/sources/ma_events.py:13-55` reads `data/enriched_sbir_ma_events.jsonl` and filters on `confidence in {"high", "medium"}` (string tier, not a numeric score). The pipeline shape is fixed; discovery must conform to it.
+The capital-events builder at `sbir_etl/capital_events/sources/ma_events.py:13-55` reads `data/enriched_sbir_ma_events.jsonl` and filters on `confidence in {"high", "medium"}` (string tier, not a numeric score). The pipeline shape is fixed; discovery must conform to it.
 
 Note: `detect_sbir_ma_events.py` writes `data/sbir_ma_events.jsonl`; the builder reads `data/enriched_sbir_ma_events.jsonl`. **No script in this branch produces the enriched file** — the press-wire enrichment step (`SyncPressWireClient` in `sbir_etl/enrichers/press_wire.py`) exists as a library but is not wired into a standalone CLI. The diagram below treats `enrich_ma_with_press.py` as a **to-be-added** component; discovery integration assumes this enrichment glue lands as part of (or before) the discovery implementation PR.
 
@@ -41,7 +41,7 @@ When a discovered row matches an existing `sbir_ma_events.jsonl` row on `(compan
 
 Discovery never *lowers* a confidence and never *overwrites* a Form D-derived acquirer. If the LLM extractor disagrees with Form D on the acquirer name, the Form D value wins and the discovered acquirer is recorded as `signals.discovered_acquirer_disagrees = "<discovered_name>"`.
 
-**Why `signals` and not a new top-level field:** `scripts/data/capital_events/sources/ma_events.py` builds the emitted `CapitalEvent.metadata` from a fixed set of keys (`signals`, `press_wire_signals`, `signal_count`, `enriched`). Any flag placed in a *new* top-level field on `enriched_sbir_ma_events.jsonl` would be silently dropped at the builder step. Adding flags inside `signals` propagates them into `capital_events.parquet` without changing the builder. The existing `signals` dict is `dict[str, bool]` — extending it with one additional `str` value (`discovered_acquirer_disagrees`) is the smallest accommodating change; if a strict-type contract is preferred, that disagreement payload can move to `signals.discovered_acquirer_disagrees: bool` plus a sibling `signals.discovered_acquirer_name: str` written by the orchestrator.
+**Why `signals` and not a new top-level field:** `sbir_etl/capital_events/sources/ma_events.py` builds the emitted `CapitalEvent.metadata` from a fixed set of keys (`signals`, `press_wire_signals`, `signal_count`, `enriched`). Any flag placed in a *new* top-level field on `enriched_sbir_ma_events.jsonl` would be silently dropped at the builder step. Adding flags inside `signals` propagates them into `capital_events.parquet` without changing the builder. The existing `signals` dict is `dict[str, bool]` — extending it with one additional `str` value (`discovered_acquirer_disagrees`) is the smallest accommodating change; if a strict-type contract is preferred, that disagreement payload can move to `signals.discovered_acquirer_disagrees: bool` plus a sibling `signals.discovered_acquirer_name: str` written by the orchestrator.
 
 ### Per-discovered-row confidence (new rows, no collision)
 
@@ -124,4 +124,4 @@ Discovery is worth landing if, after the sample run in step 7:
 - The false-positive rate (manual review of a stratified sample of 20 medium-confidence rows) is ≤ 25%.
 - Per-row cost (search + LLM) is ≤ $0.10 at the chosen backend / model combo.
 
-Below those numbers, close the draft PR and document the lessons in `specs/merger_acquisition_detection/` as a "tried, didn't pay off" note.
+Below those numbers, close the draft PR and document the lessons in `specs/archive/completed-features/merger_acquisition_detection/` as a "tried, didn't pay off" note.

--- a/tests/unit/api/test_analytics_api.py
+++ b/tests/unit/api/test_analytics_api.py
@@ -1,16 +1,24 @@
 """Contract tests for the private analytics API."""
 
 import json
+import logging
 from pathlib import Path
+from collections.abc import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
 
 from sbir_analytics.api.app import create_app
 from sbir_analytics.api.models import AnalyticsResponse, Provenance
+from sbir_analytics.api.repository import AnalyticsBackendUnavailable
+from sbir_analytics.api.snapshots import FileSnapshotRepository
 
 
 class StubService:
+    def __init__(self, *, available: bool = True):
+        self.available = available
+        self.close_calls = 0
+
     def organization(self, identifier: str) -> AnalyticsResponse:
         return AnalyticsResponse(data=[{"organization_id": identifier}], provenance=Provenance())
 
@@ -26,11 +34,28 @@ class StubService:
     def freshness(self) -> AnalyticsResponse:
         return AnalyticsResponse(data=[{"entity": "Organization"}], provenance=Provenance())
 
+    def verify_connectivity(self) -> None:
+        if not self.available:
+            raise AnalyticsBackendUnavailable("secret backend URI")
+
+    def close(self) -> None:
+        self.close_calls += 1
+
 
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
-    monkeypatch.setenv("SBIR_ANALYTICS_SNAPSHOT_DIR", str(tmp_path))
-    return TestClient(create_app(service_factory=StubService, api_token="secret"))
+def service() -> StubService:
+    return StubService()
+
+
+@pytest.fixture
+def client(service: StubService, tmp_path: Path) -> Iterator[TestClient]:
+    app = create_app(
+        service_factory=lambda: service,
+        api_token="secret",
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 def _headers() -> dict[str, str]:
@@ -58,12 +83,112 @@ def _write_snapshot(root: Path, period: str, value: int, version: str = "1.0.0")
 
 def test_authentication_and_bounded_pagination(client: TestClient) -> None:
     assert client.get("/v1/analytics/transitions").status_code == 401
-    assert client.get(
-        "/v1/analytics/transitions?limit=501", headers=_headers()
-    ).status_code == 422
+    assert client.get("/v1/analytics/transitions?limit=501", headers=_headers()).status_code == 422
     response = client.get("/v1/analytics/transitions", headers=_headers())
     assert response.status_code == 200
     assert response.json()["data"][0]["transition_rate"] == 0.5
+
+
+def test_unauthenticated_request_does_not_construct_service(tmp_path: Path) -> None:
+    factory_calls = 0
+
+    def factory() -> StubService:
+        nonlocal factory_calls
+        factory_calls += 1
+        return StubService()
+
+    app = create_app(
+        service_factory=factory,
+        api_token="secret",
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(app) as test_client:
+        response = test_client.get("/v1/data/freshness")
+    assert response.status_code == 401
+    assert factory_calls == 0
+
+
+def test_service_is_closed_once_on_shutdown(service: StubService, tmp_path: Path) -> None:
+    app = create_app(
+        service_factory=lambda: service,
+        api_token="secret",
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(app) as test_client:
+        assert test_client.get("/v1/data/freshness", headers=_headers()).status_code == 200
+        assert test_client.get("/v1/data/freshness", headers=_headers()).status_code == 200
+    assert service.close_calls == 1
+
+
+def test_readiness_reports_backend_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    healthy_app = create_app(
+        service_factory=StubService,
+        api_token="secret",
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(healthy_app) as healthy_client:
+        response = healthy_client.get("/health/ready")
+        assert response.status_code == 200
+        assert response.json()["components"] == {
+            "authentication": "ready",
+            "neo4j": "ready",
+            "snapshots": "ready",
+        }
+
+    unavailable_app = create_app(
+        service_factory=lambda: StubService(available=False),
+        api_token="secret",
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(unavailable_app) as unavailable_client:
+        assert unavailable_client.get("/health/live").status_code == 200
+        response = unavailable_client.get("/health/ready")
+        assert response.status_code == 503
+        assert response.json()["components"]["neo4j"] == "unavailable"
+
+    monkeypatch.delenv("SBIR_ANALYTICS_API_TOKEN", raising=False)
+    missing_auth_app = create_app(
+        service_factory=StubService,
+        api_token=None,
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(missing_auth_app) as missing_auth_client:
+        response = missing_auth_client.get("/health/ready")
+        assert response.status_code == 503
+        assert response.json()["components"]["authentication"] == "unavailable"
+
+
+def test_backend_error_is_sanitized_to_503(tmp_path: Path) -> None:
+    class FailingService(StubService):
+        def freshness(self) -> AnalyticsResponse:
+            raise AnalyticsBackendUnavailable("bolt://user:password@private-host")
+
+    app = create_app(
+        service_factory=FailingService,
+        api_token="secret",
+        snapshot_repository=FileSnapshotRepository(tmp_path),
+    )
+    with TestClient(app) as test_client:
+        response = test_client.get("/v1/data/freshness", headers=_headers())
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Analytics backend is unavailable"}
+    assert "password" not in response.text
+
+
+def test_audit_log_uses_route_template_and_request_id(
+    client: TestClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    caplog.set_level(logging.INFO, logger="sbir_analytics.api.audit")
+    response = client.get(
+        "/v1/organizations/sensitive-identifier?unused=secret", headers=_headers()
+    )
+    records = [record for record in caplog.records if record.name == "sbir_analytics.api.audit"]
+    payload = json.loads(records[-1].message)
+    assert payload["route"] == "/v1/organizations/{identifier}"
+    assert payload["status"] == 200
+    assert response.headers["X-Request-ID"] == payload["request_id"]
+    assert "sensitive-identifier" not in records[-1].message
+    assert "secret" not in records[-1].message
 
 
 def test_openapi_exposes_curated_routes_only(client: TestClient) -> None:
@@ -73,9 +198,7 @@ def test_openapi_exposes_curated_routes_only(client: TestClient) -> None:
     assert all("cypher" not in path and "materialize" not in path for path in paths)
 
 
-def test_snapshot_get_and_compare(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_snapshot_get_and_compare(client: TestClient, tmp_path: Path) -> None:
     _write_snapshot(tmp_path, "2025-Q4", 100)
     _write_snapshot(tmp_path, "2026-Q1", 125)
 

--- a/tests/unit/api/test_analytics_api.py
+++ b/tests/unit/api/test_analytics_api.py
@@ -1,0 +1,101 @@
+"""Contract tests for the private analytics API."""
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sbir_analytics.api.app import create_app
+from sbir_analytics.api.models import AnalyticsResponse, Provenance
+
+
+class StubService:
+    def organization(self, identifier: str) -> AnalyticsResponse:
+        return AnalyticsResponse(data=[{"organization_id": identifier}], provenance=Provenance())
+
+    def award_history(self, identifier: str, limit: int, offset: int) -> AnalyticsResponse:
+        return AnalyticsResponse(data=[], provenance=Provenance())
+
+    def transition_metrics(self, *args) -> AnalyticsResponse:
+        return AnalyticsResponse(data=[{"transition_rate": 0.5}], provenance=Provenance())
+
+    def cet_concentration(self, *args) -> AnalyticsResponse:
+        return AnalyticsResponse(data=[{"award_count_hhi": 0.25}], provenance=Provenance())
+
+    def freshness(self) -> AnalyticsResponse:
+        return AnalyticsResponse(data=[{"entity": "Organization"}], provenance=Provenance())
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+    monkeypatch.setenv("SBIR_ANALYTICS_SNAPSHOT_DIR", str(tmp_path))
+    return TestClient(create_app(service_factory=StubService, api_token="secret"))
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": "Bearer secret"}
+
+
+def _write_snapshot(root: Path, period: str, value: int, version: str = "1.0.0") -> None:
+    directory = root / "transition_rate"
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "analysis_kind": "transition_rate",
+        "period": period,
+        "as_of": f"{period[:4]}-12-31T00:00:00Z",
+        "metadata": {
+            "tool_name": "compute_transition_rate",
+            "tool_version": version,
+            "schema_version": "1",
+            "data_sources": [],
+            "warnings": [],
+        },
+        "result": {"awards": value, "transition_rate": value / 100},
+    }
+    (directory / f"{period}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_authentication_and_bounded_pagination(client: TestClient) -> None:
+    assert client.get("/v1/analytics/transitions").status_code == 401
+    assert client.get(
+        "/v1/analytics/transitions?limit=501", headers=_headers()
+    ).status_code == 422
+    response = client.get("/v1/analytics/transitions", headers=_headers())
+    assert response.status_code == 200
+    assert response.json()["data"][0]["transition_rate"] == 0.5
+
+
+def test_openapi_exposes_curated_routes_only(client: TestClient) -> None:
+    paths = client.get("/openapi.json").json()["paths"]
+    assert "/v1/analytics/cet-concentration" in paths
+    assert "/v1/snapshots/{analysis_kind}/{period}" in paths
+    assert all("cypher" not in path and "materialize" not in path for path in paths)
+
+
+def test_snapshot_get_and_compare(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    _write_snapshot(tmp_path, "2025-Q4", 100)
+    _write_snapshot(tmp_path, "2026-Q1", 125)
+
+    response = client.get(
+        "/v1/snapshots/transition_rate/2025-Q4/compare/2026-Q1", headers=_headers()
+    )
+    assert response.status_code == 200
+    assert response.json()["numeric_deltas"] == {"awards": 25.0, "transition_rate": 0.25}
+
+
+def test_missing_and_incompatible_snapshots(client: TestClient, tmp_path: Path) -> None:
+    malformed = client.get("/v1/snapshots/transition_rate/not-a-period", headers=_headers())
+    assert malformed.status_code == 422
+
+    missing = client.get("/v1/snapshots/transition_rate/2024-Q1", headers=_headers())
+    assert missing.status_code == 404
+
+    _write_snapshot(tmp_path, "2025-Q4", 100)
+    _write_snapshot(tmp_path, "2026-Q1", 125, version="2.0.0")
+    incompatible = client.get(
+        "/v1/snapshots/transition_rate/2025-Q4/compare/2026-Q1", headers=_headers()
+    )
+    assert incompatible.status_code == 409

--- a/tests/unit/api/test_repository.py
+++ b/tests/unit/api/test_repository.py
@@ -2,9 +2,11 @@
 
 from typing import Any
 
+import pytest
 from neo4j import Query
+from neo4j.exceptions import ServiceUnavailable
 
-from sbir_analytics.api.repository import AnalyticsRepository
+from sbir_analytics.api.repository import AnalyticsBackendUnavailable, AnalyticsRepository
 
 
 class FakeResult:
@@ -13,9 +15,10 @@ class FakeResult:
 
 
 class FakeSession:
-    def __init__(self):
+    def __init__(self, error: Exception | None = None):
         self.query: Query | None = None
         self.parameters: dict[str, Any] = {}
+        self.error = error
 
     def __enter__(self):
         return self
@@ -24,19 +27,29 @@ class FakeSession:
         return None
 
     def run(self, query: Query, parameters: dict[str, Any]):
+        if self.error:
+            raise self.error
         self.query = query
         self.parameters = parameters
         return FakeResult()
 
 
 class FakeDriver:
-    def __init__(self):
-        self.session_instance = FakeSession()
+    def __init__(self, error: Exception | None = None):
+        self.session_instance = FakeSession(error)
         self.options: dict[str, Any] = {}
+        self.closed = False
 
     def session(self, **kwargs: Any) -> FakeSession:
         self.options = kwargs
         return self.session_instance
+
+    def verify_connectivity(self) -> None:
+        if self.session_instance.error:
+            raise self.session_instance.error
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def test_repository_uses_read_session_and_parameters() -> None:
@@ -49,3 +62,15 @@ def test_repository_uses_read_session_and_parameters() -> None:
     assert driver.options["default_access_mode"] == "READ"
     assert driver.session_instance.parameters == {"identifier": "' MATCH (n) DELETE n //"}
     assert "$identifier" in str(driver.session_instance.query)
+
+
+def test_repository_translates_availability_errors_only() -> None:
+    unavailable = AnalyticsRepository(FakeDriver(ServiceUnavailable("private-host")))
+    with pytest.raises(AnalyticsBackendUnavailable, match="Analytics backend is unavailable"):
+        unavailable.freshness()
+    with pytest.raises(AnalyticsBackendUnavailable, match="Analytics backend is unavailable"):
+        unavailable.verify_connectivity()
+
+    programming_error = AnalyticsRepository(FakeDriver(RuntimeError("bug")))
+    with pytest.raises(RuntimeError, match="bug"):
+        programming_error.freshness()

--- a/tests/unit/api/test_repository.py
+++ b/tests/unit/api/test_repository.py
@@ -1,0 +1,51 @@
+"""Safety tests for curated Neo4j query execution."""
+
+from typing import Any
+
+from neo4j import Query
+
+from sbir_analytics.api.repository import AnalyticsRepository
+
+
+class FakeResult:
+    def __iter__(self):
+        return iter([{"item": {"organization_id": "org-1"}}])
+
+
+class FakeSession:
+    def __init__(self):
+        self.query: Query | None = None
+        self.parameters: dict[str, Any] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def run(self, query: Query, parameters: dict[str, Any]):
+        self.query = query
+        self.parameters = parameters
+        return FakeResult()
+
+
+class FakeDriver:
+    def __init__(self):
+        self.session_instance = FakeSession()
+        self.options: dict[str, Any] = {}
+
+    def session(self, **kwargs: Any) -> FakeSession:
+        self.options = kwargs
+        return self.session_instance
+
+
+def test_repository_uses_read_session_and_parameters() -> None:
+    driver = FakeDriver()
+    repository = AnalyticsRepository(driver, timeout=3.0)
+
+    result = repository.organization("' MATCH (n) DELETE n //")
+
+    assert result == [{"organization_id": "org-1"}]
+    assert driver.options["default_access_mode"] == "READ"
+    assert driver.session_instance.parameters == {"identifier": "' MATCH (n) DELETE n //"}
+    assert "$identifier" in str(driver.session_instance.query)

--- a/tests/unit/api/test_snapshots.py
+++ b/tests/unit/api/test_snapshots.py
@@ -1,0 +1,131 @@
+"""Snapshot safety, normalization, and persistence tests."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sbir_analytics.api.snapshots import (
+    AnalysisKind,
+    FileSnapshotRepository,
+    SnapshotMetadata,
+    SnapshotStoreError,
+    snapshot_from_result,
+    snapshot_from_tool_result,
+    write_snapshot,
+)
+from sbir_analytics.assets.follow_on_multiplier import FollowOnMultiplierResult
+from sbir_analytics.tools.base import DataSourceRef, ToolMetadata, ToolResult
+
+
+def _tool_result() -> ToolResult:
+    metadata = ToolMetadata(
+        tool_name="compute_transition_rate",
+        tool_version="1.0.0",
+        execution_start=datetime(2026, 1, 1, tzinfo=UTC),
+        execution_end=datetime(2026, 1, 1, 0, 1, tzinfo=UTC),
+        data_sources=[
+            DataSourceRef(
+                name="SBIR.gov Awards",
+                url="https://sbir.gov/api",
+                version="2026-Q1",
+                record_count=2,
+                access_method="bulk_download",
+            )
+        ],
+        warnings=["conservative benchmark"],
+        record_count=2,
+    )
+    return ToolResult(
+        data={
+            "results": pd.DataFrame(
+                {
+                    "company": ["A", "B"],
+                    "rate": [0.5, np.nan],
+                    "updated_at": [pd.Timestamp("2026-01-01", tz="UTC"), pd.NaT],
+                    "note": ["ok", pd.NA],
+                }
+            ),
+            "summary": {"companies": np.int64(2)},
+        },
+        metadata=metadata,
+    )
+
+
+def test_tool_result_snapshot_round_trip(tmp_path: Path) -> None:
+    snapshot = snapshot_from_tool_result(
+        AnalysisKind.TRANSITION_RATE,
+        "2026-Q1",
+        _tool_result(),
+        pipeline_run_id="run-123",
+        as_of=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+    path = write_snapshot(tmp_path, snapshot)
+    loaded = FileSnapshotRepository(tmp_path).get(AnalysisKind.TRANSITION_RATE, "2026-Q1")
+
+    assert path.name == "2026-Q1.json"
+    assert loaded.metadata.pipeline_run_id == "run-123"
+    assert loaded.metadata.data_sources[0].record_count == 2
+    assert loaded.result["results"][1]["rate"] is None
+    assert loaded.result["results"][1]["updated_at"] is None
+    assert loaded.result["results"][1]["note"] is None
+    assert loaded.result["summary"]["companies"] == 2
+
+    with pytest.raises(SnapshotStoreError, match="already exists"):
+        write_snapshot(tmp_path, snapshot)
+
+
+def test_repository_rejects_invalid_period_and_symlink_escape(tmp_path: Path) -> None:
+    repository = FileSnapshotRepository(tmp_path)
+    with pytest.raises(SnapshotStoreError, match="Invalid snapshot period"):
+        repository.get(AnalysisKind.TRANSITION_RATE, "../../outside")
+
+    outside = tmp_path.parent / "outside-snapshot.json"
+    outside.write_text("{}", encoding="utf-8")
+    directory = tmp_path / AnalysisKind.TRANSITION_RATE.value
+    directory.mkdir(parents=True)
+    (directory / "2026-Q1.json").symlink_to(outside)
+    try:
+        with pytest.raises(SnapshotStoreError, match="not safe"):
+            repository.get(AnalysisKind.TRANSITION_RATE, "2026-Q1")
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_follow_on_multiplier_result_can_be_exported(tmp_path: Path) -> None:
+    result = FollowOnMultiplierResult(
+        company=pd.DataFrame({"company_id": ["A"], "follow_on_multiplier": [4.0]}),
+        agency=pd.DataFrame(),
+        cohort=pd.DataFrame(),
+        fiscal_year=pd.DataFrame(),
+        quality=pd.DataFrame({"matched_record_count": [1]}),
+    )
+    snapshot = snapshot_from_result(
+        AnalysisKind.FOLLOW_ON_MULTIPLIER,
+        "2026-Q1",
+        result,
+        metadata=SnapshotMetadata(
+            tool_name="calculate_follow_on_multipliers",
+            tool_version="1.0.0",
+            pipeline_run_id="run-456",
+        ),
+    )
+    write_snapshot(tmp_path, snapshot)
+    loaded = FileSnapshotRepository(tmp_path).get(AnalysisKind.FOLLOW_ON_MULTIPLIER, "2026-Q1")
+    assert loaded.result["company"][0]["follow_on_multiplier"] == 4.0
+    assert loaded.result["quality"][0]["matched_record_count"] == 1
+
+
+def test_openapi_remains_read_only(tmp_path: Path) -> None:
+    from fastapi.testclient import TestClient
+
+    from sbir_analytics.api.app import create_app
+
+    app = create_app(api_token="secret", snapshot_repository=FileSnapshotRepository(tmp_path))
+    with TestClient(app) as client:
+        operations = client.get("/openapi.json").json()["paths"].values()
+    assert all(
+        not ({"post", "put", "patch", "delete"} & endpoints.keys()) for endpoints in operations
+    )

--- a/tests/unit/api/test_transport_boundaries.py
+++ b/tests/unit/api/test_transport_boundaries.py
@@ -18,6 +18,23 @@ def _imports(path: Path) -> set[str]:
     return imported
 
 
+def _forbidden_mcp_imports(path: Path) -> set[str]:
+    imports = _imports(path)
+    forbidden_roots = {"neo4j", "dagster", "sbir_graph", "duckdb"}
+    forbidden_internal = {
+        "sbir_analytics.api.repository",
+        "sbir_analytics.api.snapshots",
+        "api.repository",
+        "api.snapshots",
+    }
+    return {
+        module
+        for module in imports
+        if module.split(".", maxsplit=1)[0] in forbidden_roots
+        or any(module == prefix or module.startswith(f"{prefix}.") for prefix in forbidden_internal)
+    }
+
+
 def test_domain_layers_do_not_depend_on_fastapi() -> None:
     """The repository and service remain reusable by HTTP and future MCP transports."""
 
@@ -35,9 +52,20 @@ def test_future_mcp_adapter_cannot_bypass_service_boundary() -> None:
     if not mcp_root.exists():
         return
 
-    forbidden_roots = {"neo4j", "dagster", "sbir_graph", "duckdb"}
     for path in mcp_root.rglob("*.py"):
-        roots = {module.split(".", maxsplit=1)[0] for module in _imports(path)}
-        assert roots.isdisjoint(forbidden_roots), (
-            f"{path} bypasses the API/service boundary via {roots & forbidden_roots}"
-        )
+        forbidden = _forbidden_mcp_imports(path)
+        assert not forbidden, f"{path} bypasses the API/service boundary via {forbidden}"
+
+
+def test_mcp_boundary_detects_fully_qualified_internal_bypass(tmp_path: Path) -> None:
+    bypass = tmp_path / "tool.py"
+    bypass.write_text(
+        "from sbir_analytics.api.repository import AnalyticsRepository\n", encoding="utf-8"
+    )
+    assert _forbidden_mcp_imports(bypass) == {"sbir_analytics.api.repository"}
+
+    allowed = tmp_path / "allowed.py"
+    allowed.write_text(
+        "from sbir_analytics.api.service import AnalyticsService\n", encoding="utf-8"
+    )
+    assert not _forbidden_mcp_imports(allowed)

--- a/tests/unit/api/test_transport_boundaries.py
+++ b/tests/unit/api/test_transport_boundaries.py
@@ -1,0 +1,43 @@
+"""Architecture guardrails for API-first, MCP-adapter-only integrations."""
+
+import ast
+from pathlib import Path
+
+
+PACKAGE_ROOT = Path("packages/sbir-analytics/sbir_analytics")
+
+
+def _imports(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    return imported
+
+
+def test_domain_layers_do_not_depend_on_fastapi() -> None:
+    """The repository and service remain reusable by HTTP and future MCP transports."""
+
+    for name in ("repository.py", "service.py", "snapshots.py"):
+        assert not any(
+            module == "fastapi" or module.startswith("fastapi.")
+            for module in _imports(PACKAGE_ROOT / "api" / name)
+        )
+
+
+def test_future_mcp_adapter_cannot_bypass_service_boundary() -> None:
+    """Any future MCP package must not access storage or orchestration directly."""
+
+    mcp_root = PACKAGE_ROOT / "mcp"
+    if not mcp_root.exists():
+        return
+
+    forbidden_roots = {"neo4j", "dagster", "sbir_graph", "duckdb"}
+    for path in mcp_root.rglob("*.py"):
+        roots = {module.split(".", maxsplit=1)[0] for module in _imports(path)}
+        assert roots.isdisjoint(forbidden_roots), (
+            f"{path} bypasses the API/service boundary via {roots & forbidden_roots}"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -753,6 +762,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.139.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/af/a5f50ccfa659ec1802cb4ca842c23f06d906a8cc9aef6016a2caeea3d4ed/fastapi-0.139.0.tar.gz", hash = "sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145", size = 423016, upload-time = "2026-07-01T16:35:33.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/7c/8e3c6ad324ea5cb36604fc3f968554887891c316d9dfde57761611d907ad/fastapi-0.139.0-py3-none-any.whl", hash = "sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189", size = 130339, upload-time = "2026-07-01T16:35:32.19Z" },
 ]
 
 [[package]]
@@ -2655,20 +2680,24 @@ version = "0.1.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
+    { name = "fastapi" },
     { name = "sbir-etl", extra = ["cloud", "monitoring", "uspto"] },
     { name = "sbir-graph" },
     { name = "sbir-ml", extra = ["nlp"] },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "dagster", specifier = ">=1.7.0,<2.0.0" },
+    { name = "fastapi", specifier = ">=0.115.0,<1.0.0" },
     { name = "sbir-etl", extras = ["cloud", "uspto", "monitoring"] },
     { name = "sbir-etl", extras = ["dev"], marker = "extra == 'dev'" },
     { name = "sbir-etl", extras = ["r"], marker = "extra == 'r'" },
     { name = "sbir-graph" },
     { name = "sbir-ml", extras = ["modernbert-local"], marker = "extra == 'modernbert-local'" },
     { name = "sbir-ml", extras = ["nlp"] },
+    { name = "uvicorn", specifier = ">=0.30.0,<1.0.0" },
 ]
 provides-extras = ["r", "modernbert-local", "dev"]
 
@@ -3119,6 +3148,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
 name = "stevedore"
 version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3468,6 +3510,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.51.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl", hash = "sha256:5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b", size = 73219, upload-time = "2026-07-08T10:59:04.44Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add a private, authenticated FastAPI service for curated SBIR analytics reads
- add read-only, parameterized Neo4j queries for organizations, award history, transition metrics, CET concentration, and freshness
- add provenance-bearing analytical snapshots and compatible period comparison
- document ADR-003: domain/service → API → optional MCP adapter
- add architecture tests preventing future MCP adapters from importing Neo4j, Dagster, DuckDB, or `sbir_graph` directly
- add local Docker Compose wiring and configuration

## Why

The repository's rolling analytics are currently available primarily through scripts, Dagster, and direct graph access. A stable private API makes those results reusable by dashboards, notebooks, and partner applications. MCP can then remain a thin client adapter rather than developing a separate query, security, or orchestration surface.

## Developer impact

New callable product functionality should be implemented in a transport-neutral service and exposed through a versioned private API before an MCP tool is added. MCP adapters must delegate to that service and cannot gain privileges absent from the API.

## Validation

- `uv run ruff check packages/sbir-analytics/sbir_analytics/api tests/unit/api`
- `uv run pytest -q -n 0 tests/unit/api` — 7 passed
- `git diff --check`
- `SBIR_ANALYTICS_API_TOKEN=test docker compose --profile dev config --quiet`

The focused test run emits one upstream Starlette deprecation warning about its current TestClient/httpx integration.