### PR TITLE
Phase III undercount at award grain (141/16) + dark-count bounds (capture-recapture, frame size)

### DIFF
--- a/scripts/phase3_benchmark/pull_described_phase3.py
+++ b/scripts/phase3_benchmark/pull_described_phase3.py
@@ -1,0 +1,132 @@
+"""Manifested USAspending puller for description-flagged Phase III (the described side of the undercount).
+
+Companion to ``pull_fpds_10q.py`` (the coded side). Retrieves award-grain USAspending contract records
+whose description contains "SBIR PHASE III" for a top-tier agency, and returns rows plus a provenance
+manifest with the same shape as the FPDS puller: query, source vintage, retrieval time, per-page raw
+payload hashes, counts, field completeness, and feed-exhaustion status. Award grain is native here
+(``generated_internal_id``); no transaction collapse needed.
+
+Run: ``python scripts/phase3_benchmark/pull_described_phase3.py --agency "Department of Defense"``
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import urllib.request
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+
+ENDPOINT = "https://api.usaspending.gov/api/v2/search/spending_by_award/"
+FIELDS = ["Award ID", "Description", "Recipient Name", "Award Amount", "Awarding Agency",
+          "Awarding Sub Agency", "Action Date"]
+AWARD_TYPE_GROUPS = (["A", "B", "C", "D"], ["IDV_A", "IDV_B", "IDV_C", "IDV_D", "IDV_E"])
+REQUIRED_COMPLETENESS_FIELDS = ("generated_internal_id", "Award ID", "Description")
+Fetch = Callable[[bytes], bytes]
+
+
+def _post(body: bytes) -> bytes:
+    request = urllib.request.Request(
+        ENDPOINT, data=body, headers={"Content-Type": "application/json", "User-Agent": "sbir-phase3/1.0"}
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return response.read()
+
+
+def _request_body(agency: str, award_types: list[str], page: int,
+                  start_date: str, end_date: str) -> bytes:
+    return json.dumps({
+        "filters": {
+            "award_type_codes": award_types,
+            "time_period": [{"start_date": start_date, "end_date": end_date}],
+            "description": "SBIR PHASE III",
+            "agencies": [{"type": "awarding", "tier": "toptier", "name": agency}],
+        },
+        "fields": FIELDS, "limit": 100, "page": page,
+    }).encode()
+
+
+def _field_completeness(frame: pd.DataFrame) -> dict[str, float]:
+    if frame.empty:
+        return dict.fromkeys(REQUIRED_COMPLETENESS_FIELDS, 0.0)
+    out: dict[str, float] = {}
+    for field in REQUIRED_COMPLETENESS_FIELDS:
+        if field not in frame.columns:
+            out[field] = 0.0
+            continue
+        out[field] = round(float(frame[field].fillna("").astype(str).str.strip().ne("").mean()), 6)
+    return out
+
+
+def pull_described(agency: str, *, start_date: str = "2015-10-01", end_date: str = "2025-09-30",
+                   max_pages: int = 100, fetcher: Fetch = _post,
+                   source_vintage: str = "unknown") -> tuple[pd.DataFrame, dict[str, object]]:
+    """Retrieve description-flagged Phase III award rows for one agency, plus a provenance manifest."""
+    run_at = datetime.now(UTC).isoformat()
+    frames: list[pd.DataFrame] = []
+    digest = hashlib.sha256()
+    page_provenance: list[dict[str, object]] = []
+    termination_reason = "page_limit_reached"
+
+    for award_types in AWARD_TYPE_GROUPS:
+        for page in range(1, max_pages + 1):
+            payload = fetcher(_request_body(agency, award_types, page, start_date, end_date))
+            digest.update(payload)
+            parsed = json.loads(payload)
+            rows = pd.DataFrame(parsed.get("results", []))
+            if not rows.empty:
+                frames.append(rows)
+            has_next = bool(parsed.get("page_metadata", {}).get("hasNext"))
+            page_provenance.append({
+                "award_type_group": award_types[0][:3], "page": page, "row_count": len(rows),
+                "raw_sha256": hashlib.sha256(payload).hexdigest(), "has_next": has_next,
+            })
+            if not has_next:
+                termination_reason = "feed_exhausted"
+                break
+
+    frame = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
+    if "generated_internal_id" in frame.columns:
+        frame = frame.drop_duplicates("generated_internal_id")
+    manifest: dict[str, object] = {
+        "query": 'description="SBIR PHASE III"',
+        "endpoint": ENDPOINT,
+        "agency": agency,
+        "source_vintage": source_vintage,
+        "run_at": run_at,
+        "parameters": {"time_period": [start_date, end_date], "award_type_groups": list(AWARD_TYPE_GROUPS)},
+        "pages_retrieved": len(page_provenance),
+        "row_count": int(len(frame)),
+        "grain": "award (generated_internal_id; native award grain)",
+        "raw_pages_sha256": digest.hexdigest(),
+        "field_completeness": _field_completeness(frame),
+        "retrieval_complete": termination_reason == "feed_exhausted",
+        "termination_reason": termination_reason,
+        "page_provenance": page_provenance,
+    }
+    return frame, manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agency", default="Department of Defense")
+    parser.add_argument("--out", type=Path, default=None, help="optional parquet path for the frame")
+    parser.add_argument("--manifest", type=Path, default=None, help="optional manifest json path")
+    args = parser.parse_args(argv)
+    frame, manifest = pull_described(args.agency)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_parquet(args.out, index=False)
+    if args.manifest:
+        args.manifest.write_text(json.dumps(manifest, indent=2) + "\n")
+    manifest_summary = {k: v for k, v in manifest.items() if k != "page_provenance"}
+    print(json.dumps(manifest_summary, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase3_benchmark/undercount_award_grain.py
+++ b/scripts/phase3_benchmark/undercount_award_grain.py
@@ -1,0 +1,92 @@
+"""Award-grain Phase III undercount, computed through PR #449's identity contract.
+
+Reproduces the bounded DoD 141 / NASA 16 undercount (described-as-"SBIR PHASE III" but not `SR3`/`ST3`
+coded) at **award grain** using ``sbir_etl.utils.award_identity.award_key_series`` — the same
+compound-key / nested-parent-IDV rules as the benchmark — rather than raw FPDS transaction rows.
+
+The coded (FPDS-derived) frame carries its award identity as ``order_piid / order_agency / idv_piid /
+idv_agency``; the described (USAspending) frame carries ``generated_internal_id``. Both are supplied to
+``award_key_series`` as a precomputed ``unique_award_key`` (the contract's preferred path), so the join
+is exact and standalone contracts (no parent IDV) are handled without fabricating identities.
+
+Run: ``python scripts/phase3_benchmark/undercount_award_grain.py --derived data/derived``
+Requires the M0a derived frames (``m0a_coded_{dod,nasa}.parquet``, ``m0a_desc_phase3_{dod,nasa}.parquet``);
+the compound-key logic itself is covered by ``tests/unit/scripts/test_undercount_award_grain.py`` on a
+self-contained fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from sbir_etl.utils.award_identity import award_key_series
+
+
+def _norm(value: object) -> str:
+    return str(value).strip().upper() if value is not None else ""
+
+
+def reconstruct_coded_award_key(frame: pd.DataFrame) -> pd.Series:
+    """USAspending-form unique award key for an FPDS-derived coded frame."""
+
+    def row_key(row: pd.Series) -> str:
+        return (
+            f"CONT_AWD_{_norm(row['order_piid'])}_{_norm(row['order_agency']) or '-NONE-'}_"
+            f"{_norm(row['idv_piid']) or '-NONE-'}_{_norm(row['idv_agency']) or '-NONE-'}"
+        )
+
+    return frame.apply(row_key, axis=1)
+
+
+def undercount(coded: pd.DataFrame, described: pd.DataFrame) -> dict[str, int]:
+    """Distinct described-but-not-coded awards, keyed through #449's contract."""
+    coded = coded.assign(unique_award_key=reconstruct_coded_award_key(coded))
+    described = described.assign(
+        unique_award_key=described["generated_internal_id"].astype(str).str.upper()
+    )
+    coded_keys = set(award_key_series(coded))
+    described_keys = set(award_key_series(described))
+    return {
+        "coded_transactions": len(coded),
+        "coded_awards": len(coded_keys),
+        "described_awards": len(described_keys),
+        "described_coded_overlap": len(described_keys & coded_keys),
+        "undercount": len(described_keys - coded_keys),
+    }
+
+
+def _block(derived: Path, coded_file: str, described_file: str) -> dict[str, object]:
+    stats = undercount(
+        pd.read_parquet(derived / coded_file),
+        pd.read_parquet(derived / described_file),
+    )
+    stats["undercount_rate"] = round(stats["undercount"] / max(stats["described_awards"], 1), 4)
+    return stats
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--derived", type=Path, default=Path("data/derived"),
+                        help="directory holding the M0a coded/described parquet frames")
+    args = parser.parse_args(argv)
+
+    manifest = {
+        "identity_contract": "sbir_etl.utils.award_identity.award_key_series (PR #449)",
+        "grain": "award (not FPDS transaction)",
+        "DoD": _block(args.derived, "m0a_coded_dod.parquet", "m0a_desc_phase3_dod.parquet"),
+        "NASA": _block(args.derived, "m0a_coded_nasa.parquet", "m0a_desc_phase3_nasa.parquet"),
+    }
+    print(json.dumps(manifest, indent=2))
+
+    assert manifest["DoD"]["undercount"] == 141, manifest["DoD"]
+    assert manifest["NASA"]["undercount"] == 16, manifest["NASA"]
+    assert manifest["DoD"]["described_coded_overlap"] > 0, "coded/described key formats do not join"
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/phase3-match-benchmark/cross-agency-scope.md
+++ b/specs/phase3-match-benchmark/cross-agency-scope.md
@@ -10,10 +10,14 @@ program-wide, not DoD-only. Everything measured so far is DoD (baseline) plus a 
 ## Agency tiers (they behave differently)
 
 1. **DoD** — baseline. Undercount 14.7%; ranker AUC 0.844. Done.
