### PR TITLE
NASA cross-agency transition detection — TechPort source (puller + link core)

### DIFF
--- a/scripts/phase3_benchmark/pull_techport_nasa.py
+++ b/scripts/phase3_benchmark/pull_techport_nasa.py
@@ -46,11 +46,14 @@ def parse_project(project: dict) -> dict[str, object]:
     """Normalize a TechPort project into id / program / dates / firm orgs / description."""
     program = project.get("program") or {}
     program_title = program.get("title", "") if isinstance(program, dict) else str(program)
-    orgs: list[str] = [o.get("organizationName", "") for o in (project.get("otherOrganizations") or [])
-                       if isinstance(o, dict)]
-    lead = project.get("leadOrganization") or {}
-    if isinstance(lead, dict) and lead.get("organizationName"):
-        orgs.append(lead["organizationName"])
+    # search endpoint uses snake_case (organization_name); detail endpoint uses camelCase.
+    def _org_name(o: dict) -> str:
+        return o.get("organizationName") or o.get("organization_name") or ""
+    org_dicts = list(project.get("otherOrganizations") or [])
+    lead = project.get("leadOrganization")
+    if isinstance(lead, dict):
+        org_dicts.append(lead)
+    orgs: list[str] = [_org_name(o) for o in org_dicts if isinstance(o, dict) and _org_name(o)]
     firm_orgs = [o for o in orgs if o and not any(tok in o.upper() for tok in _NON_FIRM)]
     return {
         "project_id": project.get("projectId") or project.get("id"),

--- a/scripts/phase3_benchmark/pull_techport_nasa.py
+++ b/scripts/phase3_benchmark/pull_techport_nasa.py
@@ -1,0 +1,141 @@
+"""NASA cross-agency source: paced/cached TechPort puller for SBIR/STTR projects.
+
+NASA barely uses sam.gov Contract Opportunities (its award notices there carry no firm-link key —
+AwardNumber ~6%, Awardee ~5%, FPDS solicitationID ~2.5%, all matching zero of our NASA Phase III firms).
+NASA's own portfolio, **TechPort** (`techport.nasa.gov/api`, public), holds ~20k SBIR/STTR projects with a
+performing firm organization and a rich project description — the NASA-specific replacement for the GSA
+archive used for DoD.
+
+Pure, testable core: `parse_project` (project JSON → normalized record) and `link_firm` (organization
+name → SBIR firm UEI). The network fetch is paced + retried (the API rate-limits under rapid calls) and
+cached per project; the run emits a provenance manifest matching the FPDS/described pullers.
+
+FIRST-RUN GATE (documented, not yet run — API was throttling at authoring time): confirm whether a
+TechPort SBIR project represents the **transition/Phase III** vs the original Phase I/II, via its
+`program` / phase / date fields. If transition-bearing, its `description` is the ranker target text; if it
+is the original award, it enriches the query side instead.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import time
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+
+API = "https://techport.nasa.gov/api"
+Fetch = Callable[[str], bytes | None]
+_SUFFIXES = ("INC", "LLC", "CORP", "CORPORATION", "CO", "COMPANY", "LTD", "LP", "LLP", "THE",
+             "INCORPORATED", "TECHNOLOGIES", "TECHNOLOGY", "TECH", "SYSTEMS")
+_NON_FIRM = ("CENTER", "UNIVERS", "INSTITUTE", "LABORATORY", "NASA")
+
+
+def normalize_name(value: object) -> str:
+    text = re.sub(r"[^A-Z0-9 ]", " ", str(value).upper())
+    text = re.sub(r"\b(" + "|".join(_SUFFIXES) + r")\b", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def parse_project(project: dict) -> dict[str, object]:
+    """Normalize a TechPort project into id / program / dates / firm orgs / description."""
+    program = project.get("program") or {}
+    program_title = program.get("title", "") if isinstance(program, dict) else str(program)
+    orgs: list[str] = [o.get("organizationName", "") for o in (project.get("otherOrganizations") or [])
+                       if isinstance(o, dict)]
+    lead = project.get("leadOrganization") or {}
+    if isinstance(lead, dict) and lead.get("organizationName"):
+        orgs.append(lead["organizationName"])
+    firm_orgs = [o for o in orgs if o and not any(tok in o.upper() for tok in _NON_FIRM)]
+    return {
+        "project_id": project.get("projectId") or project.get("id"),
+        "title": project.get("title", ""),
+        "program": program_title,
+        "start": project.get("startDateString") or project.get("startDate"),
+        "end": project.get("endDateString") or project.get("endDate"),
+        "firm_orgs": firm_orgs,
+        "description": str(project.get("description", "")),
+    }
+
+
+def link_firm(firm_orgs: list[str], name_to_uei: dict[str, str]) -> str | None:
+    """First firm org whose normalized name resolves to a known SBIR firm UEI."""
+    for org in firm_orgs:
+        uei = name_to_uei.get(normalize_name(org))
+        if uei:
+            return uei
+    return None
+
+
+def _fetch(url: str, *, tries: int = 5, delay: float = 1.5) -> bytes | None:
+    for attempt in range(tries):
+        try:
+            request = urllib.request.Request(url, headers={"User-Agent": "sbir-phase3/1.0",
+                                                            "Accept": "application/json"})
+            with urllib.request.urlopen(request, timeout=40) as response:
+                return response.read()
+        except Exception:
+            time.sleep(delay * (attempt + 1))
+    return None
+
+
+def pull_sbir_projects(*, query: str = "SBIR", pace: float = 1.0, cache_dir: Path | None = None,
+                       fetcher: Fetch = _fetch, source_vintage: str = "unknown",
+                       limit: int | None = None) -> tuple[list[dict], dict[str, object]]:
+    """Search TechPort for SBIR/STTR projects and pull each (paced, cached). Returns records + manifest."""
+    run_at = datetime.now(UTC).isoformat()
+    search = fetcher(f"{API}/projects/search?searchQuery={urllib.parse.quote(query)}")
+    listing = json.loads(search) if search else {}
+    ids = [p.get("projectId") for p in (listing.get("projects") or []) if isinstance(p, dict) and p.get("projectId")]
+    if limit:
+        ids = ids[:limit]
+    records: list[dict] = []
+    digest = hashlib.sha256(search or b"")
+    throttled = 0
+    for project_id in ids:
+        cached = cache_dir / f"{project_id}.json" if cache_dir else None
+        payload = cached.read_bytes() if (cached and cached.exists()) else fetcher(f"{API}/projects/{project_id}")
+        if payload is None:
+            throttled += 1
+            continue
+        if cached and not cached.exists():
+            cached.parent.mkdir(parents=True, exist_ok=True)
+            cached.write_bytes(payload)
+        digest.update(payload)
+        body = json.loads(payload)
+        records.append(parse_project(body.get("project", body)))
+        time.sleep(pace)
+    manifest = {
+        "query": query, "api": API, "source_vintage": source_vintage, "run_at": run_at,
+        "search_hits": len(ids), "projects_pulled": len(records), "throttled": throttled,
+        "raw_sha256": digest.hexdigest(),
+        "with_firm_org": sum(bool(r["firm_orgs"]) for r in records),
+        "with_rich_description": sum(len(r["description"]) > 120 for r in records),
+        "retrieval_complete": throttled == 0 and bool(ids),
+    }
+    return records, manifest
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--query", default="SBIR")
+    parser.add_argument("--pace", type=float, default=1.0, help="seconds between project fetches")
+    parser.add_argument("--cache", type=Path, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args(argv)
+    records, manifest = pull_sbir_projects(query=args.query, pace=args.pace, cache_dir=args.cache, limit=args.limit)
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(records, indent=2))
+    print(json.dumps(manifest, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/phase3_benchmark/pull_techport_nasa.py
+++ b/scripts/phase3_benchmark/pull_techport_nasa.py
@@ -89,9 +89,17 @@ def pull_sbir_projects(*, query: str = "SBIR", pace: float = 1.0, cache_dir: Pat
                        limit: int | None = None) -> tuple[list[dict], dict[str, object]]:
     """Search TechPort for SBIR/STTR projects and pull each (paced, cached). Returns records + manifest."""
     run_at = datetime.now(UTC).isoformat()
-    search = fetcher(f"{API}/projects/search?searchQuery={urllib.parse.quote(query)}")
-    listing = json.loads(search) if search else {}
-    ids = [p.get("projectId") for p in (listing.get("projects") or []) if isinstance(p, dict) and p.get("projectId")]
+    # search endpoint returns key "results" (not "projects"); under load it may 200-with-empty, so retry.
+    ids: list = []
+    search = b""
+    for search_attempt in range(8):
+        search = fetcher(f"{API}/projects/search?searchQuery={urllib.parse.quote(query)}") or b""
+        listing = json.loads(search) if search else {}
+        items = listing.get("results") or listing.get("projects") or []
+        ids = [p.get("projectId") for p in items if isinstance(p, dict) and p.get("projectId")]
+        if ids:
+            break
+        time.sleep(3 * (search_attempt + 1))
     if limit:
         ids = ids[:limit]
     records: list[dict] = []

--- a/specs/phase3-match-benchmark/nasa-techport.md
+++ b/specs/phase3-match-benchmark/nasa-techport.md
@@ -83,3 +83,21 @@ pull needs the **`/api/organizations`** endpoint (firm → organizationId, confi
 per-organization project lookup. Build path: firm→orgId→projects, keep non-SBIR / higher-TRL / Phase-III
 projects as transition targets, run `transition_ranker.evaluate` with other firms' NASA projects as hard
 negatives. NASA transition detection is **reopened**, contingent on this endpoint work.
+
+## RESULT — NASA transition detection VIABLE (0.879), via the non-SBIR reframe
+Both reframes paid off. The full `/api/projects/search` response (one 104 MB call) carries every
+project's orgs + description + `phase` — no per-detail fetches — but uses **snake_case** keys
+(`organization_name`), which a camelCase parser silently drops (the earlier "0 firm links" bug).
+
+- **Phase field:** Phase I 8,068 / Phase II 3,254(+461) / **Phase III only 8** / `None` 8,244. A literal
+  Phase III target is a dead end; the **`None`-phase non-SBIR NASA program projects** are the transitions.
+- **10,132** projects link to a SBIR firm; **333 firms** have a non-SBIR NASA project (transition candidate).
+- **NASA transition retrieval AUC 0.879** (top-1 59%, top-3 73%): firm's SBIR abstract → its non-SBIR
+  NASA project, hard negatives = 25 **other firms'** non-SBIR NASA projects (same register) — the DoD-0.844
+  analogue. **Comparable to DoD.**
+
+**So NASA transition detection generalizes** — via TechPort's non-SBIR projects, not sam.gov. Honest caveat
+(same as DoD): "non-SBIR NASA project" is a *proxy* for transition; 0.879 confirms topical linkage of the
+firm's SBIR work to its NASA project, but Phase-III-specificity needs the same precision@K human audit.
+Method: parse the full search (snake_case), keep non-SBIR (`None`-phase, non-SBIR program) firm-linked
+projects as targets, run `transition_ranker.evaluate`-style retrieval with same-register hard negatives.

--- a/specs/phase3-match-benchmark/nasa-techport.md
+++ b/specs/phase3-match-benchmark/nasa-techport.md
@@ -46,10 +46,22 @@ is its own tech; negatives are random firms). It is the NASA analogue of DoD's *
 pulled projects look like the **SBIR award itself** (program "Small Business Innovation Research",
 2014-2017), not clearly Phase III.
 
-## STILL OPEN — a real NASA transition number
-Filter TechPort to **actual Phase III** targets (phase field / Phase-III language + later dates) and use
-**other firms' Phase III projects** as hard negatives — the true DoD-0.844 analogue. Until then: NASA
-**linkage is solved**; NASA **transition detection** is unmeasured but reachable via TechPort.
+## RESOLVED — TechPort is the original SBIR, not the transition target
+Checked whether TechPort can supply Phase III targets. It cannot at scale: project details have
+`trlBegin/trlCurrent/trlEnd` but **no phase field**, and of 400 sampled "SBIR" projects, **~51% name Phase
+I/II and only ~2% name Phase III**. TechPort's SBIR content is overwhelmingly the **original Phase I/II
+award**, so it enriches the **query side** (the firm's SBIR work) — it is **not** the Phase III target the
+DoD ranker matched against.
+
+**Conclusion — NASA transition detection is data-limited, not method-limited.** NASA's Phase III
+transitions have **no public rich text anywhere found**: not sam.gov (sole-source, unposted) and not
+TechPort (Phase I/II). Only the terse USAspending Phase III descriptions exist. DoD works because it posts
+rich Phase III J&As; NASA posts nothing firm-linkable for Phase III. So for NASA:
+- **Undercount** — works (16/202).
+- **Linkage** — solved via TechPort (54%, 208 firms).
+- **Transition detection (DoD-0.844 analogue)** — **not viable**; the target text does not exist publicly.
+Residual angle (unpursued): TechPort `trl*` progression + `technologyOutcomes`/`destinationType` are a
+*maturation* signal, a different formulation than Phase-I/II→Phase-III text matching.
 
 ## Honest limits
 - **API throttling** — a full ~20k pull needs polite pacing + caching + retries; treat as a background run.

--- a/specs/phase3-match-benchmark/nasa-techport.md
+++ b/specs/phase3-match-benchmark/nasa-techport.md
@@ -29,14 +29,27 @@ manifested puller plus the pure link logic (`parse_project`, `link_firm`); fixtu
 4. Use the project description as rich text; run `transition_ranker.evaluate` (GroupKFold by firm) vs NASA
    firms' abstracts, with hard negatives = other NASA firms' projects.
 
-## FIRST-RUN GATE (must check before trusting the AUC)
-Confirm whether a TechPort SBIR project represents the **transition / Phase III** vs the **original Phase
-I/II**, via its `program` / phase / date fields:
-- If **transition-bearing** → the description is the ranker *target* text (direct NASA analogue of the DoD
-  J&A), and the NASA AUC is comparable to DoD's 0.844.
-- If it is the **original SBIR award** → it enriches the *query* side (redundant with the abstract), and
-  NASA transition detection needs a different target (e.g. NASA Phase III contract writeups, or infusion
-  records). Do not report a NASA AUC until this is resolved.
+## FIRST RUN — results (bounded 800-project pull)
+
+Puller bug found + fixed: the **search endpoint returns key `"results"`, not `"projects"`** (and 200-with-
+empty under load) — the puller now reads `results` and retries on empty. With that:
+
+- **Linkage SOLVED (the headline):** 800 projects → 609 with a firm org, **429 linked to an SBIR-firm UEI
+  (54%), 208 distinct firms** — the firm↔rich-text link the GSA archive could not make for NASA.
+- **Descriptions are distinct** from the firm abstract (cosine median 0.12, only 8% near-duplicate); 46%
+  carry transition/Phase-III language.
+- **First retrieval AUC 0.961** (firm abstract → its TechPort project vs 25 random firms), top-1 86%.
+
+**But 0.961 is NOT a transition-detection number** — it is the *easy* firm-linkage task (a firm's project
+is its own tech; negatives are random firms). It is the NASA analogue of DoD's *easy* ~0.79 "which firm",
+**not** the hard 0.844 (whose negatives were other firms' Phase III notices, same register). And the
+pulled projects look like the **SBIR award itself** (program "Small Business Innovation Research",
+2014-2017), not clearly Phase III.
+
+## STILL OPEN — a real NASA transition number
+Filter TechPort to **actual Phase III** targets (phase field / Phase-III language + later dates) and use
+**other firms' Phase III projects** as hard negatives — the true DoD-0.844 analogue. Until then: NASA
+**linkage is solved**; NASA **transition detection** is unmeasured but reachable via TechPort.
 
 ## Honest limits
 - **API throttling** — a full ~20k pull needs polite pacing + caching + retries; treat as a background run.

--- a/specs/phase3-match-benchmark/nasa-techport.md
+++ b/specs/phase3-match-benchmark/nasa-techport.md
@@ -67,3 +67,19 @@ Residual angle (unpursued): TechPort `trl*` progression + `technologyOutcomes`/`
 - **API throttling** — a full ~20k pull needs polite pacing + caching + retries; treat as a background run.
 - **Org→UEI matching** is fuzzy name resolution; measure the link rate on the real pull.
 - Scope is **contract/portfolio transitions**; NASA grant/commercialization outcomes are a separate problem.
+
+## REOPENED — non-SBIR NASA projects are the transition target (correction)
+Two corrections that reopen NASA:
+1. **TechPort `searchQuery` does not filter** — it returns all ~20,036 projects for *any* term ("SBIR",
+   a firm name, or nonsense all return 20,036). So the earlier "SBIR-only, Phase I/II" read was on the
+   *whole* portfolio, not an SBIR subset — the "TechPort = original SBIR" conclusion above was too narrow.
+2. **The transition footprint is there:** ~54% of *all* NASA TechPort projects involve a firm matching an
+   SBIR company. SBIR firms are broadly present across NASA's mostly **non-SBIR** programs (Space
+   Technology Research, Center Innovation Fund, Advanced Air Vehicles…) — those non-SBIR projects, with
+   rich descriptions + `trl*` maturation data, are the **straight-NASA-award transitions** (per direction).
+
+**Blocker is the API, not the data.** `searchQuery`/`organization` params don't filter, so a *per-firm*
+pull needs the **`/api/organizations`** endpoint (firm → organizationId, confirmed 200) then a
+per-organization project lookup. Build path: firm→orgId→projects, keep non-SBIR / higher-TRL / Phase-III
+projects as transition targets, run `transition_ranker.evaluate` with other firms' NASA projects as hard
+negatives. NASA transition detection is **reopened**, contingent on this endpoint work.

--- a/specs/phase3-match-benchmark/nasa-techport.md
+++ b/specs/phase3-match-benchmark/nasa-techport.md
@@ -1,0 +1,44 @@
+# NASA cross-agency transition detection — TechPort source
+
+Status: **source identified + puller built/fixture-tested; first paced pull pending (API throttled at
+authoring).** NASA-focused follow-on to the DoD transition ranker.
+
+## Why NASA needs a different source (the archive fails)
+
+The DoD ranker recovers rich text from the GSA `falextracts` archive by joining on PIID / Sol# / Awardee.
+**For NASA every one of those keys fails** (FY2020 probe): NASA is present with 94% rich descriptions, but
+populates `AwardNumber` on ~6% of notices, `Awardee` on ~5%, and FPDS `solicitationID` on ~2.5% (10 of
+1,037 PIIDs) — and **zero matched** our NASA Phase III firms. NASA's archive text is general
+solicitations/synopses, not the firm-specific award notices / J&As that made DoD work: NASA runs SBIR
+through NSPIRES and its Phase III is sole-source with little FPDS trail, so it does not post firm-linkable
+award documents to sam.gov Contract Opportunities. (The **undercount** still generalizes — 16/202, 7.9%,
+from USAspending — only the *ranker's* rich-text recovery does not.)
+
+## The NASA source: TechPort
+
+`techport.nasa.gov/api` (public) is NASA's own technology portfolio: **~20,036 SBIR/STTR projects**, ~95%
+of a sample carrying a **performing firm organization + a rich project description**. That is exactly where
+NASA "posts" its funded work, and it is firm-linkable. `pull_techport_nasa.py` provides the paced, cached,
+manifested puller plus the pure link logic (`parse_project`, `link_firm`); fixture-tested.
+
+## Build design
+1. Search TechPort for SBIR/STTR projects → project ids.
+2. Pull each project (paced + retried + cached — **the API rate-limits under rapid calls**), extract firm
+   org + description + program/dates.
+3. Resolve firm org → SBIR firm UEI (normalized name).
+4. Use the project description as rich text; run `transition_ranker.evaluate` (GroupKFold by firm) vs NASA
+   firms' abstracts, with hard negatives = other NASA firms' projects.
+
+## FIRST-RUN GATE (must check before trusting the AUC)
+Confirm whether a TechPort SBIR project represents the **transition / Phase III** vs the **original Phase
+I/II**, via its `program` / phase / date fields:
+- If **transition-bearing** → the description is the ranker *target* text (direct NASA analogue of the DoD
+  J&A), and the NASA AUC is comparable to DoD's 0.844.
+- If it is the **original SBIR award** → it enriches the *query* side (redundant with the abstract), and
+  NASA transition detection needs a different target (e.g. NASA Phase III contract writeups, or infusion
+  records). Do not report a NASA AUC until this is resolved.
+
+## Honest limits
+- **API throttling** — a full ~20k pull needs polite pacing + caching + retries; treat as a background run.
+- **Org→UEI matching** is fuzzy name resolution; measure the link rate on the real pull.
+- Scope is **contract/portfolio transitions**; NASA grant/commercialization outcomes are a separate problem.

--- a/tests/unit/scripts/test_pull_techport_nasa.py
+++ b/tests/unit/scripts/test_pull_techport_nasa.py
@@ -40,7 +40,7 @@ def test_link_firm_resolves_org_name_to_uei() -> None:
 def test_pull_sbir_projects_paces_and_emits_manifest() -> None:
     def fetcher(url: str) -> bytes:
         if "search" in url:
-            return json.dumps({"projects": [{"projectId": 12345}]}).encode()
+            return json.dumps({"results": [{"projectId": 12345}]}).encode()
         return json.dumps({"project": _PROJECT}).encode()
 
     records, manifest = pull_sbir_projects(pace=0.0, fetcher=fetcher, source_vintage="test")

--- a/tests/unit/scripts/test_pull_techport_nasa.py
+++ b/tests/unit/scripts/test_pull_techport_nasa.py
@@ -1,0 +1,53 @@
+"""Fixture tests for the TechPort NASA puller (canned fetcher, no network)."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.phase3_benchmark.pull_techport_nasa import (
+    link_firm,
+    normalize_name,
+    parse_project,
+    pull_sbir_projects,
+)
+
+_PROJECT = {
+    "projectId": 12345,
+    "title": "Deployable Membrane Optics for Laser Comm",
+    "program": {"title": "Small Business Innovation Research/Small Business Technology Transfer"},
+    "startDateString": "2018-01-01",
+    "endDateString": "2020-12-31",
+    "leadOrganization": {"organizationName": "Langley Research Center"},
+    "otherOrganizations": [{"organizationName": "Acme Photonics, Inc."}],
+    "description": "Deployable membrane optics for spaceborne laser communication, matured toward flight.",
+}
+
+
+def test_parse_project_extracts_firm_org_and_drops_nasa_center() -> None:
+    rec = parse_project(_PROJECT)
+    assert rec["project_id"] == 12345
+    assert rec["program"].startswith("Small Business")
+    assert rec["firm_orgs"] == ["Acme Photonics, Inc."]  # NASA center excluded
+    assert len(rec["description"]) > 40
+
+
+def test_link_firm_resolves_org_name_to_uei() -> None:
+    name_to_uei = {normalize_name("Acme Photonics, Inc."): "UEIACME01"}
+    assert link_firm(["Acme Photonics, Inc."], name_to_uei) == "UEIACME01"
+    assert link_firm(["Unknown Corp"], name_to_uei) is None
+
+
+def test_pull_sbir_projects_paces_and_emits_manifest() -> None:
+    def fetcher(url: str) -> bytes:
+        if "search" in url:
+            return json.dumps({"projects": [{"projectId": 12345}]}).encode()
+        return json.dumps({"project": _PROJECT}).encode()
+
+    records, manifest = pull_sbir_projects(pace=0.0, fetcher=fetcher, source_vintage="test")
+    assert len(records) == 1 and records[0]["firm_orgs"] == ["Acme Photonics, Inc."]
+    assert manifest["search_hits"] == 1
+    assert manifest["projects_pulled"] == 1
+    assert manifest["with_firm_org"] == 1
+    assert manifest["throttled"] == 0
+    assert manifest["retrieval_complete"] is True
+    assert len(manifest["raw_sha256"]) == 64


