### PR TITLE
feat(tech-census): generalize drone-manufacturing analysis into a reusable, config-driven engine

### DIFF
--- a/config/tech_census/drone_manufacturing.yaml
+++ b/config/tech_census/drone_manufacturing.yaml
@@ -1,0 +1,127 @@
+area_id: drone_manufacturing
+display_name: Drone Manufacturing
+description: >-
+  Aerial unmanned systems (UAS/UAV) and purpose-built subsystems. "Drone" is
+  read as aerial only -- non-aerial unmanned systems (UGV ground robots,
+  UUV/USV maritime) are tracked separately under adjacent_nonaerial, not
+  included in the main count. Counter-UAS / counter-drone (detect-and-defeat
+  technology) is tracked separately under exclusions -- it is drone defeat,
+  not drone production. All SBIR/STTR phases are in scope (this is a
+  technology-relevance census, not a Phase II cohort for transition
+  analysis).
+
+gate:
+  # A term counts as a hit only if it appears in the award TITLE, or the
+  # TOTAL occurrence count across all gate terms in title+abstract is >= this
+  # value. Counting total occurrences (not distinct pattern names) matters:
+  # several gate patterns overlap on a single phrase (e.g. "unmanned aerial
+  # system" and "unmanned aerial" both match "unmanned aerial systems"), so a
+  # naive distinct-pattern-count rule is satisfiable by one incidental
+  # sentence. Calibrated against real award_data.csv: a hypersonic-
+  # interceptor award, a lunar-battery award, and a weather-forecasting-
+  # software award each had exactly 2 total occurrences from a single
+  # incidental mention; genuinely relevant awards ran well past that.
+  min_abstract_only_occurrences: 3
+  terms:
+    - '\bdrone[s]?\b'
+    - '\bUAV[s]?\b'
+    - '\bUAS\b'
+    - '\bsUAS\b'
+    - '\bunmanned aerial vehicle[s]?\b'
+    - '\bunmanned aerial system[s]?\b'
+    - '\bunmanned aircraft\b'
+    - '\bunmanned aerial\b'
+    - '\bquadcopter[s]?\b'
+    - '\bquadrotor[s]?\b'
+    - '\bhexacopter[s]?\b'
+    - '\bmulti-?rotor[s]?\b'
+    - '\btiltrotor (?:UAS|UAV|drone)\b'
+    - '\bmicro air vehicle[s]?\b'
+    - '\bMAV[s]?\b'
+    - '\bfixed-wing UAS\b'
+    - '\bnano-?drone[s]?\b'
+    - '\bremotely piloted aircraft\b'
+    - '\bloitering munition[s]?\b'
+    - '\bVTOL UAS\b'
+    - '\bUAS VTOL\b'
+
+# Gate-passing awards that represent an adjacent-but-distinct concept.
+# Tracked and reported separately, never silently dropped or merged into the
+# main count.
+exclusions:
+  - name: counter_uas
+    display_name: Counter-UAS / Counter-Drone
+    reason: Detect-and-defeat technology -- the opposite of manufacturing.
+    terms:
+      - '\bcounter-?UAS\b'
+      - '\bcUAS\b'
+      - '\bcounter-?drone[s]?\b'
+
+# Non-aerial unmanned systems that never reach the gate but are worth
+# tracking for context (not aerial drones, so not "drone manufacturing").
+adjacent_nonaerial:
+  - name: ugv
+    display_name: Unmanned Ground Vehicles
+    terms:
+      - '\bUGV[s]?\b'
+      - '\bunmanned ground vehicle[s]?\b'
+  - name: uuv
+    display_name: Unmanned Underwater Vehicles
+    terms:
+      - '\bUUV[s]?\b'
+      - '\bunmanned underwater vehicle[s]?\b'
+  - name: usv
+    display_name: Unmanned Surface Vehicles
+    terms:
+      - '\bUSV[s]?\b'
+      - '\bunmanned surface vehicle[s]?\b'
+
+# Priority-ordered technology subsets (most specific first). Each gate-
+# passing, non-excluded award gets exactly one subset via first match;
+# anything matching none of these falls into fallback_subset.
+subsets:
+  - name: Manufacturing Processes & Materials
+    terms:
+      - '\badditive manufactur\w*\b'
+      - '\b3D[- ]print\w*\b'
+      - '\brapid prototyp\w*\b'
+      - '\bcomposite (?:airframe|structure)s?\b'
+      - '\blow-?cost manufactur\w*\b'
+  - name: Propulsion & Power Systems
+    terms:
+      - '\bpropulsion\b'
+      - '\belectric propulsion\b'
+      - '\bhybrid-electric\b'
+      - '\bpropeller[s]?\b'
+      - '\bbattery\b'
+      - '\bbatteries\b'
+      - '\bmotor controller[s]?\b'
+      - '\bsmall (?:gas turbine|engine)[s]?\b'
+      - '\belectric motor[s]?\b'
+  - name: Autonomy, Guidance & Flight Control
+    terms:
+      - '\bautopilot\b'
+      - '\bautonomous flight\b'
+      - '\bswarm(?:ing)?\b'
+      - '\bsense[- ]and[- ]avoid\b'
+      - '\bobstacle avoidance\b'
+      - '\bBVLOS\b'
+      - '\bbeyond visual line of sight\b'
+      - '\bguidance,? navigation,? and control\b'
+      - '\bGNC\b'
+  - name: Sensors & Mission Payloads
+    terms:
+      - '\bgimbal[s]?\b'
+      - '\bpayload[s]?\b'
+      - '\bEO/?IR\b'
+      - '\bISR payload[s]?\b'
+      - '\bLIDAR\b'
+      - '\bLiDAR\b'
+  - name: Communications & Data Links
+    terms:
+      - '\bdata ?link[s]?\b'
+      - '\bcommand and control link[s]?\b'
+      - '\bground control station[s]?\b'
+      - '\banti-jam\b'
+
+fallback_subset: "Airframe & Platforms (General/Unclassified Subsystem)"

--- a/config/tech_census/drone_manufacturing.yaml
+++ b/config/tech_census/drone_manufacturing.yaml
@@ -1,26 +1,15 @@
 area_id: drone_manufacturing
+version: "2.0.0"
 display_name: Drone Manufacturing
 description: >-
-  Aerial unmanned systems (UAS/UAV) and purpose-built subsystems. "Drone" is
-  read as aerial only -- non-aerial unmanned systems (UGV ground robots,
-  UUV/USV maritime) are tracked separately under adjacent_nonaerial, not
-  included in the main count. Counter-UAS / counter-drone (detect-and-defeat
-  technology) is tracked separately under exclusions -- it is drone defeat,
-  not drone production. All SBIR/STTR phases are in scope (this is a
-  technology-relevance census, not a Phase II cohort for transition
-  analysis).
+  SBIR awards funding physical aerial-drone products, components, materials,
+  or manufacturing processes. Software-only, service, operational, generic
+  UAS-use, STTR, counter-UAS detection/defeat, and non-aerial systems are not
+  included. Use the uas_relevance profile for the broader UAS ecosystem.
+programs: [SBIR]
+overrides_file: drone_manufacturing_overrides.yaml
 
 gate:
-  # A term counts as a hit only if it appears in the award TITLE, or the
-  # TOTAL occurrence count across all gate terms in title+abstract is >= this
-  # value. Counting total occurrences (not distinct pattern names) matters:
-  # several gate patterns overlap on a single phrase (e.g. "unmanned aerial
-  # system" and "unmanned aerial" both match "unmanned aerial systems"), so a
-  # naive distinct-pattern-count rule is satisfiable by one incidental
-  # sentence. Calibrated against real award_data.csv: a hypersonic-
-  # interceptor award, a lunar-battery award, and a weather-forecasting-
-  # software award each had exactly 2 total occurrences from a single
-  # incidental mention; genuinely relevant awards ran well past that.
   min_abstract_only_occurrences: 3
   terms:
     - '\bdrone[s]?\b'
@@ -31,34 +20,201 @@ gate:
     - '\bunmanned aerial system[s]?\b'
     - '\bunmanned aircraft\b'
     - '\bunmanned aerial\b'
+    - '\buncrewed (?:aircraft|aerial vehicle|aerial system)s?\b'
+    - '\bremotely piloted aircraft\b'
     - '\bquadcopter[s]?\b'
     - '\bquadrotor[s]?\b'
     - '\bhexacopter[s]?\b'
     - '\bmulti-?rotor[s]?\b'
-    - '\btiltrotor (?:UAS|UAV|drone)\b'
     - '\bmicro air vehicle[s]?\b'
-    - '\bMAV[s]?\b'
-    - '\bfixed-wing UAS\b'
-    - '\bnano-?drone[s]?\b'
-    - '\bremotely piloted aircraft\b'
+    - '\bfixed-wing (?:UAS|UAV|drone)s?\b'
+    - '\b(?:VTOL|vertical take-?off and landing) (?:UAS|UAV|drone)s?\b'
     - '\bloitering munition[s]?\b'
-    - '\bVTOL UAS\b'
-    - '\bUAS VTOL\b'
+    - '\bone-way attack (?:aircraft|drone)s?\b'
+    - '\btarget drone[s]?\b'
+    - '\bloyal wingm[ae]n\b'
+    - '\bcollaborative combat aircraft\b'
+    - '\bCCA(?:s)?\b(?=[\s\S]{0,80}\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|autonom\w*|munition|air dominance)\b)'
+    - '\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|autonom\w*|munition|air dominance)\b[\s\S]{0,80}\bCCA(?:s)?\b'
+    - '\bautonomous collaborative platform[s]?\b'
+    - '\bACP\b(?=[\s\S]{0,80}\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|drone|UAS|UAV)\b)'
+    - '\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|drone|UAS|UAV)\b[\s\S]{0,80}\bACP\b'
+    - '\battritable (?:aircraft|airframe|platform)s?\b'
+    - '\bair-launched effect[s]?\b'
+    - '\bhigh[- ]altitude pseudo-?satellite[s]?\b'
+    - '\bhigh[- ]altitude platform (?:system|station)s?\b'
+    - '\bHAPS\b(?=[\s\S]{0,80}\b(?:high[- ]altitude|stratospher\w*|aircraft|aerial|flight|propulsion|payload|imaging|demonstrator)\b)'
+    - '\b(?:high[- ]altitude|stratospher\w*|aircraft|aerial|flight|propulsion|payload|imaging|demonstrator)\b[\s\S]{0,80}\bHAPS\b'
+    - '\bUCAV[s]?\b'
+    - '\bVTUAV[s]?\b'
+    - '\bTUAV[s]?\b'
 
-# Gate-passing awards that represent an adjacent-but-distinct concept.
-# Tracked and reported separately, never silently dropped or merged into the
-# main count.
+physical_gate:
+  title_term_always_passes: true
+  max_relationship_distance: 180
+  max_relevance_distance: 200
+  abstract_terms:
+    # Generic "aircraft" is useful in a funded-deliverable sentence, but is
+    # too broad to make a title physical by itself.
+    - '\baircraft\b'
+  title_terms:
+    # A UAS/UAV/drone named in the title normally denotes the funded physical
+    # platform. Explicit software/service/analysis titles are removed by the
+    # nonphysical_primary exclusion below.
+    - '\b(?:UAS|UAV|drone)s?\b'
+    - '\bunmanned aerial (?:vehicle|system)s?\b'
+    - '\bsensor[s]?\b'
+    - '\bradar[s]?\b'
+    - '\b(?:receiver|transmitter|transceiver)s?\b'
+  terms:
+    - '\b(?:unmanned|uncrewed) aircraft\b'
+    - '\bcollaborative combat aircraft\b'
+    - '\battritable aircraft\b'
+    - '\btarget drone[s]?\b'
+    - '\b(?:UAS|UAV|drone) (?:platform|system|vehicle|aircraft)s?\b'
+    - '\bair vehicle[s]?\b'
+    - '\bairframe[s]?\b'
+    - '\bfuselage[s]?\b'
+    - '\bwing[s]?\b'
+    - '\brotor[s]?\b'
+    - '\bpropeller[s]?\b'
+    - '\bpropulsion (?:system|unit)s?\b'
+    - '\bengine[s]?\b'
+    - '\bmotor[s]?\b'
+    - '\bactuator[s]?\b'
+    - '\bflight control computer[s]?\b'
+    - '\bavionics\b'
+    - '\bautopilot hardware\b'
+    - '\binertial measurement unit[s]?\b'
+    - '\bIMU[s]?\b'
+    - '\bGNSS receiver[s]?\b'
+    - '\bbatter(?:y|ies)\b'
+    - '\bfuel cell[s]?\b'
+    - '\bpower electronic[s]?\b'
+    - '\bthermal management\b'
+    - '\bdata ?link hardware\b'
+    - '\bradio[s]?\b'
+    - '\bantenna[s]?\b'
+    - '\bgimbal[s]?\b'
+    - '\bEO/?IR\b'
+    - '\bpayload hardware\b'
+    - '\bcomposite structure[s]?\b'
+    - '\bstructural component[s]?\b'
+    - '\bcoating[s]?\b'
+    - '\bprinted circuit board[s]?\b'
+    - '\bprototype (?:aircraft|vehicle|platform|system)s?\b'
+    - '\bmanufacturing (?:process|technology|method|tooling|cell|line)s?\b'
+    - '\bflight computer[s]?\b'
+    - '\bmission computer[s]?\b'
+    - '\b(?:power source|power system|powerplant|turbogenerator|generator)s?\b'
+    - '\b(?:launch|recovery) system[s]?\b'
+    - '\blanding gear\b'
+    - '\blauncher[s]?\b'
+    - '\bwinch\b'
+    - '\bhoist\b'
+    - '\bpod[s]?\b'
+    - '\bcamera[s]?\b'
+    - '\bimager[s]?\b'
+  relationship_terms:
+    - '\bdevelop(?:ed|ing|ment)?\b'
+    - '\bdesign(?:ed|ing)?\b'
+    - '\bfabricat(?:e|ed|ing|ion)\b'
+    - '\bmanufactur(?:e|ed|ing|able|ability)\b'
+    - '\bproduc(?:e|ed|ing|tion)\b'
+    - '\bbuild(?:ing|s|t)?\b'
+    - '\bprototype(?:d|s|ing)?\b'
+    - '\bintegrat(?:e|ed|ing|ion)\b'
+    - '\bassembl(?:e|ed|ing|y)\b'
+    - '\btest(?:ed|ing)?\b'
+    - '\bqualif(?:y|ied|ication)\b'
+    - '\bcoat(?:ed|s)?\b'
+    - '\bminiaturi[sz](?:e|ed|ing|ation)\b'
+    - '\brepair(?:ed|ing)?\b'
+
 exclusions:
   - name: counter_uas
-    display_name: Counter-UAS / Counter-Drone
-    reason: Detect-and-defeat technology -- the opposite of manufacturing.
+    display_name: Counter-UAS Detection or Defeat
+    reason: Detect/track/jam/defeat work is not manufacture of a drone.
     terms:
-      - '\bcounter-?UAS\b'
-      - '\bcUAS\b'
-      - '\bcounter-?drone[s]?\b'
+      - '\bcounter[- ]?(?:UAS|sUAS|UAV|drone)s?\b'
+      - '\bc[- ]?UAS\b'
+      - '\banti[- ]drone\b'
+      - '\b(?:UAS|UAV|drone) (?:detect|detection|counter|defen[cs]e|threat)\b'
+      - '\bdrone[- ]defen[cs]e\b'
+      - '\b(?:detect|track|identify|jam|defeat|neutralize) hostile (?:UAS|UAV|drone)s?\b'
+    unless_terms:
+      - '\binterceptor (?:UAS|UAV|drone|aircraft)s?\b'
+      - '\b(?:UAS|UAV|drone) interceptor[s]?\b'
+      - '\bkinetic interceptor drone[s]?\b'
+  - name: counter_uas
+    display_name: Counter-UAS Detection or Defeat
+    reason: The title makes detection/tracking/defeat of UAS the funded objective.
+    title_only: true
+    terms:
+      - '\b(?:UAS|UAV|drone)s?\b[\s\S]{0,80}\b(?:detect|track|identify|defeat|counter|threat)\w*\b'
+      - '\b(?:detect|track|identify|defeat|counter|threat)\w*\b[\s\S]{0,80}\b(?:UAS|UAV|drone)s?\b'
+    unless_terms:
+      - '\binterceptor (?:UAS|UAV|drone|aircraft)s?\b'
+      - '\b(?:UAS|UAV|drone) interceptor[s]?\b'
+  - name: nonphysical_primary
+    display_name: Software, Analysis, or Service-Led UAS Work
+    reason: The title identifies a nonphysical funded deliverable.
+    title_only: true
+    unless_title_only: true
+    terms:
+      - '\bsoftware\b'
+      - '\bdigital twin\b'
+      - '\bmachine learning\b'
+      - '\bartificial intelligence\b'
+      - '\bAI[- ](?:enabled|enhanced|driven|based)\b'
+      - '\balgorithm[s]?\b'
+      - '\banalysis\b'
+      - '\banalytic[s]?\b'
+      - '\bsimulation\b'
+      - '\bmission planning\b'
+      - '\bnavigation\b'
+      - '\btracking\b'
+      - '\bdetection\b'
+      - '\binspection\b'
+      - '\bmanagement\b'
+      - '\bservice[s]?\b'
+      - '\bframework\b'
+      - '\bsituational awareness\b'
+      - '\bmission planner\b'
+      - '\blocalization\b'
+      - '\bfeasibility stud(?:y|ies)\b'
+      - '\bcommunication[s]?\b'
+      - '\bdata transfer\b'
+      - '\bmonitoring\b'
+      - '\bdata collection\b'
+      - '\bremote[- ]sensing\b'
+      - '\bgeolocation\b'
+      - '\bcommand and control\b'
+      - '\bvoice control\b'
+      - '\bprotocol[s]?\b'
+      - '\boptimization\b'
+      - '\bvalidation\b'
+      - '\bdecision making\b'
+      - '\bteaming\b'
+      - '\bcoordination\b'
+      - '\bsensor fusion\b'
+    unless_terms:
+      # A generic hardware noun does not rescue a software-led title. The
+      # title must name an explicit physical deliverable or production action.
+      - '\b(?:airframes?|fuselages?|wings?|rotors?|propellers?|engines?|motors?|batter(?:y|ies)|avionics|flight computers?|mission computers?|radios?|antennas?|gimbals?|cameras?|imagers?|payloads?|sensors?|radars?|receivers?|transmitters?|transceivers?|navigation) (?:hardware|components?|assembl(?:y|ies)|prototypes?)\b'
+      - '\bmanufactur\w*\b'
+      - '\bfabricat\w*\b'
+      - '\bproduc(?:e|ed|ing|tion)\b'
+      - '\b3D[- ]print\w*\b'
+  - name: non_aerial_title
+    display_name: Non-Aerial Unmanned Systems
+    reason: The funded primary platform is ground, surface, or underwater.
+    title_only: true
+    terms:
+      - '\b(?:UGV|UUV|USV|AUV)s?\b'
+      - '\bunmanned (?:ground|underwater|surface) vehicle[s]?\b'
+      - '\bautonomous underwater vehicle[s]?\b'
 
-# Non-aerial unmanned systems that never reach the gate but are worth
-# tracking for context (not aerial drones, so not "drone manufacturing").
 adjacent_nonaerial:
   - name: ugv
     display_name: Unmanned Ground Vehicles
@@ -68,60 +224,72 @@ adjacent_nonaerial:
   - name: uuv
     display_name: Unmanned Underwater Vehicles
     terms:
-      - '\bUUV[s]?\b'
-      - '\bunmanned underwater vehicle[s]?\b'
+      - '\b(?:UUV|AUV)[s]?\b'
+      - '\b(?:unmanned|autonomous) underwater vehicle[s]?\b'
   - name: usv
     display_name: Unmanned Surface Vehicles
     terms:
       - '\bUSV[s]?\b'
       - '\bunmanned surface vehicle[s]?\b'
 
-# Priority-ordered technology subsets (most specific first). Each gate-
-# passing, non-excluded award gets exactly one subset via first match;
-# anything matching none of these falls into fallback_subset.
 subsets:
-  - name: Manufacturing Processes & Materials
+  - name: Airframes, Structures, Materials & Manufacturing
     terms:
+      - '\bairframe[s]?\b'
+      - '\bfuselage[s]?\b'
+      - '\bwing structure[s]?\b'
+      - '\bcomposite[s]?\b'
+      - '\bstructural component[s]?\b'
       - '\badditive manufactur\w*\b'
       - '\b3D[- ]print\w*\b'
-      - '\brapid prototyp\w*\b'
-      - '\bcomposite (?:airframe|structure)s?\b'
-      - '\blow-?cost manufactur\w*\b'
-  - name: Propulsion & Power Systems
+      - '\btooling\b'
+      - '\bcoating[s]?\b'
+  - name: Propulsion, Lift & Actuation
     terms:
       - '\bpropulsion\b'
-      - '\belectric propulsion\b'
-      - '\bhybrid-electric\b'
+      - '\bengine[s]?\b'
+      - '\bmotor[s]?\b'
       - '\bpropeller[s]?\b'
-      - '\bbattery\b'
-      - '\bbatteries\b'
-      - '\bmotor controller[s]?\b'
-      - '\bsmall (?:gas turbine|engine)[s]?\b'
-      - '\belectric motor[s]?\b'
-  - name: Autonomy, Guidance & Flight Control
+      - '\brotor[s]?\b'
+      - '\bactuator[s]?\b'
+      - '\bgearbox(?:es)?\b'
+  - name: Power, Energy Storage & Thermal
     terms:
-      - '\bautopilot\b'
-      - '\bautonomous flight\b'
-      - '\bswarm(?:ing)?\b'
-      - '\bsense[- ]and[- ]avoid\b'
-      - '\bobstacle avoidance\b'
-      - '\bBVLOS\b'
-      - '\bbeyond visual line of sight\b'
-      - '\bguidance,? navigation,? and control\b'
-      - '\bGNC\b'
-  - name: Sensors & Mission Payloads
+      - '\bbatter(?:y|ies)\b'
+      - '\bfuel cell[s]?\b'
+      - '\bpower electronic[s]?\b'
+      - '\benergy storage\b'
+      - '\bthermal management\b'
+      - '\bpower source[s]?\b'
+      - '\bpower system[s]?\b'
+      - '\bpowerplant[s]?\b'
+      - '\bturbogenerator[s]?\b'
+      - '\bgenerator[s]?\b'
+  - name: Avionics, Flight-Control & Navigation Hardware
     terms:
+      - '\bavionics\b'
+      - '\bflight control computer[s]?\b'
+      - '\bautopilot hardware\b'
+      - '\binertial measurement unit[s]?\b'
+      - '\bIMU[s]?\b'
+      - '\bGNSS receiver[s]?\b'
+      - '\bnavigation hardware\b'
+      - '\bflight computer[s]?\b'
+      - '\bmission computer[s]?\b'
+  - name: Communications, Data Links & Payload Hardware
+    terms:
+      - '\bdata ?link hardware\b'
+      - '\bradio[s]?\b'
+      - '\bantenna[s]?\b'
       - '\bgimbal[s]?\b'
-      - '\bpayload[s]?\b'
       - '\bEO/?IR\b'
-      - '\bISR payload[s]?\b'
-      - '\bLIDAR\b'
-      - '\bLiDAR\b'
-  - name: Communications & Data Links
-    terms:
-      - '\bdata ?link[s]?\b'
-      - '\bcommand and control link[s]?\b'
-      - '\bground control station[s]?\b'
-      - '\banti-jam\b'
+      - '\bpayload hardware\b'
+      - '\bprinted circuit board[s]?\b'
+      - '\bcamera[s]?\b'
+      - '\bimager[s]?\b'
+      - '\bsensor[s]?\b'
+      - '\bradar[s]?\b'
+      - '\b(?:receiver|transmitter|transceiver)s?\b'
 
-fallback_subset: "Airframe & Platforms (General/Unclassified Subsystem)"
+fallback_subset: Complete Platforms & Systems Integration
+fallback_scope_class: Physical Hardware & Manufacturing

--- a/config/tech_census/drone_manufacturing_overrides.yaml
+++ b/config/tech_census/drone_manufacturing_overrides.yaml
@@ -1,0 +1,4 @@
+# Reviewed exceptions to the deterministic drone-manufacturing rules.
+# Match on stable source identifiers; never on title text alone.
+version: "2026-07-14"
+overrides: []

--- a/config/tech_census/uas_relevance.yaml
+++ b/config/tech_census/uas_relevance.yaml
@@ -1,0 +1,164 @@
+area_id: uas_relevance
+version: "1.0.0"
+display_name: UAS Technology Relevance
+description: >-
+  Broad SBIR/STTR relevance to aerial uncrewed systems, including physical
+  hardware, autonomy/software, operations, and services. This preserves the
+  original PR 439 question separately from the strict physical-manufacturing
+  profile.
+programs: [SBIR, STTR]
+
+gate:
+  min_abstract_only_occurrences: 3
+  terms:
+    - '\bdrone[s]?\b'
+    - '\bUAV[s]?\b'
+    - '\bUAS\b'
+    - '\bsUAS\b'
+    - '\bunmanned aerial vehicle[s]?\b'
+    - '\bunmanned aerial system[s]?\b'
+    - '\bunmanned aircraft\b'
+    - '\bunmanned aerial\b'
+    - '\buncrewed (?:aircraft|aerial vehicle|aerial system)s?\b'
+    - '\bremotely piloted aircraft\b'
+    - '\bquadcopter[s]?\b'
+    - '\bquadrotor[s]?\b'
+    - '\bhexacopter[s]?\b'
+    - '\bmulti-?rotor[s]?\b'
+    - '\bmicro air vehicle[s]?\b'
+    - '\bfixed-wing (?:UAS|UAV|drone)s?\b'
+    - '\b(?:VTOL|vertical take-?off and landing) (?:UAS|UAV|drone)s?\b'
+    - '\bloitering munition[s]?\b'
+    - '\bone-way attack (?:aircraft|drone)s?\b'
+    - '\btarget drone[s]?\b'
+    - '\bloyal wingm[ae]n\b'
+    - '\bcollaborative combat aircraft\b'
+    - '\bCCA(?:s)?\b(?=[\s\S]{0,80}\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|autonom\w*|munition|air dominance)\b)'
+    - '\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|autonom\w*|munition|air dominance)\b[\s\S]{0,80}\bCCA(?:s)?\b'
+    - '\bautonomous collaborative platform[s]?\b'
+    - '\bACP\b(?=[\s\S]{0,80}\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|drone|UAS|UAV)\b)'
+    - '\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|drone|UAS|UAV)\b[\s\S]{0,80}\bACP\b'
+    - '\battritable (?:aircraft|airframe|platform)s?\b'
+    - '\bair-launched effect[s]?\b'
+    - '\bhigh[- ]altitude pseudo-?satellite[s]?\b'
+    - '\bhigh[- ]altitude platform (?:system|station)s?\b'
+    - '\bHAPS\b(?=[\s\S]{0,80}\b(?:high[- ]altitude|stratospher\w*|aircraft|aerial|flight|propulsion|payload|imaging|demonstrator)\b)'
+    - '\b(?:high[- ]altitude|stratospher\w*|aircraft|aerial|flight|propulsion|payload|imaging|demonstrator)\b[\s\S]{0,80}\bHAPS\b'
+    - '\bUCAV[s]?\b'
+    - '\bVTUAV[s]?\b'
+    - '\bTUAV[s]?\b'
+
+exclusions:
+  - name: counter_uas
+    display_name: Counter-UAS Detection or Defeat
+    reason: Detect/track/jam/defeat work is not technology for the UAS itself.
+    terms:
+      - '\bcounter[- ]?(?:UAS|sUAS|UAV|drone)s?\b'
+      - '\bc[- ]?UAS\b'
+      - '\banti[- ]drone\b'
+    unless_terms:
+      - '\binterceptor (?:UAS|UAV|drone|aircraft)s?\b'
+      - '\b(?:UAS|UAV|drone) interceptor[s]?\b'
+  - name: non_aerial_title
+    display_name: Non-Aerial Unmanned Systems
+    reason: The funded primary platform is ground, surface, or underwater.
+    title_only: true
+    terms:
+      - '\b(?:UGV|UUV|USV|AUV)s?\b'
+      - '\bunmanned (?:ground|underwater|surface) vehicle[s]?\b'
+      - '\bautonomous underwater vehicle[s]?\b'
+
+adjacent_nonaerial:
+  - name: ugv
+    display_name: Unmanned Ground Vehicles
+    terms:
+      - '\bUGV[s]?\b'
+      - '\bunmanned ground vehicle[s]?\b'
+  - name: uuv
+    display_name: Unmanned Underwater Vehicles
+    terms:
+      - '\b(?:UUV|AUV)[s]?\b'
+      - '\b(?:unmanned|autonomous) underwater vehicle[s]?\b'
+  - name: usv
+    display_name: Unmanned Surface Vehicles
+    terms:
+      - '\bUSV[s]?\b'
+      - '\bunmanned surface vehicle[s]?\b'
+
+subsets:
+  - name: Manufacturing Processes & Materials
+    terms:
+      - '\badditive manufactur\w*\b'
+      - '\b3D[- ]print\w*\b'
+      - '\brapid prototyp\w*\b'
+      - '\bcomposite (?:airframe|structure)s?\b'
+      - '\blow-?cost manufactur\w*\b'
+  - name: Propulsion & Power Systems
+    terms:
+      - '\bpropulsion\b'
+      - '\bhybrid-electric\b'
+      - '\bpropeller[s]?\b'
+      - '\bbatter(?:y|ies)\b'
+      - '\bmotor controller[s]?\b'
+      - '\bsmall (?:gas turbine|engine)[s]?\b'
+      - '\belectric motor[s]?\b'
+  - name: Autonomy, Guidance & Flight Control
+    terms:
+      - '\bautopilot\b'
+      - '\bautonomous flight\b'
+      - '\bswarm(?:ing)?\b'
+      - '\bsense[- ]and[- ]avoid\b'
+      - '\bobstacle avoidance\b'
+      - '\bBVLOS\b'
+      - '\bbeyond visual line of sight\b'
+      - '\bguidance,? navigation,? and control\b'
+      - '\bGNC\b'
+      - '\bmission planning\b'
+      - '\bcomputer vision\b'
+  - name: Sensors & Mission Payloads
+    terms:
+      - '\bgimbal[s]?\b'
+      - '\bpayload[s]?\b'
+      - '\bEO/?IR\b'
+      - '\bISR payload[s]?\b'
+      - '\bLiDAR\b'
+  - name: Communications & Data Links
+    terms:
+      - '\bdata ?link[s]?\b'
+      - '\bcommand and control link[s]?\b'
+      - '\bground control station[s]?\b'
+      - '\banti-jam\b'
+
+fallback_subset: Unclassified UAS Relevance
+
+scope_classes:
+  - name: Physical Hardware & Manufacturing
+    terms:
+      - '\bmanufactur\w*\b'
+      - '\bfabricat\w*\b'
+      - '\bairframe[s]?\b'
+      - '\bfuselage[s]?\b'
+      - '\bpropulsion\b'
+      - '\bengine[s]?\b'
+      - '\bmotor[s]?\b'
+      - '\bbatter(?:y|ies)\b'
+      - '\bavionics\b'
+      - '\bgimbal[s]?\b'
+  - name: Software, Autonomy & Analytics
+    terms:
+      - '\bsoftware\b'
+      - '\balgorithm[s]?\b'
+      - '\bautonom\w*\b'
+      - '\bcomputer vision\b'
+      - '\bmachine learning\b'
+      - '\banalytic[s]?\b'
+      - '\bmission planning\b'
+  - name: Operations & Services
+    terms:
+      - '\boperation[s]?\b'
+      - '\bservice[s]?\b'
+      - '\btraining\b'
+      - '\bmaintenance\b'
+      - '\binspection\b'
+
+fallback_scope_class: General UAS Relevance

--- a/packages/sbir-analytics/sbir_analytics/api/snapshots.py
+++ b/packages/sbir-analytics/sbir_analytics/api/snapshots.py
@@ -29,6 +29,7 @@ class AnalysisKind(StrEnum):
     # parameterized family). Add one line here per new
     # config/tech_census/<area>.yaml as areas are added.
     TECH_CENSUS_DRONE_MANUFACTURING = "tech_census_drone_manufacturing"
+    TECH_CENSUS_UAS_RELEVANCE = "tech_census_uas_relevance"
 
 
 class SourceReference(BaseModel):
@@ -89,6 +90,7 @@ class FileSnapshotRepository:
             AnalysisKind.TRANSITION_RATE: "transition_rate",
             AnalysisKind.FOLLOW_ON_MULTIPLIER: "follow_on_multiplier",
             AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING: "tech_census_drone_manufacturing",
+            AnalysisKind.TECH_CENSUS_UAS_RELEVANCE: "tech_census_uas_relevance",
         }
         return self.root / directories[kind]
 