-2. **NASA (contract)** — undercount **reproduces (16/202, 7.9%)**, so the *count* generalizes. But the
-   ranker's archive **recovery returned ~0 NASA notices** — NASA PIIDs (`NNX…`, `80NSSC…`) did not appear
-   as `AwardNumber` in the GSA `falextracts` archive. **Open diagnosis:** is this a PIID-format mismatch,
-   a NASA-specific posting practice (NSPIRES / NASA SEWP vs sam.gov), or genuine non-coverage? First test.
+2. **NASA (contract)** — undercount **reproduces (16/202, 7.9%)**, so the *count* generalizes. The ranker's
+   archive **recovery returned ~0 NASA notices — now DIAGNOSED** (FY2020 probe): NASA is fully present in
+   the archive (2,861 rows, **94% with rich descriptions**), but NASA populates the **`AwardNumber` field
+   on only ~6%** of its notices (vs ~21% for DoD), and **0 of our 202 NASA Phase III PIIDs matched**. So
+   the DoD-style **PIID→AwardNumber** join has nothing to hit — **not** a format issue (`80…`/`NN…`
+   prefixes match) nor non-coverage (the rich text is there). **Fix:** join NASA on a key it *does* carry
+   — **Sol#** (FPDS pull, as in the DoD rescue) or **Awardee name**. NASA recovery is feasible; the "0" was
+   a wrong-join-key artifact, not a wall.
 3. **Other contract agencies (DHS, DOT, DOE-contracts, Commerce, …)** — FPDS-coded + USAspending-described,
    same `falextracts` archive (all agencies). The undercount pulls are already **agency-parameterized**
    (`--agency`), so extension is mechanical; recovery/ranker are **untested** cross-agency.

--- a/specs/phase3-match-benchmark/cross-agency-scope.md
+++ b/specs/phase3-match-benchmark/cross-agency-scope.md
@@ -10,14 +10,17 @@ program-wide, not DoD-only. Everything measured so far is DoD (baseline) plus a 
 ## Agency tiers (they behave differently)
 
 1. **DoD** — baseline. Undercount 14.7%; ranker AUC 0.844. Done.
-2. **NASA (contract)** — undercount **reproduces (16/202, 7.9%)**, so the *count* generalizes. The ranker's
-   archive **recovery returned ~0 NASA notices — now DIAGNOSED** (FY2020 probe): NASA is fully present in
-   the archive (2,861 rows, **94% with rich descriptions**), but NASA populates the **`AwardNumber` field
-   on only ~6%** of its notices (vs ~21% for DoD), and **0 of our 202 NASA Phase III PIIDs matched**. So
-   the DoD-style **PIID→AwardNumber** join has nothing to hit — **not** a format issue (`80…`/`NN…`
-   prefixes match) nor non-coverage (the rich text is there). **Fix:** join NASA on a key it *does* carry
-   — **Sol#** (FPDS pull, as in the DoD rescue) or **Awardee name**. NASA recovery is feasible; the "0" was
-   a wrong-join-key artifact, not a wall.
+2. **NASA (contract) — ranker recovery does NOT generalize (tested, negative).** Undercount reproduces
+   (16/202, 7.9%) from USAspending, so the *count* generalizes. But the archive ranker does not: NASA is
+   present with 94% rich text, yet **every firm-link key is sparse and matched zero** of our NASA Phase III
+   firms — `AwardNumber` ~6%, **`Awardee` ~5%**, FPDS `solicitationID` ~2.5% (10 of 1,037 PIIDs). The rich
+   NASA text is **general solicitations/synopses, not the firm-specific award notices / J&As** that made
+   DoD work: NASA runs SBIR through NSPIRES and its Phase III is sole-source with almost no FPDS
+   solicitation trail, so it does not post firm-linkable award documents to sam.gov Contract Opportunities.
+   **Conclusion:** NASA transition detection needs a **NASA-specific source (NSPIRES / NASA award data)**,
+   not the GSA archive. (An earlier note called this a "wrong-join-key artifact, fixable" — the data
+   corrected that: all three keys fail.) This is the d8 hypothesis confirmed — **coverage/linkage
+   dominates per agency**: the archive ranker generalizes only to agencies that post J&As/award notices.
 3. **Other contract agencies (DHS, DOT, DOE-contracts, Commerce, …)** — FPDS-coded + USAspending-described,
    same `falextracts` archive (all agencies). The undercount pulls are already **agency-parameterized**
    (`--agency`), so extension is mechanical; recovery/ranker are **untested** cross-agency.

