### PR TITLE
feat: tech-area transition report Phase 2 — T9 asset wrapper, T20 policy-brief stub, T8 CPC Method C

### DIFF
--- a/config/transition_reports/nanotechnology.yaml
+++ b/config/transition_reports/nanotechnology.yaml
@@ -68,6 +68,10 @@ method_b_terms:
 cpc_prefixes:
   - B82Y
   - B82B
+# Method C CPC patent extract (build via:
+#   python scripts/data/extract_b82_patents.py
+# — B82 subclass is the default). Matched to Phase II firms by assignee name.
+cpc_patents_csv: data/processed/uspto/b82_patents.csv
 
 # WS5c sector go-to-market registries applicable to this area (gates
 # nano_ws5c_sector_registries.py). Nanotech has a biomedical/HHS-funded slice,

--- a/config/transition_reports/quantum_information_science.yaml
+++ b/config/transition_reports/quantum_information_science.yaml
@@ -32,7 +32,14 @@ keyword_pack:
   soft_requires: title_or_multi
   negative_patterns: []  # taxonomy negatives loaded via cet_id
 
-cpc_prefixes: []
+# Method C: CPC group G06N10 (quantum computing). G06N10 is a CPC *group*, so the
+# extract must match the cpc_group column (not cpc_subclass). Build via:
+#   python scripts/data/extract_b82_patents.py \
+#       --cpc-field cpc_group --cpc-prefixes G06N10 \
+#       --out data/processed/uspto/g06n10_patents.csv
+cpc_prefixes:
+  - G06N10
+cpc_patents_csv: data/processed/uspto/g06n10_patents.csv
 
 # No biomedical go-to-market pathway → WS5c sector registries do not apply.
 sector_registries: []

--- a/packages/sbir-analytics/sbir_analytics/assets/transition_report.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition_report.py
@@ -1,0 +1,211 @@
+"""Dagster assets for the tech-area transition-report cohorts (spec T9).
+
+Thin orchestration wrapper around ``scripts/data/build_tech_area_cohort.py``.
+That CLI is the single, bit-exact-verified source of truth for how a Phase II
+tech-area cohort is built (Method A keyword + Method B taxonomy, deficiency-class
+enrichment, external-reference reconciliation). Rather than duplicate or refactor
+that 800-line builder — and risk perturbing the parity the nanotech cutover
+verified — each asset here shells out to it (``sys.executable`` on the same repo)
+and then reads back the emitted ``overlap_summary.json`` + ``composition.json`` to
+surface cohort metrics as Dagster metadata.
+
+One asset + one non-empty asset-check per area, grouped under
+``transition_reports``. Areas are the three defined in
+``config/transition_reports/`` — add a factory call below to wire a new one.
+
+Materialization is by side effect: the builder writes CSV/JSON artifacts under
+``data/reports/<area_id>/`` (the same convention the rest of the pipeline reads),
+matching how the fiscal/cet assets in this package materialize to ``data/`` and
+emit metadata + checks rather than returning IO-managed frames.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Dagster import shim (mirrors assets/cet/utils.py): keep the module importable
+# for unit tests in environments without Dagster installed.
+# ---------------------------------------------------------------------------
+try:
+    from dagster import (
+        AssetCheckResult,
+        AssetCheckSeverity,
+        Output,
+        asset,
+        asset_check,
+    )
+except Exception:  # pragma: no cover - exercised only without Dagster
+
+    def asset(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef]
+        def _wrap(fn: Any) -> Any:
+            return fn
+
+        return _wrap
+
+    def asset_check(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef]
+        def _wrap(fn: Any) -> Any:
+            return fn
+
+        return _wrap
+
+    class Output:  # type: ignore[no-redef]
+        def __init__(self, value: Any, metadata: dict | None = None) -> None:
+            self.value = value
+            self.metadata = metadata or {}
+
+    class AssetCheckSeverity:  # type: ignore[no-redef]
+        WARN = "WARN"
+        ERROR = "ERROR"
+
+    class AssetCheckResult:  # type: ignore[no-redef]
+        def __init__(
+            self,
+            passed: bool,
+            severity: Any = None,
+            description: str | None = None,
+            metadata: dict | None = None,
+        ) -> None:
+            self.passed = passed
+            self.severity = severity
+            self.description = description
+            self.metadata = metadata or {}
+
+
+# Areas defined under config/transition_reports/. Add a factory call at the
+# bottom of this module to wire a new one.
+TECH_AREAS = (
+    "nanotechnology",
+    "quantum_information_science",
+    "hypersonics",
+)
+
+
+def _repo_root() -> Path:
+    """Locate the repo root by walking up to the cohort builder script."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "scripts" / "data" / "build_tech_area_cohort.py").exists():
+            return parent
+    raise RuntimeError("could not locate repo root (build_tech_area_cohort.py not found)")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _cohort_metrics(summary: dict, composition: dict) -> dict[str, Any]:
+    """Flatten overlap_summary.json + composition.json into scalar metrics.
+
+    Pure function (no Dagster, no I/O) so it is unit-testable against fixtures.
+    """
+    overlap = summary.get("overlap") or {}
+    totals = composition.get("totals") or {}
+    return {
+        "area_id": summary.get("area_id"),
+        "phase2_universe": summary.get("phase2_universe"),
+        "method_a_awards": composition.get("n_unique_awards"),
+        "method_b_awards": overlap.get("method_b_n"),
+        "method_a_source": summary.get("method_a_source"),
+        "method_b_source": summary.get("method_b_source"),
+        "intersection": overlap.get("intersection_n"),
+        "jaccard": overlap.get("jaccard"),
+        "phase2_dollars_m": totals.get("phase2_dollars_m"),
+        "unique_firms": totals.get("unique_firms"),
+        "agencies": len(composition.get("by_agency") or {}),
+        "signals_absent": len(summary.get("signals_absent") or []),
+        "has_deficiency_class": bool(summary.get("has_deficiency_class")),
+    }
+
+
+def _run_cohort_build(area_id: str, log: Any) -> Path:
+    """Run build_tech_area_cohort.py for one area; return its report dir."""
+    repo = _repo_root()
+    script = repo / "scripts" / "data" / "build_tech_area_cohort.py"
+    cmd = [sys.executable, str(script), "--area", area_id]
+    log.info(f"[tech_area_cohort] {' '.join(cmd)}")
+    proc = subprocess.run(cmd, cwd=str(repo), capture_output=True, text=True)
+    if proc.stdout:
+        log.info(proc.stdout[-4000:])
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"build_tech_area_cohort.py failed for area={area_id} "
+            f"(exit {proc.returncode}):\n{proc.stderr[-4000:]}"
+        )
+    return repo / "data" / "reports" / area_id
+
+
+def _make_cohort_asset(area_id: str) -> Any:
+    @asset(
+        name=f"tech_area_cohort_{area_id}",
+        group_name="transition_reports",
+        compute_kind="python",
+        description=(
+            f"Phase II tech-area cohort for {area_id}: runs "
+            "build_tech_area_cohort.py and writes cohort/composition/overlap "
+            "artifacts under data/reports/<area>/."
+        ),
+    )
+    def _cohort(context: Any) -> Output:
+        report_dir = _run_cohort_build(area_id, context.log)
+        summary = _read_json(report_dir / "overlap_summary.json")
+        composition = _read_json(report_dir / "composition.json")
+        metrics = _cohort_metrics(summary, composition)
+        if not metrics["method_a_awards"]:
+            raise RuntimeError(
+                f"tech_area_cohort_{area_id}: builder produced an empty cohort (method_a_awards=0)"
+            )
+        metadata = {k: v for k, v in metrics.items() if v is not None}
+        metadata["report_dir"] = str(report_dir)
+        return Output(metrics, metadata=metadata)
+
+    return _cohort
+
+
+def _make_cohort_check(area_id: str) -> Any:
+    @asset_check(
+        asset=f"tech_area_cohort_{area_id}",
+        description="Cohort is non-empty and carries a deficiency_class column.",
+    )
+    def _check(context: Any) -> AssetCheckResult:
+        report_dir = _repo_root() / "data" / "reports" / area_id
+        summ_path = report_dir / "overlap_summary.json"
+        comp_path = report_dir / "composition.json"
+        if not summ_path.exists() or not comp_path.exists():
+            return AssetCheckResult(
+                passed=False,
+                severity=AssetCheckSeverity.ERROR,
+                description=f"missing cohort outputs under {report_dir}",
+            )
+        metrics = _cohort_metrics(_read_json(summ_path), _read_json(comp_path))
+        n = metrics["method_a_awards"] or 0
+        passed = n > 0 and metrics["has_deficiency_class"]
+        return AssetCheckResult(
+            passed=passed,
+            severity=AssetCheckSeverity.WARN,
+            description=(
+                f"method_a_awards={n}, has_deficiency_class={metrics['has_deficiency_class']}"
+            ),
+            metadata={
+                "method_a_awards": n,
+                "has_deficiency_class": metrics["has_deficiency_class"],
+            },
+        )
+
+    return _check
+
+
+# One asset + one non-empty check per area (explicit module globals so Dagster's
+# load_assets_from_modules / load_asset_checks_from_modules discover them).
+tech_area_cohort_nanotechnology = _make_cohort_asset("nanotechnology")
+tech_area_cohort_quantum_information_science = _make_cohort_asset("quantum_information_science")
+tech_area_cohort_hypersonics = _make_cohort_asset("hypersonics")
+
+tech_area_cohort_nanotechnology_nonempty = _make_cohort_check("nanotechnology")
+tech_area_cohort_quantum_information_science_nonempty = _make_cohort_check(
+    "quantum_information_science"
+)
+tech_area_cohort_hypersonics_nonempty = _make_cohort_check("hypersonics")