@@ -273,6 +275,24 @@ def write_snapshot(
     return target
 
 
+def _tech_census_signature(snapshot: AnalyticsSnapshot) -> dict[str, Any] | None:
+    if not isinstance(snapshot.result, dict):
+        return None
+    summary = snapshot.result.get("summary")
+    if not isinstance(summary, dict) or "area_id" not in summary:
+        return None
+    return {
+        key: summary.get(key)
+        for key in (
+            "area_id",
+            "config_version",
+            "override_version",
+            "programs",
+            "reporting_window",
+        )
+    }
+
+
 def compare_snapshots(baseline: AnalyticsSnapshot, comparison: AnalyticsSnapshot) -> dict[str, Any]:
     """Compare compatible snapshots without inventing domain-specific formulas."""
 
@@ -286,6 +306,12 @@ def compare_snapshots(baseline: AnalyticsSnapshot, comparison: AnalyticsSnapshot
         raise IncompatibleSnapshotsError("Methodology versions differ")
     if not isinstance(baseline.result, dict) or not isinstance(comparison.result, dict):
         raise IncompatibleSnapshotsError("Comparison requires object-shaped results")
+    baseline_signature = _tech_census_signature(baseline)
+    comparison_signature = _tech_census_signature(comparison)
+    if baseline_signature != comparison_signature and (
+        baseline_signature is not None or comparison_signature is not None
+    ):
+        raise IncompatibleSnapshotsError("Tech-census methodologies or reporting scopes differ")
 
     deltas: dict[str, float] = {}
     for key in baseline.result.keys() & comparison.result.keys():

--- a/packages/sbir-analytics/sbir_analytics/api/snapshots.py
+++ b/packages/sbir-analytics/sbir_analytics/api/snapshots.py
@@ -24,6 +24,11 @@ class AnalysisKind(StrEnum):
     CET_PORTFOLIO = "cet_portfolio"
     TRANSITION_RATE = "transition_rate"
     FOLLOW_ON_MULTIPLIER = "follow_on_multiplier"
+    # One kind per tech-census area (same granularity as the kinds above --
+    # each represents one specific, periodically-refreshed analysis, not a
+    # parameterized family). Add one line here per new
+    # config/tech_census/<area>.yaml as areas are added.
+    TECH_CENSUS_DRONE_MANUFACTURING = "tech_census_drone_manufacturing"
 
 
 class SourceReference(BaseModel):
@@ -83,6 +88,7 @@ class FileSnapshotRepository:
             AnalysisKind.CET_PORTFOLIO: "cet_portfolio",
             AnalysisKind.TRANSITION_RATE: "transition_rate",
             AnalysisKind.FOLLOW_ON_MULTIPLIER: "follow_on_multiplier",
+            AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING: "tech_census_drone_manufacturing",
         }
         return self.root / directories[kind]
 

--- a/packages/sbir-analytics/sbir_analytics/tools/tech_census/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/tech_census/__init__.py
@@ -1,0 +1,16 @@
+"""
+Tech Census: all-phase, subset-taxonomy technology-relevance queries.
+
+Not one of the lettered statutory-benchmark missions (A/B/C) -- a standing
+capability for "how many SBIR awards, and how many dollars, are relevant to
+technology area X" questions, broken into technology subsets, by fiscal
+year. First area: drone manufacturing.
+
+Tools (1):
+- compute_tech_census: classify + aggregate SBIR awards against a
+  config/tech_census/<area>.yaml
+"""
+
+from .compute_tech_census import ComputeTechCensusTool
+
+__all__ = ["ComputeTechCensusTool"]

--- a/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
@@ -1,0 +1,130 @@
+"""
+All-phase, subset-taxonomy technology-relevance census (e.g. drone
+manufacturing) over SBIR/STTR awards.
+
+Thin ToolResult adapter around the shared, config-driven engine in
+sbir_etl.utils.tech_census -- the classification/aggregation logic itself
+lives there so the CLI script (scripts/data/build_tech_census.py) and this
+API-facing tool can never drift apart. See that module's docstring for the
+gate/exclusion/subset design.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from loguru import logger
+
+from ..base import BaseTool, DataSourceRef, ToolMetadata, ToolResult
+
+# CensusAward field names this tool expects as DataFrame columns. Unlike
+# some other tools in this package, no defensive multi-name column lookup is
+# needed: this tool and its callers (scripts/data/*.py) are the only
+# producers of the input DataFrame, so one fixed convention is enforced
+# rather than guessed at.
+_REQUIRED_COLUMNS = (
+    "title",
+    "abstract",
+    "company",
+    "agency",
+    "phase",
+    "award_year",
+    "award_amount",
+)
+
+
+class ComputeTechCensusTool(BaseTool):
+    """Classify SBIR/STTR awards into technology subsets and aggregate by fiscal year."""
+
+    name = "compute_tech_census"
+    version = "1.0.0"
+
+    def execute(
+        self,
+        metadata: ToolMetadata,
+        *,
+        awards_df: pd.DataFrame | None = None,
+        area_id: str = "drone_manufacturing",
+        **kwargs: Any,
+    ) -> ToolResult:
+        """Run the census for one configured technology area.
+
+        Args:
+            metadata: Pre-initialized metadata to populate
+            awards_df: SBIR awards with columns title/abstract/company/agency/
+                phase/award_year/award_amount (see sbir_etl.utils.tech_census.
+                CensusAward). All phases -- not Phase-II-filtered.
+            area_id: config/tech_census/<area_id>.yaml to classify against
+
+        Returns:
+            ToolResult with a per-award results DataFrame and a summary dict
+            (grand total, fy totals, subset totals, by-fy-subset breakdown,
+            exclusion/adjacent category counts).
+        """
+        from sbir_etl.utils.tech_census import CompiledCensus, load_census_config, run_census
+
+        metadata.parameters_used["area_id"] = area_id
+
+        if awards_df is None or awards_df.empty:
+            metadata.warnings.append("No awards data provided")
+            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
+
+        missing = [c for c in _REQUIRED_COLUMNS if c not in awards_df.columns]
+        if missing:
+            metadata.warnings.append(f"awards_df missing required columns: {missing}")
+            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
+
+        try:
+            cfg = load_census_config(area_id)
+        except (FileNotFoundError, ValueError) as exc:
+            metadata.warnings.append(f"Could not load tech-census config: {exc}")
+            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
+
+        compiled = CompiledCensus(cfg)
+        awards = awards_df[list(_REQUIRED_COLUMNS)].to_dict(orient="records")
+
+        logger.info(f"Running tech census for {compiled.display_name} over {len(awards):,} awards")
+        result = run_census(awards, compiled)
+
+        results_df = pd.DataFrame(result["classified_awards"])
+
+        summary = {
+            "area_id": result["area_id"],
+            "display_name": result["display_name"],
+            "grand_total": result["grand_total"],
+            "fy_totals": {str(k): v for k, v in result["fy_totals"].items()},
+            "subset_totals": result["subset_totals"],
+            "by_fy_subset": {
+                f"{fy}|{subset}": v for (fy, subset), v in result["by_fy_subset"].items()
+            },
+            "exclusion_counts": result["exclusion_counts"],
+            "adjacent_counts": result["adjacent_counts"],
+        }
+
+        metadata.record_count = len(results_df)
+        metadata.data_sources.append(
+            DataSourceRef(
+                name="SBIR.gov Awards",
+                url="https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv",
+                record_count=len(awards_df),
+                access_method="bulk_csv",
+            )
+        )
+
+        return ToolResult(data={"results": results_df, "summary": summary}, metadata=metadata)
+
+    @staticmethod
+    def _empty_result(area_id: str) -> dict[str, Any]:
+        return {
+            "results": pd.DataFrame(),
+            "summary": {
+                "area_id": area_id,
+                "grand_total": {"n": 0, "usd": 0.0},
+                "fy_totals": {},
+                "subset_totals": {},
+                "by_fy_subset": {},
+                "exclusion_counts": {},
+                "adjacent_counts": {},
+            },
+        }

--- a/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
@@ -1,28 +1,15 @@
-"""
-All-phase, subset-taxonomy technology-relevance census (e.g. drone
-manufacturing) over SBIR/STTR awards.
-
-Thin ToolResult adapter around the shared, config-driven engine in
-sbir_etl.utils.tech_census -- the classification/aggregation logic itself
-lives there so the CLI script (scripts/data/build_tech_census.py) and this
-API-facing tool can never drift apart. See that module's docstring for the
-gate/exclusion/subset design.
-"""
+"""ToolResult adapter for the shared config-driven technology census."""
 
 from __future__ import annotations
 
-from typing import Any
+import math
+from typing import Any, cast
 
 import pandas as pd
 from loguru import logger
 
 from ..base import BaseTool, DataSourceRef, ToolMetadata, ToolResult
 
-# CensusAward field names this tool expects as DataFrame columns. Unlike
-# some other tools in this package, no defensive multi-name column lookup is
-# needed: this tool and its callers (scripts/data/*.py) are the only
-# producers of the input DataFrame, so one fixed convention is enforced
-# rather than guessed at.
 _REQUIRED_COLUMNS = (
     "title",
     "abstract",
@@ -32,13 +19,50 @@ _REQUIRED_COLUMNS = (
     "award_year",
     "award_amount",
 )
+_OPTIONAL_AWARD_COLUMNS = (
+    "program",
+    "agency_tracking_number",
+    "contract",
+    "source_row",
+)
+
+
+def _is_missing(value: Any) -> bool:
+    try:
+        return bool(pd.isna(value))
+    except (TypeError, ValueError):
+        return False
+
+
+def _as_text(value: Any) -> str:
+    return "" if _is_missing(value) else str(value)
+
+
+def _as_year(value: Any) -> int | None:
+    if _is_missing(value):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return int(numeric) if math.isfinite(numeric) and numeric.is_integer() else None
+
+
+def _as_amount(value: Any) -> float:
+    if _is_missing(value):
+        return 0.0
+    try:
+        numeric = float(str(value).replace("$", "").replace(",", "").strip())
+    except (TypeError, ValueError):
+        return 0.0
+    return numeric if math.isfinite(numeric) else 0.0
 
 
 class ComputeTechCensusTool(BaseTool):
-    """Classify SBIR/STTR awards into technology subsets and aggregate by fiscal year."""
+    """Classify awards into a versioned technology profile and aggregate them."""
 
     name = "compute_tech_census"
-    version = "1.0.0"
+    version = "2.0.0"
 
     def execute(
         self,
@@ -46,60 +70,123 @@ class ComputeTechCensusTool(BaseTool):
         *,
         awards_df: pd.DataFrame | None = None,
         area_id: str = "drone_manufacturing",
+        programs: list[str] | tuple[str, ...] | None = None,
+        fiscal_years: list[int] | tuple[int, ...] | None = None,
+        source_path: str | None = None,
+        source_sha256: str | None = None,
+        source_timestamp: str | None = None,
+        data_vintage: str | None = None,
         **kwargs: Any,
     ) -> ToolResult:
-        """Run the census for one configured technology area.
+        """Run one profile, optionally narrowing its program and fiscal-year scope."""
 
-        Args:
-            metadata: Pre-initialized metadata to populate
-            awards_df: SBIR awards with columns title/abstract/company/agency/
-                phase/award_year/award_amount (see sbir_etl.utils.tech_census.
-                CensusAward). All phases -- not Phase-II-filtered.
-            area_id: config/tech_census/<area_id>.yaml to classify against
+        from sbir_etl.utils.tech_census import (
+            CensusAward,
+            CompiledCensus,
+            load_census_config,
+            run_census,
+        )
 
-        Returns:
-            ToolResult with a per-award results DataFrame and a summary dict
-            (grand total, fy totals, subset totals, by-fy-subset breakdown,
-            exclusion/adjacent category counts).
-        """
-        from sbir_etl.utils.tech_census import CompiledCensus, load_census_config, run_census
-
-        metadata.parameters_used["area_id"] = area_id
+        selected_fys = (
+            sorted({int(year) for year in fiscal_years}) if fiscal_years is not None else []
+        )
+        metadata.parameters_used.update(
+            {
+                "area_id": area_id,
+                "programs": list(programs) if programs is not None else None,
+                "fiscal_years": selected_fys or None,
+                "data_vintage": data_vintage,
+            }
+        )
 
         if awards_df is None or awards_df.empty:
             metadata.warnings.append("No awards data provided")
             return ToolResult(data=self._empty_result(area_id), metadata=metadata)
 
-        missing = [c for c in _REQUIRED_COLUMNS if c not in awards_df.columns]
-        if missing:
-            metadata.warnings.append(f"awards_df missing required columns: {missing}")
-            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
-
         try:
-            cfg = load_census_config(area_id)
+            compiled = CompiledCensus(load_census_config(area_id))
         except (FileNotFoundError, ValueError) as exc:
             metadata.warnings.append(f"Could not load tech-census config: {exc}")
             return ToolResult(data=self._empty_result(area_id), metadata=metadata)
 
-        compiled = CompiledCensus(cfg)
-        awards = awards_df[list(_REQUIRED_COLUMNS)].to_dict(orient="records")
+        effective_programs = tuple(programs) if programs is not None else compiled.programs
+        required_columns = list(_REQUIRED_COLUMNS)
+        if effective_programs:
+            required_columns.append("program")
+        missing = [column for column in required_columns if column not in awards_df.columns]
+        if missing:
+            metadata.warnings.append(f"awards_df missing required columns: {missing}")
+            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
+        if effective_programs and not (
+            awards_df["program"].fillna("").astype(str).str.strip().ne("").any()
+        ):
+            metadata.warnings.append("awards_df has no usable program values for filtering")
+            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
 
+        input_row_count = len(awards_df)
+        reporting_df = awards_df
+        if selected_fys:
+            numeric_years = pd.to_numeric(reporting_df["award_year"], errors="coerce")
+            reporting_df = reporting_df[numeric_years.isin(selected_fys)]
+
+        columns = list(_REQUIRED_COLUMNS) + [
+            column for column in _OPTIONAL_AWARD_COLUMNS if column in reporting_df.columns
+        ]
+        raw_awards = reporting_df[columns].to_dict(orient="records")
+        awards: list[CensusAward] = []
+        for raw in raw_awards:
+            normalized = cast(
+                CensusAward,
+                {
+                    "title": _as_text(raw.get("title")),
+                    "abstract": _as_text(raw.get("abstract")),
+                    "company": _as_text(raw.get("company")),
+                    "agency": _as_text(raw.get("agency")),
+                    "program": _as_text(raw.get("program")),
+                    "phase": _as_text(raw.get("phase")),
+                    "award_year": _as_year(raw.get("award_year")),
+                    "award_amount": _as_amount(raw.get("award_amount")),
+                    "agency_tracking_number": _as_text(raw.get("agency_tracking_number")),
+                    "contract": _as_text(raw.get("contract")),
+                },
+            )
+            source_row = _as_year(raw.get("source_row"))
+            if source_row is not None:
+                normalized["source_row"] = source_row
+            awards.append(normalized)
         logger.info(f"Running tech census for {compiled.display_name} over {len(awards):,} awards")
-        result = run_census(awards, compiled)
-
+        result = run_census(awards, compiled, programs=programs)
         results_df = pd.DataFrame(result["classified_awards"])
 
         summary = {
             "area_id": result["area_id"],
             "display_name": result["display_name"],
+            "config_version": result["config_version"],
+            "override_version": result["override_version"],
+            "programs": result["programs"],
             "grand_total": result["grand_total"],
-            "fy_totals": {str(k): v for k, v in result["fy_totals"].items()},
+            "fy_totals": {str(key): value for key, value in result["fy_totals"].items()},
             "subset_totals": result["subset_totals"],
+            "scope_totals": result["scope_totals"],
             "by_fy_subset": {
-                f"{fy}|{subset}": v for (fy, subset), v in result["by_fy_subset"].items()
+                f"{fy}|{subset}": value for (fy, subset), value in result["by_fy_subset"].items()
             },
             "exclusion_counts": result["exclusion_counts"],
             "adjacent_counts": result["adjacent_counts"],
+            "program_exclusion_counts": result["program_exclusion_counts"],
+            "rejection_counts": result["rejection_counts"],
+            "reporting_window": {
+                "fiscal_years": selected_fys or None,
+                "programs": result["programs"],
+            },
+            "provenance": {
+                "source_path": source_path,
+                "sha256": source_sha256,
+                "source_timestamp": source_timestamp,
+                "data_vintage": data_vintage,
+                "source_row_count": input_row_count,
+                "reporting_row_count": len(reporting_df),
+            },
         }
 
         metadata.record_count = len(results_df)
@@ -107,24 +194,40 @@ class ComputeTechCensusTool(BaseTool):
             DataSourceRef(
                 name="SBIR.gov Awards",
                 url="https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv",
-                record_count=len(awards_df),
+                version=data_vintage or source_timestamp or source_sha256,
+                record_count=input_row_count,
                 access_method="bulk_csv",
             )
         )
-
-        return ToolResult(data={"results": results_df, "summary": summary}, metadata=metadata)
+        grand_total = result["grand_total"]
+        return ToolResult(
+            data={
+                "award_count": int(grand_total["n"]),
+                "award_dollars": float(grand_total["usd"]),
+                "results": results_df,
+                "summary": summary,
+            },
+            metadata=metadata,
+        )
 
     @staticmethod
     def _empty_result(area_id: str) -> dict[str, Any]:
         return {
+            "award_count": 0,
+            "award_dollars": 0.0,
             "results": pd.DataFrame(),
             "summary": {
                 "area_id": area_id,
                 "grand_total": {"n": 0, "usd": 0.0},
                 "fy_totals": {},
                 "subset_totals": {},
+                "scope_totals": {},
                 "by_fy_subset": {},
                 "exclusion_counts": {},
                 "adjacent_counts": {},
+                "program_exclusion_counts": {},
+                "rejection_counts": {},
+                "reporting_window": {"fiscal_years": None, "programs": []},
+                "provenance": {},
             },
         }

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -1,0 +1,282 @@
+"""Config-driven, all-phase technology-relevance census over SBIR/STTR awards.
+
+Generalizes the ad hoc drone-manufacturing analysis into a reusable engine:
+given an award universe (all phases -- this is a different question from the
+Phase-II-scoped cohort work in ``build_tech_area_cohort.py`` /
+``transition_signals.py``, which exists to support Phase II -> III transition
+analysis, not a technology-relevance census) and a YAML config, classify each
+award into a technology subset and aggregate counts/dollars by fiscal year.
+
+Design, validated against real data while building the first config
+(drone manufacturing):
+
+  - A GATE of broad relevance terms decides whether an award is in scope at
+    all. A term counts as a hit only if it appears in the award TITLE, or the
+    TOTAL occurrence count across all gate terms in title+abstract meets
+    ``min_abstract_only_occurrences``. Counting total occurrences (not
+    distinct pattern names) matters: several gate patterns are near-synonyms
+    that overlap on a single phrase (e.g. "unmanned aerial system" and
+    "unmanned aerial" both match "unmanned aerial systems"), so a naive
+    "N distinct terms" rule can be satisfied by one incidental sentence.
+    Spot-checked false positives (a hypersonic-interceptor award, a
+    lunar-battery award, a weather-forecasting-software award) each produced
+    exactly 2 total occurrences from one incidental mention; genuinely
+    relevant awards ran well past that.
+  - EXCLUSIONS are gate-passing awards that represent an adjacent-but-distinct
+    concept (e.g. counter-UAS defeat technology is not drone manufacturing).
+    They are tracked and reported separately, never silently dropped.
+  - SUBSETS sub-classify the remaining awards by more specific terminology,
+    in priority order (most specific first); anything matching no subset
+    falls into the configured fallback bucket. Each award gets exactly one
+    subset, so subset totals sum to the grand total without double-counting.
+
+Config schema: see config/tech_census/drone_manufacturing.yaml for a worked
+example. Callers normalize their own data source's column names into the
+canonical award dict shape this module expects (title, abstract, company,
+agency, phase, award_year, award_amount) -- this keeps the engine independent
+of both raw award_data.csv's column names and any DataFrame-based caller's
+naming conventions.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, TypedDict
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_DIR = REPO_ROOT / "config" / "tech_census"
+
+
+class CensusAward(TypedDict, total=False):
+    """Canonical award shape the engine operates on."""
+
+    title: str
+    abstract: str
+    company: str
+    agency: str
+    phase: str
+    award_year: int
+    award_amount: float
+
+
+def load_census_config(area_id: str, config_dir: Path | None = None) -> dict[str, Any]:
+    """Load and lightly validate a tech-census area config."""
+    path = (config_dir or CONFIG_DIR) / f"{area_id}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"No tech-census config at {path}. Add config/tech_census/{area_id}.yaml"
+        )
+    cfg = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if cfg.get("area_id") and cfg["area_id"] != area_id:
+        raise ValueError(f"area_id in {path} is {cfg['area_id']!r}, expected {area_id!r}")
+    cfg["area_id"] = area_id
+    for required in ("display_name", "gate", "subsets", "fallback_subset"):
+        if required not in cfg:
+            raise ValueError(f"{path} missing required key {required!r}")
+    if not cfg["gate"].get("terms"):
+        raise ValueError(f"{path}: gate.terms must be non-empty")
+    return cfg
+
+
+def _compile(patterns: list[str]) -> list[re.Pattern]:
+    return [re.compile(p, re.IGNORECASE) for p in patterns]
+
+
+class CompiledCensus:
+    """Compiled regex form of a census config, built once and reused per award."""
+
+    def __init__(self, cfg: dict[str, Any]):
+        self.area_id: str = cfg["area_id"]
+        self.display_name: str = cfg["display_name"]
+        self.gate_terms: list[re.Pattern] = _compile(cfg["gate"]["terms"])
+        self.min_abstract_only_occurrences: int = cfg["gate"].get(
+            "min_abstract_only_occurrences", 2
+        )
+
+        self.exclusions: list[tuple[str, str, list[re.Pattern]]] = [
+            (e["name"], e.get("display_name", e["name"]), _compile(e["terms"]))
+            for e in cfg.get("exclusions", [])
+        ]
+        self.adjacent: list[tuple[str, str, list[re.Pattern]]] = [
+            (a["name"], a.get("display_name", a["name"]), _compile(a["terms"]))
+            for a in cfg.get("adjacent_nonaerial", cfg.get("adjacent", []))
+        ]
+        # Priority-ordered: first matching subset wins.
+        self.subsets: list[tuple[str, list[re.Pattern]]] = [
+            (s["name"], _compile(s["terms"])) for s in cfg["subsets"]
+        ]
+        self.fallback_subset: str = cfg["fallback_subset"]
+
+    @classmethod
+    def from_area(cls, area_id: str, config_dir: Path | None = None) -> CompiledCensus:
+        return cls(load_census_config(area_id, config_dir))
+
+
+def _text_of(award: CensusAward) -> str:
+    return f"{award.get('title', '') or ''} {award.get('abstract', '') or ''}"
+
+
+def passes_gate(award: CensusAward, compiled: CompiledCensus) -> bool:
+    """True if the award clears the relevance gate (title hit, or strong occurrence count)."""
+    text = _text_of(award)
+    title = award.get("title", "") or ""
+    matched = [rx for rx in compiled.gate_terms if rx.search(text)]
+    if not matched:
+        return False
+    if any(rx.search(title) for rx in matched):
+        return True
+    total_occurrences = sum(len(rx.findall(text)) for rx in compiled.gate_terms)
+    return total_occurrences >= compiled.min_abstract_only_occurrences
+
+
+def matched_exclusion(award: CensusAward, compiled: CompiledCensus) -> str | None:
+    """Return the exclusion category name if the award matches one, else None."""
+    text = _text_of(award)
+    for name, _display, patterns in compiled.exclusions:
+        if any(rx.search(text) for rx in patterns):
+            return name
+    return None
+
+
+def matched_adjacent(award: CensusAward, compiled: CompiledCensus) -> str | None:
+    """Return the adjacent (non-gate) category name if the award matches one, else None."""
+    text = _text_of(award)
+    for name, _display, patterns in compiled.adjacent:
+        if any(rx.search(text) for rx in patterns):
+            return name
+    return None
+
+
+def classify_subset(award: CensusAward, compiled: CompiledCensus) -> str:
+    """Assign exactly one subset via priority order; fallback if nothing matches."""
+    text = _text_of(award)
+    for name, patterns in compiled.subsets:
+        if any(rx.search(text) for rx in patterns):
+            return name
+    return compiled.fallback_subset
+
+
+def run_census(awards: list[CensusAward], compiled: CompiledCensus) -> dict[str, Any]:
+    """Classify every award and aggregate by fiscal year x subset.
+
+    Returns a dict with: in-scope classified awards (list), per-(year,subset)
+    counts/dollars, subset totals, year totals, grand total, and separately-
+    tracked exclusion/adjacent category counts (never merged into the main
+    total).
+    """
+    classified: list[dict[str, Any]] = []
+    exclusion_counts: dict[str, int] = defaultdict(int)
+    adjacent_counts: dict[str, int] = defaultdict(int)
+
+    for award in awards:
+        if not passes_gate(award, compiled):
+            excl = matched_exclusion(award, compiled)
+            adj = matched_adjacent(award, compiled)
+            # Only count non-gate-passing awards here; gate-passing exclusions
+            # are handled below so an award is never counted twice.
+            if excl:
+                exclusion_counts[excl] += 1
+            elif adj:
+                adjacent_counts[adj] += 1
+            continue
+
+        excl = matched_exclusion(award, compiled)
+        if excl:
+            exclusion_counts[excl] += 1
+            continue
+
+        subset = classify_subset(award, compiled)
+        classified.append(
+            {
+                "title": award.get("title", ""),
+                "company": award.get("company", ""),
+                "agency": award.get("agency", ""),
+                "phase": award.get("phase", ""),
+                "year": award.get("award_year"),
+                "amount": float(award.get("award_amount") or 0.0),
+                "subset": subset,
+            }
+        )
+
+    by_fy_subset: dict[tuple[int, str], dict[str, float]] = defaultdict(
+        lambda: {"n": 0, "usd": 0.0}
+    )
+    subset_totals: dict[str, dict[str, float]] = defaultdict(lambda: {"n": 0, "usd": 0.0})
+    fy_totals: dict[int, dict[str, float]] = defaultdict(lambda: {"n": 0, "usd": 0.0})
+    grand_n = 0
+    grand_usd = 0.0
+
+    for row in classified:
+        year, subset, amount = row["year"], row["subset"], row["amount"]
+        by_fy_subset[(year, subset)]["n"] += 1
+        by_fy_subset[(year, subset)]["usd"] += amount
+        subset_totals[subset]["n"] += 1
+        subset_totals[subset]["usd"] += amount
+        fy_totals[year]["n"] += 1
+        fy_totals[year]["usd"] += amount
+        grand_n += 1
+        grand_usd += amount
+
+    return {
+        "area_id": compiled.area_id,
+        "display_name": compiled.display_name,
+        "classified_awards": classified,
+        "by_fy_subset": dict(by_fy_subset),
+        "subset_totals": dict(subset_totals),
+        "fy_totals": dict(fy_totals),
+        "grand_total": {"n": grand_n, "usd": grand_usd},
+        "exclusion_counts": dict(exclusion_counts),
+        "adjacent_counts": dict(adjacent_counts),
+    }
+
+
+def _safe_amount(v: str) -> float:
+    if not v:
+        return 0.0
+    v = v.replace("$", "").replace(",", "").strip()
+    try:
+        return float(v)
+    except ValueError:
+        return 0.0
+
+
+def _safe_year(v: str) -> int | None:
+    try:
+        return int(float(v)) if v else None
+    except ValueError:
+        return None
+
+
+def load_award_data_csv(path: Path) -> list[CensusAward]:
+    """Load and normalize SBIR.gov's ``award_data.csv`` into the canonical shape.
+
+    This exact column-mapping (Award Title/Abstract/Company/Agency/Phase/
+    Award Year/Award Amount, ``utf-8-sig`` encoding for the BOM, oversized
+    field-size limit for embedded newlines in abstracts) has been rewritten
+    ad hoc several times across this repo's analysis scripts; centralized
+    here as the one shared, tested loader for this source. All phases are
+    included -- unlike ``build_tech_area_cohort.py``'s ``load_phase2_awards``,
+    a technology-relevance census is not scoped to Phase II.
+    """
+    import csv
+
+    csv.field_size_limit(2**31 - 1)
+    awards: list[CensusAward] = []
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        for row in csv.DictReader(f):
+            awards.append(
+                {
+                    "title": row.get("Award Title", "") or "",
+                    "abstract": row.get("Abstract", "") or "",
+                    "company": row.get("Company", "") or "",
+                    "agency": row.get("Agency", "") or "",
+                    "phase": row.get("Phase", "") or "",
+                    "award_year": _safe_year(row.get("Award Year", "")),
+                    "award_amount": _safe_amount(row.get("Award Amount", "")),
+                }
+            )
+    return awards

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -1,47 +1,16 @@
-"""Config-driven, all-phase technology-relevance census over SBIR/STTR awards.
+"""Config-driven technology censuses over SBIR/STTR awards.
 