--- a/specs/phase3-match-benchmark/cross-agency-scope.md
+++ b/specs/phase3-match-benchmark/cross-agency-scope.md
@@ -1,0 +1,47 @@
+# Cross-agency generalization — scope (not yet implemented)
+
+Status: **scoping.** Extends the DoD+NASA undercount and the transition ranker to other agencies. Frames
+the obstacles and the concrete tests; no code here.
+
+## Why it matters
+The FPDS Phase III undercount [L14] and the transition-thinness questions (A-CP5 / A-CP10) are
+program-wide, not DoD-only. Everything measured so far is DoD (baseline) plus a NASA cross-check.
+
+## Agency tiers (they behave differently)
+
+1. **DoD** — baseline. Undercount 14.7%; ranker AUC 0.844. Done.
+2. **NASA (contract)** — undercount **reproduces (16/202, 7.9%)**, so the *count* generalizes. But the
+   ranker's archive **recovery returned ~0 NASA notices** — NASA PIIDs (`NNX…`, `80NSSC…`) did not appear
+   as `AwardNumber` in the GSA `falextracts` archive. **Open diagnosis:** is this a PIID-format mismatch,
+   a NASA-specific posting practice (NSPIRES / NASA SEWP vs sam.gov), or genuine non-coverage? First test.
+3. **Other contract agencies (DHS, DOT, DOE-contracts, Commerce, …)** — FPDS-coded + USAspending-described,
+   same `falextracts` archive (all agencies). The undercount pulls are already **agency-parameterized**
+   (`--agency`), so extension is mechanical; recovery/ranker are **untested** cross-agency.
+4. **Grant-heavy agencies (NIH, NSF, DOE-Office-of-Science)** — Phase III is largely **grant/commercial,
+   outside FPDS entirely** (already excluded from the undercount scope). Detecting their transitions is a
+   *different problem* (Form D / SBIR.gov commercialization surveys), **out of scope** for this pipeline.
+
+## Concrete tests (in order)
+1. **NASA recovery diagnosis** — measure `falextracts` `AwardNumber`/`Sol#` coverage for NASA Phase III
+   PIIDs; check format normalization; identify whether an alt source (NSPIRES) is needed. Decides whether
+   NASA ranker coverage is fixable or structural.
+2. **Undercount across all FPDS contract agencies** — run the manifested coded (`pull_fpds_10q`, per
+   `DEPARTMENT_ID`) + described (`pull_described_phase3 --agency …`) pulls for the top contract agencies;
+   report per-agency undercount rate. Cheap (pulls are parameterized) and directly feeds A-CP5.
+3. **Ranker coverage + AUC per agency** — for agencies with recoverable rich notices, re-run recovery +
+   `transition_ranker.evaluate` (GroupKFold by firm); report per-agency AUC and recovery coverage.
+4. **Transfer test** — DoD-trained ranker applied to a held-out agency (vs per-agency retrain), to see
+   whether the jargon-lexical + structural signal is agency-portable.
+
+## Expected obstacles / hypotheses
+- **Coverage, not method**, will dominate — as with DoD sole-source, the recoverable rich-text segment is
+  the competed + J&A-posted slice; agencies that post less will yield thinner ranker coverage even where
+  the undercount count is fine.
+- **NASA** is likely an archive-coverage/format issue (fixable via a NASA-specific source or normalization),
+  not a modeling one — the undercount already works there.
+- **Grant agencies** stay out of scope; conflating them would misstate transition rates.
+
+## Effort
+- Test 1 (NASA diagnosis): small (measurement on data in hand + a targeted probe).
+- Test 2 (all-agency undercount): small–moderate (parameterized pulls already exist; manifested).
+- Tests 3–4 (ranker cross-agency): moderate–large (per-agency recovery pulls; #442 pipeline territory).

--- a/specs/phase3-match-benchmark/cross-agency-scope.md
+++ b/specs/phase3-match-benchmark/cross-agency-scope.md
@@ -21,6 +21,17 @@ program-wide, not DoD-only. Everything measured so far is DoD (baseline) plus a 
    not the GSA archive. (An earlier note called this a "wrong-join-key artifact, fixable" — the data
    corrected that: all three keys fail.) This is the d8 hypothesis confirmed — **coverage/linkage
    dominates per agency**: the archive ranker generalizes only to agencies that post J&As/award notices.
+
+   **But NASA has its own source — TechPort (confirmed viable).** `techport.nasa.gov/api` is public and holds
+   **~20,036 SBIR/STTR projects**, ~95% of a sample carrying a **performing firm org + a rich project
+   description** — NASA's own portfolio, exactly where NASA "posts" its work. This replaces the sam.gov
+   archive for NASA: match TechPort project `organizations` → our SBIR firm UEIs (fuzzy name), use the
+   project `description` as firm-linkable rich text. Caveats for the build: (a) the API **rate-limits**
+   under rapid calls → needs a paced, cached, retried pull (like the GSA archive); (b) org-name→UEI needs
+   proper fuzzy matching; (c) verify whether a TechPort project represents the **transition/Phase III** vs
+   the original Phase I/II (the `program`/date fields help). So NASA is **not a dead end** — it needs a
+   TechPort-based recovery, not the GSA archive. Other non-sam.gov leads: NSPIRES (gated), `api.nasa.gov`
+   (keyed), NASA SBIR success stories.
 3. **Other contract agencies (DHS, DOT, DOE-contracts, Commerce, …)** — FPDS-coded + USAspending-described,
    same `falextracts` archive (all agencies). The undercount pulls are already **agency-parameterized**
    (`--agency`), so extension is mechanical; recovery/ranker are **untested** cross-agency.

--- a/specs/phase3-match-benchmark/cross-agency-scope.md
+++ b/specs/phase3-match-benchmark/cross-agency-scope.md
@@ -63,3 +63,35 @@ program-wide, not DoD-only. Everything measured so far is DoD (baseline) plus a 
 - Test 1 (NASA diagnosis): small (measurement on data in hand + a targeted probe).
 - Test 2 (all-agency undercount): small–moderate (parameterized pulls already exist; manifested).
 - Tests 3–4 (ranker cross-agency): moderate–large (per-agency recovery pulls; #442 pipeline territory).
+
+## RESULTS — first cross-agency number (Test 3, DoD↔NASA)
+Substrate: the NASA TechPort non-SBIR-project pool from #456 (`nasa-techport.md`) supplies NASA-side
+targets keyed by firm UEI; DoD side is the SBIR award abstracts + the SR3/ST3-coded contract pool.
+
+**Cross-agency overlap (UEI join, data on disk):**
+
+| Crossover | N (any) | N (strict) | Clean? |
+|---|---:|---:|---|
+| DoD SBIR → NASA non-SBIR project | 310 | 72 | ✅ target genuinely non-SBIR |
+| NASA SBIR → DoD Phase III (SR3/ST3) | 308 | 3 | ❌ target pool *is* SBIR-coded |
+| Firms w/ coded Phase III at BOTH agencies | 88 | — | — |
+| Firms doing SBIR at BOTH DoD & NASA | 1,489 | — | context |
+
+**Cross-agency retrieval (DoD SBIR abstract → its NASA non-SBIR project, 25 same-register hard negatives,
+306 firms): AUC 0.828, top-1 45%, top-3 60%** [within-NASA 0.879 | within-DoD 0.844]. pos-sim median
+**0.066** — absolute cosine is tiny (agencies use different jargon registers) yet the *ranking* holds, so
+this is genuine cross-agency continuity, not firm co-occurrence (1,489 firms do both SBIR → co-occurrence
+alone would sit at 0.5). The softer top-1 (45% vs 59% within-NASA) is the empirical case for *fusion*:
+identity + temporal features (vocabulary-agnostic) recover the most exactly where cross-agency text is weakest.
+
+**Asymmetry / data block:** NASA→DoD collapses to 3 strict **not** because it's rare but because our DoD
+target pool is SR3/ST3-*coded* (SBIR by construction) — a firm in it did DoD SBIR by definition. Measuring
+NASA→DoD (and DoD-internal *uncoded* Phase III) needs a **DoD non-SBIR contract pool** (recipient-UEI-filtered
+USAspending/FPDS, excluding SBIR-coded), the DoD analogue of what TechPort is for NASA. That is the richest
+open avenue — but it is the base-rate wall in full force if scanned whole-universe (~1% prevalence → needs
+~0.95 AUC); the tractable framing is **per-firm/recipient-scoped** ranking (a firm's SBIR abstract → its own
+non-SBIR DoD contracts), which is the same retrieval frame that yields 0.828/0.844/0.879 and tames the base rate.
+
+**Gate before building the ranker:** the 72 strict DoD→NASA firms are a proxy ("DoD-SBIR firm doing a NASA
+project") that needs human confirmation (genuine transition vs unrelated NASA work) — fold ~10–15 into the
+precision@K manual-eval pass before investing in the DoD non-SBIR pull.

--- a/specs/phase3-match-benchmark/dod-nonsbir-contract-pool.md
+++ b/specs/phase3-match-benchmark/dod-nonsbir-contract-pool.md
@@ -1,0 +1,91 @@
+# DoD non-SBIR contract pool: recipient-scoped puller
+
+Status: **spec — not yet built. Gated behind the precision@K manual eval (see Gates).**
+
+## What this unlocks
+
+The NASA side has a non-SBIR target pool (TechPort, `nasa-techport.md`) that made within-NASA (0.879) and
+cross-agency DoD→NASA (0.828, `cross-agency-scope.md`) transition retrieval measurable. DoD has **no
+equivalent** — our only DoD target pool is the SR3/ST3-*coded* contracts (`m0a_coded_dod`, SBIR by
+construction). Building the DoD analogue — a recipient-scoped pull of DoD SBIR firms' **non-SBIR** contracts
+— collapses three open questions into one dataset:
+
+1. **NASA→DoD transitions** — currently 3-strict, blocked *only* because the DoD target pool is SBIR-coded.
+   A non-SBIR DoD pool makes the reverse direction measurable (run the same puller over NASA-SBIR firms' UEIs).
+2. **DoD-internal *uncoded* Phase III** — the layer below the 141. The undercount (`undercount-award-grain.md`)
+   is *described-not-coded* (the contract text still says "SBIR PHASE III"). This finds DoD SBIR tech maturing
+   into contracts with **no SBIR marking at all** — invisible to any code- or description-based count.
+3. **Real targets for the #455 DoD ranker** — today it trains on coded/described notices; recipient contracts
+   give it the actual follow-on universe.
+
+## Approach — extend `pull_described_phase3.py`, don't rebuild
+
+Same USAspending `spending_by_award` endpoint, same `Fetch = Callable[[bytes], bytes]` seam, same manifest
+shape and `_field_completeness`. Two changes: filter by **recipient**, not description; and **subtract SBIR**
+in post.
+
+New module `scripts/phase3_benchmark/pull_recipient_contracts.py`:
+
+```text
+_request_body(uei, award_types, page, start, end)   # spending_by_award, recipient_search_text=[uei],
+                                                     #   NO description filter (we want ALL contracts)
+pull_recipient(uei, *, start, end, max_pages, fetcher, source_vintage) -> (DataFrame, manifest)
+pull_recipients(ueis, *, cache_dir, pace, fetcher, ...)  -> (DataFrame, manifest)  # per-UEI cache, paced
+exclude_sbir(frame, coded_keys, described_keys)     -> DataFrame                    # the crux, below
+main(argv)                                           # --ueis-file --agency --out --manifest --cache --limit
+```
+
+- **Recipient filter:** `filters.recipient_search_text: [uei]` (USAspending matches UEI here). Award types
+  contracts only: `["A","B","C","D"]` + IDV group, mirroring `AWARD_TYPE_GROUPS`. Fields add `PSC Code`,
+  `NAICS Code`, `Recipient UEI`, `generated_internal_id` to the existing `FIELDS`.
+- **SBIR exclusion (three layers, most-reliable first):**
+  1. drop award keys present in the SR3/ST3-coded pool (`m0a_coded_dod`, via `award_key_series`);
+  2. drop keys present in the described-Phase-III pull (the 141/962 — already counted);
+  3. drop rows whose `Description` matches `SBIR|STTR|PHASE\s*(I|II|III)` (belt-and-suspenders).
+  The residual = the firm's DoD contracts with **no SBIR signal** = the uncoded candidate transition pool.
+- **Output contract:** one row per (recipient UEI, non-SBIR DoD contract): award key, UEI, description,
+  amount, action date, awarding sub-agency, PSC, NAICS. This is the **target** side for the ranker
+  (query = firm SBIR abstract), keyed by UEI — drops straight into `transition_ranker.evaluate`.
+- **Manifest parity:** `endpoint`, `source_vintage`, `run_at`, `recipients_requested`, `recipients_returned`,
+  `rows_total`, `rows_after_sbir_exclusion`, per-recipient `raw_sha256`, `field_completeness`,
+  `retrieval_complete` (all recipients paged to feed exhaustion, none throttled-out).
+
+## This does NOT defeat the base-rate wall — scoping does
+
+The output is **not** a Phase III classification. A global "is this DoD contract a Phase III?" is the
+~1%-prevalence / need-0.95-AUC trap. This pool is only ever consumed **per-firm**: "which of *this firm's*
+non-SBIR contracts continue *its* SBIR tech?" — firm-scoping tames the base rate, and it is the identical
+retrieval frame that already yields 0.828 / 0.844 / 0.879. Evaluation is firm-clustered retrieval
+(`evaluate`, GroupKFold by firm, same-register hard negatives = other firms' non-SBIR DoD contracts). No
+count is emitted from the pool itself.
+
+## Scale & cost
+
+~8,064 DoD SBIR firms (UEI). USAspending pages 100/award; most firms hold <100 contracts → ~1–3 pages each
+→ ~8–24k requests, paced + per-UEI cached → **resumable**, moderate effort. Scope **v1 to a subset** to
+validate before the full sweep:
+- the 1,487 firms already in `m0a_coded_dod` (known DoD Phase III performers), or
+- the 306 cross-agency firms (lets us close NASA↔DoD both directions on a known cohort first).
+
+## Testing (mirror `test_pull_described_phase3.py`)
+
+Fixture with a canned `fetcher`; no network. Assert: (1) `_request_body` carries the UEI in
+`recipient_search_text` and no description filter; (2) `exclude_sbir` drops coded + described keys and keeps
+the uncoded residual; (3) manifest shape + `retrieval_complete` logic (throttle → False); (4)
+`rows_after_sbir_exclusion` ≤ `rows_total`.
+
+## Gates (do not build ahead of these)
+
+1. **Manual eval confirms the proxy.** The precision@K pass must show that "a firm's non-SBIR contract that
+   its SBIR abstract retrieves" is a *genuine* transition, not unrelated firm work — sample the 72 strict
+   DoD→NASA cases + a within-DoD stratum first. If the proxy is weak, this pull harvests noise.
+2. **v1 scoped subset** (coded-pool or cross-agency-306 firms) before the 8k sweep.
+3. **Precision@K on ranker top-candidates** before any DoD-internal uncoded figure is reported — same
+   discipline as the 141 (`undercount-award-grain.md`): a retrievable candidate is not a confirmed Phase III.
+
+## Relation to PRs
+
+Puller lives with the others in `scripts/phase3_benchmark/`. Feeds the #455 DoD ranker (real targets),
+unlocks the `cross-agency-scope.md` NASA→DoD reverse direction, and supplies the DoD-internal uncoded
+candidate layer. Symmetric with `pull_techport_nasa.py` — together they give both agencies a non-SBIR
+target pool keyed by firm UEI.

--- a/specs/phase3-match-benchmark/mse-dark-phase3.md
+++ b/specs/phase3-match-benchmark/mse-dark-phase3.md
@@ -135,6 +135,47 @@ signal (the feasibility gate found none). The productive path is **tightening th
 design that uses the detector for what it's good at (ranking to concentrate the base rate) rather than as a
 counter.
 
+## Heterogeneity-stratified capture-recapture (run 2026-07-18)
+
+Chapman per sub-agency stratum (labels normalized across lists — a naive string match fabricates phantom
+zero-overlap strata; 5/821 overlap pairs genuinely disagree on sub-agency across lists, immaterial):
+
+| stratum | n1 (coded) | n2 (desc) | overlap | dark | code-miss rate |
+|---|--:|--:|--:|--:|--:|
+| Air Force | 2,467 | 352 | 304 | 340 | 13.6% |
+| Navy | 1,642 | 253 | 205 | 335 | 18.9% |
+| DCMA | 607 | 77 | 58 | 177 | **24.4%** |
+| Army | 994 | 194 | 165 | 145 | 14.9% |
+| DLA / MDA / other | 641 | 86 | 84 | 10 | ~0–9% |
+| **Stratified sum** | | | | **1,007 [812–1,202]** | |
+
+- **The floor rises 949 → 1,007** — the direction heterogeneity theory predicts (pooled LP is biased low when
+  capture rates vary). Office-prefix stratification gives 733 as a weak-stratification sensitivity point; the
+  honest reporting band is **dark ≈ 950–1,200, floor ~1,000**.
+- **The miss rate is organizationally structured, not random:** DCMA 24% (administers others' awards — coding
+  context lost), Navy 19%, AF 14%, MDA ~0%. This targets the fix: the undercount concentrates where contract
+  *administration* is separated from the awarding program office.
+
+## Rank-then-stratify: evaluated and NOT currently viable (run 2026-07-18)
+
+Test: use coded Phase IIIs (n=5,282) as pretend-dark positives vs the 471-contract un-flagged pool; measure
+how much available *structural* features concentrate the 0.7% frame prevalence.
+
+- **Office lineage INVERTS** (LR 0.9×): un-flagged contracts match the firm's SBIR office *more* often (46.5%)
+  than Phase IIIs do (41.9%) — a firm's routine work stays at the office that knows it, while Phase III
+  production often moves to a *different* buying command. The presumed-best lineage feature is anti-signal.
+- Timing helps (65% vs 33% within [−2,+5] of last SBIR year) but combined LR is only **1.4×** → best band
+  prevalence ~**1.0%**, requiring **~3,000 hand labels for ~30 hits.** Not a feasible adjudication design.
+- Caveats: negatives are from 44 established firms (not the full frame); positives are coded P3 (the usual
+  has/lacks-property caution). But the effect sizes are nowhere near the ~30–50× concentration needed, so the
+  conclusion is robust to those.
+
+**Consequence: the upper bound cannot be cheaply tightened.** Remaining options, in order: (a) re-pull the
+frame sample with PSC/competition/amount fields and retest richer structural features (one bounded spike —
+sole-source + R&D-PSC is the last plausible concentrator); (b) accept the bounds as final for the memo — the
+defensible package is *"141 proven + dark ≈ 950–1,200 (stratified floor ~1,000), organizationally concentrated
+(DCMA/Navy)"* — and let the §638 linkage field be the fix rather than better detection.
+
 ## Relation to PRs
 
 Extends the undercount work here on #454 (`undercount-award-grain.md`: 141 described-not-coded is exactly the

--- a/specs/phase3-match-benchmark/mse-dark-phase3.md
+++ b/specs/phase3-match-benchmark/mse-dark-phase3.md
@@ -156,6 +156,37 @@ zero-overlap strata; 5/821 overlap pairs genuinely disagree on sub-agency across
   context lost), Navy 19%, AF 14%, MDA ~0%. This targets the fix: the undercount concentrates where contract
   *administration* is separated from the awarding program office.
 
+## What further stratification teaches (run 2026-07-18)
+
+**Contract vehicle — the cleanest and biggest axis** (encoded in the award key itself, so per-stratum
+overlaps sum to exactly 821; no cross-list assignment error possible):
+
+| vehicle | n1 | n2 | overlap | miss rate | dark |
+|---|--:|--:|--:|--:|--:|
+| standalone contract | 2,692 | 578 | 524 | **9.3%** | 223 |
+| task order under IDV | 3,659 | 384 | 297 | **22.6%** | 982 |
+| **sum** | | | | | **1,205** |
+
+The 10Q code is lost **at the order level under contract vehicles** — task orders miss 2.4× more than
+standalone contracts. This corroborates and sharpens the DCMA finding (24% miss): the undercount concentrates
+where award and administration separate. **Floor progression: pooled 949 → sub-agency 1,007 → vehicle 1,205**
+— each finer (valid) stratification raises the floor, exactly as heterogeneity predicts. Best defensible floor
+now **~1,200**.
+
+**Time trend — the miss rate is WORSENING.** Using origination-year bands parsed identically from the PIID on
+both lists (the naive version — coded transaction-FY vs desc origination-FY — puts the same contract in
+different bands and explodes the estimate; caught via the overlap-sum check, 561≠821):
+
+| origination band | miss rate | dark |
+|---|--:|--:|
+| pre-FY16 | 18.2% | 93 |
+| FY16–18 | 5.0% | 38 |
+| FY19–21 | 13.5% | 202 |
+| FY22–25 | **17.3%** | 490 |
+
+Coding compliance deteriorated ~3.5× from FY16-18 to FY22-25. The undercount is a *growing* problem, not a
+legacy one — directly relevant to the urgency of the linkage-field fix.
+
 ## Rank-then-stratify: evaluated and NOT currently viable (run 2026-07-18)
 
 Test: use coded Phase IIIs (n=5,282) as pretend-dark positives vs the 471-contract un-flagged pool; measure
@@ -170,11 +201,15 @@ how much available *structural* features concentrate the 0.7% frame prevalence.
   has/lacks-property caution). But the effect sizes are nowhere near the ~30–50× concentration needed, so the
   conclusion is robust to those.
 
-**Consequence: the upper bound cannot be cheaply tightened.** Remaining options, in order: (a) re-pull the
-frame sample with PSC/competition/amount fields and retest richer structural features (one bounded spike —
-sole-source + R&D-PSC is the last plausible concentrator); (b) accept the bounds as final for the memo — the
-defensible package is *"141 proven + dark ≈ 950–1,200 (stratified floor ~1,000), organizationally concentrated
-(DCMA/Navy)"* — and let the §638 linkage field be the fix rather than better detection.
+**Spike (a) RUN — richer features tested, verdict unchanged.** Re-pulled the pool with PSC (710 contracts,
+100% PSC coverage; `Type of Set Aside` is None throughout — dead end confirmed). R&D-PSC alone: LR 1.6×
+(P3 49.3% vs un-flagged 30.8%). Best combination (R&D-PSC + gap∈[−2,+5]): **LR 4.4×**, band ~8.9k contracts
+at **~3.0% prevalence → ~1,000 labels for 30 hits**, and the band captures only 29% of Phase IIIs (out-of-band
+dark would still need a model). Better than 1.4×, still not a feasible human adjudication design.
+**Final posture: accept the bounds** — *141 proven + dark ≈ 1,200–?* (vehicle-stratified floor), miss rate
+worsening (17.3% in FY22-25) and structurally concentrated (task orders 22.6%, DCMA 24%) — with the §638
+linkage field as the fix rather than better detection. (A future LLM-assisted screen of the ~8.9k band with
+human verification of hits could revisit this, but introduces its own validation loop.)
 
 ## Relation to PRs
 

--- a/specs/phase3-match-benchmark/mse-dark-phase3.md
+++ b/specs/phase3-match-benchmark/mse-dark-phase3.md
@@ -1,6 +1,7 @@
 # Quantifying dark Phase III: 3-source capture-recapture (multiple-systems estimation)
 
-Status: **spec — not built.** Turns the 2-source lower bound (~949) into a defensible point estimate + CI.
+Status: **feasibility gate RUN — no clean structured 3rd signal; MSE stays 2-source (~949 lower bound).**
+The 3-source design below is retained for the J&A sensitivity extension and the eventual linkage-field world.
 
 ## What this resolves
 
@@ -33,10 +34,23 @@ authority (15 U.S.C. §638). Build it from USAspending/FPDS `other_than_full_and
 GSA archive (the sole-source J&As cite "Phase III" + SBIR authority). It is **independent of both the 10Q
 code and the description text** — the property MSE needs.
 
-- **Feasibility gate (do first):** confirm FPDS exposes an SBIR/STTR-specific non-competed reason code and
-  measure its precision (does it flag non-SBIR sole-source too?). If the structured code is not SBIR-specific,
-  fall back to J&A-text authority (lower coverage, higher precision). If neither yields a clean high-precision
-  list, MSE stays 2-source (report 949 as a bound only).
+- **Feasibility gate — RUN 2026-07-17, result: no clean structured FPDS signal.** On 100 known DoD
+  "SBIR PHASE III" contracts (USAspending): `Type of Set Aside` is **None/`SBA` (generic "Small Business
+  Set-Aside — Total")** — *not* SBIR-specific, so it flags the entire small-business sole-source universe
+  (terrible precision). `extent_competed` is mixed (D "full & open after exclusion", F "competed under SAP")
+  with **no SBIR-specific non-competed reason**; `other_than_full_and_open` is unpopulated. The only
+  SBIR-Phase-III-specific FPDS field is the 10Q code itself (= list 1). **There is no independent second
+  structured FPDS signal.**
+- **Fallback — J&A text (partial).** The GSA-archive J&A notices (~273 notices / 165 firms, high-precision,
+  explicitly cite "SBIR Phase III") are independent of code and USAspending description. But two limits make
+  them unfit as a *headline*-carrying third list: (a) **low coverage** (~165 of ~1,487 Phase III firms), and
+  (b) **subtype skew** — J&As exist only for *sole-source* actions, so the list systematically misses
+  competed Phase IIIs (a reachability bias, not just thin sampling).
+- **Decision (per the gate's own rule): MSE stays 2-source; report ~949 as a defensible LOWER BOUND.** The
+  J&A list is worth adding only as a **sensitivity extension** (a 3-source fit on the sole-source stratum, to
+  probe the code×description dependence), NOT as the basis for a headline point estimate. The clean upgrade
+  path is the missing **linkage field** (`eval-validity.md`): if a parent-SBIR-award-ID were populated, there
+  would be no dark cell to estimate — the MSE quantifies the cost of its absence.
 
 ## Method
 

--- a/specs/phase3-match-benchmark/mse-dark-phase3.md
+++ b/specs/phase3-match-benchmark/mse-dark-phase3.md
@@ -1,0 +1,100 @@
+# Quantifying dark Phase III: 3-source capture-recapture (multiple-systems estimation)
+
+Status: **spec — not built.** Turns the 2-source lower bound (~949) into a defensible point estimate + CI.
+
+## What this resolves
+
+The dark Phase III count (contracts that are genuinely SBIR Phase III but carry neither the FPDS code nor a
+"SBIR PHASE III" description) cannot be reached by a classifier — at ~1% prevalence that needs ~0.95 AUC,
+unreachable by text, and DoD's descriptions are empty anyway (`eval-validity.md`: median 43 chars; a dense
+model does *worse* on that boilerplate, 0.659 vs 0.714). **Capture-recapture sidesteps the wall entirely**:
+it never classifies a contract; it infers the total from the overlap of incomplete high-precision *lists* —
+the method a census uses to estimate its own undercount and epidemiology uses for hidden populations.
+
+**Already computed (2-source, Lincoln-Petersen/Chapman):** code (6,351) × description (962), overlap 821 →
+total ≈ 7,441, **dark ≈ 949 [95% CI 767–1,130]**. But two-source *assumes the signals are independent*, and
+they are positively correlated (a CO who codes SR3 also writes "SBIR PHASE III"), which inflates the overlap
+and **underestimates** the total — so **949 is a lower bound, not an estimate.** A third list breaks this: it
+lets a log-linear model *estimate* the dependence instead of assuming it away.
+
+## The three capture lists
+
+| # | Signal | Source | Have? | Precision |
+|---|---|---|---|---|
+| 1 | **CODE** — FPDS element-10Q SR3/ST3 | `m0a_coded_dod` (6,351, award-grain) | ✅ | high |
+| 2 | **DESCRIPTION** — "SBIR PHASE III" text | `m0a_desc_phase3_dod` (962) | ✅ | high (exact phrase) |
+| 3 | **AUTHORITY** — sole-source under SBIR statute | FPDS competition fields + J&A text | ⚠️ build | needs validation |
+
+**Third signal = the sole-source/authority list, and it must be STRUCTURAL, not text** — the dense-model
+result proves DoD text is uninformative, so a retrieval-threshold list would be weak *and* correlated with
+list 2. Phase III contracts are typically awarded other-than-full-and-open citing SBIR/STTR statutory
+authority (15 U.S.C. §638). Build it from USAspending/FPDS `other_than_full_and_open_competition_code` /
+`extent_competed` / `reason_not_competed`, cross-checked against the J&A notice text already pulled from the
+GSA archive (the sole-source J&As cite "Phase III" + SBIR authority). It is **independent of both the 10Q
+code and the description text** — the property MSE needs.
+
+- **Feasibility gate (do first):** confirm FPDS exposes an SBIR/STTR-specific non-competed reason code and
+  measure its precision (does it flag non-SBIR sole-source too?). If the structured code is not SBIR-specific,
+  fall back to J&A-text authority (lower coverage, higher precision). If neither yields a clean high-precision
+  list, MSE stays 2-source (report 949 as a bound only).
+
+## Method
+
+1. **Link the three lists at award grain** via `sbir_etl.utils.award_identity.award_key_series` (#449) — the
+   compound key, NOT bare PIID ([[fpds-piid-not-a-key]]). Linkage error (same contract counted twice across
+   lists) is the single biggest threat; a mislinked pair fabricates a phantom "caught by one" unit.
+2. **Build the 2³−1 = 7 observed capture cells** (which lists caught each contract; the 000 cell is the dark
+   unknown).
+3. **Fit log-linear Poisson models** to the 7 cells (statsmodels GLM, or hand-rolled IPF). Main effects =
+   per-list capture rates; pairwise interactions = list dependence. The 3-way interaction is unidentifiable
+   (would saturate) — that residual assumption is stated, not hidden. Predict the 000 cell → dark count.
+4. **Model selection + sensitivity:** fit the independence model and each 2-way-interaction model; report the
+   **range** across plausible models by AIC/BIC, not a single point.
+5. **Chao (1987) lower-bound estimator** alongside — heterogeneity-robust, gives a defensible floor whatever
+   the dependence structure. Report `[Chao lower bound, log-linear point estimate, CI]`.
+6. **CIs** via the log-linear asymptotic covariance or a nonparametric bootstrap over contracts.
+
+## Assumptions & failure modes (the honest core)
+
+- **Closed population** — fix a FY window (FY2016–2025, the archive/coding coverage). Contracts are units.
+- **List precision** — every list must flag *only* true Phase IIIs; false positives inflate. Code/description
+  are clean; the authority list is the one to validate (see gate).
+- **Heterogeneity** — big obvious Phase IIIs get all three signals, small ones none; this positive dependence
+  biases toward underestimate. Chao mitigates; stratifying by agency/size/year helps.
+- **Reachability** — MSE estimates Phase III *reachable by these three capture processes*. A truly trace-less
+  follow-on remains invisible; the structural authority signal is chosen precisely to extend reach past text.
+- **3-way dependence** unidentifiable with 3 lists — the one assumption that survives; a 4th list (e.g. the
+  thresholded retrieval ranker, or cross-agency TechPort) would relax it further.
+
+## Validation — the gold-standard tie-in
+
+The blind hand-adjudication (`~/Documents/phase3_adjudication_*`) is the external check: (a) it measures each
+list's **precision** (are flagged contracts really Phase III?), and (b) adjudicating a random sample of
+**un-flagged** DoD contracts directly estimates the false-negative rate → an *independent* read on the dark
+cell to cross-check the MSE extrapolation. If the direct sample and the MSE disagree, the model assumptions
+are wrong and we learn which.
+
+## Deliverables
+
+- `scripts/phase3_benchmark/build_authority_list.py` — construct + precision-validate list 3 (the real work).
+- `scripts/phase3_benchmark/phase3_mse.py` — pure cores: `capture_cells`, `loglinear_estimate`,
+  `chao_lower_bound`, `bootstrap_ci`; + unit tests on synthetic data with a KNOWN N (recover it).
+- `specs/phase3-match-benchmark/mse-findings.md` — estimate, model-sensitivity range, assumptions, validation.
+
+## Scope boundaries
+
+- **IN:** DoD, FY-windowed, award-grain, 3 signals, log-linear + Chao, sensitivity range, CI, adjudication check.
+- **OUT:** cross-agency (separate universe — could be a parallel MSE), a universe-wide classifier (base-rate
+  wall), the detection ranker as a *counter* (it enters only as an optional high-precision 4th list).
+
+## Effort & gates
+
+- **Gate 1:** the feasibility check on signal 3 (SBIR-specific non-competed code + its precision). Cheap; do first.
+- **Gate 2:** adjudication precision on the three lists before publishing any point estimate.
+- Log-linear fitting is small (statsmodels/scipy); the authority-list construction + validation is the effort.
+
+## Relation to PRs
+
+Extends the undercount work here on #454 (`undercount-award-grain.md`: 141 described-not-coded is exactly the
+desc-only capture cell). The detection ranker (#455) can later join as a 4th list. This is the rigorous
+version of the "~1,000 dark" figure that has floated as an unmodeled guess.

--- a/specs/phase3-match-benchmark/mse-dark-phase3.md
+++ b/specs/phase3-match-benchmark/mse-dark-phase3.md
@@ -107,6 +107,34 @@ are wrong and we learn which.
 - **Gate 2:** adjudication precision on the three lists before publishing any point estimate.
 - Log-linear fitting is small (statsmodels/scipy); the authority-list construction + validation is the effort.
 
+## Frame size, the bounds, and why direct validation is base-rate-blocked (measured 2026-07-18)
+
+The **frame** = all un-flagged post-SBIR DoD contracts to the 8,064 DoD SBIR firms (a dark Phase III *must*
+live here: post-SBIR, to an SBIR firm, caught by neither signal, not the SBIR award itself). Uniform sample
+n=300 (USAspending recipient pulls, paginated; earlier runs failed on a pre-2007 `start_date` that returns a
+misleading HTTP 500 — the indexed window starts 2007-10-01):
+
+- **Frame ≈ 131,000 contracts** — 95% CI [71k, 202k]. Mean **16.3/firm**, median **0** (53% of SBIR firms have
+  zero un-flagged post-SBIR contracts; the frame is concentrated in an established-firm minority, max 599).
+
+This pins the **bounds on the dark cell**: `949 ≤ dark ≤ 131,000`. The lower bound (capture-recapture,
+list-overlap) is a real estimate; the upper bound is the *trivial* ceiling (every un-flagged contract being a
+Phase III — absurd). So the count is well-constrained below and barely constrained above: **total DoD Phase
+III ∈ [≥7,441, ~137,500]**, dark ∈ [949, 131,000] — two orders of magnitude wide on the high side.
+
+**Implied dark Y-rate for 949 = 949/131,000 = 0.7%.** This kills direct-sampling validation at small n: at a
+0.7% rate a 15-row dark-cell probe expects **0.1 hits** (P(0 hits | 949 true) ≈ 90%), so it cannot distinguish
+949 from 0 or from 3,000; observing ~5 hits needs **~700** hand-adjudicated rows. **The base-rate wall that
+blocked the detector also blocks the validation.** Capture-recapture stands alone (it infers from overlap, not
+sampling); the 15-row dark-cell stratum is demoted to an *existence scan*, not a count check.
+
+**To narrow the range** (the real open problem): the lower bound won't move without a clean independent 3rd
+signal (the feasibility gate found none). The productive path is **tightening the UPPER bound** — rank the
+131k frame with the *structural* (non-text) detector and estimate the Phase-III rate per score band via
+**stratified adjudication**, yielding a point estimate + CI instead of only the 949 floor. That is the one
+design that uses the detector for what it's good at (ranking to concentrate the base rate) rather than as a
+counter.
+
 ## Relation to PRs
 
 Extends the undercount work here on #454 (`undercount-award-grain.md`: 141 described-not-coded is exactly the

--- a/specs/phase3-match-benchmark/undercount-award-grain.md
+++ b/specs/phase3-match-benchmark/undercount-award-grain.md
@@ -1,0 +1,47 @@
+# Phase III undercount: award-grain reproduction
+
+Status: **reproduced at award grain through PR #449's identity contract.**
+
+## What this resolves
+
+`findings.md` retains the donor's bounded DoD result (141 of 962 described records, 14.7%, ≈$244.2M)
+only as a provisional figure "not yet reportable here… may be restated only after the run is reproduced
+with PR #449's compound-key and award-grade rules." This note supplies that reproduction.
+
+## Result
+
+`scripts/phase3_benchmark/undercount_award_grain.py` computes the described-but-not-coded undercount at
+**award grain** using `sbir_etl.utils.award_identity.award_key_series` — the same nested-parent-IDV
+compound-key rules as the benchmark. The coded (FPDS-derived) frame supplies its award identity via the
+reconstructed USAspending unique key; the described (USAspending) frame supplies `generated_internal_id`;
+both go through `award_key_series` as a precomputed `unique_award_key`, so standalone contracts (no parent
+IDV) are keyed without fabricating identities.
+
+| Agency | Coded transactions | Coded awards | Described awards | Overlap | **Undercount** |
+|---|--:|--:|--:|--:|--:|
+| DoD | 6,351 | 6,351 | 962 | 821 | **141 (14.7%)** |
+| NASA | 1,038 | 1,038 | 202 | 186 | **16 (7.9%)** |
+
+The coded frame is already award-grain (collapse ratio 1.00; 58% carry a nested parent-IDV), and the
+non-zero described∩coded overlaps (821/186) prove the two sources join on the same key — so the figure
+is **not** an artifact of counting FPDS transaction rows.
+
+## Scope and honest limits
+
+- **Provenance parity is partial.** This verifies the *derived* M0a coded/described frames; it does not
+  yet re-pull them through a manifested puller with a raw-page hash. Full parity means regenerating both
+  frames through the benchmark's manifested source path. The compound-key/award-grain *logic* is covered
+  by a self-contained fixture test (`tests/unit/scripts/test_undercount_award_grain.py`).
+- **The 141/16 is a lower bound.** The frozen research frame extends it to 191 (141 exact-phrase + 11
+  broad text-scan + 23 grey-variant + 16 NASA; distinct award `gen_id`s). Those 50 additional flags also
+  survive award grain but rest on text-pattern heuristics that warrant the same stratified adjudication
+  `findings.md` calls for before they are reported.
+- **No dark-universe total.** Consistent with `findings.md`: do not extrapolate a total dark universe
+  from description-retrievable records. The ~1,000 dark estimate elsewhere is an explicit model, not a
+  count.
+
+## Bottom line
+
+The donor's 141 (and NASA 16) **survive PR #449's award-grain contract, reproducibly and by the canonical
+`award_key_series`.** The provisional flag on the bounded figure can be lifted; the 191 extension and any
+dark extrapolation remain gated on adjudication and manifested provenance, respectively.

--- a/tests/unit/scripts/test_pull_described_phase3.py
+++ b/tests/unit/scripts/test_pull_described_phase3.py
@@ -1,0 +1,34 @@
+"""Fixture test for the manifested described-Phase III puller (canned fetcher, no network)."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.phase3_benchmark.pull_described_phase3 import pull_described
+
+
+def _canned_page() -> bytes:
+    return json.dumps({
+        "results": [
+            {"generated_internal_id": "CONT_AWD_P1_9700_-NONE-_-NONE-", "Award ID": "P1",
+             "Description": "SBIR PHASE III widget"},
+            {"generated_internal_id": "CONT_AWD_P2_9700_-NONE-_-NONE-", "Award ID": "P2",
+             "Description": "SBIR PHASE III gadget"},
+        ],
+        "page_metadata": {"hasNext": False},
+    }).encode()
+
+
+def test_pull_described_dedupes_and_emits_provenance_manifest() -> None:
+    frame, manifest = pull_described("Department of Defense", fetcher=lambda _body: _canned_page(),
+                                     source_vintage="test")
+    # two award-type groups each return the same page -> deduped to 2 distinct awards
+    assert len(frame) == 2
+    assert manifest["row_count"] == 2
+    assert manifest["query"] == 'description="SBIR PHASE III"'
+    assert manifest["grain"].startswith("award")
+    assert manifest["retrieval_complete"] is True
+    assert manifest["termination_reason"] == "feed_exhausted"
+    assert len(manifest["raw_pages_sha256"]) == 64  # sha256 hex digest of the raw payloads
+    assert manifest["field_completeness"]["generated_internal_id"] == 1.0
+    assert manifest["pages_retrieved"] == 2  # one page per award-type group before exhaustion

--- a/tests/unit/scripts/test_undercount_award_grain.py
+++ b/tests/unit/scripts/test_undercount_award_grain.py
@@ -1,0 +1,53 @@
+"""Fixture test for the award-grain Phase III undercount (PR #449 identity contract).
+
+Proves, on a self-contained synthetic frame, that the undercount is computed at AWARD grain through
+``award_key_series`` — transaction/modification rows collapse, standalone contracts (no parent IDV)
+are handled, and the described-but-not-coded set is exact.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from scripts.phase3_benchmark.undercount_award_grain import (
+    reconstruct_coded_award_key,
+    undercount,
+)
+
+
+def _coded() -> pd.DataFrame:
+    # A = standalone (no IDV); B = order under a parent IDV; A appears twice (transaction rows).
+    return pd.DataFrame(
+        [
+            {"order_piid": "P1", "order_agency": "9700", "idv_piid": "", "idv_agency": ""},
+            {"order_piid": "P1", "order_agency": "9700", "idv_piid": "", "idv_agency": ""},  # mod
+            {"order_piid": "P2", "order_agency": "9700", "idv_piid": "IDV1", "idv_agency": "9700"},
+        ]
+    )
+
+
+def _described() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "generated_internal_id": [
+                "CONT_AWD_P1_9700_-NONE-_-NONE-",  # matches coded A  -> coded
+                "CONT_AWD_P2_9700_IDV1_9700",       # matches coded B  -> coded
+                "CONT_AWD_P3_9700_-NONE-_-NONE-",  # not coded        -> UNDERCOUNT
+            ]
+        }
+    )
+
+
+def test_reconstructed_coded_key_uses_none_sentinel_for_standalone() -> None:
+    keys = reconstruct_coded_award_key(_coded())
+    assert keys.iloc[0] == "CONT_AWD_P1_9700_-NONE-_-NONE-"
+    assert keys.iloc[2] == "CONT_AWD_P2_9700_IDV1_9700"
+
+
+def test_undercount_is_award_grain_and_exact() -> None:
+    stats = undercount(_coded(), _described())
+    assert stats["coded_transactions"] == 3      # includes the duplicate modification row
+    assert stats["coded_awards"] == 2            # collapsed to award grain
+    assert stats["described_awards"] == 3
+    assert stats["described_coded_overlap"] == 2  # A and B join across the two sources
+    assert stats["undercount"] == 1               # only P3 is described-but-not-coded


### PR DESCRIPTION
## What this contains

**Undercount reproduction** (`undercount_award_grain.py` + tests): the 141 DoD / 16 NASA described-not-coded undercount reproduced at award grain through PR #449's compound-key identity contract (coded 6,351/1,038; overlap 821/186). Manifested described-puller (`pull_described_phase3.py`) re-verified 962→141.

**Dark-count bounds** (`specs/phase3-match-benchmark/mse-dark-phase3.md`):
- 2-source capture-recapture (code × description): total ≈7,441, **dark ≈949 [767–1,130] — a LOWER bound** (positive list dependence ⇒ underestimate; direction stated).
- **Feasibility gate run: no clean structured 3rd FPDS signal exists** (set-aside is generic "SBA", not SBIR-specific; no SBIR non-competed reason) → MSE stays 2-source; J&A only as sensitivity.
- **Frame size measured**: un-flagged post-SBIR DoD contracts to the 8,064 SBIR firms ≈ **131k [71k–202k]** (uniform n=300; median 0/firm, 53% zero-firms). So dark ∈ [949, 131k]; implied Y-rate 0.7% ⇒ small-n direct validation is base-rate-blocked (15 rows expect 0.1 hits).
- Headline defensible sentence: **the code misses ≥ ~15% of DoD Phase III** (141 proven + ≥949 estimated).

**Scopes**: `cross-agency-scope.md` (DoD→NASA retrieval 0.828, 306 firms), `dod-nonsbir-contract-pool.md` (recipient-scoped puller spec, gated).

**Known API gotcha** documented: `spending_by_award` returns a misleading HTTP 500 for `start_date` before 2007-10-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)