--- a/packages/sbir-analytics/sbir_analytics/assets/transition_report.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition_report.py
@@ -22,6 +22,7 @@ emit metadata + checks rather than returning IO-managed frames.
 from __future__ import annotations
 
 import json
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -126,14 +127,17 @@ def _run_cohort_build(area_id: str, log: Any) -> Path:
     repo = _repo_root()
     script = repo / "scripts" / "data" / "build_tech_area_cohort.py"
     cmd = [sys.executable, str(script), "--area", area_id]
-    log.info(f"[tech_area_cohort] {' '.join(cmd)}")
+    log.info(f"[tech_area_cohort] {shlex.join(cmd)}")
     proc = subprocess.run(cmd, cwd=str(repo), capture_output=True, text=True)
     if proc.stdout:
-        log.info(proc.stdout[-4000:])
+        log.info(f"[tech_area_cohort:{area_id}] stdout tail:\n{proc.stdout[-4000:]}")
+    if proc.stderr:
+        log.info(f"[tech_area_cohort:{area_id}] stderr tail:\n{proc.stderr[-4000:]}")
     if proc.returncode != 0:
         raise RuntimeError(
-            f"build_tech_area_cohort.py failed for area={area_id} "
-            f"(exit {proc.returncode}):\n{proc.stderr[-4000:]}"
+            f"build_tech_area_cohort.py failed for area={area_id} (exit {proc.returncode}).\n"
+            f"stdout tail:\n{proc.stdout[-2000:]}\n"
+            f"stderr tail:\n{proc.stderr[-2000:]}"
         )
     return repo / "data" / "reports" / area_id
 
@@ -149,14 +153,18 @@ def _make_cohort_asset(area_id: str) -> Any:
             "artifacts under data/reports/<area>/."
         ),
     )
-    def _cohort(context: Any) -> Output:
+    # NOTE: `context` is intentionally left unannotated — Dagster rejects an
+    # explicit `Any` annotation on the context parameter.
+    def _cohort(context) -> Output:
         report_dir = _run_cohort_build(area_id, context.log)
         summary = _read_json(report_dir / "overlap_summary.json")
         composition = _read_json(report_dir / "composition.json")
         metrics = _cohort_metrics(summary, composition)
-        if not metrics["method_a_awards"]:
+        n = metrics["method_a_awards"]
+        if not n:
             raise RuntimeError(
-                f"tech_area_cohort_{area_id}: builder produced an empty cohort (method_a_awards=0)"
+                f"tech_area_cohort_{area_id}: builder produced an empty/invalid cohort "
+                f"(method_a_awards={n!r})"
             )
         metadata = {k: v for k, v in metrics.items() if v is not None}
         metadata["report_dir"] = str(report_dir)
@@ -170,7 +178,7 @@ def _make_cohort_check(area_id: str) -> Any:
         asset=f"tech_area_cohort_{area_id}",
         description="Cohort is non-empty and carries a deficiency_class column.",
     )
-    def _check(context: Any) -> AssetCheckResult:
+    def _check(context) -> AssetCheckResult:
         report_dir = _repo_root() / "data" / "reports" / area_id
         summ_path = report_dir / "overlap_summary.json"
         comp_path = report_dir / "composition.json"
@@ -198,14 +206,10 @@ def _make_cohort_check(area_id: str) -> Any:
     return _check
 
 
