### PR TITLE
fix(data): enforce award identity and dataset-grain contracts

### DIFF
--- a/docs/steering/data-quality.md
+++ b/docs/steering/data-quality.md
@@ -82,6 +82,24 @@ The quality framework above governs the Dagster pipeline (`sbir_etl`). The one-o
 - **Hand-typed, non-reproducible figures are the highest-risk category.** The one error with no backing script at all (Finding 2's acquisition-timing paragraph — a median and an outlier example, asserted directly in prose) was also the most wrong: not a rounding slip but the wrong firm identified as the outlier. A number nobody can rerun is a number nobody re-verifies. Prefer computing every reportable figure in a script, even a throwaway one; if a figure must be asserted by hand (e.g. reasoning about a small hand-curated table), say so explicitly in the text so it gets extra scrutiny during review.
 - **Build the audit script alongside the report, not after.** `nano_verify_report_figures.py` recomputes every load-bearing number in the report from source and diffs it against the value actually printed in the markdown. Keep this pattern for any new findings report (the quantum/hypersonics generalization is a natural next user) — rerun it whenever an upstream script or source CSV changes, not just once at publication.
 
+## Contract Award Identity and Grain
+
+- **A PIID is not an award key.** Order PIIDs such as `0001` repeat under different
+  parent IDVs, and legacy PIIDs can repeat across agencies. Prefer a complete
+  precomputed key such as `contract_award_unique_key`. Otherwise require a
+  non-null compound of awarding agency, parent-IDV identifier, and PIID.
+- **Partial keys fail loudly.** A key column being present is insufficient: every
+  row must contain all required identity components, and conflicting alias
+  columns are an error. `contract_id` is not presumed unique because several
+  ingestion paths use it for a bare PIID.
+- **Declare transaction versus award grain.** FPDS/USAspending inputs commonly
+  contain modifications. Use `sbir_etl.utils.award_identity` to construct the
+  award key and collapse representative rows explicitly. Its latest-transaction
+  policy does not aggregate financial amounts.
+- **Aggregate status before collapsing.** A coded Phase III value on any
+  transaction makes the whole award coded. Filtering individual transactions
+  first can leave uncoded modifications behind and manufacture false candidates.
+
 ## Related Documents
 
 - **[configuration.md](../configuration.md)** - Complete quality configuration examples

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/assets.py
@@ -391,7 +391,14 @@ def _candidate_dataframe(candidates: list[PhaseIIICandidate]) -> pd.DataFrame:
 
 
 def _default_retrospective_loader(_context: Any) -> pd.DataFrame:
-    """Read FPDS contracts parquet from disk; returns empty frame when file is missing."""
+    """Read and normalize the extractor's persisted contract schema.
+
+    Older ``FederalContract.model_dump()`` parquets retained the canonical
+    USAspending award id only in ``metadata.award_id``. Promote that value
+    rather than treating the bare-PIID ``contract_id`` as unique. Element 10Q
+    is likewise promoted when a legacy producer retained it in metadata; old
+    extracts without it receive an explicit null ``research`` column.
+    """
 
     contracts_path = Path("data/transition/contracts_ingestion.parquet")
     if not contracts_path.exists():
@@ -399,7 +406,31 @@ def _default_retrospective_loader(_context: Any) -> pd.DataFrame:
     if not contracts_path.exists():
         return pd.DataFrame()
     try:
-        return pd.read_parquet(contracts_path)
+        contracts = pd.read_parquet(contracts_path)
+        metadata = contracts.get("metadata", pd.Series([None] * len(contracts)))
+
+        def _metadata_field(value: object, field: str) -> object:
+            return value.get(field) if isinstance(value, dict) else None
+
+        metadata_award_id = metadata.map(lambda value: _metadata_field(value, "award_id"))
+        metadata_research = metadata.map(lambda value: _metadata_field(value, "research"))
+
+        if "generated_unique_award_id" not in contracts.columns:
+            contracts["generated_unique_award_id"] = metadata_award_id
+        else:
+            missing_id = contracts["generated_unique_award_id"].isna() | contracts[
+                "generated_unique_award_id"
+            ].astype(str).str.strip().eq("")
+            contracts.loc[missing_id, "generated_unique_award_id"] = metadata_award_id[missing_id]
+
+        if "research" not in contracts.columns:
+            contracts["research"] = metadata_research
+        else:
+            missing_research = contracts["research"].isna() | contracts["research"].astype(
+                str
+            ).str.strip().eq("")
+            contracts.loc[missing_research, "research"] = metadata_research[missing_research]
+        return contracts
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("Failed to read contracts parquet at {}: {}", contracts_path, exc)
         return pd.DataFrame()

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/pairing.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/pairing.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import pandas as pd
 
+from sbir_etl.utils.award_identity import (
+    award_key_series,
+    collapse_transactions_to_award_grain,
+)
+
 # FPDS Element 10Q codes that mark a contract as already-coded Phase III.
 # Duplicated intentionally — avoids cross-package import for a five-element set.
 _PHASE_III_RESEARCH_CODES = frozenset({"SR3", "ST3"})
 
 # Tokens we accept as evidence that ``sbir_phase`` already says "Phase III".
 _PHASE_III_LABELS = frozenset({"PHASE III", "III", "3", "PHASE 3"})
+
+# If neither column exists, the already-coded exclusion cannot run safely.
+_CODED_STATUS_COLUMNS: tuple[str, ...] = ("research", "sbir_phase")
 
 
 PAIR_S1_COLUMNS: list[str] = [
@@ -124,14 +132,26 @@ def _prepare_contracts(contracts: pd.DataFrame) -> pd.DataFrame:
 
     df = contracts.copy()
 
-    # Compute "already coded" mask before column projection so we can read
-    # whichever raw column the input frame carries.
-    coded_mask = (
+    if not any(column in df.columns for column in _CODED_STATUS_COLUMNS):
+        raise ValueError(
+            "contracts frame carries no Phase III coding column "
+            f"(need one of {_CODED_STATUS_COLUMNS}); the already-coded exclusion cannot run"
+        )
+
+    # Code status is an award-level property. If any transaction is explicitly
+    # Phase III, exclude every transaction for that award.
+    df = df.assign(_award_key=award_key_series(df))
+    row_coded = (
         df.apply(_is_phase_iii_already_coded, axis=1) if len(df) else pd.Series([], dtype=bool)
     )
-    df = df.loc[~coded_mask].copy()
+    award_coded = row_coded.groupby(df["_award_key"], sort=False).transform("any")
+    df = df.loc[~award_coded].copy()
     if df.empty:
         return pd.DataFrame(columns=[c for c in PAIR_S1_COLUMNS if c.startswith("target_")])
+
+    # One representative row per award. The shared helper documents that this
+    # selects the latest transaction and does not aggregate financial fields.
+    df = collapse_transactions_to_award_grain(df, award_keys=df["_award_key"])
 
     def _pick(*names: str) -> pd.Series:
         for n in names:
@@ -141,7 +161,7 @@ def _prepare_contracts(contracts: pd.DataFrame) -> pd.DataFrame:
 
     out = pd.DataFrame(
         {
-            "target_id": _pick("contract_id", "piid", "generated_unique_award_id"),
+            "target_id": df["_award_key"],
             "target_recipient_uei": _pick("vendor_uei", "recipient_uei", "uei"),
             "target_agency": _pick("awarding_agency_name", "agency", "awarding_agency"),
             "target_sub_agency": _pick("awarding_sub_tier_agency_name", "sub_agency"),

--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -365,6 +365,7 @@ class ContractExtractor:
             contract_id_value = get_col(28, get_col(1, f"unknown_{row_data[0]}"))  # PIID (col 28)
             contract = FederalContract(
                 contract_id=contract_id_value,
+                generated_unique_award_id=get_col(1),
                 agency=get_col(12),  # awarding_agency_name
                 sub_agency=get_col(14),  # awarding_sub_tier_agency_name
                 vendor_name=get_col(9),  # recipient_name

--- a/sbir_etl/models/transition_models.py
+++ b/sbir_etl/models/transition_models.py
@@ -211,6 +211,14 @@ class FederalContract(BaseModel):
     """
 
     contract_id: str = Field(..., description="Contract identifier (e.g., PIID).")
+    generated_unique_award_id: str | None = Field(
+        None,
+        description="Canonical USAspending award identifier across transaction rows.",
+    )
+    research: str | None = Field(
+        None,
+        description="FPDS SBIR/STTR indicator (Element 10Q) when supplied by the source.",
+    )
     agency: str | None = Field(None, description="Agency code or name (e.g., 'DOD', 'NASA').")
     sub_agency: str | None = Field(None, description="Sub-agency or office.")
     vendor_name: str | None = Field(None, description="Vendor name string as present on contract.")

--- a/sbir_etl/utils/award_identity.py
+++ b/sbir_etl/utils/award_identity.py
@@ -91,18 +91,31 @@ def award_key_series(df: pd.DataFrame) -> pd.Series:
     if df.empty:
         return pd.Series(index=df.index, dtype="object", name="_award_key")
 
+    complete_keys: dict[str, pd.Series] = {}
     for column in UNIQUE_AWARD_KEY_COLUMNS:
         if column not in df.columns:
             continue
         values = _normalized_series(df, column)
         nonempty = values.ne("")
         if nonempty.all():
-            return values.rename("_award_key")
+            complete_keys[column] = values
+            continue
         if nonempty.any():
             rows = list(df.index[~nonempty][:5])
             raise AwardIdentityError(
                 f"precomputed award key {column!r} is partial; missing at rows {rows}"
             )
+
+    if complete_keys:
+        normalized = pd.DataFrame(complete_keys, index=df.index)
+        conflicts = normalized.apply(lambda row: len(set(row)) > 1, axis=1)
+        if conflicts.any():
+            rows = list(df.index[conflicts][:5])
+            columns = tuple(complete_keys)
+            raise AwardIdentityError(
+                f"conflicting precomputed award key aliases {columns} at rows {rows}"
+            )
+        return normalized.iloc[:, 0].rename("_award_key")
 
     piid = _coalesce_required_component(df, PIID_COLUMNS, component="PIID")
     agency = _coalesce_required_component(

--- a/sbir_etl/utils/award_identity.py
+++ b/sbir_etl/utils/award_identity.py
@@ -1,0 +1,165 @@
+"""Stable contract-award identity and transaction-grain helpers."""
+
+from collections.abc import Sequence
+
+import pandas as pd
+
+
+UNIQUE_AWARD_KEY_COLUMNS: tuple[str, ...] = (
+    "contract_award_unique_key",
+    "generated_unique_award_id",
+    "unique_award_key",
+)
+PIID_COLUMNS: tuple[str, ...] = ("piid", "PIID", "award_id")
+AWARDING_AGENCY_COLUMNS: tuple[str, ...] = (
+    "agencyID",
+    "agency_id",
+    "awarding_agency_code",
+)
+PARENT_IDV_COLUMNS: tuple[str, ...] = (
+    "referencedIDVID",
+    "referenced_idv_piid",
+    "parent_contract_id",
+    "parent_award_id",
+)
+DEFAULT_TRANSACTION_DATE_COLUMNS: tuple[str, ...] = (
+    "action_date",
+    "award_date",
+    "signedDate",
+    "effectiveDate",
+)
+
+
+class AwardIdentityError(ValueError):
+    """Raised when a frame cannot produce an award-grade identity safely."""
+
+
+def normalize_award_key_value(value: object) -> str:
+    """Normalize source identifiers without turning nulls into string keys."""
+
+    if value is None or value is pd.NA:
+        return ""
+    normalized = str(value).strip().upper()
+    return "" if normalized in {"", "NAN", "NAT", "NONE", "<NA>"} else normalized
+
+
+def _normalized_series(df: pd.DataFrame, column: str) -> pd.Series:
+    return df[column].map(normalize_award_key_value)
+
+
+def _coalesce_required_component(
+    df: pd.DataFrame,
+    candidates: Sequence[str],
+    *,
+    component: str,
+) -> pd.Series:
+    present = [column for column in candidates if column in df.columns]
+    if not present:
+        raise AwardIdentityError(
+            f"contracts frame has no {component} column (need one of {tuple(candidates)})"
+        )
+
+    normalized = pd.DataFrame(
+        {column: _normalized_series(df, column) for column in present},
+        index=df.index,
+    )
+    conflicts = normalized.apply(
+        lambda row: len({value for value in row if value}) > 1,
+        axis=1,
+    )
+    if conflicts.any():
+        rows = list(df.index[conflicts][:5])
+        raise AwardIdentityError(f"conflicting {component} aliases at rows {rows}")
+
+    values = normalized.replace("", pd.NA).bfill(axis=1).iloc[:, 0].fillna("")
+    missing = values.eq("")
+    if missing.any():
+        rows = list(df.index[missing][:5])
+        raise AwardIdentityError(f"missing {component} at rows {rows}")
+    return values.astype(str)
+
+
+def award_key_series(df: pd.DataFrame) -> pd.Series:
+    """Return an award-grade key for every row, failing on partial identities.
+
+    A complete precomputed USAspending award key is preferred. Otherwise the
+    required compound is awarding agency + parent IDV + PIID. ``contract_id``
+    is deliberately excluded because this repository commonly uses it for a
+    bare PIID. Repeated keys are valid for transaction/modification rows.
+    """
+
+    if df.empty:
+        return pd.Series(index=df.index, dtype="object", name="_award_key")
+
+    for column in UNIQUE_AWARD_KEY_COLUMNS:
+        if column not in df.columns:
+            continue
+        values = _normalized_series(df, column)
+        nonempty = values.ne("")
+        if nonempty.all():
+            return values.rename("_award_key")
+        if nonempty.any():
+            rows = list(df.index[~nonempty][:5])
+            raise AwardIdentityError(
+                f"precomputed award key {column!r} is partial; missing at rows {rows}"
+            )
+
+    piid = _coalesce_required_component(df, PIID_COLUMNS, component="PIID")
+    agency = _coalesce_required_component(
+        df,
+        AWARDING_AGENCY_COLUMNS,
+        component="awarding agency",
+    )
+    parent_idv = _coalesce_required_component(
+        df,
+        PARENT_IDV_COLUMNS,
+        component="parent IDV",
+    )
+    return agency.str.cat(parent_idv, sep="|").str.cat(piid, sep="|").rename("_award_key")
+
+
+def collapse_transactions_to_award_grain(
+    df: pd.DataFrame,
+    *,
+    award_keys: pd.Series | None = None,
+    date_columns: Sequence[str] = DEFAULT_TRANSACTION_DATE_COLUMNS,
+) -> pd.DataFrame:
+    """Keep one representative transaction per award, preferring the latest.
+
+    This is a row-selection policy, not a financial aggregation: amount fields
+    remain values from the selected transaction. Callers must aggregate amounts
+    separately when they need award totals.
+    """
+
+    if df.empty:
+        result = df.copy()
+        result["_award_key"] = pd.Series(index=result.index, dtype="object")
+        return result
+
+    keys = award_key_series(df) if award_keys is None else award_keys.reindex(df.index)
+    normalized_keys = keys.map(normalize_award_key_value)
+    missing = normalized_keys.eq("")
+    if missing.any():
+        rows = list(df.index[missing][:5])
+        raise AwardIdentityError(f"missing award key before grain collapse at rows {rows}")
+
+    result = df.copy().assign(_award_key=normalized_keys)
+    date_column = next((column for column in date_columns if column in result.columns), None)
+    if date_column is not None:
+        result = result.assign(
+            _award_sort_date=pd.to_datetime(result[date_column], errors="coerce", utc=True)
+        ).sort_values("_award_sort_date", kind="mergesort", na_position="first")
+        result = result.drop(columns="_award_sort_date")
+    return result.drop_duplicates("_award_key", keep="last").reset_index(drop=True)
+
+
+__all__ = [
+    "AWARDING_AGENCY_COLUMNS",
+    "AwardIdentityError",
+    "PARENT_IDV_COLUMNS",
+    "PIID_COLUMNS",
+    "UNIQUE_AWARD_KEY_COLUMNS",
+    "award_key_series",
+    "collapse_transactions_to_award_grain",
+    "normalize_award_key_value",
+]

--- a/tests/integration/test_phase_iii_retrospective_asset.py
+++ b/tests/integration/test_phase_iii_retrospective_asset.py
@@ -107,6 +107,7 @@ def _build_fixture():
         contracts.append(
             {
                 "contract_id": f"C-pos-{i:03d}",
+                "contract_award_unique_key": f"C-POS-{i:03d}",
                 "vendor_uei": _make_uei(i),
                 "awarding_agency_name": "DEPARTMENT OF DEFENSE",
                 "awarding_sub_tier_agency_name": "DEPARTMENT OF THE NAVY",
@@ -129,6 +130,7 @@ def _build_fixture():
         contracts.append(
             {
                 "contract_id": f"C-coded-{i:03d}",
+                "contract_award_unique_key": f"C-CODED-{i:03d}",
                 "vendor_uei": _make_uei(i),
                 "awarding_agency_name": "DEPARTMENT OF DEFENSE",
                 "awarding_sub_tier_agency_name": "DEPARTMENT OF THE NAVY",
@@ -151,6 +153,7 @@ def _build_fixture():
         contracts.append(
             {
                 "contract_id": f"C-neg-{i:03d}",
+                "contract_award_unique_key": f"C-NEG-{i:03d}",
                 "vendor_uei": _make_uei(900 + i),  # not in priors
                 "awarding_agency_name": "GENERAL SERVICES ADMINISTRATION",
                 "awarding_sub_tier_agency_name": "FEDERAL ACQUISITION SERVICE",
@@ -174,6 +177,7 @@ def _build_fixture():
         contracts.append(
             {
                 "contract_id": f"C-low-{i:03d}",
+                "contract_award_unique_key": f"C-LOW-{i:03d}",
                 "vendor_uei": _make_uei(i),
                 "awarding_agency_name": "DEPARTMENT OF DEFENSE",
                 "awarding_sub_tier_agency_name": "DEPARTMENT OF THE NAVY",
@@ -208,8 +212,8 @@ def _patched_pair_filter(priors: pd.DataFrame, contracts: pd.DataFrame) -> pd.Da
     if pairs.empty or "target_cet" not in contracts.columns:
         return pairs
     cet_lookup = (
-        contracts.loc[:, ["contract_id", "target_cet"]]
-        .rename(columns={"contract_id": "target_id"})
+        contracts.loc[:, ["contract_award_unique_key", "target_cet"]]
+        .rename(columns={"contract_award_unique_key": "target_id"})
         .drop_duplicates(subset=["target_id"])
     )
     return pairs.merge(cet_lookup, on="target_id", how="left")
@@ -261,7 +265,7 @@ def test_phase_iii_retrospective_asset_materializes(tmp_path, monkeypatch):
     PhaseIIICandidate(**df.iloc[0].to_dict())
 
     # No coded contracts in output.
-    assert not df["target_id"].astype(str).str.startswith("C-coded-").any()
+    assert not df["target_id"].astype(str).str.startswith("C-CODED-").any()
 
     # Parquet was written and matches the dataframe.
     parquet_path = Path(tmp_path) / CANDIDATES_OUTPUT_PATH
@@ -295,7 +299,7 @@ def test_phase_iii_retrospective_asset_materializes(tmp_path, monkeypatch):
 
     # Precision gate: HIGH precision over the engineered positives must be
     # at or above the spec threshold of 0.85.
-    positives = df.loc[df["target_id"].astype(str).str.startswith("C-pos-")]
+    positives = df.loc[df["target_id"].astype(str).str.startswith("C-POS-")]
     assert len(positives) == 30
     high_positives = int(positives["is_high_confidence"].sum())
     precision = high_positives / len(positives)
@@ -305,7 +309,7 @@ def test_phase_iii_retrospective_asset_materializes(tmp_path, monkeypatch):
     )
 
     # Low-content same-vendor contracts should NOT be high-confidence.
-    low = df.loc[df["target_id"].astype(str).str.startswith("C-low-")]
+    low = df.loc[df["target_id"].astype(str).str.startswith("C-LOW-")]
     assert len(low) == 30
     assert int(low["is_high_confidence"].sum()) == 0
 
@@ -315,11 +319,11 @@ def test_pair_filter_s1_excludes_already_coded_phase_iii():
     pairs = pair_filter_s1(priors_df, contracts_df)
     assert not pairs.empty
     target_ids = pairs["target_id"].astype(str).tolist()
-    assert not any(t.startswith("C-coded-") for t in target_ids)
+    assert not any(t.startswith("C-CODED-") for t in target_ids)
     # Negatives (different vendor) are dropped by the UEI inner join.
-    assert not any(t.startswith("C-neg-") for t in target_ids)
+    assert not any(t.startswith("C-NEG-") for t in target_ids)
     # Both the positives and the low-content same-vendor contracts pass.
-    assert sum(1 for t in target_ids if t.startswith("C-pos-")) == 30
-    assert sum(1 for t in target_ids if t.startswith("C-low-")) == 30
+    assert sum(1 for t in target_ids if t.startswith("C-POS-")) == 30
+    assert sum(1 for t in target_ids if t.startswith("C-LOW-")) == 30
     # Office is the finest agency match.
     assert (pairs["agency_match_level"] == "office").all()

--- a/tests/integration/test_phase_iii_retrospective_asset.py
+++ b/tests/integration/test_phase_iii_retrospective_asset.py
@@ -30,9 +30,11 @@ from sbir_analytics.assets.phase_iii_candidates.assets import (
     EVIDENCE_OUTPUT_PATH,
     HIGH_THRESHOLD_RETROSPECTIVE,
     WEIGHTS_RETROSPECTIVE,
+    _default_retrospective_loader,
     build_candidate_asset,
 )
-from sbir_analytics.assets.phase_iii_candidates.pairing import pair_filter_s1
+from sbir_analytics.assets.phase_iii_candidates.pairing import _prepare_contracts, pair_filter_s1
+from sbir_etl.extractors.contract_extractor import ContractExtractor
 from sbir_etl.models.phase_iii_candidate import PhaseIIICandidate, SignalClass
 
 
@@ -327,3 +329,41 @@ def test_pair_filter_s1_excludes_already_coded_phase_iii():
     assert sum(1 for t in target_ids if t.startswith("C-LOW-")) == 30
     # Office is the finest agency match.
     assert (pairs["agency_match_level"] == "office").all()
+
+
+def test_default_loader_accepts_contract_extractor_model_dump(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    output_path = Path("data/transition/contracts_ingestion.parquet")
+    row = ["\\N"] * 103
+    row[0] = "TX-1"
+    row[1] = "CONT_AWD_PIID-1_9700_PARENT-1"
+    row[2] = "20240115"
+    row[3] = "A"
+    row[5] = "A"
+    row[7] = "Follow-on production"
+    row[9] = "EXAMPLE COMPANY"
+    row[11] = "9700"
+    row[12] = "DEPARTMENT OF DEFENSE"
+    row[14] = "DEPARTMENT OF THE NAVY"
+    row[28] = "PIID-1"
+    row[29] = "1000"
+    row[71] = "20240115"
+    row[96] = "UEI000000001"
+    row[99] = "NONE"
+    row[100] = "A"
+    row[101] = "9700"
+    row[102] = "PARENT-1"
+
+    extractor = ContractExtractor()
+    contract = extractor._parse_contract_row(row)
+    assert contract is not None
+    output_path.parent.mkdir(parents=True)
+    assert extractor._collect_and_write([contract], output_path) == 1
+
+    loaded = _default_retrospective_loader(None)
+    assert loaded.loc[0, "generated_unique_award_id"] == row[1]
+    assert "research" in loaded.columns
+    assert pd.isna(loaded.loc[0, "research"])
+    targets = _prepare_contracts(loaded)
+    assert targets.loc[0, "target_id"] == row[1]
+    assert targets.loc[0, "target_id"] != row[28]

--- a/tests/unit/extractors/test_contract_extractor.py
+++ b/tests/unit/extractors/test_contract_extractor.py
@@ -367,6 +367,8 @@ class TestParseContractRow:
         contract = extractor._parse_contract_row(sample_contract_row_full)
 
         assert contract is not None
+        assert contract.generated_unique_award_id == "CONT_AWD_1234_9700_SPE4A924D0001"
+        assert contract.research is None
         assert "transaction_id" in contract.metadata
         assert "award_id" in contract.metadata
         assert "modification_number" in contract.metadata

--- a/tests/unit/phase_iii_candidates/test_award_key_grain.py
+++ b/tests/unit/phase_iii_candidates/test_award_key_grain.py
@@ -1,0 +1,76 @@
+"""Phase III pairing regressions for award identity and transaction grain."""
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.phase_iii_candidates.pairing import _prepare_contracts
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def _repeated_order_rows() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "piid": "0001",
+                "agencyID": "2100",
+                "referenced_idv_piid": "W1",
+                "research": "SR3",
+                "vendor_uei": "UEI1",
+                "awarding_agency_name": "ARMY",
+                "action_date": "2022-01-01",
+            },
+            {
+                "piid": "0001",
+                "agencyID": "2100",
+                "referenced_idv_piid": "W1",
+                "research": None,
+                "vendor_uei": "UEI1",
+                "awarding_agency_name": "ARMY",
+                "action_date": "2022-06-01",
+            },
+            {
+                "piid": "0001",
+                "agencyID": "2100",
+                "referenced_idv_piid": "W2",
+                "research": None,
+                "vendor_uei": "UEI1",
+                "awarding_agency_name": "ARMY",
+                "action_date": "2023-01-01",
+            },
+            {
+                "piid": "0001",
+                "agencyID": "2100",
+                "referenced_idv_piid": "W2",
+                "research": None,
+                "vendor_uei": "UEI1",
+                "awarding_agency_name": "ARMY",
+                "action_date": "2023-06-01",
+            },
+        ]
+    )
+
+
+def test_coded_status_and_collapse_are_applied_at_award_grain():
+    targets = _prepare_contracts(_repeated_order_rows())
+
+    assert len(targets) == 1
+    assert targets.iloc[0]["target_id"] == "2100|W2|0001"
+    assert targets.iloc[0]["target_action_date"] == "2023-06-01"
+
+
+def test_missing_coding_column_fails_loudly():
+    frame = pd.DataFrame([{"contract_award_unique_key": "A", "vendor_uei": "UEI1"}])
+
+    with pytest.raises(ValueError, match="no Phase III coding column"):
+        _prepare_contracts(frame)
+
+
+def test_contract_id_is_not_treated_as_precomputed_unique_key():
+    frame = pd.DataFrame(
+        [{"contract_id": "0001", "piid": "0001", "agencyID": "2100", "research": None}]
+    )
+
+    with pytest.raises(ValueError, match="parent IDV"):
+        _prepare_contracts(frame)

--- a/tests/unit/utils/test_award_identity.py
+++ b/tests/unit/utils/test_award_identity.py
@@ -38,6 +38,29 @@ def test_partial_precomputed_key_fails_instead_of_emitting_blank_identity():
         award_key_series(frame)
 
 
+def test_conflicting_complete_precomputed_key_aliases_fail():
+    frame = pd.DataFrame(
+        {
+            "contract_award_unique_key": ["CONT_AWD_1", "CONT_AWD_2"],
+            "generated_unique_award_id": ["cont_awd_1", "CONT_AWD_DIFFERENT"],
+        }
+    )
+
+    with pytest.raises(AwardIdentityError, match="conflicting precomputed award key aliases"):
+        award_key_series(frame)
+
+
+def test_matching_complete_precomputed_key_aliases_are_accepted():
+    frame = pd.DataFrame(
+        {
+            "contract_award_unique_key": ["CONT_AWD_1", " CONT_AWD_2 "],
+            "generated_unique_award_id": ["cont_awd_1", "cont_awd_2"],
+        }
+    )
+
+    assert award_key_series(frame).tolist() == ["CONT_AWD_1", "CONT_AWD_2"]
+
+
 def test_compound_key_distinguishes_repeated_order_piid_across_parent_idvs():
     frame = pd.DataFrame(
         {

--- a/tests/unit/utils/test_award_identity.py
+++ b/tests/unit/utils/test_award_identity.py
@@ -1,0 +1,111 @@
+"""Regression tests for contract-award identity and dataset grain."""
+
+import pandas as pd
+import pytest
+
+from sbir_etl.utils.award_identity import (
+    AwardIdentityError,
+    award_key_series,
+    collapse_transactions_to_award_grain,
+)
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def test_complete_precomputed_award_key_is_preferred():
+    frame = pd.DataFrame(
+        {
+            "contract_award_unique_key": ["CONT_AWD_1", " cont_awd_2 "],
+            "contract_id": ["0001", "0001"],
+        }
+    )
+
+    assert award_key_series(frame).tolist() == ["CONT_AWD_1", "CONT_AWD_2"]
+
+
+def test_partial_precomputed_key_fails_instead_of_emitting_blank_identity():
+    frame = pd.DataFrame(
+        {
+            "contract_award_unique_key": ["CONT_AWD_1", None],
+            "piid": ["0001", "0002"],
+            "agencyID": ["2100", "2100"],
+            "referenced_idv_piid": ["W1", "W2"],
+        }
+    )
+
+    with pytest.raises(AwardIdentityError, match="is partial"):
+        award_key_series(frame)
+
+
+def test_compound_key_distinguishes_repeated_order_piid_across_parent_idvs():
+    frame = pd.DataFrame(
+        {
+            "piid": ["0001", "0001"],
+            "agencyID": ["2100", "2100"],
+            "referenced_idv_piid": ["W1", "W2"],
+        }
+    )
+
+    assert award_key_series(frame).tolist() == ["2100|W1|0001", "2100|W2|0001"]
+
+
+@pytest.mark.parametrize(
+    ("frame", "message"),
+    [
+        (pd.DataFrame([{"piid": "0001", "agencyID": "2100"}]), "parent IDV"),
+        (
+            pd.DataFrame(
+                [
+                    {
+                        "piid": "0001",
+                        "agencyID": "2100",
+                        "referenced_idv_piid": None,
+                    }
+                ]
+            ),
+            "missing parent IDV",
+        ),
+        (
+            pd.DataFrame([{"contract_id": "0001", "piid": "0001", "agencyID": "2100"}]),
+            "parent IDV",
+        ),
+    ],
+)
+def test_bare_or_partial_compound_keys_fail(frame, message):
+    with pytest.raises(AwardIdentityError, match=message):
+        award_key_series(frame)
+
+
+def test_conflicting_alias_values_fail():
+    frame = pd.DataFrame(
+        [
+            {
+                "piid": "0001",
+                "PIID": "0002",
+                "agencyID": "2100",
+                "referenced_idv_piid": "W1",
+            }
+        ]
+    )
+
+    with pytest.raises(AwardIdentityError, match="conflicting PIID aliases"):
+        award_key_series(frame)
+
+
+def test_transaction_collapse_selects_latest_row_per_award():
+    frame = pd.DataFrame(
+        [
+            {"contract_award_unique_key": "A", "action_date": "2023-01-01", "value": 1},
+            {"contract_award_unique_key": "A", "action_date": "2023-06-01", "value": 2},
+            {"contract_award_unique_key": "B", "action_date": "2023-02-01", "value": 3},
+        ]
+    )
+
+    collapsed = collapse_transactions_to_award_grain(frame)
+
+    assert collapsed["_award_key"].tolist() == ["B", "A"]
+    assert dict(zip(collapsed["_award_key"], collapsed["value"], strict=True)) == {
+        "A": 2,
+        "B": 3,
+    }


### PR DESCRIPTION
Closes #447
Supersedes #425
Parent epic: #441

## What this isolates

- adds one shared, strict contract-award identity utility
- rejects partial or conflicting award keys instead of silently using bare PIIDs
- requires agency + actual parent IDV + PIID when no complete precomputed key exists
- collapses FPDS/USAspending modifications explicitly to award grain
- evaluates Phase III coded status across every transaction before candidate filtering
- documents the transaction-grain and financial-aggregation boundary
- updates the Phase III integration fixture to exercise an explicit award-grade key

This salvages the useful identity work from orphan commit `4c000729` on the retained #425 donor branch, then tightens it so every row must carry a complete identity and parent-agency fields cannot stand in for parent-IDV identifiers. It is rebased directly on the consolidated `main` and deliberately excludes the Phase III research scripts and product-spec work.

## Verification

- focused award identity, Phase III grain, and affected integration regressions: **13 passed**
- Ruff: **all checks passed**
- mypy on the changed utility and pairing module: **success**
- GitHub Actions: **fully green**, including integration, fast/slow unit suites, package mypy, static analysis, performance, and S3 integration

The donor branch is retained for provenance until this successor is reviewed.