-Generalizes the ad hoc drone-manufacturing analysis into a reusable engine:
-given an award universe (all phases -- this is a different question from the
-Phase-II-scoped cohort work in ``build_tech_area_cohort.py`` /
-``transition_signals.py``, which exists to support Phase II -> III transition
-analysis, not a technology-relevance census) and a YAML config, classify each
-award into a technology subset and aggregate counts/dollars by fiscal year.
-
-Design, validated against real data while building the first config
-(drone manufacturing):
-
-  - A GATE of broad relevance terms decides whether an award is in scope at
-    all. A term counts as a hit only if it appears in the award TITLE, or the
-    TOTAL occurrence count across all gate terms in title+abstract meets
-    ``min_abstract_only_occurrences``. Counting total occurrences (not
-    distinct pattern names) matters: several gate patterns are near-synonyms
-    that overlap on a single phrase (e.g. "unmanned aerial system" and
-    "unmanned aerial" both match "unmanned aerial systems"), so a naive
-    "N distinct terms" rule can be satisfied by one incidental sentence.
-    Spot-checked false positives (a hypersonic-interceptor award, a
-    lunar-battery award, a weather-forecasting-software award) each produced
-    exactly 2 total occurrences from one incidental mention; genuinely
-    relevant awards ran well past that.
-  - EXCLUSIONS are gate-passing awards that represent an adjacent-but-distinct
-    concept (e.g. counter-UAS defeat technology is not drone manufacturing).
-    They are tracked and reported separately, never silently dropped.
-  - SUBSETS sub-classify the remaining awards by more specific terminology,
-    in priority order (most specific first); anything matching no subset
-    falls into the configured fallback bucket. Each award gets exactly one
-    subset, so subset totals sum to the grand total without double-counting.
-
-Config schema: see config/tech_census/drone_manufacturing.yaml for a worked
-example. Callers normalize their own data source's column names into the
-canonical award dict shape this module expects (title, abstract, company,
-agency, phase, award_year, award_amount) -- this keeps the engine independent
-of both raw award_data.csv's column names and any DataFrame-based caller's
-naming conventions.
+Profiles answer two separate questions: broad technology relevance and a
+stricter physical-product/manufacturing census.  The engine keeps the
+classification rules in versioned YAML and emits enough evidence and source
+identifiers to audit every included award.
 """
 
 from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -52,20 +21,26 @@ CONFIG_DIR = REPO_ROOT / "config" / "tech_census"
 
 
 class CensusAward(TypedDict, total=False):
-    """Canonical award shape the engine operates on."""
+    """Canonical award shape used by the census engine."""
 
     title: str
     abstract: str
     company: str
     agency: str
+    program: str
     phase: str
-    award_year: int
+    award_year: int | None
     award_amount: float
+    agency_tracking_number: str
+    contract: str
+    source_row: int
 
 
 def load_census_config(area_id: str, config_dir: Path | None = None) -> dict[str, Any]:
-    """Load and lightly validate a tech-census area config."""
-    path = (config_dir or CONFIG_DIR) / f"{area_id}.yaml"
+    """Load and validate a census profile and its optional override ledger."""
+
+    directory = (config_dir or CONFIG_DIR).resolve()
+    path = directory / f"{area_id}.yaml"
     if not path.exists():
         raise FileNotFoundError(
             f"No tech-census config at {path}. Add config/tech_census/{area_id}.yaml"
@@ -79,126 +54,416 @@ def load_census_config(area_id: str, config_dir: Path | None = None) -> dict[str
             raise ValueError(f"{path} missing required key {required!r}")
     if not cfg["gate"].get("terms"):
         raise ValueError(f"{path}: gate.terms must be non-empty")
+    physical_gate = cfg.get("physical_gate")
+    if physical_gate and (
+        not physical_gate.get("terms") or not physical_gate.get("relationship_terms")
+    ):
+        raise ValueError(f"{path}: physical_gate requires terms and relationship_terms")
+
+    cfg["_overrides"] = []
+    cfg["_override_version"] = None
+    override_name = cfg.get("overrides_file")
+    if override_name:
+        override_path = (directory / str(override_name)).resolve()
+        try:
+            override_path.relative_to(directory)
+        except ValueError as exc:
+            raise ValueError(f"{path}: overrides_file must remain under {directory}") from exc
+        if not override_path.exists():
+            raise FileNotFoundError(f"Override ledger not found: {override_path}")
+        ledger = yaml.safe_load(override_path.read_text(encoding="utf-8")) or {}
+        cfg["_overrides"] = ledger.get("overrides", []) or []
+        cfg["_override_version"] = str(ledger.get("version", "unversioned"))
     return cfg
 
 
-def _compile(patterns: list[str]) -> list[re.Pattern]:
-    return [re.compile(p, re.IGNORECASE) for p in patterns]
+def _compile(patterns: Iterable[str]) -> list[re.Pattern[str]]:
+    return [re.compile(pattern, re.IGNORECASE) for pattern in patterns]
+
+
+def _compiled_rule(rule: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": rule["name"],
+        "display_name": rule.get("display_name", rule["name"]),
+        "reason": rule.get("reason", ""),
+        "title_only": bool(rule.get("title_only", False)),
+        "unless_title_only": bool(rule.get("unless_title_only", False)),
+        "terms": _compile(rule.get("terms", [])),
+        "unless_terms": _compile(rule.get("unless_terms", [])),
+    }
 
 
 class CompiledCensus:
-    """Compiled regex form of a census config, built once and reused per award."""
+    """Compiled regular-expression form of a census profile."""
 
     def __init__(self, cfg: dict[str, Any]):
-        self.area_id: str = cfg["area_id"]
-        self.display_name: str = cfg["display_name"]
-        self.gate_terms: list[re.Pattern] = _compile(cfg["gate"]["terms"])
-        self.min_abstract_only_occurrences: int = cfg["gate"].get(
-            "min_abstract_only_occurrences", 2
+        self.area_id = str(cfg["area_id"])
+        self.display_name = str(cfg["display_name"])
+        self.version = str(cfg.get("version", "unversioned"))
+        self.programs = tuple(str(value).strip().upper() for value in cfg.get("programs", []))
+        self.gate_terms = _compile(cfg["gate"]["terms"])
+        self.gate_any = re.compile(
+            "|".join(f"(?:{pattern.pattern})" for pattern in self.gate_terms),
+            re.IGNORECASE,
+        )
+        self.min_abstract_only_occurrences = int(
+            cfg["gate"].get("min_abstract_only_occurrences", 2)
         )
 
-        self.exclusions: list[tuple[str, str, list[re.Pattern]]] = [
-            (e["name"], e.get("display_name", e["name"]), _compile(e["terms"]))
-            for e in cfg.get("exclusions", [])
+        physical = cfg.get("physical_gate") or {}
+        self.physical_terms = _compile(physical.get("terms", []))
+        self.physical_title_terms = self.physical_terms + _compile(physical.get("title_terms", []))
+        self.physical_abstract_terms = self.physical_terms + _compile(
+            physical.get("abstract_terms", [])
+        )
+        self.relationship_terms = _compile(physical.get("relationship_terms", []))
+        self.physical_title_always_passes = bool(physical.get("title_term_always_passes", True))
+        self.max_relationship_distance = int(physical.get("max_relationship_distance", 180))
+        self.max_relevance_distance = int(physical.get("max_relevance_distance", 240))
+
+        self.exclusions = [_compiled_rule(rule) for rule in cfg.get("exclusions", [])]
+        self.adjacent = [
+            _compiled_rule(rule) for rule in cfg.get("adjacent_nonaerial", cfg.get("adjacent", []))
         ]
-        self.adjacent: list[tuple[str, str, list[re.Pattern]]] = [
-            (a["name"], a.get("display_name", a["name"]), _compile(a["terms"]))
-            for a in cfg.get("adjacent_nonaerial", cfg.get("adjacent", []))
+        self.subsets = [
+            (str(rule["name"]), _compile(rule.get("terms", []))) for rule in cfg["subsets"]
         ]
-        # Priority-ordered: first matching subset wins.
-        self.subsets: list[tuple[str, list[re.Pattern]]] = [
-            (s["name"], _compile(s["terms"])) for s in cfg["subsets"]
+        self.fallback_subset = str(cfg["fallback_subset"])
+        self.scope_classes = [
+            (str(rule["name"]), _compile(rule.get("terms", [])))
+            for rule in cfg.get("scope_classes", [])
         ]
-        self.fallback_subset: str = cfg["fallback_subset"]
+        self.fallback_scope_class = str(cfg.get("fallback_scope_class", "Unclassified"))
+        self.overrides = list(cfg.get("_overrides", []))
+        self.override_version = cfg.get("_override_version")
+        self._validate_overrides()
+
+    def _validate_overrides(self) -> None:
+        for index, override in enumerate(self.overrides, start=1):
+            action = str(override.get("action", "")).lower()
+            if action not in {"include", "exclude"}:
+                raise ValueError(f"override {index}: action must be include or exclude")
+            if not override.get("identifiers"):
+                raise ValueError(f"override {index}: identifiers must be non-empty")
+            if not str(override.get("reason", "")).strip():
+                raise ValueError(f"override {index}: reason is required")
 
     @classmethod
     def from_area(cls, area_id: str, config_dir: Path | None = None) -> CompiledCensus:
         return cls(load_census_config(area_id, config_dir))
 
 
+def _title_of(award: CensusAward) -> str:
+    return str(award.get("title", "") or "")
+
+
 def _text_of(award: CensusAward) -> str:
-    return f"{award.get('title', '') or ''} {award.get('abstract', '') or ''}"
+    return f"{_title_of(award)} {award.get('abstract', '') or ''}".strip()
+
+
+def _merged_matches(text: str, patterns: Iterable[re.Pattern[str]]) -> list[tuple[int, int, str]]:
+    """Return non-overlapping evidence spans, merging regex aliases on one phrase."""
+
+    spans = sorted(
+        (match.start(), match.end())
+        for pattern in patterns
+        for match in pattern.finditer(text)
+        if match.end() > match.start()
+    )
+    merged: list[list[int]] = []
+    for start, end in spans:
+        if merged and start < merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return [(start, end, text[start:end]) for start, end in merged]
+
+
+def _evidence(text: str, patterns: Iterable[re.Pattern[str]]) -> list[str]:
+    return [literal for _start, _end, literal in _merged_matches(text, patterns)]
+
+
+def gate_evidence(award: CensusAward, compiled: CompiledCensus) -> list[str]:
+    """Return distinct textual mentions supporting the relevance gate."""
+
+    text = _text_of(award)
+    if not compiled.gate_any.search(text):
+        return []
+    return _evidence(text, compiled.gate_terms)
 
 
 def passes_gate(award: CensusAward, compiled: CompiledCensus) -> bool:
-    """True if the award clears the relevance gate (title hit, or strong occurrence count)."""
-    text = _text_of(award)
-    title = award.get("title", "") or ""
-    matched = [rx for rx in compiled.gate_terms if rx.search(text)]
-    if not matched:
-        return False
-    if any(rx.search(title) for rx in matched):
+    """Return whether title evidence or repeated abstract evidence clears the gate."""
+
+    title = _title_of(award)
+    if any(pattern.search(title) for pattern in compiled.gate_terms):
         return True
-    total_occurrences = sum(len(rx.findall(text)) for rx in compiled.gate_terms)
-    return total_occurrences >= compiled.min_abstract_only_occurrences
+    return len(gate_evidence(award, compiled)) >= compiled.min_abstract_only_occurrences
+
+
+def _span_distance(left: tuple[int, int, str], right: tuple[int, int, str]) -> int:
+    if left[1] < right[0]:
+        return right[0] - left[1]
+    if right[1] < left[0]:
+        return left[0] - right[1]
+    return 0
+
+
+def physical_gate_evidence(award: CensusAward, compiled: CompiledCensus) -> list[str]:
+    """Return physical and funded-development evidence supporting strict scope."""
+
+    if not compiled.physical_terms:
+        return []
+    title = _title_of(award)
+    title_matches = _merged_matches(title, compiled.physical_title_terms)
+    title_has_relevance = any(pattern.search(title) for pattern in compiled.gate_terms)
+    if compiled.physical_title_always_passes and title_matches and title_has_relevance:
+        evidence = [f"physical: {match[2]}" for match in title_matches]
+        abstract = str(award.get("abstract", "") or "")
+        relationship_matches = _merged_matches(abstract, compiled.relationship_terms)
+        if relationship_matches:
+            evidence.append(f"relationship: {relationship_matches[0][2]}")
+        return evidence
+
+    abstract = str(award.get("abstract", "") or "")
+    physical_matches = _merged_matches(abstract, compiled.physical_abstract_terms)
+    relationship_matches = _merged_matches(abstract, compiled.relationship_terms)
+    relevance_matches = _merged_matches(abstract, compiled.gate_terms)
+    best: (
+        tuple[
+            int,
+            tuple[int, int, str],
+            tuple[int, int, str],
+            tuple[int, int, str],
+        ]
+        | None
+    ) = None
+    for physical in physical_matches:
+        for relationship in relationship_matches:
+            # A single regex span cannot prove both that a deliverable is
+            # physical and that funded development work is being performed.
+            # For example, ``coating`` appears in both vocabularies.
+            if physical[0] < relationship[1] and relationship[0] < physical[1]:
+                continue
+            relationship_distance = _span_distance(physical, relationship)
+            if relationship_distance > compiled.max_relationship_distance:
+                continue
+            for relevance in relevance_matches:
+                relevance_distance = _span_distance(physical, relevance)
+                combined_distance = relationship_distance + relevance_distance
+                if relevance_distance <= compiled.max_relevance_distance and (
+                    best is None or combined_distance < best[0]
+                ):
+                    best = (combined_distance, physical, relationship, relevance)
+    if best is None:
+        return []
+    return [
+        f"physical: {best[1][2]}",
+        f"relationship: {best[2][2]}",
+        f"relevance: {best[3][2]}",
+    ]
+
+
+def _matched_rule(award: CensusAward, rules: Iterable[dict[str, Any]]) -> dict[str, Any] | None:
+    full_text = _text_of(award)
+    title = _title_of(award)
+    for rule in rules:
+        text = title if rule["title_only"] else full_text
+        unless_text = title if rule["unless_title_only"] else full_text
+        if any(pattern.search(text) for pattern in rule["terms"]) and not any(
+            pattern.search(unless_text) for pattern in rule["unless_terms"]
+        ):
+            return rule
+    return None
 
 
 def matched_exclusion(award: CensusAward, compiled: CompiledCensus) -> str | None:
-    """Return the exclusion category name if the award matches one, else None."""
-    text = _text_of(award)
-    for name, _display, patterns in compiled.exclusions:
-        if any(rx.search(text) for rx in patterns):
-            return name
-    return None
+    """Return a matching exclusion category name, if any."""
+
+    rule = _matched_rule(award, compiled.exclusions)
+    return str(rule["name"]) if rule else None
 
 
 def matched_adjacent(award: CensusAward, compiled: CompiledCensus) -> str | None:
-    """Return the adjacent (non-gate) category name if the award matches one, else None."""
+    """Return a matching adjacent non-aerial category name, if any."""
+
+    rule = _matched_rule(award, compiled.adjacent)
+    return str(rule["name"]) if rule else None
+
+
+def _classification(
+    award: CensusAward,
+    rules: Iterable[tuple[str, list[re.Pattern[str]]]],
+    fallback: str,
+) -> tuple[str, list[str]]:
+    title = _title_of(award)
+    for name, patterns in rules:
+        evidence = _evidence(title, patterns)
+        if evidence:
+            return name, evidence
     text = _text_of(award)
-    for name, _display, patterns in compiled.adjacent:
-        if any(rx.search(text) for rx in patterns):
-            return name
-    return None
+    for name, patterns in rules:
+        evidence = _evidence(text, patterns)
+        if evidence:
+            return name, evidence
+    return fallback, []
 
 
 def classify_subset(award: CensusAward, compiled: CompiledCensus) -> str:
-    """Assign exactly one subset via priority order; fallback if nothing matches."""
-    text = _text_of(award)
-    for name, patterns in compiled.subsets:
-        if any(rx.search(text) for rx in patterns):
-            return name
-    return compiled.fallback_subset
+    """Assign one priority-ordered technology subset."""
+
+    return _classification(award, compiled.subsets, compiled.fallback_subset)[0]
 
 
-def run_census(awards: list[CensusAward], compiled: CompiledCensus) -> dict[str, Any]:
-    """Classify every award and aggregate by fiscal year x subset.
+def classify_scope(award: CensusAward, compiled: CompiledCensus) -> str:
+    """Assign the orthogonal scope class (hardware, software, services, etc.)."""
 