-# One asset + one non-empty check per area (explicit module globals so Dagster's
-# load_assets_from_modules / load_asset_checks_from_modules discover them).
-tech_area_cohort_nanotechnology = _make_cohort_asset("nanotechnology")
-tech_area_cohort_quantum_information_science = _make_cohort_asset("quantum_information_science")
-tech_area_cohort_hypersonics = _make_cohort_asset("hypersonics")
-
-tech_area_cohort_nanotechnology_nonempty = _make_cohort_check("nanotechnology")
-tech_area_cohort_quantum_information_science_nonempty = _make_cohort_check(
-    "quantum_information_science"
-)
-tech_area_cohort_hypersonics_nonempty = _make_cohort_check("hypersonics")
+# One asset + one non-empty check per area, generated from TECH_AREAS (single
+# source of truth). Bound to module globals so Dagster's load_assets_from_modules
+# / load_asset_checks_from_modules discover them.
+for _area in TECH_AREAS:
+    globals()[f"tech_area_cohort_{_area}"] = _make_cohort_asset(_area)
+    globals()[f"tech_area_cohort_{_area}_nonempty"] = _make_cohort_check(_area)
+del _area

--- a/sbir_etl/utils/transition_report_paths.py
+++ b/sbir_etl/utils/transition_report_paths.py
@@ -63,6 +63,7 @@ ARTIFACT_STEMS = {
     "overlap_summary": "overlap_summary.json",
     "composition": "composition.json",
     "methodology_stub": "methodology_stub.md",
+    "policy_brief_stub": "policy_brief_stub.md",
 }
 
 # Legacy PR #428 filenames under data/ (nanotech only)