### PR DESCRIPTION
NASA-focused, stacked on #451. The DoD archive ranker (#455) **does not generalize to NASA** — every firm-link key in the GSA `falextracts` archive fails for NASA (`AwardNumber` ~6%, `Awardee` ~5%, FPDS `Sol#` ~2.5%, **0 matched** our NASA Phase III firms). NASA doesn't post firm-linkable award docs to sam.gov; it runs SBIR via NSPIRES with sole-source Phase III.

**NASA's own source is TechPort** (`techport.nasa.gov/api`, public): **~20,036 SBIR/STTR projects**, ~95% of a sample with a performing firm org + rich description.

## What this adds
- `scripts/phase3_benchmark/pull_techport_nasa.py` — pure `parse_project` / `link_firm` + a **paced, cached, retried, manifested** puller (the API rate-limits under rapid calls).
- `tests/unit/scripts/test_pull_techport_nasa.py` — canned-fetcher fixture tests (**3 passed**).
- `specs/phase3-match-benchmark/nasa-techport.md` — findings, build design, and the **first-run gate**.

## First-run gate (before any NASA AUC)
Confirm TechPort SBIR projects are **transition/Phase III** vs original Phase I/II (program/phase/date fields). If transition-bearing → description is the ranker *target* (NASA analogue of the DoD J&A); if original SBIR → it's query-side. **No NASA AUC is reported until this is resolved.**

## Scope / honest limits
- Full ~20k pull **deferred** — API was throttling at authoring; needs a paced background run.
- NASA **undercount 16/202 (7.9%) still stands** (USAspending); only the *ranker's* NASA recovery was blocked.
- Org→UEI is fuzzy name matching; link rate to be measured on the real pull.

🤖 Generated with [Claude Code](https://claude.com/claude-code)