-    Returns a dict with: in-scope classified awards (list), per-(year,subset)
-    counts/dollars, subset totals, year totals, grand total, and separately-
-    tracked exclusion/adjacent category counts (never merged into the main
-    total).
-    """
+    return _classification(award, compiled.scope_classes, compiled.fallback_scope_class)[0]
+
+
+def _matching_override(award: CensusAward, compiled: CompiledCensus) -> dict[str, Any] | None:
+    for override in compiled.overrides:
+        identifiers = override.get("identifiers", {})
+        if all(
+            str(award.get(key, "") or "").strip().casefold() == str(expected).strip().casefold()
+            for key, expected in identifiers.items()
+        ):
+            return override
+    return None
+
+
+def _audit_identity(award: CensusAward) -> dict[str, Any]:
+    return {
+        "title": award.get("title", ""),
+        "company": award.get("company", ""),
+        "program": award.get("program", ""),
+        "agency_tracking_number": award.get("agency_tracking_number", ""),
+        "contract": award.get("contract", ""),
+        "source_row": award.get("source_row"),
+    }
+
+
+def run_census(
+    awards: list[CensusAward],
+    compiled: CompiledCensus,
+    programs: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Classify awards and aggregate counts/dollars by year, subset, and scope."""
+
+    effective_programs = (
+        tuple(str(value).strip().upper() for value in programs)
+        if programs is not None
+        else compiled.programs
+    )
+    allowed_programs = set(effective_programs)
     classified: list[dict[str, Any]] = []
+    excluded_awards: list[dict[str, Any]] = []
     exclusion_counts: dict[str, int] = defaultdict(int)
     adjacent_counts: dict[str, int] = defaultdict(int)
+    program_exclusion_counts: dict[str, int] = defaultdict(int)
+    rejection_counts: dict[str, int] = defaultdict(int)
 
     for award in awards:
-        if not passes_gate(award, compiled):
-            excl = matched_exclusion(award, compiled)
-            adj = matched_adjacent(award, compiled)
-            # Only count non-gate-passing awards here; gate-passing exclusions
-            # are handled below so an award is never counted twice.
-            if excl:
-                exclusion_counts[excl] += 1
-            elif adj:
-                adjacent_counts[adj] += 1
+        program = str(award.get("program", "") or "").strip().upper()
+        if allowed_programs and program not in allowed_programs:
+            program_exclusion_counts[program or "UNKNOWN"] += 1
             continue
 
-        excl = matched_exclusion(award, compiled)
-        if excl:
-            exclusion_counts[excl] += 1
+        override = _matching_override(award, compiled)
+        if override and str(override["action"]).lower() == "exclude":
+            exclusion_counts["manual_override"] += 1
+            excluded_awards.append(
+                {
+                    **_audit_identity(award),
+                    "reason": override["reason"],
+                    "classification_source": "override",
+                }
+            )
             continue
 
-        subset = classify_subset(award, compiled)
+        relevance_evidence = gate_evidence(award, compiled)
+        title_has_relevance = any(
+            pattern.search(_title_of(award)) for pattern in compiled.gate_terms
+        )
+        standard_relevance = title_has_relevance or (
+            len(relevance_evidence) >= compiled.min_abstract_only_occurrences
+        )
+        if not relevance_evidence and not override:
+            rejection_counts["relevance_gate"] += 1
+            adjacent = matched_adjacent(award, compiled)
+            if adjacent:
+                adjacent_counts[adjacent] += 1
+            continue
+
+        physical_evidence = physical_gate_evidence(award, compiled)
+        # A strict profile has an independent physical-development gate.  In
+        # that profile, one abstract UAS mention plus nearby physical/action
+        # evidence is stronger than three repeated UAS mentions alone.
+        clears_relevance = standard_relevance or bool(compiled.physical_terms and physical_evidence)
+        if not (override and str(override["action"]).lower() == "include") and not (
+            clears_relevance
+        ):
+            rejection_counts["relevance_gate"] += 1
+            adjacent = matched_adjacent(award, compiled)
+            exclusion_rule = _matched_rule(award, compiled.exclusions)
+            if exclusion_rule:
+                name = str(exclusion_rule["name"])
+                exclusion_counts[name] += 1
+                excluded_awards.append(
+                    {
+                        **_audit_identity(award),
+                        "reason": exclusion_rule["reason"] or exclusion_rule["display_name"],
+                        "classification_source": "rules",
+                    }
+                )
+            elif adjacent:
+                adjacent_counts[adjacent] += 1
+            continue
+
+        exclusion_rule = _matched_rule(award, compiled.exclusions)
+        if not override and exclusion_rule:
+            name = str(exclusion_rule["name"])
+            exclusion_counts[name] += 1
+            excluded_awards.append(
+                {
+                    **_audit_identity(award),
+                    "reason": exclusion_rule["reason"] or exclusion_rule["display_name"],
+                    "classification_source": "rules",
+                }
+            )
+            continue
+
+        if compiled.physical_terms and not override and not physical_evidence:
+            rejection_counts["physical_gate"] += 1
+            continue
+
+        subset, subset_evidence = _classification(award, compiled.subsets, compiled.fallback_subset)
+        scope, scope_evidence = _classification(
+            award, compiled.scope_classes, compiled.fallback_scope_class
+        )
+        classification_source = "rules"
+        override_reason = ""
+        if override:
+            subset = str(override.get("subset", subset))
+            scope = str(override.get("scope_class", scope))
+            classification_source = "override"
+            override_reason = str(override["reason"])
+
         classified.append(
             {
-                "title": award.get("title", ""),
-                "company": award.get("company", ""),
+                **_audit_identity(award),
                 "agency": award.get("agency", ""),
                 "phase": award.get("phase", ""),
                 "year": award.get("award_year"),
                 "amount": float(award.get("award_amount") or 0.0),
                 "subset": subset,
+                "scope_class": scope,
+                "gate_evidence": relevance_evidence,
+                "physical_evidence": physical_evidence,
+                "subset_evidence": subset_evidence,
+                "scope_evidence": scope_evidence,
+                "classification_source": classification_source,
+                "override_reason": override_reason,
             }
         )
 
@@ -206,77 +471,88 @@ def run_census(awards: list[CensusAward], compiled: CompiledCensus) -> dict[str,
         lambda: {"n": 0, "usd": 0.0}
     )
     subset_totals: dict[str, dict[str, float]] = defaultdict(lambda: {"n": 0, "usd": 0.0})
+    scope_totals: dict[str, dict[str, float]] = defaultdict(lambda: {"n": 0, "usd": 0.0})
     fy_totals: dict[int, dict[str, float]] = defaultdict(lambda: {"n": 0, "usd": 0.0})
     grand_n = 0
     grand_usd = 0.0
-
     for row in classified:
-        year, subset, amount = row["year"], row["subset"], row["amount"]
-        by_fy_subset[(year, subset)]["n"] += 1
-        by_fy_subset[(year, subset)]["usd"] += amount
+        year = row["year"]
+        subset = str(row["subset"])
+        scope = str(row["scope_class"])
+        amount = float(row["amount"])
+        if isinstance(year, int):
+            by_fy_subset[(year, subset)]["n"] += 1
+            by_fy_subset[(year, subset)]["usd"] += amount
+            fy_totals[year]["n"] += 1
+            fy_totals[year]["usd"] += amount
         subset_totals[subset]["n"] += 1
         subset_totals[subset]["usd"] += amount
-        fy_totals[year]["n"] += 1
-        fy_totals[year]["usd"] += amount
+        scope_totals[scope]["n"] += 1
+        scope_totals[scope]["usd"] += amount
         grand_n += 1
         grand_usd += amount
+
+    for totals_by_key in (by_fy_subset, subset_totals, scope_totals, fy_totals):
+        for totals in totals_by_key.values():
+            totals["usd"] = round(totals["usd"], 2)
 
     return {
         "area_id": compiled.area_id,
         "display_name": compiled.display_name,
+        "config_version": compiled.version,
+        "override_version": compiled.override_version,
+        "programs": sorted(allowed_programs),
         "classified_awards": classified,
+        "excluded_awards": excluded_awards,
         "by_fy_subset": dict(by_fy_subset),
         "subset_totals": dict(subset_totals),
+        "scope_totals": dict(scope_totals),
         "fy_totals": dict(fy_totals),
-        "grand_total": {"n": grand_n, "usd": grand_usd},
+        "grand_total": {"n": grand_n, "usd": round(grand_usd, 2)},
         "exclusion_counts": dict(exclusion_counts),
         "adjacent_counts": dict(adjacent_counts),
+        "program_exclusion_counts": dict(program_exclusion_counts),
+        "rejection_counts": dict(rejection_counts),
     }
 
 
-def _safe_amount(v: str) -> float:
-    if not v:
-        return 0.0
-    v = v.replace("$", "").replace(",", "").strip()
+def _safe_amount(value: str) -> float:
+    cleaned = (value or "").replace("$", "").replace(",", "").strip()
     try:
-        return float(v)
+        return float(cleaned) if cleaned else 0.0
     except ValueError:
         return 0.0
 
 
-def _safe_year(v: str) -> int | None:
+def _safe_year(value: str) -> int | None:
     try:
-        return int(float(v)) if v else None
+        return int(float(value)) if value else None
     except ValueError:
         return None
 
 
 def load_award_data_csv(path: Path) -> list[CensusAward]:
-    """Load and normalize SBIR.gov's ``award_data.csv`` into the canonical shape.
+    """Load and normalize SBIR.gov's ``award_data.csv`` export."""
 