--- a/scripts/data/build_tech_area_cohort.py
+++ b/scripts/data/build_tech_area_cohort.py
@@ -257,6 +257,65 @@ def build_method_b_cohort(
     return cohort
 
 
+def load_cpc_assignees(path: Path) -> dict[str, dict]:
+    """CPC patent-assignee rows keyed by normalized organization name.
+
+    Returns ``{normalized_org: {orgs, patent_ids, grant_dates, filing_dates,
+    subclasses}}``; empty when the extract is absent (absence of data is not
+    absence of activity). Mirrors ``build_nano_cohort.load_b82_assignees``,
+    generalized to any CPC extract path (from ``extract_b82_patents.py``).
+    """
+    by_norm: dict[str, dict] = {}
+    if not path.exists():
+        return by_norm
+    with open(path, newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            norm = _norm_firm(row["assignee_organization"])
+            if not norm:
+                continue
+            rec = by_norm.setdefault(
+                norm,
+                {"orgs": set(), "patent_ids": set(), "grant_dates": [],
+                 "filing_dates": [], "subclasses": set()},
+            )
+            rec["orgs"].add(row["assignee_organization"])
+            rec["patent_ids"].add(row["patent_id"])
+            if row.get("grant_date"):
+                rec["grant_dates"].append(row["grant_date"])
+            if row.get("filing_date"):
+                rec["filing_dates"].append(row["filing_date"])
+            rec["subclasses"].update(s for s in (row.get("cpc_subclasses") or "").split("|") if s)
+    return by_norm
+
+
+def build_cpc_cohort(awards: list[dict], cpc_csv: Path) -> list[dict]:
+    """Method C: CPC-classified patent assignees matched to Phase II firm names.
+
+    Exact normalized-name match (same rule as ``build_nano_cohort.py``). Returns
+    ``[]`` when the CPC extract is absent. The emitted columns keep the historical
+    ``b82`` labels (``cpc_first_b82_grant`` / ``cpc_first_b82_filing`` /
+    ``cpc_b82_patent_count``) for backward compatibility with the dark-majority
+    consumers (capture-recapture, figure verification) regardless of area.
+    """
+    cpc = load_cpc_assignees(cpc_csv)
+    if not cpc:
+        return []
+    cohort = []
+    for aw in awards:
+        rec = cpc.get(_norm_firm(aw.get("company", "")))
+        if not rec:
+            continue
+        r = dict(aw)
+        r["cohort_cpc"] = True
+        r["cpc_matched_assignees"] = "|".join(sorted(rec["orgs"])[:3])
+        r["cpc_b82_patent_count"] = len(rec["patent_ids"])
+        r["cpc_first_b82_grant"] = min(rec["grant_dates"]) if rec["grant_dates"] else ""
+        r["cpc_first_b82_filing"] = min(rec["filing_dates"]) if rec["filing_dates"] else ""
+        r["cpc_subclasses"] = "|".join(sorted(rec["subclasses"]))
+        cohort.append(r)
+    return cohort
+
+
 def overlap_stats(a_ids: set[str], b_ids: set[str]) -> dict:
     inter = a_ids & b_ids
     union = a_ids | b_ids
@@ -855,6 +914,22 @@ def main() -> int:
     cet_cohort = build_method_b_cohort(awards, compiled_b, src_b)
     print(f"  {len(cet_cohort):,} awards matched")
 
+    # Method C (optional): CPC-classified patent assignees matched to firms.
+    # Configured per area via `cpc_patents_csv` (output of extract_b82_patents.py
+    # run for the area's `cpc_prefixes`, e.g. B82 for nanotech, G06N10 for QIS).
+    cpc_csv_cfg = cfg.get("cpc_patents_csv")
+    cpc_cohort: list[dict] = []
+    cpc_csv_path: Path | None = None
+    if cpc_csv_cfg:
+        cpc_csv_path = Path(cpc_csv_cfg)
+        if not cpc_csv_path.is_absolute():
+            cpc_csv_path = REPO / cpc_csv_path
+        cpc_cohort = build_cpc_cohort(awards, cpc_csv_path)
+        if cpc_cohort:
+            print(f"Method C (CPC): {len(cpc_cohort):,} awards matched from {cpc_csv_path.name}")
+        else:
+            print(f"Method C (CPC): extract absent ({cpc_csv_path}) — cohort_cpc empty")
+
     ext_ref_a = external_reference_reconciliation(kw_cohort, cfg)
     ext_ref_b = external_reference_reconciliation(cet_cohort, cfg)
     if ext_ref_a:
@@ -867,6 +942,17 @@ def main() -> int:
     a_ids = {r["award_id"] for r in kw_cohort if r.get("award_id")}
     b_ids = {r["award_id"] for r in cet_cohort if r.get("award_id")}
     stats = overlap_stats(a_ids, b_ids)
+
+    c_ids = {r["award_id"] for r in cpc_cohort if r.get("award_id")}
+    method_c = None
+    if cpc_csv_cfg:
+        method_c = {
+            "method_c_n": len(c_ids),
+            "a_intersect_c": len(a_ids & c_ids),
+            "b_intersect_c": len(b_ids & c_ids),
+            "cpc_extract": str(cpc_csv_path),
+            "extract_present": bool(cpc_csv_path and cpc_csv_path.exists()),
+        }
     if stats["jaccard"] is not None and stats["containment_a_in_b"] is not None:
         print(
             f"Overlap: ∩={stats['intersection_n']:,}  "
@@ -915,6 +1001,8 @@ def main() -> int:
     paths.ensure_dirs()
     write_csv(enriched, paths.artifact("cohort_keyword"))
     write_csv(cet_cohort, paths.artifact("cohort_cet"))
+    if cpc_csv_cfg:
+        write_csv(cpc_cohort, paths.artifact("cohort_cpc"))
 
     composition = aggregate_composition(enriched)
     paths.artifact("composition").write_text(
@@ -935,6 +1023,7 @@ def main() -> int:
         "method_a_source": src_a,
         "method_b_source": src_b,
         "overlap": stats,
+        "method_c": method_c,
         "signals_absent": absent,
         "channels": channel_summary,
         "spotcheck": spot,

--- a/scripts/data/build_tech_area_cohort.py
+++ b/scripts/data/build_tech_area_cohort.py
@@ -554,6 +554,119 @@ def write_methodology_stub(
     out.write_text("\n".join(lines), encoding="utf-8")
 
 
+def render_policy_brief_stub(cfg: dict, summary: dict, composition: dict) -> str:
+    """Render a policy-leader-facing brief SCAFFOLD from cohort aggregates (T20).
+
+    Auto-generated skeleton per ``publication-format.md``: the headline table and
+    channel-status rows are derived from ``overlap_summary.json`` +
+    ``composition.json``; findings / takeaways / language sections are left as
+    TODO placeholders for a human or agent to complete. Never invents channel
+    rates — absent signal artifacts are reported as "Not computed", not zero.
+    """
+
+    def _n(v: object) -> str:
+        if v is None:
+            return "n/a"
+        return f"{v:,}" if isinstance(v, int) else str(v)
+
+    display = cfg.get("display_name") or cfg.get("area_id") or "Technology"
+    audience = cfg.get("audience") or "S&T policy leaders"
+    overlap = summary.get("overlap") or {}
+    totals = composition.get("totals") or {}
+    by_agency = composition.get("by_agency") or {}
+    program = composition.get("program_split") or {}
+    censoring = composition.get("censoring") or {}
+    ent = composition.get("entity_resolution") or {}
+    n_awards = composition.get("n_unique_awards") or 0
+
+    dollars = totals.get("phase2_dollars_m")
+    dollars_s = "n/a" if dollars is None else f"${dollars:,}M"
+    jaccard = overlap.get("jaccard")
+    jaccard_s = "n/a" if jaccard is None else f"{jaccard:.3f}"
+    # by_agency values are {"awards": n, ...} dicts already sorted desc by awards
+    # (aggregate_composition); tolerate a plain-int shape too.
+    def _awards(v: object) -> object:
+        return v.get("awards") if isinstance(v, dict) else v
+
+    top_agencies = list(by_agency.items())[:5]
+    agency_mix = ", ".join(f"{a} {_awards(v)}" for a, v in top_agencies) or "n/a"
+
+    lines = [
+        f"# {display} SBIR/STTR Phase II Outcomes: What Policy Leaders Can Safely Conclude",
+        "",
+        f"**Prepared for:** {audience}  ",
+        "**Status:** Provisional; bounded estimates, not final program rates  ",
+        "**Data through:** _TODO: fill explicit input vintages_  ",
+        "**Technical appendix:** `methodology_stub.md` (same directory)",
+        "",
+        "> Auto-generated scaffold from `build_tech_area_cohort.py` "
+        "(`overlap_summary.json` + `composition.json`). The headline table and "
+        "channel-status rows are data-derived; the findings, takeaways, and "
+        "language sections below are **placeholders to complete by hand** — do "
+        "not publish as-is.",
+        "",
+        "## Bottom line",
+        "",
+        "_TODO: one paragraph — what this cohort is, and what it is not._",
+        "",
+        "| Measure | Result | How to use it |",
+        "|---|---|---|",
+        f"| Phase II cohort (Method A keyword) | {_n(n_awards)} awards | "
+        "Cohort scope — not a transition count |",
+        f"| Unique firms | {_n(totals.get('unique_firms'))} | Firm-level denominator |",
+        f"| Phase II obligations | {dollars_s} | Federal R&D investment in scope |",
+        f"| Program split | {_n(program.get('SBIR'))} SBIR / {_n(program.get('STTR'))} STTR "
+        f"({_n(program.get('sttr_pct'))}% STTR) | Program-mix context |",
+        f"| Agency mix (top 5 by awards) | {agency_mix} | Funder concentration |",
+        f"| Method A∩B overlap | {_n(overlap.get('intersection_n'))} (Jaccard {jaccard_s}) | "
+        "Triangulation across cohort definitions |",
+        f"| Recency (post-{_n(censoring.get('censor_year'))}) | "
+        f"{_n(censoring.get('censored_awards'))} censored / {_n(censoring.get('mature_awards'))} "
+        "mature | Outcomes still developing for recent awards |",
+        f"| Entity-resolution gap | {_n(ent.get('no_uei_awards'))} awards without UEI "
+        f"({_n(ent.get('no_uei_pct'))}%) | Lower-bound caveat on firm-level joins |",
+        "",
+        "## Channel status",
+        "",
+    ]
+
+    signals_absent = summary.get("signals_absent") or []
+    if signals_absent:
+        lines += [
+            "Transition-signal artifacts absent this run — **Not computed (not zero).** "
+            "Each requires the next pipeline step before any rate claim:",
+            "",
+            "| Channel artifact | Status |",
+            "|---|---|",
+            *[f"| `{s}` | Not computed — not zero |" for s in signals_absent],
+            "",
+        ]
+    else:
+        lines += ["All expected transition-signal artifacts were present this run.", ""]
+
+    lines += [
+        "## Findings",
+        "",
+        "_TODO: one Fact block + Policy interpretation per evidence channel "
+        "(procurement, private capital, acquisition, patents, subawards — as "
+        "available). Lead with counts; keep methodology in the appendix._",
+        "",
+        "## What policy leaders should take away",
+        "",
+        "_TODO: 5–8 imperative, actionable items for agency reporting standards._",
+        "",
+        "## Language to avoid",
+        "",
+        "| Avoid | Use instead |",
+        "|---|---|",
+        '| "transition rate" | "observable evidence from channel X" |',
+        '| "did not commercialize" | "remain indeterminate after recovery checks applied" |',
+        '| "patents prove commercialization" | "commercialization-adjacent evidence" |',
+        "",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def signal_paths() -> dict[str, Path]:
     return {
         "prospect_digest": DATA / "processed" / "sbir_phase3" / "fy25_phase3_prospect_digest.csv",
@@ -839,6 +952,9 @@ def main() -> int:
     write_methodology_stub(
         cfg, paths.artifact("methodology_stub"), stats, absent, channel_summary,
         external_reference=summary["external_reference"],
+    )
+    paths.artifact("policy_brief_stub").write_text(
+        render_policy_brief_stub(cfg, summary, composition), encoding="utf-8"
     )
     print(f"Wrote {paths.report_dir}/")
     return 0

--- a/scripts/data/extract_b82_patents.py
+++ b/scripts/data/extract_b82_patents.py
@@ -1,15 +1,20 @@
 #!/usr/bin/env python3
 """
-Extract USPTO CPC B82Y/B82B (nanotechnology) patents with assignees and dates.
+Extract USPTO CPC patents with assignees and dates, filtered to a CPC range.
 
-Streams the PatentsView PVGPATDIS zip archives without extracting them,
-filters ~60M CPC rows to the B82 subclasses, and joins assignee organizations
-and grant dates for the matched patents. Output feeds Method C of the
-nanotech cohort analysis (build_nano_cohort.py).
+Streams the PatentsView PVGPATDIS zip archives without extracting them, filters
+~60M CPC rows to the requested CPC prefixes, and joins assignee organizations
+and grant dates for the matched patents. Output feeds Method C of the tech-area
+cohort analysis (build_tech_area_cohort.py).
 
-CPC scope:
-  B82B — nanostructures formed by manipulation of individual atoms/molecules
-  B82Y — specific uses or applications of nanostructures
+Defaults reproduce the original nanotech B82 extract exactly (subclass field,
+``B82`` prefix, ``b82_patents.csv``). Other tech areas parameterize the CPC
+range — e.g. quantum information science (G06N10, a CPC *group* rather than a
+subclass) via ``--cpc-field cpc_group --cpc-prefixes G06N10``.
+
+CPC prefix levels:
+  B82B / B82Y — nanostructures + their applications (matched at the subclass level)
+  G06N10      — quantum computing (matched at the group level, cpc_group column)
 
 Inputs (download via: python scripts/data/download_uspto.py --dataset patentsview
         --table {cpc,assignee,patent,application} --local data/raw/uspto/patentsview):
@@ -19,12 +24,16 @@ Inputs (download via: python scripts/data/download_uspto.py --dataset patentsvie
   data/raw/uspto/patentsview/g_application.tsv.zip   — filing dates (capability-vs-outcome timing)
 
 Outputs:
-  data/processed/uspto/b82_patents.csv — one row per (patent, org assignee)
+  <--out> (default data/processed/uspto/b82_patents.csv) — one row per (patent, org assignee)
 
 Usage:
-  python scripts/data/extract_b82_patents.py
+  python scripts/data/extract_b82_patents.py            # nanotech B82 (default)
+  python scripts/data/extract_b82_patents.py \\
+      --cpc-field cpc_group --cpc-prefixes G06N10 \\
+      --out data/processed/uspto/g06n10_patents.csv     # quantum G06N10
 """
 
+import argparse
 import csv
 import io
 import sys
@@ -36,7 +45,10 @@ REPO = Path(__file__).resolve().parents[2]
 RAW = REPO / "data/raw/uspto/patentsview"
 OUT_CSV = REPO / "data/processed/uspto/b82_patents.csv"
 
-B82_SUBCLASS_PREFIX = "B82"
+
+def cpc_matches(symbol: str, prefixes: tuple[str, ...]) -> bool:
+    """True if the CPC symbol starts with any requested prefix."""
+    return any(symbol.startswith(p) for p in prefixes)
 
 
 def tsv_rows(zip_path: Path):
@@ -51,32 +63,54 @@ def tsv_rows(zip_path: Path):
             yield idx, row
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cpc-prefixes", nargs="+", default=["B82"],
+        help="CPC symbol prefixes to keep (default: B82 = nanotech B82B/B82Y)",
+    )
+    parser.add_argument(
+        "--cpc-field", default="cpc_subclass",
+        help="g_cpc_current column to prefix-match (default: cpc_subclass; "
+             "use cpc_group for group-level ranges like G06N10)",
+    )
+    parser.add_argument(
+        "--out", type=Path, default=OUT_CSV,
+        help=f"Output CSV path (default: {OUT_CSV})",
+    )
+    parser.add_argument(
+        "--raw", type=Path, default=RAW,
+        help=f"PatentsView raw dir (default: {RAW})",
+    )
+    args = parser.parse_args(argv)
+    prefixes = tuple(args.cpc_prefixes)
+    label = "/".join(prefixes)
+
     required = {
-        "cpc": RAW / "g_cpc_current.tsv.zip",
-        "assignee": RAW / "g_assignee_disambiguated.tsv.zip",
-        "patent": RAW / "g_patent.tsv.zip",
-        "application": RAW / "g_application.tsv.zip",
+        "cpc": args.raw / "g_cpc_current.tsv.zip",
+        "assignee": args.raw / "g_assignee_disambiguated.tsv.zip",
+        "patent": args.raw / "g_patent.tsv.zip",
+        "application": args.raw / "g_application.tsv.zip",
     }
     for table, p in required.items():
         if not p.exists():
             print(
                 f"ERROR: {p} not found — run scripts/data/download_uspto.py "
-                f"--dataset patentsview --table {table} --local {RAW}",
+                f"--dataset patentsview --table {table} --local {args.raw}",
                 file=sys.stderr,
             )
             return 1
 
-    print("Pass 1/4: scanning g_cpc_current for B82 subclasses...")
+    print(f"Pass 1/4: scanning g_cpc_current[{args.cpc_field}] for {label}...")
     subclasses: dict[str, set[str]] = defaultdict(set)
     rows_seen = 0
     for idx, row in tsv_rows(required["cpc"]):
         rows_seen += 1
-        sub = row[idx["cpc_subclass"]]
-        if sub.startswith(B82_SUBCLASS_PREFIX):
+        sub = row[idx[args.cpc_field]]
+        if cpc_matches(sub, prefixes):
             subclasses[row[idx["patent_id"]]].add(sub)
     b82_ids = set(subclasses)
-    print(f"  {rows_seen:,} CPC rows scanned; {len(b82_ids):,} unique B82 patents")
+    print(f"  {rows_seen:,} CPC rows scanned; {len(b82_ids):,} unique {label} patents")
 
     print("Pass 2/4: joining assignee organizations...")
     org_rows: dict[str, list[tuple[str, str]]] = defaultdict(list)  # patent_id → [(org, type)]
@@ -100,7 +134,7 @@ def main() -> int:
         pid = row[idx["patent_id"]]
         if pid in b82_ids:
             meta[pid] = (row[idx["patent_date"]], row[idx["patent_title"]][:120])
-    print(f"  {len(meta):,} B82 patents matched in g_patent")
+    print(f"  {len(meta):,} {label} patents matched in g_patent")
 
     print("Pass 4/4: joining filing dates...")
     filing: dict[str, str] = {}
@@ -111,11 +145,11 @@ def main() -> int:
             # g_application contains typo'd dates (e.g. year 1074); keep plausible only
             if len(fd) == 10 and "1900" <= fd[:4] <= "2030":
                 filing[pid] = fd
-    print(f"  {len(filing):,} B82 patents with plausible filing dates")
+    print(f"  {len(filing):,} {label} patents with plausible filing dates")
 
-    OUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
     n_out = 0
-    with open(OUT_CSV, "w", newline="", encoding="utf-8") as f:
+    with open(args.out, "w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
         w.writerow(
             ["patent_id", "grant_date", "filing_date", "assignee_organization", "assignee_type",
@@ -129,14 +163,14 @@ def main() -> int:
                      "|".join(sorted(subclasses[pid])), title]
                 )
                 n_out += 1
-    print(f"  Written: {OUT_CSV} ({n_out:,} patent-assignee rows)")
+    print(f"  Written: {args.out} ({n_out:,} patent-assignee rows)")
 
     unique_orgs = {org.upper() for rows in org_rows.values() for org, _ in rows}
     print()
     print("=" * 60)
-    print("B82 EXTRACTION SUMMARY")
+    print(f"{label} CPC EXTRACTION SUMMARY")
     print("=" * 60)
-    print(f"Unique B82 patents:                  {len(b82_ids):,}")
+    print(f"Unique {label} patents:              {len(b82_ids):,}")
     print(f"  with organization assignee:        {len(org_rows):,}")
     print(f"  individual-only / unassigned:      {len(individual_only):,}")
     print(f"Unique assignee organizations:       {len(unique_orgs):,}")

--- a/specs/tech-area-transition-report/tasks.md
+++ b/specs/tech-area-transition-report/tasks.md
@@ -83,5 +83,10 @@
 - [ ] T19 When digest / Form D / M&A exist: extend Q/H policy-brief headline tables with
       channel rows (`Measure | Result | How to use it`) + Policy interpretation blocks;
       hypersonics prioritizes WS1 + WS5a over Form D; quantum keeps small-N caveats
-- [ ] T20 Optional: `build_tech_area_cohort.py` emits `policy_brief_stub.md` from
-      `overlap_summary.json` + agency aggregates
+- [x] T20 `build_tech_area_cohort.py` emits `policy_brief_stub.md` from
+      `overlap_summary.json` + agency aggregates — pure `render_policy_brief_stub`
+      builds a policy-leader scaffold (headline table from composition, agency
+      mix, program split, recency, overlap; per-signal "Not computed — not zero"
+      channel-status rows; findings/takeaways/language left as TODO placeholders,
+      never fabricating channel rates). New `policy_brief_stub` ReportPaths stem;
+      unit-tested (signals absent/present + missing-block tolerance).

--- a/specs/tech-area-transition-report/tasks.md
+++ b/specs/tech-area-transition-report/tasks.md
@@ -71,7 +71,22 @@
       `build_nano_cohort.py` intentionally NOT migrated — it is the legacy v0
       cohort builder that `build_tech_area_cohort.py` replaces; migrating it would
       create two builders both writing the area cohort.
-- [ ] T8 Optional Method C for quantum (`G06N10`) once CPC extract is generalized
+- [x] T8 Method C for quantum (`G06N10`) — generalized the CPC extract + wired
+      Method C into `build_tech_area_cohort.py`.
+      - `extract_b82_patents.py` parameterized: `--cpc-prefixes` / `--cpc-field`
+        / `--out` (defaults reproduce the nanotech B82 extract exactly). Quantum
+        uses `--cpc-field cpc_group --cpc-prefixes G06N10` (G06N10 is a CPC group,
+        not a subclass).
+      - `build_cpc_cohort` / `load_cpc_assignees` ported from `build_nano_cohort`,
+        area-gated on a `cpc_patents_csv` config field; emits `cohort_cpc.csv`
+        (keeping the legacy `cpc_first_b82_*` column names for capture-recapture /
+        figure-verification compat) + a `method_c` block (size, A∩C, B∩C) in
+        `overlap_summary.json`. Absent extract → empty cohort, no side effects.
+      - Config: nanotech `cpc_patents_csv: …/b82_patents.csv`; quantum
+        `cpc_prefixes: [G06N10]` + `…/g06n10_patents.csv`; hypersonics unset.
+      - Unit-tested (CPC prefix predicate for B82 subclass vs G06N10 group;
+        Method-C assignee matching + absent-extract). Note: can't run the
+        extractor end-to-end here (needs the ~60M-row PatentsView CPC dump).
 - [x] T9 Dagster asset wrapper (CLI now stable across the 3 areas + cutover done)
       — `packages/sbir-analytics/sbir_analytics/assets/transition_report.py`: one
       `tech_area_cohort_<area>` asset + non-empty check per area (group

--- a/specs/tech-area-transition-report/tasks.md
+++ b/specs/tech-area-transition-report/tasks.md
@@ -72,7 +72,14 @@
       cohort builder that `build_tech_area_cohort.py` replaces; migrating it would
       create two builders both writing the area cohort.
 - [ ] T8 Optional Method C for quantum (`G06N10`) once CPC extract is generalized
-- [ ] T9 Dagster asset wrapper (only after CLI is stable across ≥3 areas)
+- [x] T9 Dagster asset wrapper (CLI now stable across the 3 areas + cutover done)
+      — `packages/sbir-analytics/sbir_analytics/assets/transition_report.py`: one
+      `tech_area_cohort_<area>` asset + non-empty check per area (group
+      `transition_reports`), auto-discovered by `load_assets_from_modules`. Each
+      asset shells out to `build_tech_area_cohort.py` (the bit-exact-verified
+      builder, left untouched) and surfaces cohort metrics from
+      `overlap_summary.json` + `composition.json` as Dagster metadata. Pure
+      `_cohort_metrics` helper unit-tested; module carries a Dagster import shim.
 - [ ] T19 When digest / Form D / M&A exist: extend Q/H policy-brief headline tables with
       channel rows (`Measure | Result | How to use it`) + Policy interpretation blocks;
       hypersonics prioritizes WS1 + WS5a over Form D; quantum keeps small-N caveats

--- a/tests/unit/assets/test_transition_report_assets.py
+++ b/tests/unit/assets/test_transition_report_assets.py
@@ -1,0 +1,83 @@
+"""Unit tests for the tech-area transition-report Dagster assets (spec T9).
+
+The asset module carries a Dagster import shim, so it imports even without
+Dagster installed. We load it by file path to test its pure helper
+(`_cohort_metrics`) and confirm the per-area asset/check factory wired up all
+three areas — no Dagster runtime required.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[3]
+MODULE_PATH = (
+    REPO / "packages" / "sbir-analytics" / "sbir_analytics" / "assets" / "transition_report.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("_transition_report_asset", MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+def test_cohort_metrics_flattens_summary_and_composition(mod):
+    summary = {
+        "area_id": "quantum_information_science",
+        "phase2_universe": 40000,
+        "method_a_source": "keyword_pack",
+        "method_b_source": "taxonomy",
+        "overlap": {"method_b_n": 512, "intersection_n": 88, "jaccard": 0.123},
+        "signals_absent": ["form_d", "ma_signal"],
+        "has_deficiency_class": True,
+    }
+    composition = {
+        "n_unique_awards": 640,
+        "totals": {"phase2_dollars_m": 512.4, "unique_firms": 410},
+        "by_agency": {"DoD": 300, "NSF": 200, "DOE": 140},
+    }
+    m = mod._cohort_metrics(summary, composition)
+    assert m["area_id"] == "quantum_information_science"
+    assert m["method_a_awards"] == 640
+    assert m["method_b_awards"] == 512
+    assert m["intersection"] == 88
+    assert m["jaccard"] == 0.123
+    assert m["phase2_dollars_m"] == 512.4
+    assert m["unique_firms"] == 410
+    assert m["agencies"] == 3
+    assert m["signals_absent"] == 2
+    assert m["has_deficiency_class"] is True
+
+
+def test_cohort_metrics_tolerates_missing_blocks(mod):
+    # Missing overlap / totals / by_agency must not raise; scalars degrade to None/0.
+    m = mod._cohort_metrics({"area_id": "hypersonics"}, {"n_unique_awards": 0})
+    assert m["area_id"] == "hypersonics"
+    assert m["method_a_awards"] == 0
+    assert m["method_b_awards"] is None
+    assert m["jaccard"] is None
+    assert m["agencies"] == 0
+    assert m["signals_absent"] == 0
+    assert m["has_deficiency_class"] is False
+
+
+def test_repo_root_resolves_to_the_builder(mod):
+    root = mod._repo_root()
+    assert (root / "scripts" / "data" / "build_tech_area_cohort.py").exists()
+
+
+def test_factory_wired_all_three_areas(mod):
+    for area in mod.TECH_AREAS:
+        assert hasattr(mod, f"tech_area_cohort_{area}")
+        assert hasattr(mod, f"tech_area_cohort_{area}_nonempty")

--- a/tests/unit/scripts/test_build_tech_area_cohort.py
+++ b/tests/unit/scripts/test_build_tech_area_cohort.py
@@ -359,3 +359,65 @@ def test_aggregate_composition_agency_sorted_desc():
     comp = mod.aggregate_composition(_fixture_cohort())
     counts = [v["awards"] for v in comp["by_agency"].values()]
     assert counts == sorted(counts, reverse=True)
+
+
+# --- T20: policy_brief_stub emitter --------------------------------------------
+
+_CFG = {"area_id": "hypersonics", "display_name": "Hypersonics", "audience": "NSC staff"}
+
+
+def _summary(signals_absent):
+    return {
+        "area_id": "hypersonics",
+        "display_name": "Hypersonics",
+        "overlap": {"intersection_n": 12, "jaccard": 0.34, "method_b_n": 40},
+        "signals_absent": signals_absent,
+    }
+
+
+def _composition():
+    return {
+        "n_unique_awards": 300,
+        "totals": {"awards": 300, "phase2_dollars_m": 512.4, "unique_firms": 210},
+        "by_agency": {  # already sorted desc by awards (aggregate_composition shape)
+            "DoD": {"awards": 250, "phase2_dollars_m": 400.0, "unique_firms": 180},
+            "NASA": {"awards": 50, "phase2_dollars_m": 112.4, "unique_firms": 30},
+        },
+        "program_split": {"SBIR": 270, "STTR": 30, "sttr_pct": 10.0},
+        "censoring": {"censor_year": 2023, "mature_awards": 240, "censored_awards": 60},
+        "entity_resolution": {"no_uei_awards": 15, "no_uei_pct": 5.0},
+    }
+
+
+def test_policy_brief_stub_signals_absent_reports_not_computed():
+    md = mod.render_policy_brief_stub(
+        _CFG, _summary(["form_d_post_phase2", "ma_signal"]), _composition()
+    )
+    # Title + audience + provisional status from publication-format.md
+    assert md.startswith("# Hypersonics SBIR/STTR Phase II Outcomes")
+    assert "**Prepared for:** NSC staff" in md
+    assert "Provisional" in md
+    # Data-derived headline table
+    assert "| Phase II cohort (Method A keyword) | 300 awards |" in md
+    assert "DoD 250, NASA 50" in md
+    assert "$512.4M" in md
+    assert "Jaccard 0.340" in md
+    # Absent signals are Not computed — never zero
+    assert "`form_d_post_phase2` | Not computed — not zero" in md
+    assert "`ma_signal` | Not computed — not zero" in md
+    # Scaffold placeholders present, not published as-is
+    assert "_TODO" in md
+    assert "do not publish as-is" in md
+
+
+def test_policy_brief_stub_signals_present():
+    md = mod.render_policy_brief_stub(_CFG, _summary([]), _composition())
+    assert "All expected transition-signal artifacts were present this run." in md
+    assert "Not computed" not in md
+
+
+def test_policy_brief_stub_tolerates_missing_blocks():
+    # Minimal summary/composition must not raise; scalars degrade to n/a.
+    md = mod.render_policy_brief_stub({"area_id": "x"}, {"signals_absent": []}, {})
+    assert md.startswith("# x SBIR/STTR Phase II Outcomes")
+    assert "n/a" in md

--- a/tests/unit/scripts/test_build_tech_area_cohort.py
+++ b/tests/unit/scripts/test_build_tech_area_cohort.py
@@ -421,3 +421,56 @@ def test_policy_brief_stub_tolerates_missing_blocks():
     md = mod.render_policy_brief_stub({"area_id": "x"}, {"signals_absent": []}, {})
     assert md.startswith("# x SBIR/STTR Phase II Outcomes")
     assert "n/a" in md
+
+
+# --- T8: Method C (CPC patent-assignee) cohort ---------------------------------
+
+_CPC_HEADER = [
+    "patent_id",
+    "grant_date",
+    "filing_date",
+    "assignee_organization",
+    "assignee_type",
+    "cpc_subclasses",
+    "patent_title",
+]
+
+
+def _write_cpc_csv(path, rows):
+    import csv as _csv
+
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = _csv.writer(f)
+        w.writerow(_CPC_HEADER)
+        w.writerows(rows)
+
+
+def test_build_cpc_cohort_matches_by_normalized_assignee(tmp_path):
+    cpc = tmp_path / "g06n10_patents.csv"
+    _write_cpc_csv(
+        cpc,
+        [
+            ["11", "2021-03-01", "2019-06-01", "Acme Quantum LLC", "2", "G06N10/00", "Qubit"],
+            ["12", "2022-05-01", "2020-01-01", "Acme Quantum LLC", "2", "G06N10/40", "Gate"],
+            ["13", "2020-01-01", "2018-01-01", "Unrelated Corp", "2", "G06N10/00", "Other"],
+        ],
+    )
+    awards = [
+        {"award_id": "A1", "company": "Acme Quantum Inc"},  # normalizes to match
+        {"award_id": "A2", "company": "Nobody Systems"},  # no patent
+    ]
+    cohort = mod.build_cpc_cohort(awards, cpc)
+    assert [r["award_id"] for r in cohort] == ["A1"]
+    r = cohort[0]
+    assert r["cohort_cpc"] is True
+    assert r["cpc_b82_patent_count"] == 2  # legacy column name kept for compat
+    assert r["cpc_first_b82_grant"] == "2021-03-01"
+    assert r["cpc_first_b82_filing"] == "2019-06-01"
+    assert "G06N10/00" in r["cpc_subclasses"] and "G06N10/40" in r["cpc_subclasses"]
+
+
+def test_build_cpc_cohort_absent_extract_returns_empty(tmp_path):
+    # Absence of the extract is not absence of activity — empty, no side effects.
+    assert (
+        mod.build_cpc_cohort([{"award_id": "A1", "company": "X"}], tmp_path / "missing.csv") == []
+    )

--- a/tests/unit/scripts/test_extract_cpc_patents.py
+++ b/tests/unit/scripts/test_extract_cpc_patents.py
@@ -1,0 +1,49 @@
+"""Unit tests for the generalized CPC patent extractor (T8).
+
+The extractor is data-heavy (streams ~60M PatentsView CPC rows), so we cover its
+one generalization-critical pure function — the CPC prefix predicate that lets it
+serve nanotech (B82 subclass) and quantum (G06N10 group) from the same code.
+"""
+
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "data" / "extract_b82_patents.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("extract_b82_patents", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_script()
+
+
+def test_cpc_matches_b82_subclass_default():
+    # Nanotech default: B82 prefix over the cpc_subclass field.
+    assert mod.cpc_matches("B82Y", ("B82",))
+    assert mod.cpc_matches("B82B", ("B82",))
+    assert not mod.cpc_matches("G06N", ("B82",))
+
+
+def test_cpc_matches_g06n10_group():
+    # Quantum: G06N10 is a CPC group, matched over the cpc_group field
+    # (e.g. "G06N10/00"); the narrower prefix must not catch sibling G06N groups.
+    assert mod.cpc_matches("G06N10/00", ("G06N10",))
+    assert mod.cpc_matches("G06N10/40", ("G06N10",))
+    assert not mod.cpc_matches("G06N3/00", ("G06N10",))  # neural nets, not QIS
+    assert not mod.cpc_matches("G06N20/00", ("G06N10",))
+
+
+def test_cpc_matches_multiple_prefixes():
+    assert mod.cpc_matches("B82Y", ("B82Y", "B82B"))
+    assert not mod.cpc_matches("H01L", ("B82Y", "B82B"))
+
+
+def test_extractor_defaults_are_backward_compatible():
+    # Sanity: the module still targets the nanotech B82 output by default so an
+    # unflagged run reproduces the original extract.
+    assert mod.OUT_CSV.name == "b82_patents.csv"


### PR DESCRIPTION
## Description

The three actionable Phase 2 follow-ups from `specs/tech-area-transition-report`, all unblocked now that the CLI is stable across the 3 areas and the nanotech cutover landed. (The only items left after this — T19 policy-brief channel rows — are blocked on Q/H signal artifacts that don't exist yet.)

### T9 — Dagster asset wrapper
`packages/sbir-analytics/sbir_analytics/assets/transition_report.py`: one `tech_area_cohort_<area>` asset + one non-empty asset-check per area (generated from a `TECH_AREAS` tuple, auto-discovered). Each asset shells out to `build_tech_area_cohort.py` via `sys.executable` (builder untouched) and surfaces cohort metrics from `overlap_summary.json` + `composition.json` as Dagster metadata. Verified: `Definitions` loads the 3 assets + 3 checks (98→101, 43→46).

### T20 — policy_brief_stub emitter
`build_tech_area_cohort.py` writes a policy-leader scaffold alongside the technical `methodology_stub`. `render_policy_brief_stub()` (pure, tested) builds the header + a data-derived headline table + a **Channel status** section marking each absent signal "Not computed — not zero" (never a fabricated rate); findings/takeaways/language are TODO placeholders. New `policy_brief_stub` stem.

### T8 — CPC Method C for quantum (G06N10)
- **Generalized `extract_b82_patents.py`**: `--cpc-prefixes` / `--cpc-field` / `--out`. Defaults reproduce the nanotech B82 extract exactly; quantum uses `--cpc-field cpc_group --cpc-prefixes G06N10` (G06N10 is a CPC *group*, not a subclass — the key subtlety).
- **Method C in the builder**: `build_cpc_cohort` / `load_cpc_assignees` ported from `build_nano_cohort` (exact normalized assignee↔firm match), gated on a `cpc_patents_csv` config field. Emits `cohort_cpc.csv` + a `method_c` block (size, A∩C, B∩C) in `overlap_summary.json`. **Keeps the legacy `cpc_first_b82_*` column names** so the dark-majority consumers (capture-recapture, figure verification) keep working for every area. Method A/B paths untouched (parity preserved).
- Config: nanotech → `b82_patents.csv`; quantum → `[G06N10]` + `g06n10_patents.csv`; hypersonics unset.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (spec `tasks.md`)

## Testing

- [x] Unit tests added — asset metrics/factory (4); policy-brief-stub cases (3); Method-C assignee matching + CPC prefix predicate for B82-subclass vs G06N10-group incl. sibling-group exclusion (6).
- [x] **Root-caused and fixed the earlier CI failure**: Dagster rejects an `Any` annotation on the asset `context` param, which made `_safe_import` skip the module. Fixed (unannotated `context`); verified with the full stack that assets register and tests pass with and without Dagster.
- [x] `ruff check` + `ruff format --check` + `mypy` clean on the in-scope files.
- Note: the CPC extractor can't be run end-to-end here (needs the ~60M-row PatentsView CPC dump); its generalization is covered by the prefix-predicate tests, and Method C matching is covered against fixtures.

## Review comments

All four Copilot comments from the first review addressed and resolved (shlex.join logging, stderr on success + both tails in errors, empty-cohort actual value, globals generated from `TECH_AREAS`).

## Checklist

- [x] Follows project style (cet/fiscal asset conventions + shim; ported Method C matches the legacy builder exactly)
- [x] Self-reviewed
- [x] Documentation updated (spec `tasks.md`: T9 + T20 + T8 marked done)
- [x] No new warnings — ruff/format/mypy clean on in-scope files
- [x] New and existing unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)