-    This exact column-mapping (Award Title/Abstract/Company/Agency/Phase/
-    Award Year/Award Amount, ``utf-8-sig`` encoding for the BOM, oversized
-    field-size limit for embedded newlines in abstracts) has been rewritten
-    ad hoc several times across this repo's analysis scripts; centralized
-    here as the one shared, tested loader for this source. All phases are
-    included -- unlike ``build_tech_area_cohort.py``'s ``load_phase2_awards``,
-    a technology-relevance census is not scoped to Phase II.
-    """
     import csv
 
     csv.field_size_limit(2**31 - 1)
     awards: list[CensusAward] = []
-    with open(path, newline="", encoding="utf-8-sig") as f:
-        for row in csv.DictReader(f):
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        for source_row, row in enumerate(csv.DictReader(handle), start=2):
             awards.append(
                 {
                     "title": row.get("Award Title", "") or "",
                     "abstract": row.get("Abstract", "") or "",
                     "company": row.get("Company", "") or "",
                     "agency": row.get("Agency", "") or "",
+                    "program": row.get("Program", "") or "",
                     "phase": row.get("Phase", "") or "",
                     "award_year": _safe_year(row.get("Award Year", "")),
                     "award_amount": _safe_amount(row.get("Award Amount", "")),
+                    "agency_tracking_number": row.get("Agency Tracking Number", "") or "",
+                    "contract": row.get("Contract", "") or "",
+                    "source_row": source_row,
                 }
             )
     return awards

--- a/scripts/data/build_tech_census.py
+++ b/scripts/data/build_tech_census.py
@@ -7,7 +7,7 @@ This is a different question from build_tech_area_cohort.py's Phase II
 cohort work: no Method A/B overlap, no external-reference reconciliation, no
 transition-channel signals -- just "how many awards, and how many dollars,
 are relevant to this technology area, broken into technology subsets, by
-fiscal year." All SBIR/STTR phases are included.
+fiscal year." All phases in the profile's configured program scope are included.
 
 Usage:
   python scripts/data/build_tech_census.py --area drone_manufacturing
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 import argparse
 import csv
+import hashlib
 import json
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -32,6 +34,18 @@ from sbir_etl.utils.tech_census import (  # noqa: E402
     load_census_config,
     run_census,
 )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_timestamp(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat()
 
 
 def main() -> int:
@@ -48,6 +62,24 @@ def main() -> int:
         default=3,
         help="Number of most-recent fiscal years to print individually (default 3)",
     )
+    parser.add_argument(
+        "--program",
+        dest="programs",
+        action="append",
+        choices=("SBIR", "STTR"),
+        help="Override configured program scope; repeat to select both",
+    )
+    parser.add_argument(
+        "--fiscal-year",
+        dest="fiscal_years",
+        action="append",
+        type=int,
+        help="Limit the report to a fiscal year; repeat for multiple years",
+    )
+    parser.add_argument(
+        "--data-vintage",
+        help="Optional source-data release/download vintage (not inferred from local file mtime)",
+    )
     args = parser.parse_args()
 
     awards_csv = Path(args.awards)
@@ -63,7 +95,13 @@ def main() -> int:
     awards = load_award_data_csv(awards_csv)
     print(f"  {len(awards):,} total awards")
 
-    result = run_census(awards, compiled)
+    selected_fys = sorted(set(args.fiscal_years or []))
+    reporting_awards = (
+        [award for award in awards if award.get("award_year") in selected_fys]
+        if selected_fys
+        else awards
+    )
+    result = run_census(reporting_awards, compiled, programs=args.programs)
     grand = result["grand_total"]
     print(f"\nIn-scope awards: {grand['n']:,}  (${grand['usd'] / 1e6:,.1f}M)")
     if result["exclusion_counts"]:
@@ -78,19 +116,28 @@ def main() -> int:
     years = sorted({r["year"] for r in result["classified_awards"] if r["year"]})
     if not years:
         print("\nNo in-scope awards found.")
-        return 0
-    current_fy = years[-1]
-    recent_fys = [current_fy - i for i in range(args.recent_fys)]
+    if selected_fys:
+        recent_fys = sorted(selected_fys, reverse=True)
+    elif years:
+        current_fy = years[-1]
+        recent_fys = [current_fy - i for i in range(args.recent_fys)]
+    else:
+        recent_fys = []
 
     print()
     print("=" * 100)
-    print(f"{compiled.display_name.upper()} -- SBIR/STTR AWARDS BY TECHNOLOGY SUBSET x FISCAL YEAR")
+    program_label = "/".join(result.get("programs", [])) or "ALL PROGRAM"
+    print(
+        f"{compiled.display_name.upper()} -- {program_label} AWARDS "
+        "BY TECHNOLOGY SUBSET x FISCAL YEAR"
+    )
     print("=" * 100)
     subset_names = [name for name, _ in compiled.subsets] + [compiled.fallback_subset]
+    aggregate_label = "SELECTED TOTAL" if selected_fys else "ALL-TIME"
     header = (
         f"{'Subset':<48}"
         + "".join(f"{'FY' + str(fy):>16}" for fy in recent_fys)
-        + f"{'ALL-TIME':>18}"
+        + f"{aggregate_label:>18}"
     )
     print(header)
     for subset in subset_names:
@@ -119,13 +166,36 @@ def main() -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     awards_csv_path = out_dir / "classified_awards.csv"
+    rows = result["classified_awards"]
+    preferred_columns = [
+        "company",
+        "title",
+        "agency",
+        "program",
+        "phase",
+        "year",
+        "amount",
+        "subset",
+        "scope_class",
+        "agency_tracking_number",
+        "contract",
+        "source_row",
+        "gate_evidence",
+        "physical_evidence",
+        "subset_evidence",
+        "scope_evidence",
+        "classification_source",
+        "override_reason",
+    ]
+    extra_columns = [key for row in rows for key in row if key not in preferred_columns]
+    cols = list(dict.fromkeys(preferred_columns + extra_columns))
     with open(awards_csv_path, "w", newline="", encoding="utf-8") as f:
-        cols = ["company", "title", "agency", "phase", "year", "amount", "subset"]
         w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
         w.writeheader()
-        w.writerows(result["classified_awards"])
+        w.writerows(rows)
 
     summary_path = out_dir / "summary.json"
+    source_timestamp = _source_timestamp(awards_csv)
     json_safe = {
         "area_id": result["area_id"],
         "display_name": result["display_name"],
@@ -135,6 +205,24 @@ def main() -> int:
         "by_fy_subset": {f"{fy}|{subset}": v for (fy, subset), v in result["by_fy_subset"].items()},
         "exclusion_counts": result["exclusion_counts"],
         "adjacent_counts": result["adjacent_counts"],
+        "program_exclusion_counts": result["program_exclusion_counts"],
+        "rejection_counts": result["rejection_counts"],
+        "config_version": result["config_version"],
+        "override_version": result["override_version"],
+        "programs": result["programs"],
+        "scope_totals": result["scope_totals"],
+        "reporting_window": {
+            "fiscal_years": selected_fys or None,
+            "programs": result["programs"],
+        },
+        "provenance": {
+            "source_path": str(awards_csv.resolve()),
+            "sha256": _sha256(awards_csv),
+            "source_timestamp": source_timestamp,
+            "data_vintage": args.data_vintage,
+            "source_row_count": len(awards),
+            "reporting_row_count": len(reporting_awards),
+        },
     }
     summary_path.write_text(json.dumps(json_safe, indent=2) + "\n", encoding="utf-8")
 

--- a/scripts/data/build_tech_census.py
+++ b/scripts/data/build_tech_census.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Build an all-phase, subset-taxonomy technology-relevance census over SBIR
+awards, driven by a config/tech_census/<area>.yaml.
+
+This is a different question from build_tech_area_cohort.py's Phase II
+cohort work: no Method A/B overlap, no external-reference reconciliation, no
+transition-channel signals -- just "how many awards, and how many dollars,
+are relevant to this technology area, broken into technology subsets, by
+fiscal year." All SBIR/STTR phases are included.
+
+Usage:
+  python scripts/data/build_tech_census.py --area drone_manufacturing
+  python scripts/data/build_tech_census.py --area drone_manufacturing --recent-fys 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DATA = REPO / "data"
+
+sys.path.insert(0, str(REPO))
+from sbir_etl.utils.tech_census import (  # noqa: E402
+    CompiledCensus,
+    load_award_data_csv,
+    load_census_config,
+    run_census,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--area", required=True, help="area_id under config/tech_census/")
+    parser.add_argument(
+        "--awards",
+        default=str(DATA / "raw" / "sbir" / "award_data.csv"),
+        help="SBIR.gov award_data.csv path",
+    )
+    parser.add_argument(
+        "--recent-fys",
+        type=int,
+        default=3,
+        help="Number of most-recent fiscal years to print individually (default 3)",
+    )
+    args = parser.parse_args()
+
+    awards_csv = Path(args.awards)
+    if not awards_csv.exists():
+        print(f"ERROR: awards CSV not found: {awards_csv}", file=sys.stderr)
+        return 1
+
+    cfg = load_census_config(args.area)
+    compiled = CompiledCensus(cfg)
+    print(f"Area: {compiled.display_name} ({compiled.area_id})")
+
+    print("Loading SBIR/STTR awards (all phases)...")
+    awards = load_award_data_csv(awards_csv)
+    print(f"  {len(awards):,} total awards")
+
+    result = run_census(awards, compiled)
+    grand = result["grand_total"]
+    print(f"\nIn-scope awards: {grand['n']:,}  (${grand['usd'] / 1e6:,.1f}M)")
+    if result["exclusion_counts"]:
+        print("Excluded (adjacent, not in scope):")
+        for name, n in sorted(result["exclusion_counts"].items()):
+            print(f"  {name}: {n:,}")
+    if result["adjacent_counts"]:
+        print("Adjacent non-gate-passing categories (context only):")
+        for name, n in sorted(result["adjacent_counts"].items()):
+            print(f"  {name}: {n:,}")
+
+    years = sorted({r["year"] for r in result["classified_awards"] if r["year"]})
+    if not years:
+        print("\nNo in-scope awards found.")
+        return 0
+    current_fy = years[-1]
+    recent_fys = [current_fy - i for i in range(args.recent_fys)]
+
+    print()
+    print("=" * 100)
+    print(f"{compiled.display_name.upper()} -- SBIR/STTR AWARDS BY TECHNOLOGY SUBSET x FISCAL YEAR")
+    print("=" * 100)
+    subset_names = [name for name, _ in compiled.subsets] + [compiled.fallback_subset]
+    header = (
+        f"{'Subset':<48}"
+        + "".join(f"{'FY' + str(fy):>16}" for fy in recent_fys)
+        + f"{'ALL-TIME':>18}"
+    )
+    print(header)
+    for subset in subset_names:
+        cells = []
+        for fy in recent_fys:
+            d = result["by_fy_subset"].get((fy, subset), {"n": 0, "usd": 0.0})
+            cells.append(f"{d['n']:>5,} (${d['usd'] / 1e6:>6.1f}M)")
+        tot = result["subset_totals"].get(subset, {"n": 0, "usd": 0.0})
+        print(
+            f"{subset:<48}"
+            + "".join(f"{c:>16}" for c in cells)
+            + f"{tot['n']:>7,} (${tot['usd'] / 1e6:>7.1f}M)"
+        )
+    print("-" * 100)
+    fy_cells = []
+    for fy in recent_fys:
+        d = result["fy_totals"].get(fy, {"n": 0, "usd": 0.0})
+        fy_cells.append(f"{d['n']:>5,} (${d['usd'] / 1e6:>6.1f}M)")
+    print(
+        f"{'TOTAL':<48}"
+        + "".join(f"{c:>16}" for c in fy_cells)
+        + f"{grand['n']:>7,} (${grand['usd'] / 1e6:>7.1f}M)"
+    )
+
+    out_dir = DATA / "tech_census" / compiled.area_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    awards_csv_path = out_dir / "classified_awards.csv"
+    with open(awards_csv_path, "w", newline="", encoding="utf-8") as f:
+        cols = ["company", "title", "agency", "phase", "year", "amount", "subset"]
+        w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
+        w.writeheader()
+        w.writerows(result["classified_awards"])
+
+    summary_path = out_dir / "summary.json"
+    json_safe = {
+        "area_id": result["area_id"],
+        "display_name": result["display_name"],
+        "grand_total": result["grand_total"],
+        "fy_totals": {str(k): v for k, v in result["fy_totals"].items()},
+        "subset_totals": result["subset_totals"],
+        "by_fy_subset": {f"{fy}|{subset}": v for (fy, subset), v in result["by_fy_subset"].items()},
+        "exclusion_counts": result["exclusion_counts"],
+        "adjacent_counts": result["adjacent_counts"],
+    }
+    summary_path.write_text(json.dumps(json_safe, indent=2) + "\n", encoding="utf-8")
+
+    print(f"\nWrote {awards_csv_path} ({grand['n']:,} rows)")
+    print(f"Wrote {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/data/build_tech_census_snapshot.py
+++ b/scripts/data/build_tech_census_snapshot.py
@@ -17,6 +17,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
@@ -42,7 +43,20 @@ from sbir_analytics.tools.tech_census import ComputeTechCensusTool  # noqa: E402
 # config/tech_census/<area_id>.yaml as areas are added.
 _AREA_TO_KIND = {
     "drone_manufacturing": AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING,
+    "uas_relevance": AnalysisKind.TECH_CENSUS_UAS_RELEVANCE,
 }
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_timestamp(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat()
 
 
 def main() -> int:
@@ -50,7 +64,11 @@ def main() -> int:
     parser.add_argument(
         "--area", required=True, choices=sorted(_AREA_TO_KIND), help="tech-census area_id"
     )
-    parser.add_argument("--period", required=True, help="Snapshot period, e.g. 2026 or 2026-Q1")
+    parser.add_argument(
+        "--period",
+        required=True,
+        help="Snapshot identifier/as-of period, e.g. 2026 or 2026-Q1; not a data filter",
+    )
     parser.add_argument(
         "--awards",
         default=str(DATA / "raw" / "sbir" / "award_data.csv"),
@@ -64,6 +82,24 @@ def main() -> int:
     parser.add_argument(
         "--overwrite", action="store_true", help="Replace an existing snapshot for this period"
     )
+    parser.add_argument(
+        "--program",
+        dest="programs",
+        action="append",
+        choices=("SBIR", "STTR"),
+        help="Override configured program scope; repeat to select both",
+    )
+    parser.add_argument(
+        "--fiscal-year",
+        dest="fiscal_years",
+        action="append",
+        type=int,
+        help="Limit the reporting window to a fiscal year; repeat for multiple years",
+    )
+    parser.add_argument(
+        "--data-vintage",
+        help="Optional source-data release/download vintage (not inferred from local file mtime)",
+    )
     args = parser.parse_args()
 
     awards_csv = Path(args.awards)
@@ -76,12 +112,26 @@ def main() -> int:
     awards_df = pd.DataFrame(awards)
     print(f"  {len(awards_df):,} total awards")
 
+    source_timestamp = _source_timestamp(awards_csv)
     tool = ComputeTechCensusTool()
-    result = tool.run(awards_df=awards_df, area_id=args.area)
+    result = tool.run(
+        awards_df=awards_df,
+        area_id=args.area,
+        programs=args.programs,
+        fiscal_years=args.fiscal_years,
+        source_path=str(awards_csv.resolve()),
+        source_sha256=_sha256(awards_csv),
+        source_timestamp=source_timestamp,
+        data_vintage=args.data_vintage,
+    )
+    if result.metadata.warnings:
+        for warning in result.metadata.warnings:
+            print(f"ERROR: {warning}", file=sys.stderr)
+        print("ERROR: snapshot was not written because census validation failed", file=sys.stderr)
+        return 1
+
     grand = result.data["summary"]["grand_total"]
     print(f"Classified {grand['n']:,} in-scope awards (${grand['usd'] / 1e6:,.1f}M)")
-    for warning in result.metadata.warnings:
-        print(f"  warning: {warning}", file=sys.stderr)
 
     snapshot = snapshot_from_tool_result(
         _AREA_TO_KIND[args.area],

--- a/scripts/data/build_tech_census_snapshot.py
+++ b/scripts/data/build_tech_census_snapshot.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Run a tech-census area through ComputeTechCensusTool and persist the result
+as an API-servable snapshot (packages/sbir-analytics/sbir_analytics/api/snapshots.py).
+
+Unlike build_tech_census.py, which writes a human-readable CSV/JSON report
+under data/tech_census/<area>/, this script produces the machine-readable
+AnalyticsSnapshot the private analytics API reads from
+SBIR_ANALYTICS_SNAPSHOT_DIR (default reports/analytics_snapshots/) and serves
+at GET /v1/snapshots/<analysis_kind>/<period>.
+
+Usage:
+  python scripts/data/build_tech_census_snapshot.py --area drone_manufacturing --period 2026
+  python scripts/data/build_tech_census_snapshot.py --area drone_manufacturing --period 2026 --overwrite
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+DATA = REPO / "data"
+
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "packages" / "sbir-analytics"))
+
+import pandas as pd  # noqa: E402
+
+from sbir_etl.utils.tech_census import load_award_data_csv  # noqa: E402
+from sbir_analytics.api.snapshots import (  # noqa: E402
+    AnalysisKind,
+    SnapshotStoreError,
+    snapshot_from_tool_result,
+    write_snapshot,
+)
+from sbir_analytics.tools.tech_census import ComputeTechCensusTool  # noqa: E402
+
+# One AnalysisKind per tech-census area -- keep in sync with AnalysisKind and
+# config/tech_census/<area_id>.yaml as areas are added.
+_AREA_TO_KIND = {
+    "drone_manufacturing": AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING,
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--area", required=True, choices=sorted(_AREA_TO_KIND), help="tech-census area_id"
+    )
+    parser.add_argument("--period", required=True, help="Snapshot period, e.g. 2026 or 2026-Q1")
+    parser.add_argument(
+        "--awards",
+        default=str(DATA / "raw" / "sbir" / "award_data.csv"),
+        help="SBIR.gov award_data.csv path",
+    )
+    parser.add_argument(
+        "--snapshot-dir",
+        default=str(REPO / "reports" / "analytics_snapshots"),
+        help="Snapshot store root (must match SBIR_ANALYTICS_SNAPSHOT_DIR the API reads)",
+    )
+    parser.add_argument(
+        "--overwrite", action="store_true", help="Replace an existing snapshot for this period"
+    )
+    args = parser.parse_args()
+
+    awards_csv = Path(args.awards)
+    if not awards_csv.exists():
+        print(f"ERROR: awards CSV not found: {awards_csv}", file=sys.stderr)
+        return 1
+
+    print(f"Loading SBIR/STTR awards (all phases) from {awards_csv}...")
+    awards = load_award_data_csv(awards_csv)
+    awards_df = pd.DataFrame(awards)
+    print(f"  {len(awards_df):,} total awards")
+
+    tool = ComputeTechCensusTool()
+    result = tool.run(awards_df=awards_df, area_id=args.area)
+    grand = result.data["summary"]["grand_total"]
+    print(f"Classified {grand['n']:,} in-scope awards (${grand['usd'] / 1e6:,.1f}M)")
+    for warning in result.metadata.warnings:
+        print(f"  warning: {warning}", file=sys.stderr)
+
+    snapshot = snapshot_from_tool_result(
+        _AREA_TO_KIND[args.area],
+        args.period,
+        result,
+        as_of=datetime.now(UTC),
+    )
+
+    try:
+        path = write_snapshot(Path(args.snapshot_dir), snapshot, overwrite=args.overwrite)
+    except SnapshotStoreError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/api/test_snapshots.py
+++ b/tests/unit/api/test_snapshots.py
@@ -129,3 +129,81 @@ def test_openapi_remains_read_only(tmp_path: Path) -> None:
     assert all(
         not ({"post", "put", "patch", "delete"} & endpoints.keys()) for endpoints in operations
     )
+
+
+def test_tech_census_snapshot_is_servable_end_to_end(tmp_path: Path) -> None:
+    """A real ComputeTechCensusTool run, written as a snapshot, is servable, listable, and comparable."""
+
+    from fastapi.testclient import TestClient
+
+    from sbir_analytics.api.app import create_app
+    from sbir_analytics.tools.tech_census import ComputeTechCensusTool
+
+    def _award(title: str, year: int, amount: float) -> dict:
+        return {
+            "title": title,
+            "abstract": "",
+            "company": "Acme",
+            "agency": "Department of Defense",
+            "phase": "Phase II",
+            "award_year": year,
+            "award_amount": amount,
+        }
+
+    tool = ComputeTechCensusTool()
+    result_2025 = tool.run(
+        awards_df=pd.DataFrame(
+            [
+                _award("Drone battery hybridizer", 2025, 1_000_000.0),
+                _award("Drone gimbal payload system", 2025, 500_000.0),
+            ]
+        ),
+        area_id="drone_manufacturing",
+    )
+    result_2026 = tool.run(
+        awards_df=pd.DataFrame([_award("Drone propulsion system", 2026, 750_000.0)]),
+        area_id="drone_manufacturing",
+    )
+
+    write_snapshot(
+        tmp_path,
+        snapshot_from_tool_result(
+            AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING, "2025", result_2025
+        ),
+    )
+    write_snapshot(
+        tmp_path,
+        snapshot_from_tool_result(
+            AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING, "2026", result_2026
+        ),
+    )
+
+    app = create_app(api_token="secret", snapshot_repository=FileSnapshotRepository(tmp_path))
+    with TestClient(app) as client:
+        headers = {"Authorization": "Bearer secret"}
+
+        get_response = client.get(
+            "/v1/snapshots/tech_census_drone_manufacturing/2025", headers=headers
+        )
+        assert get_response.status_code == 200
+        assert get_response.json()["result"]["summary"]["grand_total"] == {
+            "n": 2,
+            "usd": 1_500_000.0,
+        }
+
+        list_response = client.get(
+            "/v1/snapshots",
+            params={"analysis_kind": "tech_census_drone_manufacturing"},
+            headers=headers,
+        )
+        assert list_response.status_code == 200
+        periods = {entry["period"] for entry in list_response.json()["data"]}
+        assert periods == {"2025", "2026"}
+
+        compare_response = client.get(
+            "/v1/snapshots/tech_census_drone_manufacturing/2025/compare/2026", headers=headers
+        )
+        assert compare_response.status_code == 200
+        # compare_snapshots only diffs top-level int/float result keys; "results"
+        # (list) and "summary" (dict) are both structured, so nothing qualifies.
+        assert compare_response.json()["numeric_deltas"] == {}

--- a/tests/unit/api/test_snapshots.py
+++ b/tests/unit/api/test_snapshots.py
@@ -10,8 +10,10 @@ import pytest
 from sbir_analytics.api.snapshots import (
     AnalysisKind,
     FileSnapshotRepository,
+    IncompatibleSnapshotsError,
     SnapshotMetadata,
     SnapshotStoreError,
+    compare_snapshots,
     snapshot_from_result,
     snapshot_from_tool_result,
     write_snapshot,
@@ -145,9 +147,13 @@ def test_tech_census_snapshot_is_servable_end_to_end(tmp_path: Path) -> None:
             "abstract": "",
             "company": "Acme",
             "agency": "Department of Defense",
+            "program": "SBIR",
             "phase": "Phase II",
             "award_year": year,
             "award_amount": amount,
+            "agency_tracking_number": f"TRACK-{year}-{amount}",
+            "contract": f"CONTRACT-{year}-{amount}",
+            "source_row": 2,
         }
 
     tool = ComputeTechCensusTool()
@@ -204,6 +210,46 @@ def test_tech_census_snapshot_is_servable_end_to_end(tmp_path: Path) -> None:
             "/v1/snapshots/tech_census_drone_manufacturing/2025/compare/2026", headers=headers
         )
         assert compare_response.status_code == 200
-        # compare_snapshots only diffs top-level int/float result keys; "results"
-        # (list) and "summary" (dict) are both structured, so nothing qualifies.
-        assert compare_response.json()["numeric_deltas"] == {}
+        assert compare_response.json()["numeric_deltas"] == {
+            "award_count": -1,
+            "award_dollars": -750_000.0,
+        }
+
+
+def test_uas_relevance_snapshot_has_its_own_directory(tmp_path: Path) -> None:
+    repository = FileSnapshotRepository(tmp_path)
+    assert repository._directory(AnalysisKind.TECH_CENSUS_UAS_RELEVANCE).name == (
+        "tech_census_uas_relevance"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "different_value"),
+    [
+        ("config_version", "2.1.0"),
+        ("override_version", "review-2"),
+        ("programs", ["STTR"]),
+        ("reporting_window", {"fiscal_years": [2025], "programs": ["SBIR"]}),
+    ],
+)
+def test_tech_census_comparison_rejects_different_methodology_or_scope(
+    field: str, different_value: object
+) -> None:
+    def _snapshot(period: str, **summary_overrides: object):
+        summary = {
+            "area_id": "drone_manufacturing",
+            "config_version": "2.0.0",
+            "override_version": "review-1",
+            "programs": ["SBIR"],
+            "reporting_window": {"fiscal_years": None, "programs": ["SBIR"]},
+        }
+        summary.update(summary_overrides)
+        return snapshot_from_result(
+            AnalysisKind.TECH_CENSUS_DRONE_MANUFACTURING,
+            period,
+            {"award_count": 1, "award_dollars": 1.0, "summary": summary},
+            metadata=SnapshotMetadata(tool_name="compute_tech_census", tool_version="2.0.0"),
+        )
+
+    with pytest.raises(IncompatibleSnapshotsError, match="methodologies or reporting scopes"):
+        compare_snapshots(_snapshot("2025"), _snapshot("2026", **{field: different_value}))

--- a/tests/unit/scripts/test_build_tech_census_snapshot.py
+++ b/tests/unit/scripts/test_build_tech_census_snapshot.py
@@ -1,0 +1,46 @@
+"""Safety tests for the tech-census snapshot publishing CLI."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "data" / "build_tech_census_snapshot.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("build_tech_census_snapshot", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_validation_warning_blocks_zero_snapshot_publish(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    awards = tmp_path / "awards.csv"
+    awards.write_text(
+        "Award Title,Abstract,Company,Agency,Program,Phase,Award Year,Award Amount\n"
+        "Drone Airframe,Build it,Acme,DOD,,Phase II,2025,100000\n",
+        encoding="utf-8",
+    )
+    snapshot_dir = tmp_path / "snapshots"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            str(SCRIPT_PATH),
+            "--area",
+            "drone_manufacturing",
+            "--period",
+            "2026",
+            "--awards",
+            str(awards),
+            "--snapshot-dir",
+            str(snapshot_dir),
+        ],
+    )
+
+    assert _load_script().main() == 1
+    assert not list(snapshot_dir.rglob("*.json"))
+    assert "no usable program values" in capsys.readouterr().err

--- a/tests/unit/tools/test_tech_census.py
+++ b/tests/unit/tools/test_tech_census.py
@@ -10,6 +10,7 @@ def _award(
     abstract="",
     company="Acme",
     agency="Department of Defense",
+    program="SBIR",
     phase="Phase II",
     year=2024,
     amount=500_000.0,
@@ -19,9 +20,13 @@ def _award(
         "abstract": abstract,
         "company": company,
         "agency": agency,
+        "program": program,
         "phase": phase,
         "award_year": year,
         "award_amount": amount,
+        "agency_tracking_number": "TRACK",
+        "contract": "CONTRACT",
+        "source_row": 2,
     }
 
 
@@ -63,6 +68,8 @@ class TestComputeTechCensusTool:
         result = tool.run(awards_df=df, area_id="drone_manufacturing")
         summary = result.data["summary"]
         assert summary["grand_total"] == {"n": 2, "usd": 1_500_000.0}
+        assert result.data["award_count"] == 2
+        assert result.data["award_dollars"] == 1_500_000.0
         assert result.metadata.record_count == 2
         assert len(result.metadata.data_sources) == 1
         assert (
@@ -76,3 +83,81 @@ class TestComputeTechCensusTool:
         results_df = result.data["results"]
         assert len(results_df) == 1
         assert set(results_df.columns) >= {"title", "company", "year", "amount", "subset"}
+
+    def test_strict_and_broad_profiles_apply_different_program_scope(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame(
+            [
+                _award(title="Drone airframe", program="SBIR"),
+                _award(title="Drone airframe", program="STTR"),
+            ]
+        )
+        strict = tool.run(awards_df=df, area_id="drone_manufacturing")
+        broad = tool.run(awards_df=df, area_id="uas_relevance")
+        assert strict.data["award_count"] == 1
+        assert strict.data["summary"]["program_exclusion_counts"] == {"STTR": 1}
+        assert broad.data["award_count"] == 2
+
+    def test_fiscal_year_filter_and_provenance_are_reported(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame(
+            [
+                _award(title="Drone airframe", year=2024, amount=100_000),
+                _award(title="Drone airframe", year=2025, amount=200_000),
+            ]
+        )
+        result = tool.run(
+            awards_df=df,
+            area_id="drone_manufacturing",
+            fiscal_years=[2025],
+            source_path="/data/award_data.csv",
+            source_sha256="abc123",
+            source_timestamp="2026-07-14T12:00:00+00:00",
+            data_vintage="2026-07-14",
+        )
+        assert result.data["award_count"] == 1
+        assert result.data["award_dollars"] == 200_000.0
+        summary = result.data["summary"]
+        assert summary["reporting_window"]["fiscal_years"] == [2025]
+        assert summary["provenance"] == {
+            "source_path": "/data/award_data.csv",
+            "sha256": "abc123",
+            "source_timestamp": "2026-07-14T12:00:00+00:00",
+            "data_vintage": "2026-07-14",
+            "source_row_count": 2,
+            "reporting_row_count": 1,
+        }
+        assert result.metadata.data_sources[0].version == "2026-07-14"
+
+    def test_result_rows_include_audit_columns(self):
+        result = ComputeTechCensusTool().run(
+            awards_df=pd.DataFrame([_award(title="Drone avionics")]),
+            area_id="drone_manufacturing",
+        )
+        assert set(result.data["results"].columns) >= {
+            "program",
+            "agency_tracking_number",
+            "contract",
+            "source_row",
+            "gate_evidence",
+            "physical_evidence",
+            "scope_class",
+            "classification_source",
+        }
+
+    def test_nullable_and_string_years_are_normalized_before_aggregation(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame(
+            [
+                _award(title="Drone airframe", year=2025, amount=100_000),
+                _award(title="Drone airframe", year=None, amount=None),
+                _award(title="Drone airframe", year="2024", amount="$250,000"),
+            ]
+        )
+        result = tool.run(awards_df=df, area_id="drone_manufacturing")
+        assert result.data["award_count"] == 3
+        assert result.data["award_dollars"] == 350_000.0
+        assert result.data["summary"]["fy_totals"] == {
+            "2025": {"n": 1, "usd": 100_000.0},
+            "2024": {"n": 1, "usd": 250_000.0},
+        }

--- a/tests/unit/tools/test_tech_census.py
+++ b/tests/unit/tools/test_tech_census.py
@@ -1,0 +1,78 @@
+"""Tests for the Tech Census tool (all-phase, subset-taxonomy queries)."""
+
+import pandas as pd
+
+from sbir_analytics.tools.tech_census import ComputeTechCensusTool
+
+
+def _award(
+    title="",
+    abstract="",
+    company="Acme",
+    agency="Department of Defense",
+    phase="Phase II",
+    year=2024,
+    amount=500_000.0,
+):
+    return {
+        "title": title,
+        "abstract": abstract,
+        "company": company,
+        "agency": agency,
+        "phase": phase,
+        "award_year": year,
+        "award_amount": amount,
+    }
+
+
+class TestComputeTechCensusTool:
+    def test_empty_dataframe(self):
+        tool = ComputeTechCensusTool()
+        result = tool.run(awards_df=pd.DataFrame(), area_id="drone_manufacturing")
+        assert result.data["summary"]["grand_total"] == {"n": 0, "usd": 0.0}
+        assert "No awards data provided" in result.metadata.warnings
+
+    def test_none_dataframe(self):
+        tool = ComputeTechCensusTool()
+        result = tool.run(area_id="drone_manufacturing")
+        assert result.data["summary"]["grand_total"] == {"n": 0, "usd": 0.0}
+
+    def test_missing_columns_warns_not_raises(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame([{"title": "Drone thing"}])  # missing most required columns
+        result = tool.run(awards_df=df, area_id="drone_manufacturing")
+        assert result.data["summary"]["grand_total"] == {"n": 0, "usd": 0.0}
+        assert any("missing required columns" in w for w in result.metadata.warnings)
+
+    def test_unknown_area_warns_not_raises(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame([_award(title="Drone battery")])
+        result = tool.run(awards_df=df, area_id="no_such_area")
+        assert result.data["summary"]["grand_total"] == {"n": 0, "usd": 0.0}
+        assert any("Could not load tech-census config" in w for w in result.metadata.warnings)
+
+    def test_classifies_and_aggregates_real_drone_config(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame(
+            [
+                _award(title="Drone battery hybridizer", year=2024, amount=1_000_000.0),
+                _award(title="Drone gimbal payload system", year=2024, amount=500_000.0),
+                _award(title="Unrelated antibiotic research", year=2024, amount=750_000.0),
+            ]
+        )
+        result = tool.run(awards_df=df, area_id="drone_manufacturing")
+        summary = result.data["summary"]
+        assert summary["grand_total"] == {"n": 2, "usd": 1_500_000.0}
+        assert result.metadata.record_count == 2
+        assert len(result.metadata.data_sources) == 1
+        assert (
+            result.metadata.data_sources[0].record_count == 3
+        )  # all rows passed in, not just matches
+
+    def test_results_dataframe_shape(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame([_award(title="Drone propulsion system")])
+        result = tool.run(awards_df=df, area_id="drone_manufacturing")
+        results_df = result.data["results"]
+        assert len(results_df) == 1
+        assert set(results_df.columns) >= {"title", "company", "year", "amount", "subset"}

--- a/tests/unit/utils/test_tech_census.py
+++ b/tests/unit/utils/test_tech_census.py
@@ -1,0 +1,234 @@
+"""Unit tests for the generalized tech-census engine (sbir_etl.utils.tech_census).
+
+Synthetic fixtures only -- the real drone_manufacturing.yaml config is
+verified against real award_data.csv separately (data-bearing, not run in
+CI), following the same split used for nano_verify_report_figures.py /
+verify_tech_area_figures.py elsewhere in this repo.
+"""
+
+import pytest
+
+from sbir_etl.utils.tech_census import (
+    CompiledCensus,
+    classify_subset,
+    load_census_config,
+    matched_adjacent,
+    matched_exclusion,
+    passes_gate,
+    run_census,
+)
+
+
+def _award(
+    title="",
+    abstract="",
+    company="Acme",
+    agency="Department of Defense",
+    phase="Phase II",
+    year=2024,
+    amount=1_000_000.0,
+):
+    return {
+        "title": title,
+        "abstract": abstract,
+        "company": company,
+        "agency": agency,
+        "phase": phase,
+        "award_year": year,
+        "award_amount": amount,
+    }
+
+
+# A minimal, deliberately synthetic config exercising the same shape as
+# drone_manufacturing.yaml, including two overlapping gate patterns (to
+# reproduce the exact false-positive mechanism found and fixed while
+# building the real config).
+TOY_CFG = {
+    "area_id": "toy_drones",
+    "display_name": "Toy Drones",
+    "gate": {
+        "min_abstract_only_occurrences": 3,
+        "terms": [
+            r"\bdrone[s]?\b",
+            r"\bunmanned aerial system[s]?\b",
+            r"\bunmanned aerial\b",  # overlaps with the pattern above
+        ],
+    },
+    "exclusions": [
+        {
+            "name": "counter_uas",
+            "display_name": "Counter-UAS",
+            "terms": [r"\bcounter-?drone[s]?\b"],
+        }
+    ],
+    "adjacent_nonaerial": [
+        {"name": "ugv", "display_name": "UGV", "terms": [r"\bUGV[s]?\b"]},
+    ],
+    "subsets": [
+        {"name": "Propulsion", "terms": [r"\bbattery\b", r"\bpropulsion\b"]},
+        {"name": "Sensors", "terms": [r"\bgimbal[s]?\b"]},
+    ],
+    "fallback_subset": "General",
+}
+
+
+def _compiled():
+    return CompiledCensus(dict(TOY_CFG))
+
+
+# --------------------------------------------------------------------------- #
+# config loading
+# --------------------------------------------------------------------------- #
+
+
+def test_load_real_drone_config():
+    cfg = load_census_config("drone_manufacturing")
+    assert cfg["area_id"] == "drone_manufacturing"
+    assert len(cfg["gate"]["terms"]) > 0
+    assert cfg["fallback_subset"]
+
+
+def test_load_missing_config_raises():
+    with pytest.raises(FileNotFoundError):
+        load_census_config("no_such_area")
+
+
+@pytest.mark.parametrize("missing_key", ["display_name", "gate", "subsets", "fallback_subset"])
+def test_config_missing_required_key_raises(tmp_path, missing_key):
+    import yaml
+
+    cfg = dict(TOY_CFG)
+    del cfg[missing_key]
+    path = tmp_path / "broken.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_census_config("broken", config_dir=tmp_path)
+
+
+# --------------------------------------------------------------------------- #
+# gate: title hit vs occurrence threshold
+# --------------------------------------------------------------------------- #
+
+
+def test_gate_title_hit_always_admits():
+    c = _compiled()
+    award = _award(title="A New Drone Platform", abstract="Nothing else relevant here.")
+    assert passes_gate(award, c) is True
+
+
+def test_gate_single_incidental_mention_rejected():
+    c = _compiled()
+    # One mention, "unmanned aerial system" also matches the overlapping
+    # "unmanned aerial" pattern -- 2 total occurrences, below the threshold.
+    award = _award(
+        title="Advanced Battery Chemistry Benchmark",
+        abstract="This exceeds the requirement seen in unmanned aerial systems today.",
+    )
+    assert passes_gate(award, c) is False
+
+
+def test_gate_overlapping_patterns_do_not_inflate_a_single_mention():
+    """The exact false-positive mechanism found in the real data: two gate
+    patterns matching the SAME phrase must not count as independent evidence."""
+    c = _compiled()
+    award = _award(
+        title="Directed Energy Weapon Power System",
+        abstract="Adversary use of unmanned aerial systems is growing rapidly.",
+    )
+    text_occurrences = sum(
+        len(rx.findall(f"{award['title']} {award['abstract']}")) for rx in c.gate_terms
+    )
+    assert text_occurrences == 2  # "unmanned aerial system" + "unmanned aerial" overlap
+    assert passes_gate(award, c) is False
+
+
+def test_gate_repeated_mentions_admit():
+    c = _compiled()
+    award = _award(
+        title="Generic Platform Study",
+        abstract=(
+            "We develop a drone for logistics. The drone flies autonomously. "
+            "Field tests of the drone were completed in 2023."
+        ),
+    )
+    assert passes_gate(award, c) is True
+
+
+def test_gate_no_terms_rejected():
+    c = _compiled()
+    award = _award(title="Unrelated Widget", abstract="Nothing to see here.")
+    assert passes_gate(award, c) is False
+
+
+# --------------------------------------------------------------------------- #
+# exclusions / adjacent categories
+# --------------------------------------------------------------------------- #
+
+
+def test_exclusion_detected_on_gate_passing_award():
+    c = _compiled()
+    award = _award(title="Counter-drone Radar System", abstract="Detects and defeats hostile UAVs.")
+    assert passes_gate(award, c) is True
+    assert matched_exclusion(award, c) == "counter_uas"
+
+
+def test_adjacent_nonaerial_detected():
+    c = _compiled()
+    award = _award(title="UGV Chassis Design", abstract="A ground robot chassis.")
+    assert passes_gate(award, c) is False
+    assert matched_adjacent(award, c) == "ugv"
+
+
+# --------------------------------------------------------------------------- #
+# subset classification
+# --------------------------------------------------------------------------- #
+
+
+def test_subset_priority_first_match_wins():
+    c = _compiled()
+    # Mentions both a Propulsion term and a Sensors term -- Propulsion is
+    # listed first in TOY_CFG, so it should win.
+    award = _award(title="Drone battery and gimbal integration")
+    assert classify_subset(award, c) == "Propulsion"
+
+
+def test_subset_fallback_when_no_specific_match():
+    c = _compiled()
+    award = _award(title="Generic drone airframe")
+    assert classify_subset(award, c) == "General"
+
+
+# --------------------------------------------------------------------------- #
+# run_census: end-to-end aggregation
+# --------------------------------------------------------------------------- #
+
+
+def test_run_census_aggregates_correctly():
+    c = _compiled()
+    awards = [
+        _award(title="Drone battery system", year=2024, amount=100_000.0),
+        _award(title="Drone battery system", year=2024, amount=200_000.0),
+        _award(title="Drone gimbal payload", year=2025, amount=50_000.0),
+        _award(title="Counter-drone radar", year=2025, amount=999_999.0),  # excluded
+        _award(title="UGV wheels", year=2025, amount=999_999.0),  # adjacent, not gate-passing
+        _award(title="Unrelated widget", year=2025, amount=999_999.0),  # not relevant at all
+    ]
+    result = run_census(awards, c)
+
+    assert result["grand_total"] == {"n": 3, "usd": 350_000.0}
+    assert result["subset_totals"]["Propulsion"] == {"n": 2, "usd": 300_000.0}
+    assert result["subset_totals"]["Sensors"] == {"n": 1, "usd": 50_000.0}
+    assert result["fy_totals"][2024] == {"n": 2, "usd": 300_000.0}
+    assert result["fy_totals"][2025] == {"n": 1, "usd": 50_000.0}
+    assert result["by_fy_subset"][(2024, "Propulsion")] == {"n": 2, "usd": 300_000.0}
+    assert result["exclusion_counts"] == {"counter_uas": 1}
+    assert result["adjacent_counts"] == {"ugv": 1}
+    # subset totals sum to grand total -- no double-counting, nothing dropped
+    assert sum(v["n"] for v in result["subset_totals"].values()) == result["grand_total"]["n"]
+
+
+def test_run_census_empty_input():
+    c = _compiled()
+    result = run_census([], c)
+    assert result["grand_total"] == {"n": 0, "usd": 0.0}
+    assert result["classified_awards"] == []

--- a/tests/unit/utils/test_tech_census.py
+++ b/tests/unit/utils/test_tech_census.py
@@ -1,16 +1,15 @@
-"""Unit tests for the generalized tech-census engine (sbir_etl.utils.tech_census).
+"""Unit and curated golden-case tests for the tech-census engine."""
 
-Synthetic fixtures only -- the real drone_manufacturing.yaml config is
-verified against real award_data.csv separately (data-bearing, not run in
-CI), following the same split used for nano_verify_report_figures.py /
-verify_tech_area_figures.py elsewhere in this repo.
-"""
+from pathlib import Path
 
 import pytest
+import yaml
 
 from sbir_etl.utils.tech_census import (
     CompiledCensus,
     classify_subset,
+    gate_evidence,
+    load_award_data_csv,
     load_census_config,
     matched_adjacent,
     matched_exclusion,
@@ -20,29 +19,34 @@ from sbir_etl.utils.tech_census import (
 
 
 def _award(
-    title="",
-    abstract="",
-    company="Acme",
-    agency="Department of Defense",
-    phase="Phase II",
-    year=2024,
-    amount=1_000_000.0,
-):
+    title: str = "",
+    abstract: str = "",
+    *,
+    company: str = "Acme",
+    agency: str = "Department of Defense",
+    program: str = "SBIR",
+    phase: str = "Phase II",
+    year: int = 2024,
+    amount: float = 1_000_000.0,
+    tracking: str = "T-1",
+    contract: str = "C-1",
+    source_row: int = 2,
+) -> dict:
     return {
         "title": title,
         "abstract": abstract,
         "company": company,
         "agency": agency,
+        "program": program,
         "phase": phase,
         "award_year": year,
         "award_amount": amount,
+        "agency_tracking_number": tracking,
+        "contract": contract,
+        "source_row": source_row,
     }
 
 
-# A minimal, deliberately synthetic config exercising the same shape as
-# drone_manufacturing.yaml, including two overlapping gate patterns (to
-# reproduce the exact false-positive mechanism found and fixed while
-# building the real config).
 TOY_CFG = {
     "area_id": "toy_drones",
     "display_name": "Toy Drones",
@@ -50,19 +54,16 @@ TOY_CFG = {
         "min_abstract_only_occurrences": 3,
         "terms": [
             r"\bdrone[s]?\b",
+            r"\bUAS\b",
             r"\bunmanned aerial system[s]?\b",
-            r"\bunmanned aerial\b",  # overlaps with the pattern above
+            r"\bunmanned aerial\b",
         ],
     },
     "exclusions": [
-        {
-            "name": "counter_uas",
-            "display_name": "Counter-UAS",
-            "terms": [r"\bcounter-?drone[s]?\b"],
-        }
+        {"name": "counter_uas", "terms": [r"\bcounter-?drone[s]?\b"]},
     ],
     "adjacent_nonaerial": [
-        {"name": "ugv", "display_name": "UGV", "terms": [r"\bUGV[s]?\b"]},
+        {"name": "ugv", "terms": [r"\bUGV[s]?\b"]},
     ],
     "subsets": [
         {"name": "Propulsion", "terms": [r"\bbattery\b", r"\bpropulsion\b"]},
@@ -72,163 +73,312 @@ TOY_CFG = {
 }
 
 
-def _compiled():
+def _compiled() -> CompiledCensus:
     return CompiledCensus(dict(TOY_CFG))
 
 
-# --------------------------------------------------------------------------- #
-# config loading
-# --------------------------------------------------------------------------- #
+def test_profiles_keep_broad_relevance_separate_from_strict_manufacturing() -> None:
+    strict = load_census_config("drone_manufacturing")
+    broad = load_census_config("uas_relevance")
+    assert strict["programs"] == ["SBIR"]
+    assert broad["programs"] == ["SBIR", "STTR"]
+    assert strict["physical_gate"]["terms"]
+    assert "physical_gate" not in broad
+    assert strict["version"] == "2.0.0"
 
 
-def test_load_real_drone_config():
-    cfg = load_census_config("drone_manufacturing")
-    assert cfg["area_id"] == "drone_manufacturing"
-    assert len(cfg["gate"]["terms"]) > 0
-    assert cfg["fallback_subset"]
-
-
-def test_load_missing_config_raises():
+def test_load_missing_config_raises() -> None:
     with pytest.raises(FileNotFoundError):
         load_census_config("no_such_area")
 
 
 @pytest.mark.parametrize("missing_key", ["display_name", "gate", "subsets", "fallback_subset"])
-def test_config_missing_required_key_raises(tmp_path, missing_key):
-    import yaml
-
+def test_config_missing_required_key_raises(tmp_path: Path, missing_key: str) -> None:
     cfg = dict(TOY_CFG)
     del cfg[missing_key]
-    path = tmp_path / "broken.yaml"
-    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    (tmp_path / "broken.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
     with pytest.raises(ValueError):
         load_census_config("broken", config_dir=tmp_path)
 
 
-# --------------------------------------------------------------------------- #
-# gate: title hit vs occurrence threshold
-# --------------------------------------------------------------------------- #
+def test_gate_title_hit_always_admits() -> None:
+    assert passes_gate(_award(title="A New Drone Platform"), _compiled())
 
 
-def test_gate_title_hit_always_admits():
-    c = _compiled()
-    award = _award(title="A New Drone Platform", abstract="Nothing else relevant here.")
-    assert passes_gate(award, c) is True
-
-
-def test_gate_single_incidental_mention_rejected():
-    c = _compiled()
-    # One mention, "unmanned aerial system" also matches the overlapping
-    # "unmanned aerial" pattern -- 2 total occurrences, below the threshold.
+def test_overlapping_aliases_do_not_inflate_one_mention() -> None:
+    compiled = _compiled()
     award = _award(
-        title="Advanced Battery Chemistry Benchmark",
-        abstract="This exceeds the requirement seen in unmanned aerial systems today.",
+        title="Advanced Battery Chemistry",
+        abstract="A requirement used by an unmanned aerial system (UAS).",
     )
-    assert passes_gate(award, c) is False
+    raw_hits = sum(
+        len(pattern.findall(f"{award['title']} {award['abstract']}"))
+        for pattern in compiled.gate_terms
+    )
+    assert raw_hits == 3
+    assert gate_evidence(award, compiled) == ["unmanned aerial system", "UAS"]
+    assert not passes_gate(award, compiled)
 
 
-def test_gate_overlapping_patterns_do_not_inflate_a_single_mention():
-    """The exact false-positive mechanism found in the real data: two gate
-    patterns matching the SAME phrase must not count as independent evidence."""
-    c = _compiled()
+def test_repeated_nonoverlapping_mentions_admit() -> None:
     award = _award(
-        title="Directed Energy Weapon Power System",
-        abstract="Adversary use of unmanned aerial systems is growing rapidly.",
+        title="Generic Study",
+        abstract="A drone is built. The drone is tested. A third drone is delivered.",
     )
-    text_occurrences = sum(
-        len(rx.findall(f"{award['title']} {award['abstract']}")) for rx in c.gate_terms
+    assert passes_gate(award, _compiled())
+
+
+def test_exclusion_adjacent_and_subset_priority() -> None:
+    compiled = _compiled()
+    assert matched_exclusion(_award(title="Counter-drone radar"), compiled) == "counter_uas"
+    assert matched_adjacent(_award(title="UGV chassis"), compiled) == "ugv"
+    assert classify_subset(_award(title="Drone battery and gimbal"), compiled) == "Propulsion"
+    assert classify_subset(_award(title="Generic drone"), compiled) == "General"
+
+
+def test_run_census_aggregates_without_double_counting() -> None:
+    result = run_census(
+        [
+            _award(title="Drone battery", year=2024, amount=100_000),
+            _award(title="Drone battery", year=2024, amount=200_000, tracking="T-2"),
+            _award(title="Drone gimbal", year=2025, amount=50_000, tracking="T-3"),
+            _award(title="Counter-drone radar", amount=999_999),
+            _award(title="UGV wheels", amount=999_999),
+        ],
+        _compiled(),
     )
-    assert text_occurrences == 2  # "unmanned aerial system" + "unmanned aerial" overlap
-    assert passes_gate(award, c) is False
-
-
-def test_gate_repeated_mentions_admit():
-    c = _compiled()
-    award = _award(
-        title="Generic Platform Study",
-        abstract=(
-            "We develop a drone for logistics. The drone flies autonomously. "
-            "Field tests of the drone were completed in 2023."
-        ),
-    )
-    assert passes_gate(award, c) is True
-
-
-def test_gate_no_terms_rejected():
-    c = _compiled()
-    award = _award(title="Unrelated Widget", abstract="Nothing to see here.")
-    assert passes_gate(award, c) is False
-
-
-# --------------------------------------------------------------------------- #
-# exclusions / adjacent categories
-# --------------------------------------------------------------------------- #
-
-
-def test_exclusion_detected_on_gate_passing_award():
-    c = _compiled()
-    award = _award(title="Counter-drone Radar System", abstract="Detects and defeats hostile UAVs.")
-    assert passes_gate(award, c) is True
-    assert matched_exclusion(award, c) == "counter_uas"
-
-
-def test_adjacent_nonaerial_detected():
-    c = _compiled()
-    award = _award(title="UGV Chassis Design", abstract="A ground robot chassis.")
-    assert passes_gate(award, c) is False
-    assert matched_adjacent(award, c) == "ugv"
-
-
-# --------------------------------------------------------------------------- #
-# subset classification
-# --------------------------------------------------------------------------- #
-
-
-def test_subset_priority_first_match_wins():
-    c = _compiled()
-    # Mentions both a Propulsion term and a Sensors term -- Propulsion is
-    # listed first in TOY_CFG, so it should win.
-    award = _award(title="Drone battery and gimbal integration")
-    assert classify_subset(award, c) == "Propulsion"
-
-
-def test_subset_fallback_when_no_specific_match():
-    c = _compiled()
-    award = _award(title="Generic drone airframe")
-    assert classify_subset(award, c) == "General"
-
-
-# --------------------------------------------------------------------------- #
-# run_census: end-to-end aggregation
-# --------------------------------------------------------------------------- #
-
-
-def test_run_census_aggregates_correctly():
-    c = _compiled()
-    awards = [
-        _award(title="Drone battery system", year=2024, amount=100_000.0),
-        _award(title="Drone battery system", year=2024, amount=200_000.0),
-        _award(title="Drone gimbal payload", year=2025, amount=50_000.0),
-        _award(title="Counter-drone radar", year=2025, amount=999_999.0),  # excluded
-        _award(title="UGV wheels", year=2025, amount=999_999.0),  # adjacent, not gate-passing
-        _award(title="Unrelated widget", year=2025, amount=999_999.0),  # not relevant at all
-    ]
-    result = run_census(awards, c)
-
     assert result["grand_total"] == {"n": 3, "usd": 350_000.0}
     assert result["subset_totals"]["Propulsion"] == {"n": 2, "usd": 300_000.0}
-    assert result["subset_totals"]["Sensors"] == {"n": 1, "usd": 50_000.0}
-    assert result["fy_totals"][2024] == {"n": 2, "usd": 300_000.0}
     assert result["fy_totals"][2025] == {"n": 1, "usd": 50_000.0}
-    assert result["by_fy_subset"][(2024, "Propulsion")] == {"n": 2, "usd": 300_000.0}
     assert result["exclusion_counts"] == {"counter_uas": 1}
     assert result["adjacent_counts"] == {"ugv": 1}
-    # subset totals sum to grand total -- no double-counting, nothing dropped
-    assert sum(v["n"] for v in result["subset_totals"].values()) == result["grand_total"]["n"]
 
 
-def test_run_census_empty_input():
-    c = _compiled()
-    result = run_census([], c)
-    assert result["grand_total"] == {"n": 0, "usd": 0.0}
-    assert result["classified_awards"] == []
+def test_strict_program_filter_excludes_sttr_and_unknown() -> None:
+    compiled = CompiledCensus.from_area("drone_manufacturing")
+    awards = [
+        _award(title="Drone airframe", program="SBIR"),
+        _award(title="Drone airframe", program="STTR", tracking="T-2"),
+        _award(title="Drone airframe", program="", tracking="T-3"),
+    ]
+    result = run_census(awards, compiled)
+    assert result["grand_total"]["n"] == 1
+    assert result["program_exclusion_counts"] == {"STTR": 1, "UNKNOWN": 1}
+
+
+def test_explicit_empty_program_override_disables_filtering() -> None:
+    compiled = CompiledCensus.from_area("drone_manufacturing")
+    result = run_census([_award(title="Drone airframe", program="STTR")], compiled, programs=[])
+    assert result["grand_total"]["n"] == 1
+    assert result["programs"] == []
+
+
+def test_broad_profile_includes_software_that_strict_profile_rejects() -> None:
+    award = _award(title="Drone Mission Planning Software", abstract="Autonomy algorithms")
+    broad = run_census([award], CompiledCensus.from_area("uas_relevance"))
+    strict = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert broad["grand_total"]["n"] == 1
+    assert broad["classified_awards"][0]["scope_class"] == "Software, Autonomy & Analytics"
+    assert strict["grand_total"]["n"] == 0
+    assert strict["exclusion_counts"] == {"nonphysical_primary": 1}
+
+
+def test_nonphysical_title_is_excluded_even_with_incidental_hardware_evidence() -> None:
+    award = _award(
+        title="AI-Enabled UAS Airworthiness Certification Software",
+        abstract="We develop an aircraft integration prototype for the UAS.",
+    )
+    result = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["grand_total"]["n"] == 0
+    assert result["exclusion_counts"] == {"nonphysical_primary": 1}
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "UAS Sensor Fusion Software",
+        "Machine Learning for UAS Radar Classification",
+        "Drone Wing Structural Analysis Software",
+    ],
+)
+def test_generic_hardware_noun_does_not_rescue_nonphysical_title(title: str) -> None:
+    result = run_census([_award(title=title)], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["grand_total"]["n"] == 0
+    assert result["exclusion_counts"] == {"nonphysical_primary": 1}
+
+
+def test_explicit_hardware_deliverable_can_rescue_mixed_title() -> None:
+    result = run_census(
+        [_award(title="Machine-Learning UAS Sensor Hardware")],
+        CompiledCensus.from_area("drone_manufacturing"),
+    )
+    assert result["grand_total"]["n"] == 1
+
+
+def test_strict_profile_includes_modern_physical_platform_alias() -> None:
+    award = _award(title="Fabricated Composite Wing for Collaborative Combat Aircraft")
+    result = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["grand_total"]["n"] == 1
+    assert result["classified_awards"][0]["subset"].startswith("Airframes")
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "CCA Airframe Manufacturing",
+        "ACP Avionics Hardware",
+        "HAPS Propulsion System",
+    ],
+)
+def test_broad_relevance_profile_is_superset_for_modern_physical_aliases(title: str) -> None:
+    award = _award(title=title)
+    strict = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    broad = run_census([award], CompiledCensus.from_area("uas_relevance"))
+    assert strict["grand_total"]["n"] == 1
+    assert broad["grand_total"]["n"] == 1
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "Circuit Card Assembly (CCA) Manufacturing Process",
+        "Advanced Care Planning (ACP) Platform Software",
+        "Hamiltonian Analysis-Based Prediction Service (HAPS)",
+    ],
+)
+def test_ambiguous_modern_acronyms_require_aerial_context(title: str) -> None:
+    award = _award(title=title)
+    strict = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    broad = run_census([award], CompiledCensus.from_area("uas_relevance"))
+    assert strict["grand_total"]["n"] == 0
+    assert broad["grand_total"]["n"] == 0
+
+
+def test_one_uas_mention_with_nearby_physical_development_evidence_passes() -> None:
+    award = _award(
+        title="Advanced Ceramic Coating",
+        abstract="We develop an engine coating for an unmanned aerial system.",
+    )
+    result = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["grand_total"]["n"] == 1
+    assert result["classified_awards"][0]["physical_evidence"] == [
+        "physical: coating",
+        "relationship: develop",
+        "relevance: unmanned aerial system",
+    ]
+
+
+def test_same_span_cannot_supply_physical_and_relationship_evidence() -> None:
+    award = _award(
+        title="Advanced Ceramic Coating",
+        abstract="A coating is used on an unmanned aerial system.",
+    )
+    result = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["grand_total"]["n"] == 0
+    assert result["rejection_counts"] == {"relevance_gate": 1}
+
+
+def test_physical_noun_without_funded_relationship_is_rejected() -> None:
+    award = _award(
+        title="Mission Analysis",
+        abstract="Drone missions use drones. Another drone may carry a battery in the future.",
+    )
+    result = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["grand_total"]["n"] == 0
+    assert result["exclusion_counts"] == {"nonphysical_primary": 1}
+
+
+def test_failed_relevance_exclusion_is_preserved_in_audit_rows() -> None:
+    award = _award(
+        title="Generic Radar",
+        abstract="This counter-UAS system tracks one UAS.",
+    )
+    result = run_census([award], CompiledCensus.from_area("drone_manufacturing"))
+    assert result["exclusion_counts"] == {"counter_uas": 1}
+    assert len(result["excluded_awards"]) == 1
+    assert result["excluded_awards"][0]["classification_source"] == "rules"
+
+
+def test_counter_uas_and_nonaerial_are_excluded_but_interceptor_hardware_is_not() -> None:
+    compiled = CompiledCensus.from_area("drone_manufacturing")
+    result = run_census(
+        [
+            _award(title="Counter-UAS Radar Battery System", tracking="T-1"),
+            _award(title="UUV Airframe with UAV Interoperability", tracking="T-2"),
+            _award(title="Counter-UAS Interceptor Drone Airframe", tracking="T-3"),
+        ],
+        compiled,
+    )
+    assert result["grand_total"]["n"] == 1
+    assert result["classified_awards"][0]["agency_tracking_number"] == "T-3"
+    assert result["exclusion_counts"] == {"counter_uas": 1, "non_aerial_title": 1}
+
+
+def test_classified_rows_preserve_audit_evidence_and_source_ids() -> None:
+    award = _award(title="Drone Avionics", tracking="TRACK", contract="CONTRACT", source_row=42)
+    row = run_census([award], CompiledCensus.from_area("drone_manufacturing"))["classified_awards"][
+        0
+    ]
+    assert row["program"] == "SBIR"
+    assert row["agency_tracking_number"] == "TRACK"
+    assert row["contract"] == "CONTRACT"
+    assert row["source_row"] == 42
+    assert row["gate_evidence"] and row["physical_evidence"]
+    assert "subset_evidence" in row and "scope_evidence" in row
+    assert row["classification_source"] == "rules"
+
+
+def test_versioned_override_ledger_can_include_and_exclude(tmp_path: Path) -> None:
+    cfg = dict(TOY_CFG)
+    cfg["overrides_file"] = "overrides.yaml"
+    (tmp_path / "overrides.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": "review-1",
+                "overrides": [
+                    {
+                        "identifiers": {"agency_tracking_number": "IN"},
+                        "action": "include",
+                        "subset": "Sensors",
+                        "reason": "Reviewed physical deliverable",
+                    },
+                    {
+                        "identifiers": {"agency_tracking_number": "OUT"},
+                        "action": "exclude",
+                        "reason": "Reviewed false positive",
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "toy_drones.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    compiled = CompiledCensus.from_area("toy_drones", tmp_path)
+    result = run_census(
+        [
+            _award(title="Unrelated", tracking="IN"),
+            _award(title="Drone gimbal", tracking="OUT"),
+        ],
+        compiled,
+    )
+    assert result["override_version"] == "review-1"
+    assert result["grand_total"]["n"] == 1
+    assert result["classified_awards"][0]["classification_source"] == "override"
+    assert result["classified_awards"][0]["subset"] == "Sensors"
+    assert result["exclusion_counts"] == {"manual_override": 1}
+
+
+def test_csv_loader_preserves_program_identifiers_and_source_row(tmp_path: Path) -> None:
+    path = tmp_path / "awards.csv"
+    path.write_text(
+        "Award Title,Abstract,Company,Agency,Program,Phase,Award Year,Award Amount,"
+        "Agency Tracking Number,Contract\n"
+        'Drone Airframe,"Build it",Acme,DOD,SBIR,Phase II,2024,"$1,250",TRACK,CONTRACT\n',
+        encoding="utf-8",
+    )
+    award = load_award_data_csv(path)[0]
+    assert award["program"] == "SBIR"
+    assert award["agency_tracking_number"] == "TRACK"
+    assert award["contract"] == "CONTRACT"
+    assert award["source_row"] == 2
+    assert award["award_amount"] == 1_250.0

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=5.18.0,<7.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0,<5.0.0" },
     { name = "psutil", marker = "extra == 'monitoring'", specifier = ">=5.9.0,<8.0.0" },
-    { name = "pyarrow", specifier = ">=14.0.2,<25.0.0" },
+    { name = "pyarrow", specifier = ">=14.0.2,<26.0.0" },
     { name = "pydantic", specifier = ">=2.8.0,<3.0.0" },
     { name = "pyreadstat", marker = "extra == 'uspto'", specifier = ">=1.1.4,<2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3,<10.0.0" },


### PR DESCRIPTION
## Summary

This PR now separates two questions that the original implementation treated as one:

1. **Drone manufacturing** — SBIR awards funding a physical aerial-drone product, component, material, or manufacturing process.
2. **Broad UAS relevance** — the wider SBIR/STTR ecosystem, including hardware, software/autonomy, operations, and services.

The reusable census engine remains the right foundation, but the strict manufacturing report now has its own physical-development gate, SBIR-only default, hardware taxonomy, exclusion rules, audit evidence, and versioned override ledger. The broader question is preserved as a separate `uas_relevance` profile instead of being labeled manufacturing.

## What changed

- Added versioned `drone_manufacturing` and `uas_relevance` profiles with separate program scopes and taxonomies.
- Added a proximity-aware physical-development gate. Abstract-only matches need distinct physical, funded-action, and UAS evidence; one regex span cannot satisfy multiple evidence roles.
- Added contextual modern aliases (CCA, ACP, HAPS, ALE, UCAV/VTUAV/TUAV, attritable aircraft, and related terms) while rejecting ambiguous acronym uses such as circuit-card assemblies and advance-care planning.
- Tightened counter-UAS, non-aerial, and software/analysis/service exclusions. Generic nouns such as “sensor,” “radar,” or “wing” no longer rescue a software-led title.
- Added SBIR/STTR program filtering and explicit fiscal-year reporting windows.
- Preserved source row, program, tracking number, contract, rule evidence, classification source, and override reason for included awards.
- Added a versioned manual include/exclude ledger keyed by stable source identifiers.
- Added source path, SHA-256, local file timestamp, optional explicit data vintage, row counts, config version, and override version to report provenance.
- Added top-level award-count and dollar scalars so snapshot comparisons produce useful deltas.
- Prevented comparisons across different census configs, override versions, program scopes, or fiscal-year windows.
- Prevented malformed or schema-incomplete inputs from publishing authoritative zero-award snapshots; legitimate zero-match windows remain publishable.
- Added a separate API snapshot kind for broad UAS relevance.

## Calibration output

Run against the 219,503-row SBIR.gov export used for this review (`sbir_award_data_20260714.csv`).

### Strict drone-manufacturing profile — SBIR only

| Period | Awards | Dollars |
|---|---:|---:|
| FY2024 | 127 | $111,363,496.20 |
| FY2025 | 107 | $98,670,364.71 |
| FY2026 (partial source year) | 3 | $526,081.00 |
| FY2024–FY2026 | 237 | $210,559,941.91 |
| Program lifetime | 2,241 | $1,132,448,315.17 |

FY2024–FY2026 technology subsets:

| Technology subset | Awards | Dollars |
|---|---:|---:|
| Airframes, Structures, Materials & Manufacturing | 40 | $31,186,020.64 |
| Propulsion, Lift & Actuation | 37 | $24,548,289.82 |
| Power, Energy Storage & Thermal | 30 | $24,558,218.08 |
| Avionics, Flight-Control & Navigation Hardware | 4 | $549,436.00 |
| Communications, Data Links & Payload Hardware | 84 | $86,241,658.24 |
| Complete Platforms & Systems Integration | 42 | $43,476,319.13 |

### Broad UAS-relevance profile — SBIR and STTR

Program lifetime: **2,963 awards / $1,485,652,984.15**.

This is the improved equivalent of PR 439’s original broad approach. It is retained for ecosystem questions, but it is not presented as a drone-manufacturing total.

## Methodology and caveats

- Counts are deterministic, rule-derived census estimates, not a claim of full manual adjudication.
- The override ledger is intentionally empty at introduction; reviewed exceptions can be added reproducibly without changing code.
- Source rows are counted as supplied. This PR does not introduce automatic award deduplication.
- FY2026 reflects the partial contents of the reviewed source export and is not a forecast.
- A local file modification time is recorded as `source_timestamp`; it is not mislabeled as a data-release vintage. `data_vintage` is populated only when supplied explicitly.

## Test plan

- [x] 52 focused engine/tool/API/CLI safety tests
- [x] Full unit suite: **4,639 passed, 7 skipped**
- [x] Ruff format/check clean on all touched Python files
- [x] mypy clean for `sbir_etl` (192 files)
- [x] mypy clean for `sbir_analytics` (120 files)
- [x] Full-source calibration completed for both profiles
