### PR TITLE
fix(deploy): harden Mac server runtime

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -6,8 +6,8 @@
 # Load it explicitly for the server stack (the Make targets do this for you):
 #   docker compose -f docker-compose.server.yml --env-file .env.server --profile server ...
 #
-# SECURITY: every host port below binds to loopback (SERVER_LOOPBACK=127.0.0.1).
-# Nothing is reachable over the LAN. Tailscale Serve is the only ingress.
+# SECURITY: Compose hardcodes every host port to 127.0.0.1. Nothing is
+# reachable over the LAN. Tailscale Serve is the only ingress.
 
 # -----------------------------------------------------------------------------
 # Runtime
@@ -21,12 +21,12 @@ IMAGE_NAME=ghcr.io/hollomancer/sbir-analytics
 IMAGE_TAG=latest
 
 # -----------------------------------------------------------------------------
-# Host bind address — MUST stay loopback. `make server-check` rejects anything
-# other than 127.0.0.1 / ::1 / localhost.
+# Compatibility guard — Compose does not interpolate this value, and
+# `make server-check` rejects anything other than loopback.
 # -----------------------------------------------------------------------------
 SERVER_LOOPBACK=127.0.0.1
 
-# Host ports (all bound to SERVER_LOOPBACK only)
+# Host ports (all hard-bound to 127.0.0.1)
 NEO4J_HTTP_PORT=7474
 NEO4J_BOLT_PORT=7687
 DAGSTER_PORT=3000
@@ -61,6 +61,7 @@ SERVER_REPORTS_DIR=./reports
 SERVER_LOGS_DIR=./logs
 SERVER_ARTIFACTS_DIR=./artifacts
 SERVER_NEO4J_DIR=./data/neo4j
+SERVER_BACKUP_DIR=./backups
 
 # -----------------------------------------------------------------------------
 # Schedule controls (see packages/sbir-analytics/sbir_analytics/definitions.py).

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -11,6 +11,7 @@ on:
       - 'packages/**'
       - 'scripts/**'
       - 'config/**'
+      - 'workspace.server.yaml'
       - '.github/workflows/build-images.yml'
   schedule:
     # Weekly rebuild on Sunday at 4 AM UTC (after weekly tests at 2 AM)
@@ -49,12 +50,15 @@ jobs:
               - 'pyproject.toml'
               - 'uv.lock'
               - 'Dockerfile.python-base'
+              # A workflow-only change (such as adding arm64) must rebuild the
+              # base immediately after merge instead of waiting for Sunday.
               - '.github/workflows/build-images.yml'
             etl-code:
               - 'sbir_etl/**'
               - 'packages/**'
               - 'scripts/**'
               - 'config/**'
+              - 'workspace.server.yaml'
               - 'Dockerfile'
               - '.github/workflows/build-images.yml'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY packages/sbir-graph/sbir_graph/ /app/sbir_graph/
 COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY scripts/ /app/scripts/
 COPY config/ /app/config/
+COPY workspace.server.yaml /app/workspace.server.yaml
 COPY data/reference/ /app/data/reference/
 COPY migrations/ /app/migrations/
 COPY pyproject.toml /app/

--- a/Makefile
+++ b/Makefile
@@ -593,6 +593,7 @@ validate: lint test ## Run linting, type checking, and tests
 SERVER_COMPOSE_FILE ?= docker-compose.server.yml
 SERVER_ENV_FILE     ?= .env.server
 SERVER_COMPOSE       = $(DOCKER_COMPOSE) -f $(SERVER_COMPOSE_FILE) --env-file $(SERVER_ENV_FILE)
+SERVER_PYTHON_BASE_IMAGE ?= ghcr.io/hollomancer/sbir-analytics-python-base:latest
 
 .PHONY: server-env-check
 server-env-check: ## Ensure .env.server exists
@@ -609,10 +610,21 @@ server-check: ## Validate server prerequisites (Docker, storage, ports, Tailscal
 	@$(call info,Checking Tailscale-only server prerequisites)
 	$(call run,SERVER_ENV_FILE=$(SERVER_ENV_FILE) ./scripts/server/check-prerequisites.sh)
 
+.PHONY: server-base-image
+server-base-image: server-check ## Pull the native Python base, or build it locally
+	@$(call info,Preparing the native Python base image)
+	@set -euo pipefail; \
+	 if docker pull $(SERVER_PYTHON_BASE_IMAGE); then \
+	   $(call success,Native Python base image is available); \
+	 else \
+	   $(call warn,Published base is unavailable for this architecture; building locally); \
+	   docker build -f Dockerfile.python-base -t $(SERVER_PYTHON_BASE_IMAGE) .; \
+	 fi
+
 .PHONY: server-up
-server-up: server-env-check ## Start the always-on server stack (profile=server)
+server-up: server-base-image ## Preflight and start the always-on server stack (profile=server)
 	@$(call info,Starting server stack (profile: server))
-	$(call run,$(SERVER_COMPOSE) --profile server up -d --build)
+	$(call run,$(SERVER_COMPOSE) --profile server up -d --build --wait --wait-timeout 300)
 	$(call run,$(SERVER_COMPOSE) --profile server ps)
 	@$(call success,Server stack ready (localhost-only; expose via 'make server-tailscale-up'))
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -3,13 +3,14 @@
 # An ARM64-native, private server profile for a single always-on Mac mini.
 # It runs only the services needed to serve the graph and analytics:
 #   - neo4j              (private graph store; host port bound to loopback only)
+#   - dagster-code-server (shared internal Dagster code location)
 #   - analytics-api      (authenticated read-only API)
 #   - dagster-webserver  (orchestration UI, production mode)
 #   - dagster-daemon     (schedules/sensors)
 #
 # Security boundary:
-#   * Every host port is bound to 127.0.0.1 (SERVER_LOOPBACK). Nothing binds to
-#     0.0.0.0, so no service is reachable over the LAN.
+#   * Every host port is hardcoded to 127.0.0.1. Nothing binds to 0.0.0.0, so
+#     no service is reachable over the LAN.
 #   * Tailscale Serve is the ONLY ingress (tailnet-only HTTPS):
 #       443  -> Dagster (127.0.0.1:3000)
 #       8443 -> analytics API (127.0.0.1:8010)
@@ -69,14 +70,13 @@ services:
       - NEO4J_db_logs_query_enabled=${NEO4J_db_logs_query_enabled:-OFF}
     ports:
       # Loopback-only. Neo4j is intentionally NOT exposed through Tailscale.
-      - "${SERVER_LOOPBACK:-127.0.0.1}:${NEO4J_HTTP_PORT:-7474}:7474"
-      - "${SERVER_LOOPBACK:-127.0.0.1}:${NEO4J_BOLT_PORT:-7687}:7687"
+      - "127.0.0.1:${NEO4J_HTTP_PORT:-7474}:7474"
+      - "127.0.0.1:${NEO4J_BOLT_PORT:-7687}:7687"
     volumes:
       - ${SERVER_NEO4J_DIR:-./data/neo4j}/data:/data
       - ${SERVER_NEO4J_DIR:-./data/neo4j}/logs:/logs
       - ${SERVER_NEO4J_DIR:-./data/neo4j}/import:/var/lib/neo4j/import
-      - ./config/neo4j/certs:/certs:ro
-      - ./config/neo4j/plugins:/plugins:rw
+      - neo4j_plugins:/plugins
     networks:
       - sbir-server-network
     healthcheck:
@@ -92,6 +92,70 @@ services:
       resources:
         limits:
           memory: 2G
+        reservations:
+          memory: 1G
+
+  # ===========================================================================
+  # Dagster code location (internal gRPC; never published to the host)
+  # ===========================================================================
+  dagster-code-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: runtime
+    image: ${IMAGE_NAME:-sbir-analytics}:${IMAGE_TAG:-local}
+    container_name: ${DAGSTER_CODE_SERVER_CONTAINER_NAME:-sbir-server-dagster-code}
+    profiles:
+      - server
+    environment: *server-environment
+    command:
+      - dagster
+      - api
+      - grpc
+      - --host
+      - 0.0.0.0
+      - --port
+      - "4000"
+      - --module-name
+      - sbir_analytics.definitions
+      - --location-name
+      - sbir-analytics-production
+    volumes:
+      - ./config:/app/config:rw
+      - ${SERVER_REPORTS_DIR:-./reports}:/app/reports:rw
+      - ${SERVER_LOGS_DIR:-./logs}:/app/logs:rw
+      - ${SERVER_DATA_DIR:-./data}:/app/data:rw
+      - ${SERVER_ARTIFACTS_DIR:-./artifacts}:/app/artifacts:rw
+      - dagster_home:/app/dagster_home
+    expose:
+      - "4000"
+    depends_on:
+      neo4j:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD
+        - dagster
+        - api
+        - grpc-health-check
+        - --host
+        - localhost
+        - --port
+        - "4000"
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - sbir-server-network
+    restart: ${SERVER_RESTART_POLICY:-unless-stopped}
+    deploy:
+      resources:
+        limits:
+          # DefaultRunLauncher starts ETL subprocesses through this gRPC
+          # server, so the execution budget belongs here rather than on the
+          # lightweight daemon.
+          memory: 3G
         reservations:
           memory: 1G
 
@@ -121,7 +185,7 @@ services:
       - ${SERVER_REPORTS_DIR:-./reports}:/app/reports:ro
     ports:
       # Loopback-only; Tailscale Serve maps HTTPS 8443 -> 127.0.0.1:8010.
-      - "${SERVER_LOOPBACK:-127.0.0.1}:${SBIR_ANALYTICS_API_PORT:-8010}:${SBIR_ANALYTICS_API_PORT:-8010}"
+      - "127.0.0.1:${SBIR_ANALYTICS_API_PORT:-8010}:${SBIR_ANALYTICS_API_PORT:-8010}"
     depends_on:
       neo4j:
         condition: service_healthy
@@ -160,8 +224,9 @@ services:
       # Healthchecks run inside the container; DAGSTER_PORT is the host mapping.
       HEALTHCHECK_PORT: "3000"
       HEALTHCHECK_PATH: ${DAGSTER_HEALTH_PATH:-/server_info}
-    # Invoke the entrypoint so ENVIRONMENT=prod runs `dagster-webserver` (not
-    # the dev auto-reload server). Do NOT set ENV_DAGSTER_CMD here.
+      ENV_DAGSTER_CMD: dagster-webserver -h 0.0.0.0 -p 3000 -w /app/workspace.server.yaml
+    # The entrypoint performs dependency checks, then uses the explicit
+    # production command above to connect to the shared code location.
     command: ["sh", "/app/scripts/docker/entrypoint.sh", "dagster-webserver"]
     volumes:
       - ./config:/app/config:rw
@@ -172,9 +237,11 @@ services:
       - dagster_home:/app/dagster_home
     ports:
       # Loopback-only; Tailscale Serve maps HTTPS 443 -> 127.0.0.1:3000.
-      - "${SERVER_LOOPBACK:-127.0.0.1}:${DAGSTER_PORT:-3000}:3000"
+      - "127.0.0.1:${DAGSTER_PORT:-3000}:3000"
     depends_on:
       neo4j:
+        condition: service_healthy
+      dagster-code-server:
         condition: service_healthy
     healthcheck:
       test:
@@ -208,7 +275,12 @@ services:
       - server
     environment:
       <<: *server-environment
+      # The daemon runs in a separate container; localhost would point back to
+      # itself and make the startup gate wait for the full timeout.
       DAGSTER_HOST: dagster-webserver
+      HEALTHCHECK_PORT: 3000
+      HEALTHCHECK_PATH: ${DAGSTER_HEALTH_PATH:-/server_info}
+      ENV_DAGSTER_CMD: dagster-daemon run -w /app/workspace.server.yaml
     command: ["sh", "/app/scripts/docker/entrypoint.sh", "dagster-daemon"]
     volumes:
       - ./config:/app/config:rw
@@ -219,6 +291,8 @@ services:
       - dagster_home:/app/dagster_home
     depends_on:
       neo4j:
+        condition: service_healthy
+      dagster-code-server:
         condition: service_healthy
       dagster-webserver:
         condition: service_healthy
@@ -236,9 +310,9 @@ services:
     deploy:
       resources:
         limits:
-          memory: 4G
+          memory: 768M
         reservations:
-          memory: 1G
+          memory: 384M
 
 # =============================================================================
 # Named volumes
@@ -246,6 +320,8 @@ services:
 volumes:
   # Shared Dagster metadata (schedule ticks, run storage) across web + daemon.
   dagster_home:
+    driver: local
+  neo4j_plugins:
     driver: local
 
 # =============================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,6 +329,12 @@ services:
       - ./tests:/app/tests:ro
       # Repo-root server contract exercised by fast unit tests.
       - ./.env.server.example:/app/.env.server.example:ro
+      - ./.github/workflows/build-images.yml:/app/.github/workflows/build-images.yml:ro
+      - ./Dockerfile:/app/Dockerfile:ro
+      - ./Makefile:/app/Makefile:ro
+      - ./docker-compose.server.yml:/app/docker-compose.server.yml:ro
+      - ./docker-compose.yml:/app/docker-compose.yml:ro
+      - ./workspace.server.yaml:/app/workspace.server.yaml:ro
       - ./config:/app/config:ro
       - ./scripts:/app/scripts:ro
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -327,6 +327,8 @@ services:
       # in the ci profile command (above) finds tests/. Without this, pytest
       # exits with code 5 ("no tests collected") and breaks Container Build.
       - ./tests:/app/tests:ro
+      # Repo-root server contract exercised by fast unit tests.
+      - ./.env.server.example:/app/.env.server.example:ro
       - ./config:/app/config:ro
       - ./scripts:/app/scripts:ro
     restart: "no"

--- a/docs/deployment/mac-mini-server.md
+++ b/docs/deployment/mac-mini-server.md
@@ -6,12 +6,13 @@ tailnet — there is no public DNS, no port forwarding, and no LAN exposure.
 
 ## What runs here
 
-The `server` Compose profile (`docker-compose.server.yml`) runs exactly four
+The `server` Compose profile (`docker-compose.server.yml`) runs exactly five
 services:
 
 | Service | Purpose | Host bind | Tailnet ingress |
 |---------|---------|-----------|-----------------|
 | `neo4j` | Graph store | `127.0.0.1:7474` / `7687` | **none** (private) |
+| `dagster-code-server` | Shared Dagster code location | none | none |
 | `analytics-api` | Read-only API (bearer token) | `127.0.0.1:8010` | HTTPS `8443` |
 | `dagster-webserver` | Orchestration UI (prod mode) | `127.0.0.1:3000` | HTTPS `443` |
 | `dagster-daemon` | Schedules + sensors | — | none |
@@ -24,8 +25,8 @@ Heavy assets (ML/CET, fiscal, USPTO NLP) are **disabled** on the server
 
 - **Every host port binds to `127.0.0.1`.** Nothing listens on `0.0.0.0`, so
   the stack is invisible to other machines on the same LAN.
-  `make server-check` refuses to start if `SERVER_LOOPBACK` is anything other
-  than loopback.
+  Compose hardcodes this address; `make server-check` also rejects a legacy
+  `SERVER_LOOPBACK` value that is anything other than loopback.
 - **Tailscale Serve is the only ingress.** It provides tailnet-only HTTPS and
   terminates TLS automatically
   ([docs](https://tailscale.com/docs/features/tailscale-serve)):
@@ -95,12 +96,17 @@ With MagicDNS enabled the services are reachable at your node's DNS name:
 ```bash
 cp .env.server.example .env.server     # fill in NEO4J_PASSWORD + API token
 make server-check                      # docker, storage, ports, tailscale, bindings
-make server-up                         # localhost-only stack
+make server-up                         # repeats preflight, then starts localhost-only stack
 make server-tailscale-up               # expose via Tailscale Serve
 make server-status
 ```
 
 Generate the API token with `openssl rand -hex 32`.
+
+`make server-up` first pulls the published native Python base image. If GHCR
+does not yet have a manifest for the Mac's architecture, it builds
+`Dockerfile.python-base` locally and then continues. The first fallback build
+can take several minutes; later builds use the local image cache.
 
 ## Tailscale grant (least privilege)
 
@@ -142,6 +148,12 @@ over the tailnet.
 and all bind-mounted data. `make server-tailscale-down` removes **only** the
 443/8443 routes and never runs the destructive global
 `tailscale serve reset`.
+
+Neo4j Community Edition cannot create an online `neo4j-admin` dump. The backup
+helper therefore stops Neo4j briefly, writes the dump, and always attempts to
+restart it—even if the dump fails or the command is interrupted. API requests
+can fail during that short window. A completed dump is retained if restart
+fails so recovery work cannot erase the backup.
 
 ### Schedules
 

--- a/packages/sbir-analytics/sbir_analytics/assets/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/__init__.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import importlib
 import logging
 import os
-import pkgutil
 from collections.abc import Iterator, Sequence
 from functools import lru_cache
+from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING
 
@@ -18,15 +18,15 @@ if TYPE_CHECKING:
 LOG = logging.getLogger(__name__)
 
 
-# Heavy modules that can be skipped in resource-constrained environments
-HEAVY_ASSET_MODULES = {
-    "sbir_analytics.assets.fiscal_assets",  # R dependencies, economic modeling
-    "sbir_analytics.assets.modernbert.embeddings",  # Sentence transformers, ML models, similarity
-    "sbir_analytics.assets.ml.cet_training",  # scikit-learn, model training
-    "sbir_analytics.assets.ml.cet_inference",  # Model inference
-    "sbir_analytics.assets.ml.cet_drift_detection",  # Statistical analysis
-    "sbir_analytics.assets.uspto.ai_extraction",  # spaCy, NLP processing
-}
+# Asset families excluded from resource-constrained environments. Prefixes are
+# used because several families span packages rather than a single module.
+HEAVY_ASSET_PREFIXES = (
+    "sbir_analytics.assets.cet",
+    "sbir_analytics.assets.fiscal_assets",
+    "sbir_analytics.assets.sbir_fiscal_impacts",
+    "sbir_analytics.assets.modernbert",
+    "sbir_analytics.assets.uspto.ai_extraction",
+)
 
 # Jobs whose selections depend on one or more heavy asset modules above.  Job
 # discovery must apply the same deployment gate as asset discovery; otherwise
@@ -47,11 +47,18 @@ def _iter_modules(
 ) -> Iterator[str]:
     """Yield fully qualified module names for a package tree."""
 
-    prefix = package.__name__ + "."
-    for module_info in pkgutil.walk_packages(package.__path__, prefix=prefix):
-        if any(module_info.name.startswith(skip) for skip in skip_prefixes):
-            continue
-        yield module_info.name
+    module_names: set[str] = set()
+    for package_path in package.__path__:
+        root = Path(package_path)
+        for module_path in root.rglob("*.py"):
+            if module_path.name == "__init__.py":
+                continue
+            relative = module_path.relative_to(root).with_suffix("")
+            module_name = f"{package.__name__}.{'.'.join(relative.parts)}"
+            if any(module_name.startswith(skip) for skip in skip_prefixes):
+                continue
+            module_names.add(module_name)
+    yield from sorted(module_names)
 
 
 def _safe_import(module_name: str) -> ModuleType | None:
@@ -64,7 +71,7 @@ def _safe_import(module_name: str) -> ModuleType | None:
         return None
 
 
-def _should_load_heavy_assets() -> bool:
+def should_load_heavy_assets() -> bool:
     """Check if heavy assets should be loaded based on environment."""
     # Load heavy assets by default (local/hybrid), skip in serverless mode
     env_value = os.getenv("DAGSTER_LOAD_HEAVY_ASSETS", "true").lower()
@@ -87,12 +94,15 @@ def iter_asset_modules() -> list[ModuleType]:
     Skips heavy asset modules in resource-constrained environments
     based on DAGSTER_LOAD_HEAVY_ASSETS environment variable.
     """
-    load_heavy = _should_load_heavy_assets()
+    load_heavy = should_load_heavy_assets()
 
     modules: list[ModuleType] = []
     for module_name in _asset_module_names():
         # Skip heavy modules if configured
-        if not load_heavy and module_name in HEAVY_ASSET_MODULES:
+        if not load_heavy and any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in HEAVY_ASSET_PREFIXES
+        ):
             LOG.info(
                 "Skipping heavy asset module (DAGSTER_LOAD_HEAVY_ASSETS=false): %s", module_name
             )
@@ -111,7 +121,7 @@ def _job_module_names() -> tuple[str, ...]:
 
 
 def iter_job_modules() -> list[ModuleType]:
-    load_heavy = _should_load_heavy_assets()
+    load_heavy = should_load_heavy_assets()
     modules: list[ModuleType] = []
     for module_name in _job_module_names():
         if not load_heavy and module_name in HEAVY_JOB_MODULES:
@@ -175,4 +185,5 @@ __all__ = [
     "iter_sensor_modules",
     "iter_public_jobs",
     "iter_public_sensors",
+    "should_load_heavy_assets",
 ]

--- a/packages/sbir-analytics/sbir_analytics/assets/uspto/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/uspto/__init__.py
@@ -36,16 +36,21 @@ Exported Assets:
 
 from __future__ import annotations
 
+from .. import should_load_heavy_assets
+
+
 # AI Extraction module
-from .ai_extraction import (
-    enriched_uspto_ai_patent_join,
-    raw_uspto_ai_extract,
-    raw_uspto_ai_human_sample,
-    raw_uspto_ai_human_sample_extraction,
-    raw_uspto_ai_predictions,
-    uspto_ai_deduplicate,
-    validated_uspto_ai_cache_stats,
-)
+_LOAD_HEAVY_ASSETS = should_load_heavy_assets()
+if _LOAD_HEAVY_ASSETS:
+    from .ai_extraction import (
+        enriched_uspto_ai_patent_join as enriched_uspto_ai_patent_join,
+        raw_uspto_ai_extract as raw_uspto_ai_extract,
+        raw_uspto_ai_human_sample as raw_uspto_ai_human_sample,
+        raw_uspto_ai_human_sample_extraction as raw_uspto_ai_human_sample_extraction,
+        raw_uspto_ai_predictions as raw_uspto_ai_predictions,
+        uspto_ai_deduplicate as uspto_ai_deduplicate,
+        validated_uspto_ai_cache_stats as validated_uspto_ai_cache_stats,
+    )
 
 # Extraction module
 from .extraction import (
@@ -140,14 +145,6 @@ __all__ = [
     "patent_load_success_rate",
     "assignment_load_success_rate",
     "patent_relationship_cardinality",
-    # AI Extraction
-    "raw_uspto_ai_extract",
-    "uspto_ai_deduplicate",
-    "raw_uspto_ai_human_sample_extraction",
-    "raw_uspto_ai_predictions",
-    "validated_uspto_ai_cache_stats",
-    "raw_uspto_ai_human_sample",
-    "enriched_uspto_ai_patent_join",
     # Backward compatibility aliases
     "neo4j_patents",
     "neo4j_patent_assignments",
@@ -161,3 +158,16 @@ __all__ = [
     "AssetIn",
     "MetadataValue",
 ]
+
+if _LOAD_HEAVY_ASSETS:
+    __all__.extend(
+        [
+            "raw_uspto_ai_extract",
+            "uspto_ai_deduplicate",
+            "raw_uspto_ai_human_sample_extraction",
+            "raw_uspto_ai_predictions",
+            "validated_uspto_ai_cache_stats",
+            "raw_uspto_ai_human_sample",
+            "enriched_uspto_ai_patent_join",
+        ]
+    )

--- a/packages/sbir-analytics/sbir_analytics/definitions.py
+++ b/packages/sbir-analytics/sbir_analytics/definitions.py
@@ -1,5 +1,6 @@
 """Dagster definitions for SBIR ETL pipeline."""
 
+import logging
 import os
 
 from dagster import (
@@ -13,8 +14,16 @@ from dagster import (
     load_asset_checks_from_modules,
     load_assets_from_modules,
 )
+from dagster._core.definitions.unresolved_asset_job_definition import (
+    UnresolvedAssetJobDefinition,
+)
+from dagster._core.errors import DagsterInvalidSubsetError
 
 from . import assets as assets_pkg
+
+
+LOG = logging.getLogger(__name__)
+DiscoveredJob = JobDefinition | UnresolvedAssetJobDefinition
 
 
 def _schedule_status(env_var: str, *, default_running: bool) -> DefaultScheduleStatus:
@@ -34,10 +43,20 @@ all_assets = load_assets_from_modules(asset_modules)
 all_asset_checks = load_asset_checks_from_modules(asset_modules)
 
 
-def _discover_jobs() -> dict[str, JobDefinition]:
+def _discover_jobs() -> dict[str, DiscoveredJob]:
     """Discover job definitions exposed under src.assets.jobs."""
 
-    return {job.name: job for job in assets_pkg.iter_public_jobs()}
+    jobs: dict[str, DiscoveredJob] = {}
+    load_heavy = assets_pkg.should_load_heavy_assets()
+    for job in assets_pkg.iter_public_jobs():
+        if not load_heavy and isinstance(job, UnresolvedAssetJobDefinition):
+            try:
+                job.selection.resolve(all_assets)
+            except DagsterInvalidSubsetError as exc:
+                LOG.info("Skipping job %s because its assets are not loaded: %s", job.name, exc)
+                continue
+        jobs[job.name] = job
+    return jobs
 
 
 def _discover_sensors() -> list[SensorDefinition]:
@@ -49,7 +68,7 @@ def _discover_sensors() -> list[SensorDefinition]:
 auto_jobs = _discover_jobs()
 
 
-def _get_job(name: str) -> JobDefinition | None:
+def _get_job(name: str) -> DiscoveredJob | None:
     """Retrieve a named job or return None if it is missing."""
     return auto_jobs.get(name)
 
@@ -145,13 +164,10 @@ if cet_drift_job is not None:
 all_sensors = _discover_sensors()
 
 # Aggregate jobs for repository registration
-job_definitions: list[JobDefinition] = [
-    etl_job,  # type: ignore[list-item]
-    core_refresh_job,  # type: ignore[list-item]
-]
+job_definitions: list[DiscoveredJob] = [etl_job, core_refresh_job]
 # Add conditional jobs if they exist
 if cet_drift_job is not None:
-    job_definitions.append(cet_drift_job)  # type: ignore[arg-type]
+    job_definitions.append(cet_drift_job)
 
 # Add auto-discovered jobs that aren't already in the list
 job_definitions.extend(job for job in auto_jobs.values() if job not in job_definitions)

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -25,7 +25,7 @@
 #
 # Notes:
 # - This script is intentionally POSIX-sh compatible for maximum portability.
-# - It uses sbir-analytics/scripts/docker/wait-for-service.sh if present to perform health checks.
+# - It probes dependencies with nc when available and Python otherwise.
 # - The script will exec the final command so the process receives container signals.
 set -eu
 
@@ -102,42 +102,39 @@ _make_exec_prefix() {
   printf '%s' "$exec_prefix"
 }
 
-# Wait for the Neo4j service to be available using the included wait script if present.
+probe_tcp() {
+  host="$1"
+  port="$2"
+
+  if command -v nc >/dev/null 2>&1; then
+    nc -z "$host" "$port" >/dev/null 2>&1
+    return $?
+  fi
+
+  # Python is guaranteed by the application image and works under /bin/sh,
+  # unlike the non-portable /dev/tcp fallback.
+  if command -v python >/dev/null 2>&1; then
+    python -c \
+      'import socket, sys; sock = socket.create_connection((sys.argv[1], int(sys.argv[2])), timeout=2); sock.close()' \
+      "$host" "$port" >/dev/null 2>&1
+    return $?
+  fi
+
+  (exec 3<>"/dev/tcp/$host/$port") >/dev/null 2>&1
+}
+
+# Wait for the Neo4j service to accept TCP connections.
 wait_for_neo4j() {
   HOST="${SBIR_ETL__NEO4J__HOST:-${NEO4J_HOST:-neo4j}}"
   PORT="${SBIR_ETL__NEO4J__PORT:-${NEO4J_PORT:-7687}}"
   TIMEOUT="${SERVICE_STARTUP_TIMEOUT:-120}"
-  WAIT_SCRIPT="/app/scripts/docker/wait-for-service.sh"
-
-  if [ -x "$WAIT_SCRIPT" ]; then
-    log "Waiting for Neo4j at ${HOST}:${PORT} (timeout=${TIMEOUT}s)..."
-    # prefer TCP probe for bolt port
-    "$WAIT_SCRIPT" --host "$HOST" --port "$PORT" --proto tcp --timeout "$TIMEOUT" --interval 5 || {
-      log "Neo4j did not become available within ${TIMEOUT}s"
-      return 1
-    }
-    log "Neo4j is available"
-    return 0
-  fi
-
-  # Fallback: simple loop using nc or /dev/tcp
-  log "No wait script found; performing basic TCP probe for Neo4j at ${HOST}:${PORT}"
+  log "Waiting for Neo4j at ${HOST}:${PORT} (timeout=${TIMEOUT}s)..."
   start=$(date +%s)
   deadline=$((start + TIMEOUT))
   while [ "$(date +%s)" -le "$deadline" ]; do
-    if command -v nc >/dev/null 2>&1; then
-      if nc -z "$HOST" "$PORT" >/dev/null 2>&1; then
-        log "Neo4j available (nc)."
-        return 0
-      fi
-    else
-      # Try /dev/tcp if shell supports it
-      if (exec 3<>"/dev/tcp/$HOST/$PORT") >/dev/null 2>&1; then
-        exec 3<&- || true
-        exec 3>&- || true
-        log "Neo4j available (/dev/tcp)."
-        return 0
-      fi
+    if probe_tcp "$HOST" "$PORT"; then
+      log "Neo4j is available"
+      return 0
     fi
     log "Neo4j not ready yet; sleeping 5s..."
     sleep 5
@@ -173,7 +170,9 @@ wait_for_dagster_web() {
   start=$(date +%s)
   deadline=$((start + TIMEOUT))
   while [ "$(date +%s)" -le "$deadline" ]; do
-    code=$(curl -s -o /dev/null -w '%{http_code}' "http://${WEB_HOST}:${WEB_PORT}${HEALTH_PATH}" || echo 000)
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+      "http://${WEB_HOST}:${WEB_PORT}${HEALTH_PATH}" || true)
+    [ -n "$code" ] || code=000
     case "$code" in
       2*|3*)
         log "Dagster webserver responded with HTTP ${code}"
@@ -282,7 +281,13 @@ main() {
         log "Warning: Dagster webserver did not become healthy in time; proceeding anyway"
       fi
 
-      CMD="dagster-daemon run"
+      if [ -n "${ENV_DAGSTER_CMD-}" ]; then
+        CMD="${ENV_DAGSTER_CMD}"
+      elif [ -n "${DAGSTER_CMD-}" ]; then
+        CMD="${DAGSTER_CMD}"
+      else
+        CMD="dagster-daemon run"
+      fi
       log "Exec: ${EXEC_PREFIX} ${CMD}"
       if [ -n "$EXEC_PREFIX" ]; then
         eval "exec ${EXEC_PREFIX} sh -c '${CMD}'"

--- a/scripts/server/backup.sh
+++ b/scripts/server/backup.sh
@@ -1,53 +1,161 @@
 #!/usr/bin/env sh
-# sbir-analytics/scripts/server/backup.sh
-#
 # Offline-consistent Neo4j backup for the Mac mini server profile.
-#
-# Uses `neo4j-admin database dump` inside the running Neo4j container and copies
-# the dump to ${SERVER_BACKUP_DIR}. The Compose stack keeps running; only the
-# `neo4j` database is briefly quiesced by neo4j-admin as needed.
-#
-# Env (from .env.server):
-#   SERVER_BACKUP_DIR   destination for dumps (default ./backups)
-#   NEO4J_CONTAINER_NAME  container to target (default sbir-server-neo4j)
-#
-# Usage:
-#   scripts/server/backup.sh
 
 set -eu
 
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.server.yml}"
 ENV_FILE="${SERVER_ENV_FILE:-.env.server}"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=scripts/server/env-file.sh
+. "$SCRIPT_DIR/env-file.sh"
+load_env_key SERVER_BACKUP_DIR
+load_env_key SERVER_NEO4J_DIR
+
 BACKUP_DIR="${SERVER_BACKUP_DIR:-./backups}"
+NEO4J_DIR="${SERVER_NEO4J_DIR:-./data/neo4j}"
 DB_NAME="${NEO4J_DATABASE:-neo4j}"
+STAMP="${BACKUP_STAMP:-$(date -u '+%Y%m%dT%H%M%SZ')}"
+RESTART_TIMEOUT="${BACKUP_RESTART_TIMEOUT:-180}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; BLUE='\033[0;34m'; NC='\033[0m'
 info()    { printf "${BLUE}➤${NC} %s\n" "$1"; }
 success() { printf "${GREEN}✓${NC} %s\n" "$1"; }
-error()   { printf "${RED}✖${NC} %s\n" "$1"; }
+error()   { printf "${RED}✖${NC} %s\n" "$1" >&2; }
 
-COMPOSE="docker compose -f ${COMPOSE_FILE}"
-if [ -f "$ENV_FILE" ]; then
-  COMPOSE="docker compose -f ${COMPOSE_FILE} --env-file ${ENV_FILE}"
-fi
+compose() {
+  if [ -f "$ENV_FILE" ]; then
+    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" "$@"
+  else
+    docker compose -f "$COMPOSE_FILE" "$@"
+  fi
+}
 
-# Timestamp is passed in so the script stays deterministic for callers/tests.
-STAMP="${BACKUP_STAMP:-$(date -u '+%Y%m%dT%H%M%SZ')}"
+case "$DB_NAME" in
+  ''|*[!A-Za-z0-9_.-]*)
+    error "NEO4J_DATABASE may contain only letters, digits, dots, underscores, and hyphens."
+    exit 2
+    ;;
+esac
+case "$STAMP" in
+  ''|*[!A-Za-z0-9_.-]*)
+    error "BACKUP_STAMP may contain only letters, digits, dots, underscores, and hyphens."
+    exit 2
+    ;;
+esac
+case "$RESTART_TIMEOUT" in
+  ''|*[!0-9]*) error "BACKUP_RESTART_TIMEOUT must be a positive integer."; exit 2 ;;
+esac
+[ "$RESTART_TIMEOUT" -gt 0 ] || {
+  error "BACKUP_RESTART_TIMEOUT must be positive."
+  exit 2
+}
+
+for pair in "backup:$BACKUP_DIR" "Neo4j data:$NEO4J_DIR"; do
+  label=${pair%%:*}
+  path=${pair#*:}
+  if ! path_has_active_external_volume "$path"; then
+    volume=$(volume_root_for_path "$path" || printf '%s' /Volumes/unknown)
+    error "$label path $path requires $volume to be actively mounted."
+    exit 1
+  fi
+done
+
 mkdir -p "$BACKUP_DIR"
+BACKUP_DIR=$(CDPATH= cd -- "$BACKUP_DIR" && pwd)
+DEST="${BACKUP_DIR}/${DB_NAME}-${STAMP}.dump"
 
-info "Dumping Neo4j database '${DB_NAME}' inside the container..."
-# Dump to a temp path inside the container, then copy out.
-$COMPOSE --profile server exec -T neo4j sh -c \
-  "neo4j-admin database dump ${DB_NAME} --to-path=/tmp/backup --overwrite-destination=true" \
-  || { error "neo4j-admin dump failed"; exit 1; }
+lock_dir="${BACKUP_DIR}/.neo4j-backup.lock"
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  error "Another backup is running, or a stale lock exists: $lock_dir"
+  exit 1
+fi
+printf '%s\n' "$$" >"$lock_dir/pid"
 
-CID="$($COMPOSE --profile server ps -q neo4j)"
-if [ -z "$CID" ]; then
-  error "Could not resolve the neo4j container id."
+stage_dir=""
+staged_dump=""
+restart_required=0
+reserved_dest=0
+backup_complete=0
+
+restart_neo4j() {
+  compose --profile server up -d --no-deps --wait \
+    --wait-timeout "$RESTART_TIMEOUT" neo4j >/dev/null
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT HUP INT TERM
+  set +e
+  if [ "$restart_required" -eq 1 ]; then
+    info "Restarting Neo4j after interrupted or failed backup..."
+    if ! restart_neo4j; then
+      error "Neo4j could not be restarted and become healthy; run: make server-up"
+      status=1
+    fi
+  fi
+  if [ -n "$staged_dump" ]; then
+    rm -f "$staged_dump"
+  fi
+  if [ -n "$stage_dir" ]; then
+    rmdir "$stage_dir" 2>/dev/null
+  fi
+  if [ "$reserved_dest" -eq 1 ] && [ "$backup_complete" -eq 0 ]; then
+    rm -f "$DEST"
+  fi
+  rm -f "$lock_dir/pid"
+  rmdir "$lock_dir" 2>/dev/null
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+# Reserve the final name atomically before stopping Neo4j. The operation lock
+# prevents another invocation from racing the dump; noclobber protects against
+# an independently-created file with the same timestamp.
+if ! (umask 077; set -C; : >"$DEST") 2>/dev/null; then
+  error "Backup already exists; refusing to overwrite: $DEST"
+  exit 1
+fi
+reserved_dest=1
+
+if [ -z "$(compose --profile server ps --status running -q neo4j)" ]; then
+  error "Neo4j is not running. Start the server stack before backing it up."
   exit 1
 fi
 
-DEST="${BACKUP_DIR}/${DB_NAME}-${STAMP}.dump"
-docker cp "${CID}:/tmp/backup/${DB_NAME}.dump" "$DEST"
-success "Backup written: ${DEST}"
+stage_dir=$(mktemp -d "${BACKUP_DIR}/.neo4j-backup.XXXXXX")
+staged_dump="${stage_dir}/${DB_NAME}.dump"
+
+info "Stopping Neo4j briefly for an offline-consistent dump..."
+restart_required=1
+if ! compose --profile server stop -t 120 neo4j; then
+  error "Neo4j stop did not complete cleanly; attempting recovery."
+  exit 1
+fi
+
+info "Dumping Neo4j database '$DB_NAME'..."
+compose --profile server run --rm --no-deps -T \
+  -v "${stage_dir}:/backup" \
+  --entrypoint neo4j-admin neo4j \
+  database dump "$DB_NAME" --to-path=/backup --overwrite-destination=true
+
+if [ ! -s "$staged_dump" ]; then
+  error "neo4j-admin did not produce a nonempty dump."
+  exit 1
+fi
+chmod 600 "$staged_dump"
+mv "$staged_dump" "$DEST"
+reserved_dest=0
+backup_complete=1
+
+info "Restarting Neo4j..."
+if ! restart_neo4j; then
+  error "Backup completed, but Neo4j did not restart healthy; run: make server-up"
+  exit 1
+fi
+restart_required=0
+
+success "Backup written: $DEST"
 info "Copy this off-device (the external SSD is not a backup by itself)."

--- a/scripts/server/check-prerequisites.sh
+++ b/scripts/server/check-prerequisites.sh
@@ -45,15 +45,23 @@ warn()    { printf "${YELLOW}⚠${NC} %s\n" "$1"; warnings=$((warnings + 1)); }
 error()   { printf "${RED}✖${NC} %s\n" "$1"; errors=$((errors + 1)); }
 
 # ---------------------------------------------------------------------------
-# Load .env.server (best effort; never abort on a malformed line)
+# Load allowlisted .env.server values as data (never execute the file)
 # ---------------------------------------------------------------------------
 ENV_FILE="${SERVER_ENV_FILE:-.env.server}"
+COMPOSE_FILE="${SERVER_COMPOSE_FILE:-docker-compose.server.yml}"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 if [ -f "$ENV_FILE" ]; then
   info "Loading environment from $ENV_FILE"
-  set +eu
-  # shellcheck disable=SC1090
-  . "$ENV_FILE" 2>/dev/null || true
-  set -eu
+  # shellcheck source=scripts/server/env-file.sh
+  . "$SCRIPT_DIR/env-file.sh"
+  for key in \
+    SERVER_LOOPBACK NEO4J_PASSWORD SBIR_ANALYTICS_API_TOKEN \
+    SERVER_DATA_DIR SERVER_REPORTS_DIR SERVER_LOGS_DIR \
+    SERVER_ARTIFACTS_DIR SERVER_NEO4J_DIR SERVER_BACKUP_DIR \
+    NEO4J_HTTP_PORT NEO4J_BOLT_PORT DAGSTER_PORT \
+    SBIR_ANALYTICS_API_PORT; do
+    load_env_key "$key"
+  done
 elif [ "$MODE" = "all" ]; then
   error "$ENV_FILE not found. Copy .env.server.example → .env.server first."
 fi
@@ -112,8 +120,8 @@ check_docker() {
   fi
   success "Docker daemon is reachable."
 
-  # Total memory available to the Docker VM (bytes). Stack needs ~7.25 GiB of
-  # limits (Neo4j 2 + daemon 4 + web 0.75 + API 0.5); warn under 8 GiB.
+  # Total memory available to the Docker VM (bytes). Stack has ~7 GiB of
+  # limits across Neo4j, Dagster, and the API; warn under 8 GiB.
   total_mem=$(docker info --format '{{.MemTotal}}' 2>/dev/null || echo 0)
   if [ "${total_mem:-0}" -gt 0 ]; then
     min_bytes=$((8 * 1024 * 1024 * 1024))
@@ -134,22 +142,19 @@ check_storage() {
     "SERVER_REPORTS_DIR:${SERVER_REPORTS_DIR:-./reports}" \
     "SERVER_LOGS_DIR:${SERVER_LOGS_DIR:-./logs}" \
     "SERVER_ARTIFACTS_DIR:${SERVER_ARTIFACTS_DIR:-./artifacts}" \
-    "SERVER_NEO4J_DIR:${SERVER_NEO4J_DIR:-./data/neo4j}"; do
+    "SERVER_NEO4J_DIR:${SERVER_NEO4J_DIR:-./data/neo4j}" \
+    "SERVER_BACKUP_DIR:${SERVER_BACKUP_DIR:-./backups}"; do
     name="${pair%%:*}"
     dir="${pair#*:}"
-    case "$dir" in
-      /Volumes/*)
-        parent="/$(printf '%s' "$dir" | cut -d/ -f2)/$(printf '%s' "$dir" | cut -d/ -f3)"
-        if [ ! -d "$parent" ]; then
-          error "$name points at $dir but the volume $parent is not mounted."
-          continue
-        fi
-        ;;
-    esac
+    if ! path_has_active_external_volume "$dir"; then
+      parent=$(volume_root_for_path "$dir" || printf '%s' /Volumes/unknown)
+      error "$name points at $dir but $parent is not an active mount."
+      continue
+    fi
     if [ -d "$dir" ] && [ -w "$dir" ]; then
       success "$name is writable: $dir"
     elif [ ! -e "$dir" ]; then
-      warn "$name does not exist yet: $dir (create it before server-up)."
+      error "$name does not exist yet: $dir (create it before server-up)."
     else
       error "$name is not writable: $dir"
     fi
@@ -169,16 +174,50 @@ port_in_use() {
   return 1
 }
 
+compose() {
+  if [ -f "$ENV_FILE" ]; then
+    docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" "$@"
+  else
+    docker compose -f "$COMPOSE_FILE" "$@"
+  fi
+}
+
+server_service_owns_port() {
+  service="$1"
+  container_port="$2"
+  host_port="$3"
+  cid=$(compose --profile server ps --status running -q "$service" 2>/dev/null || true)
+  [ -n "$cid" ] || return 1
+  docker port "$cid" "${container_port}/tcp" 2>/dev/null | \
+    grep -Fqx "127.0.0.1:${host_port}"
+}
+
+valid_port() {
+  case "$1" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  [ "$1" -ge 1 ] && [ "$1" -le 65535 ]
+}
+
 check_ports() {
   for pair in \
-    "Neo4j HTTP:${NEO4J_HTTP_PORT:-7474}" \
-    "Neo4j Bolt:${NEO4J_BOLT_PORT:-7687}" \
-    "Dagster:${DAGSTER_PORT:-3000}" \
-    "API:${SBIR_ANALYTICS_API_PORT:-8010}"; do
-    label="${pair%%:*}"
-    p="${pair#*:}"
+    "Neo4j HTTP|neo4j|7474|${NEO4J_HTTP_PORT:-7474}" \
+    "Neo4j Bolt|neo4j|7687|${NEO4J_BOLT_PORT:-7687}" \
+    "Dagster|dagster-webserver|3000|${DAGSTER_PORT:-3000}" \
+    "API|analytics-api|${SBIR_ANALYTICS_API_PORT:-8010}|${SBIR_ANALYTICS_API_PORT:-8010}"; do
+    label=${pair%%|*}; rest=${pair#*|}
+    service=${rest%%|*}; rest=${rest#*|}
+    container_port=${rest%%|*}; p=${rest#*|}
+    if ! valid_port "$p"; then
+      error "$label host port '$p' is not an integer from 1 through 65535."
+      continue
+    fi
     if port_in_use "$p"; then
-      error "$label host port $p is already in use."
+      if server_service_owns_port "$service" "$container_port" "$p"; then
+        success "$label host port $p is already owned by this server stack."
+      else
+        error "$label host port $p is already in use."
+      fi
     else
       success "$label host port $p is free."
     fi
@@ -199,15 +238,35 @@ check_tailscale() {
   fi
   success "Tailscale is up."
 
-  # Refuse to clobber existing Serve routes on 443 / 8443.
-  serve_json="$(tailscale serve status --json 2>/dev/null || echo '')"
-  for port in 443 8443; do
-    if printf '%s' "$serve_json" | grep -q "\"$port\""; then
-      error "Tailscale Serve already maps port $port. Refusing to overwrite it."
-      error "  Inspect with: tailscale serve status"
-    else
-      success "Tailscale Serve port $port is free."
+  if ! command -v python3 >/dev/null 2>&1; then
+    error "python3 is required to validate Tailscale Serve ownership safely."
+    return
+  fi
+
+  # Allow our exact routes (for idempotent restarts), allow free ports, and
+  # reject every other mapping or Funnel-enabled route.
+  if ! serve_json=$(tailscale serve status --json 2>/dev/null); then
+    error "Could not inspect the Tailscale Serve configuration."
+    return
+  fi
+  for pair in \
+    "443:http://127.0.0.1:${DAGSTER_PORT:-3000}" \
+    "8443:http://127.0.0.1:${SBIR_ANALYTICS_API_PORT:-8010}"; do
+    port=${pair%%:*}
+    target=${pair#*:}
+    if ! state=$(printf '%s' "$serve_json" | \
+      python3 "$SCRIPT_DIR/tailscale-route-state.py" "$port" "$target"); then
+      error "Tailscale Serve returned invalid JSON."
+      return
     fi
+    case "$state" in
+      free) success "Tailscale Serve port $port is free." ;;
+      owned) success "Tailscale Serve port $port already has the expected route." ;;
+      *)
+        error "Tailscale Serve port $port has a different owner or target."
+        error "  Inspect with: tailscale serve status"
+        ;;
+    esac
   done
 }
 

--- a/scripts/server/check-prerequisites.sh
+++ b/scripts/server/check-prerequisites.sh
@@ -50,10 +50,11 @@ error()   { printf "${RED}✖${NC} %s\n" "$1"; errors=$((errors + 1)); }
 ENV_FILE="${SERVER_ENV_FILE:-.env.server}"
 COMPOSE_FILE="${SERVER_COMPOSE_FILE:-docker-compose.server.yml}"
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# Helpers are required by the full preflight even when the env file is absent.
+# shellcheck source=scripts/server/env-file.sh
+. "$SCRIPT_DIR/env-file.sh"
 if [ -f "$ENV_FILE" ]; then
   info "Loading environment from $ENV_FILE"
-  # shellcheck source=scripts/server/env-file.sh
-  . "$SCRIPT_DIR/env-file.sh"
   for key in \
     SERVER_LOOPBACK NEO4J_PASSWORD SBIR_ANALYTICS_API_TOKEN \
     SERVER_DATA_DIR SERVER_REPORTS_DIR SERVER_LOGS_DIR \

--- a/scripts/server/env-file.sh
+++ b/scripts/server/env-file.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env sh
+# Read allowlisted values from a Docker Compose env file without executing it.
+#
+# The operational scripts intentionally accept only simple literal values for
+# the keys they consume. Docker Compose supports interpolation and several
+# quoting/comment forms; silently approximating those rules could make the
+# preflight validate a different value from the one Compose uses.
+
+read_env_value() {
+  key="$1"
+  awk -v key="$key" '
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line !~ "^[[:space:]]*" key "[[:space:]]*=") {
+        next
+      }
+      sub("^[[:space:]]*" key "[[:space:]]*=[[:space:]]*", "", line)
+      sub(/[[:space:]]*$/, "", line)
+      value = line
+      matches++
+    }
+    END {
+      if (matches > 1) {
+        exit 3
+      }
+      if (matches == 1) {
+        print value
+      }
+    }
+  ' "$ENV_FILE"
+}
+
+load_env_key() {
+  key="$1"
+  # The caller supplies literal, allowlisted names. Environment variables take
+  # precedence over the file, matching Docker Compose interpolation behavior.
+  eval "is_set=\${$key+x}"
+  if [ "$is_set" = "x" ] || [ ! -f "$ENV_FILE" ]; then
+    return 0
+  fi
+
+  if ! value=$(read_env_value "$key"); then
+    printf 'Invalid %s: %s is defined more than once.\n' "$ENV_FILE" "$key" >&2
+    return 1
+  fi
+  case "$value" in
+    *'$'*|*'#'*|*'"'*|*"'"*|*'\'*)
+      printf 'Invalid %s: %s must be an unquoted literal without #, $, or backslashes.\n' \
+        "$ENV_FILE" "$key" >&2
+      return 1
+      ;;
+  esac
+  if [ -n "$value" ]; then
+    export "$key=$value"
+  fi
+}
+
+volume_root_for_path() {
+  path="$1"
+  case "$path" in
+    /Volumes/*)
+      relative=${path#/Volumes/}
+      volume_name=${relative%%/*}
+      [ -n "$volume_name" ] || return 1
+      printf '/Volumes/%s\n' "$volume_name"
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+is_active_mountpoint() {
+  expected="$1"
+  [ -d "$expected" ] || return 1
+  # POSIX df -P keeps each filesystem on one line. Reassemble fields 6..N so
+  # volume names containing spaces are compared as a complete mount path.
+  df -P "$expected" 2>/dev/null | awk -v expected="$expected" '
+    NR > 1 {
+      mounted = $6
+      for (i = 7; i <= NF; i++) {
+        mounted = mounted " " $i
+      }
+    }
+    END { exit !(mounted == expected) }
+  '
+}
+
+path_has_active_external_volume() {
+  path="$1"
+  if ! root=$(volume_root_for_path "$path"); then
+    return 0
+  fi
+  is_active_mountpoint "$root"
+}

--- a/scripts/server/tailscale-route-state.py
+++ b/scripts/server/tailscale-route-state.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Classify ownership of one Tailscale Serve HTTPS route."""
+
+import json
+import sys
+from typing import Any
+
+
+def _matches_port(value: str, port: str) -> bool:
+    return value == port or value.rsplit(":", 1)[-1] == port
+
+
+def _references_port(value: Any, port: str) -> bool:
+    if isinstance(value, dict):
+        return any(
+            _matches_port(str(key), port) or _references_port(item, port)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return any(_references_port(item, port) for item in value)
+    return False
+
+
+def classify(config: dict[str, Any], port: str, target: str) -> str:
+    tcp = config.get("TCP", {})
+    web = config.get("Web", {})
+    funnel = config.get("AllowFunnel", {})
+    foreground = config.get("Foreground", {})
+    if not all(isinstance(section, dict) for section in (tcp, web, funnel)):
+        return "occupied"
+
+    tcp_entry = tcp.get(port)
+    web_entries = {key: value for key, value in web.items() if _matches_port(str(key), port)}
+    funnel_entries = {key: value for key, value in funnel.items() if _matches_port(str(key), port)}
+    foreground_uses_port = _references_port(foreground, port)
+
+    expected_handlers = {"Handlers": {"/": {"Proxy": target}}}
+    owned = (
+        tcp_entry == {"HTTPS": True}
+        and len(web_entries) == 1
+        and next(iter(web_entries.values())) == expected_handlers
+        and not any(bool(value) for value in funnel_entries.values())
+        and not foreground_uses_port
+    )
+    if owned:
+        return "owned"
+
+    if tcp_entry is None and not web_entries and not funnel_entries and not foreground_uses_port:
+        return "free"
+    return "occupied"
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: tailscale-route-state.py PORT TARGET", file=sys.stderr)
+        return 2
+    try:
+        config = json.load(sys.stdin)
+    except (json.JSONDecodeError, TypeError) as exc:
+        print(f"invalid Tailscale Serve JSON: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(config, dict):
+        print("invalid Tailscale Serve JSON: expected an object", file=sys.stderr)
+        return 2
+    print(classify(config, sys.argv[1], sys.argv[2]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/server/tailscale-serve.sh
+++ b/scripts/server/tailscale-serve.sh
@@ -15,7 +15,6 @@ API_PORT="${SBIR_ANALYTICS_API_PORT:-8010}"
 DAGSTER_TARGET="http://127.0.0.1:${DAGSTER_PORT}"
 API_TARGET="http://127.0.0.1:${API_PORT}"
 STATE_HELPER="$SCRIPT_DIR/tailscale-route-state.py"
-MUTATION_PID=""
 MUTATION_OUTPUT=""
 LAST_MUTATION_OUTPUT=""
 PENDING_PORT=""
@@ -30,25 +29,8 @@ success() { printf "${GREEN}✓${NC} %s\n" "$1"; }
 warn()    { printf "${YELLOW}⚠${NC} %s\n" "$1"; }
 error()   { printf "${RED}✖${NC} %s\n" "$1" >&2; }
 
-stop_mutation() {
-  if [ -n "$MUTATION_PID" ] && kill -0 "$MUTATION_PID" 2>/dev/null; then
-    kill "$MUTATION_PID" 2>/dev/null || true
-    grace=0
-    while kill -0 "$MUTATION_PID" 2>/dev/null && [ "$grace" -lt 3 ]; do
-      sleep 1
-      grace=$((grace + 1))
-    done
-    if kill -0 "$MUTATION_PID" 2>/dev/null; then
-      kill -9 "$MUTATION_PID" 2>/dev/null || true
-    fi
-  fi
-  [ -z "$MUTATION_PID" ] || wait "$MUTATION_PID" 2>/dev/null || true
-}
-
 cleanup_mutation() {
-  stop_mutation
   [ -z "$MUTATION_OUTPUT" ] || rm -f "$MUTATION_OUTPUT"
-  MUTATION_PID=""
   MUTATION_OUTPUT=""
 }
 
@@ -101,31 +83,42 @@ run_tailscale_mutation() {
 
   LAST_MUTATION_OUTPUT=""
   MUTATION_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/sbir-tailscale-serve.XXXXXX")
-  tailscale "$@" >"$MUTATION_OUTPUT" 2>&1 &
-  MUTATION_PID=$!
-  elapsed=0
-  while kill -0 "$MUTATION_PID" 2>/dev/null; do
-    if [ "$elapsed" -ge "$timeout" ]; then
-      stop_mutation
-      LAST_MUTATION_OUTPUT=$(cat "$MUTATION_OUTPUT")
-      [ -z "$LAST_MUTATION_OUTPUT" ] || printf '%s\n' "$LAST_MUTATION_OUTPUT" >&2
-      error "Tailscale Serve did not finish within ${timeout}s."
-      error "If HTTPS consent is pending, enable it using the URL above and rerun."
-      cleanup_mutation
-      return 124
-    fi
-    sleep 1
-    elapsed=$((elapsed + 1))
-  done
+  if python3 - "$timeout" "$MUTATION_OUTPUT" tailscale "$@" <<'PY'
+import subprocess
+import sys
 
-  if wait "$MUTATION_PID"; then
+timeout = int(sys.argv[1])
+output_path = sys.argv[2]
+command = sys.argv[3:]
+
+with open(output_path, "wb") as output:
+    try:
+        result = subprocess.run(
+            command,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        raise SystemExit(124)
+
+raise SystemExit(result.returncode)
+PY
+  then
     status=0
   else
     status=$?
   fi
   LAST_MUTATION_OUTPUT=$(cat "$MUTATION_OUTPUT")
   cleanup_mutation
-  [ -z "$LAST_MUTATION_OUTPUT" ] || printf '%s\n' "$LAST_MUTATION_OUTPUT"
+  if [ "$status" -eq 124 ]; then
+    [ -z "$LAST_MUTATION_OUTPUT" ] || printf '%s\n' "$LAST_MUTATION_OUTPUT" >&2
+    error "Tailscale Serve did not finish within ${timeout}s."
+    error "If HTTPS consent is pending, enable it using the URL above and rerun."
+  else
+    [ -z "$LAST_MUTATION_OUTPUT" ] || printf '%s\n' "$LAST_MUTATION_OUTPUT"
+  fi
   return "$status"
 }
 

--- a/scripts/server/tailscale-serve.sh
+++ b/scripts/server/tailscale-serve.sh
@@ -1,50 +1,79 @@
 #!/usr/bin/env sh
-# sbir-analytics/scripts/server/tailscale-serve.sh
-#
-# Manage the *only* ingress for the Mac mini server: persistent Tailscale Serve
-# routes (tailnet-only HTTPS, automatic TLS termination). See:
-#   https://tailscale.com/docs/features/tailscale-serve
-#
-# Routes managed here (and ONLY these):
-#   HTTPS 443  -> Dagster           127.0.0.1:${DAGSTER_PORT:-3000}
-#   HTTPS 8443 -> analytics API      127.0.0.1:${SBIR_ANALYTICS_API_PORT:-8010}
-#
-# Neo4j is NEVER served. Tailscale Funnel is NEVER enabled (tailnet-only).
-#
-# Subcommands:
-#   up      create the routes with --bg (persist across restarts).
-#           Refuses to replace an existing mapping on 443 or 8443.
-#   status  show current Serve configuration.
-#   down    remove ONLY the two routes above. Never runs the destructive
-#           global `tailscale serve reset`.
-#
-# Usage:
-#   scripts/server/tailscale-serve.sh up|status|down
+# Manage the two tailnet-only HTTPS routes for the Mac mini server profile.
 
 set -eu
 
-# Load .env.server tolerantly (values may contain spaces, e.g. cron strings).
 ENV_FILE="${SERVER_ENV_FILE:-.env.server}"
-if [ -f "$ENV_FILE" ]; then
-  set +eu
-  # shellcheck disable=SC1090
-  . "$ENV_FILE" 2>/dev/null || true
-  set -eu
-fi
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+# shellcheck source=scripts/server/env-file.sh
+. "$SCRIPT_DIR/env-file.sh"
+load_env_key DAGSTER_PORT
+load_env_key SBIR_ANALYTICS_API_PORT
 
 DAGSTER_PORT="${DAGSTER_PORT:-3000}"
 API_PORT="${SBIR_ANALYTICS_API_PORT:-8010}"
-LOOPBACK="127.0.0.1"
+DAGSTER_TARGET="http://127.0.0.1:${DAGSTER_PORT}"
+API_TARGET="http://127.0.0.1:${API_PORT}"
+STATE_HELPER="$SCRIPT_DIR/tailscale-route-state.py"
+MUTATION_PID=""
+MUTATION_OUTPUT=""
+LAST_MUTATION_OUTPUT=""
+PENDING_PORT=""
+PENDING_TARGET=""
+CREATED_443=0
+CREATED_8443=0
+ROLLBACK_ON_EXIT=0
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
 info()    { printf "${BLUE}➤${NC} %s\n" "$1"; }
 success() { printf "${GREEN}✓${NC} %s\n" "$1"; }
 warn()    { printf "${YELLOW}⚠${NC} %s\n" "$1"; }
-error()   { printf "${RED}✖${NC} %s\n" "$1"; }
+error()   { printf "${RED}✖${NC} %s\n" "$1" >&2; }
+
+stop_mutation() {
+  if [ -n "$MUTATION_PID" ] && kill -0 "$MUTATION_PID" 2>/dev/null; then
+    kill "$MUTATION_PID" 2>/dev/null || true
+    grace=0
+    while kill -0 "$MUTATION_PID" 2>/dev/null && [ "$grace" -lt 3 ]; do
+      sleep 1
+      grace=$((grace + 1))
+    done
+    if kill -0 "$MUTATION_PID" 2>/dev/null; then
+      kill -9 "$MUTATION_PID" 2>/dev/null || true
+    fi
+  fi
+  [ -z "$MUTATION_PID" ] || wait "$MUTATION_PID" 2>/dev/null || true
+}
+
+cleanup_mutation() {
+  stop_mutation
+  [ -z "$MUTATION_OUTPUT" ] || rm -f "$MUTATION_OUTPUT"
+  MUTATION_PID=""
+  MUTATION_OUTPUT=""
+}
+
+cleanup_all() {
+  cleanup_exit_status=$?
+  trap - EXIT HUP INT TERM
+  set +e
+  cleanup_mutation
+  if [ "$ROLLBACK_ON_EXIT" -eq 1 ]; then
+    rollback_transaction
+  fi
+  exit "$cleanup_exit_status"
+}
+trap cleanup_all EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 require_tailscale() {
   if ! command -v tailscale >/dev/null 2>&1; then
     error "tailscale CLI not found. Install Tailscale and sign in."
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    error "python3 is required for safe Tailscale Serve route inspection."
     exit 1
   fi
   if ! tailscale status >/dev/null 2>&1; then
@@ -53,76 +82,212 @@ require_tailscale() {
   fi
 }
 
-serve_json() { tailscale serve status --json 2>/dev/null || echo ''; }
+route_state() {
+  port="$1"
+  target="$2"
+  if ! json=$(tailscale serve status --json 2>/dev/null); then
+    error "Could not inspect the current Tailscale Serve configuration."
+    return 1
+  fi
+  printf '%s' "$json" | python3 "$STATE_HELPER" "$port" "$target"
+}
 
-port_mapped() {
-  # Returns 0 if the given HTTPS port already appears in Serve config.
-  printf '%s' "$(serve_json)" | grep -q "\"$1\""
+run_tailscale_mutation() {
+  timeout="${TAILSCALE_SERVE_TIMEOUT:-15}"
+  case "$timeout" in
+    ''|*[!0-9]*) error "TAILSCALE_SERVE_TIMEOUT must be a positive integer."; return 2 ;;
+  esac
+  [ "$timeout" -gt 0 ] || { error "TAILSCALE_SERVE_TIMEOUT must be positive."; return 2; }
+
+  LAST_MUTATION_OUTPUT=""
+  MUTATION_OUTPUT=$(mktemp "${TMPDIR:-/tmp}/sbir-tailscale-serve.XXXXXX")
+  tailscale "$@" >"$MUTATION_OUTPUT" 2>&1 &
+  MUTATION_PID=$!
+  elapsed=0
+  while kill -0 "$MUTATION_PID" 2>/dev/null; do
+    if [ "$elapsed" -ge "$timeout" ]; then
+      stop_mutation
+      LAST_MUTATION_OUTPUT=$(cat "$MUTATION_OUTPUT")
+      [ -z "$LAST_MUTATION_OUTPUT" ] || printf '%s\n' "$LAST_MUTATION_OUTPUT" >&2
+      error "Tailscale Serve did not finish within ${timeout}s."
+      error "If HTTPS consent is pending, enable it using the URL above and rerun."
+      cleanup_mutation
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+  done
+
+  if wait "$MUTATION_PID"; then
+    status=0
+  else
+    status=$?
+  fi
+  LAST_MUTATION_OUTPUT=$(cat "$MUTATION_OUTPUT")
+  cleanup_mutation
+  [ -z "$LAST_MUTATION_OUTPUT" ] || printf '%s\n' "$LAST_MUTATION_OUTPUT"
+  return "$status"
+}
+
+configure_route() {
+  port="$1"
+  target="$2"
+  PENDING_PORT="$port"
+  PENDING_TARGET="$target"
+  if ! run_tailscale_mutation serve --yes --bg "--https=$port" "$target"; then
+    case "$LAST_MUTATION_OUTPUT" in
+      *"Serve is not enabled"*|*"serve is not enabled"*)
+        error "Enable Tailscale Serve HTTPS using the consent URL above, then rerun this command."
+        ;;
+    esac
+    return 1
+  fi
+
+  state=$(route_state "$port" "$target") || return 1
+  if [ "$state" != "owned" ]; then
+    error "Tailscale did not install the expected HTTPS $port route."
+    return 1
+  fi
+  case "$port" in
+    443) CREATED_443=1 ;;
+    8443) CREATED_8443=1 ;;
+  esac
+  PENDING_PORT=""
+  PENDING_TARGET=""
+}
+
+remove_owned_route() {
+  port="$1"
+  target="$2"
+  state=$(route_state "$port" "$target") || return 1
+  if [ "$state" != "owned" ]; then
+    error "HTTPS $port changed ownership; refusing to remove it."
+    return 1
+  fi
+  run_tailscale_mutation serve --yes "--https=$port" off || return 1
+  state=$(route_state "$port" "$target") || return 1
+  if [ "$state" != "free" ]; then
+    error "HTTPS $port was not removed cleanly."
+    return 1
+  fi
+}
+
+rollback_expected_route() {
+  port="$1"
+  target="$2"
+  if ! state=$(route_state "$port" "$target"); then
+    warn "Could not inspect HTTPS $port during rollback; inspect it manually."
+    return 1
+  fi
+  case "$state" in
+    owned)
+      warn "Rolling back the newly-created HTTPS $port route."
+      remove_owned_route "$port" "$target" || {
+        warn "Could not roll back HTTPS $port; inspect it manually."
+        return 1
+      }
+      ;;
+    free) ;;
+    *) warn "HTTPS $port changed after creation; leaving it untouched." ;;
+  esac
+}
+
+rollback_transaction() {
+  # Disable recursive rollback before issuing any further Tailscale commands.
+  ROLLBACK_ON_EXIT=0
+  if [ -n "$PENDING_PORT" ]; then
+    rollback_expected_route "$PENDING_PORT" "$PENDING_TARGET" || true
+    PENDING_PORT=""
+    PENDING_TARGET=""
+  fi
+  if [ "$CREATED_8443" -eq 1 ]; then
+    rollback_expected_route 8443 "$API_TARGET" || true
+    CREATED_8443=0
+  fi
+  if [ "$CREATED_443" -eq 1 ]; then
+    rollback_expected_route 443 "$DAGSTER_TARGET" || true
+    CREATED_443=0
+  fi
 }
 
 cmd_up() {
   require_tailscale
+  state_443=$(route_state 443 "$DAGSTER_TARGET") || exit 1
+  state_8443=$(route_state 8443 "$API_TARGET") || exit 1
 
-  # Guard: never clobber an existing route on either port.
-  if port_mapped 443; then
-    error "Serve already maps HTTPS 443. Refusing to overwrite it."
-    error "  Inspect: tailscale serve status  •  Remove ours: $0 down"
-    exit 1
+  for pair in "443:$state_443" "8443:$state_8443"; do
+    port=${pair%%:*}
+    state=${pair#*:}
+    if [ "$state" = "occupied" ]; then
+      error "HTTPS $port has a different Serve owner or target; refusing to overwrite it."
+      error "Inspect with: tailscale serve status"
+      exit 1
+    fi
+  done
+
+  ROLLBACK_ON_EXIT=1
+  if [ "$state_443" = "free" ]; then
+    info "Configuring HTTPS 443 -> $DAGSTER_TARGET..."
+    configure_route 443 "$DAGSTER_TARGET" || exit 1
+  else
+    success "HTTPS 443 already has the expected Dagster route."
   fi
-  if port_mapped 8443; then
-    error "Serve already maps HTTPS 8443. Refusing to overwrite it."
-    error "  Inspect: tailscale serve status  •  Remove ours: $0 down"
-    exit 1
+
+  if [ "$state_8443" = "free" ]; then
+    info "Configuring HTTPS 8443 -> $API_TARGET..."
+    configure_route 8443 "$API_TARGET" || exit 1
+  else
+    success "HTTPS 8443 already has the expected API route."
   fi
 
-  info "Configuring persistent Tailscale Serve routes (--bg)..."
-  # 443 -> Dagster
-  tailscale serve --bg --https 443 "http://${LOOPBACK}:${DAGSTER_PORT}"
-  success "HTTPS 443  -> Dagster (${LOOPBACK}:${DAGSTER_PORT})"
-  # 8443 -> API
-  tailscale serve --bg --https 8443 "http://${LOOPBACK}:${API_PORT}"
-  success "HTTPS 8443 -> analytics API (${LOOPBACK}:${API_PORT})"
-
-  echo ""
-  info "Tailnet URLs (MagicDNS):"
-  host="$(tailscale status --json 2>/dev/null | grep -oE '"DNSName":"[^"]+"' | head -1 | cut -d'"' -f4 | sed 's/\.$//')"
+  host=$(tailscale status --json 2>/dev/null | python3 -c '
+import json, sys
+print(json.load(sys.stdin).get("Self", {}).get("DNSName", "").rstrip("."))
+' || true)
   if [ -n "$host" ]; then
-    echo "  Dagster: https://${host}/"
-    echo "  API:     https://${host}:8443/"
+    info "Dagster: https://${host}/"
+    info "API:     https://${host}:8443/"
   fi
-  warn "Tailscale Funnel is intentionally NOT enabled. These are tailnet-only."
+  ROLLBACK_ON_EXIT=0
+  success "Tailscale Serve routes are active (Funnel remains disabled)."
 }
 
 cmd_status() {
   require_tailscale
   info "Current Tailscale Serve configuration:"
-  tailscale serve status || true
+  tailscale serve status
 }
 
 cmd_down() {
   require_tailscale
-  info "Removing ONLY the SBIR server Serve routes (443, 8443)..."
-  # `--https <port> off` removes just that mapping; the global
-  # `tailscale serve reset` is intentionally NEVER used here.
-  if port_mapped 443; then
-    tailscale serve --https 443 off || warn "Could not remove HTTPS 443 route."
-    success "Removed HTTPS 443 route."
-  else
-    warn "No HTTPS 443 route to remove."
+  state_443=$(route_state 443 "$DAGSTER_TARGET") || exit 1
+  state_8443=$(route_state 8443 "$API_TARGET") || exit 1
+
+  if [ "$state_443" = "occupied" ] || [ "$state_8443" = "occupied" ]; then
+    error "A requested port has a different Serve owner or target; nothing was removed."
+    error "Inspect with: tailscale serve status"
+    exit 1
   fi
-  if port_mapped 8443; then
-    tailscale serve --https 8443 off || warn "Could not remove HTTPS 8443 route."
-    success "Removed HTTPS 8443 route."
+
+  if [ "$state_443" = "owned" ]; then
+    remove_owned_route 443 "$DAGSTER_TARGET"
+    success "Removed the SBIR HTTPS 443 route."
   else
-    warn "No HTTPS 8443 route to remove."
+    warn "No SBIR HTTPS 443 route to remove."
   fi
-  info "Left all other Tailscale configuration untouched."
+  if [ "$state_8443" = "owned" ]; then
+    remove_owned_route 8443 "$API_TARGET"
+    success "Removed the SBIR HTTPS 8443 route."
+  else
+    warn "No SBIR HTTPS 8443 route to remove."
+  fi
+  info "All other Tailscale configuration was left untouched."
 }
 
 case "${1:-}" in
-  up)     cmd_up ;;
+  up) cmd_up ;;
   status) cmd_status ;;
-  down)   cmd_down ;;
+  down) cmd_down ;;
   *)
     echo "Usage: $0 {up|status|down}" >&2
     exit 2

--- a/tests/unit/assets/test_asset_discovery.py
+++ b/tests/unit/assets/test_asset_discovery.py
@@ -1,5 +1,8 @@
 """Tests for automatic asset/job/sensor discovery helpers."""
 
+import os
+import subprocess
+import sys
 import types
 
 import pytest
@@ -71,3 +74,37 @@ def test_iter_public_sensors_returns_sensor_definitions():
 
     sensors = assets_pkg.iter_public_sensors()
     assert all(isinstance(sensor, SensorDefinition) for sensor in sensors)
+
+
+def test_light_mode_does_not_import_heavy_asset_families():
+    code = """
+import sys
+from dagster import Definitions
+import sbir_analytics.definitions as definitions
+
+Definitions.validate_loadable(definitions.defs)
+blocked = (
+    "sbir_analytics.assets.cet",
+    "sbir_analytics.assets.fiscal_assets",
+    "sbir_analytics.assets.sbir_fiscal_impacts",
+    "sbir_analytics.assets.modernbert",
+    "sbir_analytics.assets.uspto.ai_extraction",
+)
+leaked = sorted(
+    name
+    for name in sys.modules
+    if any(name == prefix or name.startswith(prefix + ".") for prefix in blocked)
+)
+assert not leaked, leaked
+"""
+    env = os.environ.copy()
+    env["DAGSTER_LOAD_HEAVY_ASSETS"] = "false"
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/unit/test_server_env_defaults.py
+++ b/tests/unit/test_server_env_defaults.py
@@ -14,17 +14,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 ENV_EXAMPLE = REPO_ROOT / ".env.server.example"
 SERVER_COMPOSE = REPO_ROOT / "docker-compose.server.yml"
 WAIT_FOR_SERVICE = REPO_ROOT / "scripts" / "docker" / "wait-for-service.sh"
+CI_COMPOSE = REPO_ROOT / "docker-compose.yml"
+BUILD_IMAGES_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "build-images.yml"
 
-# The runtime container only mounts select directories, so repo-root files like
-# .env.server.example are absent there. Skip rather than fail when it's missing.
-pytestmark = [
-    pytest.mark.fast,
-    pytest.mark.unit,
-    pytest.mark.skipif(
-        not ENV_EXAMPLE.is_file(),
-        reason=".env.server.example not present in this environment",
-    ),
-]
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
 
 
 def _parse_env(path: Path) -> dict[str, str]:
@@ -71,6 +64,7 @@ def test_storage_defaults_are_repo_local():
         "SERVER_LOGS_DIR",
         "SERVER_ARTIFACTS_DIR",
         "SERVER_NEO4J_DIR",
+        "SERVER_BACKUP_DIR",
     ):
         assert env[key].startswith("./"), f"{key} default should be repository-local"
 
@@ -107,3 +101,16 @@ def test_dependency_wait_contract_matches_slim_server_image():
     assert "command -v python" in wait_script
     assert 'HEALTH_PATH="${HEALTHCHECK_PATH:-/server_info}"' in dagster_healthcheck
     assert "dagster-daemon liveness-check" in daemon_healthcheck
+
+
+def test_ci_container_mounts_server_env_contract():
+    compose = CI_COMPOSE.read_text()
+    assert "./.env.server.example:/app/.env.server.example:ro" in compose
+
+
+def test_image_workflow_rebuilds_arm64_images_when_workflow_changes():
+    workflow = BUILD_IMAGES_WORKFLOW.read_text()
+    assert workflow.count("platforms: linux/amd64,linux/arm64") == 2
+    # One paths entry triggers the workflow and two filter entries ensure the
+    # base and ETL jobs actually run on the merge commit.
+    assert workflow.count("'.github/workflows/build-images.yml'") == 3

--- a/tests/unit/test_server_ops.py
+++ b/tests/unit/test_server_ops.py
@@ -39,7 +39,7 @@ def _run_script(
         env.pop(key, None)
     env.update(
         {
-            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "PATH": f"{bin_dir}:{Path(sys.executable).parent}:/usr/bin:/bin",
             "SERVER_ENV_FILE": str(env_file),
         }
     )

--- a/tests/unit/test_server_ops.py
+++ b/tests/unit/test_server_ops.py
@@ -1,0 +1,386 @@
+"""Behavioral tests for server backup, Tailscale, and startup helpers."""
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BACKUP = REPO_ROOT / "scripts" / "server" / "backup.sh"
+TAILSCALE = REPO_ROOT / "scripts" / "server" / "tailscale-serve.sh"
+
+
+def _executable(path: Path, body: str) -> None:
+    path.write_text(f"#!{sys.executable}\n" + textwrap.dedent(body))
+    path.chmod(0o755)
+
+
+def _run_script(
+    script: Path,
+    *args: str,
+    env_file: Path,
+    bin_dir: Path,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    for key in (
+        "SERVER_BACKUP_DIR",
+        "DAGSTER_PORT",
+        "SBIR_ANALYTICS_API_PORT",
+        "NEO4J_DATABASE",
+    ):
+        env.pop(key, None)
+    env.update(
+        {
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+            "SERVER_ENV_FILE": str(env_file),
+        }
+    )
+    env.update(extra_env or {})
+    return subprocess.run(
+        ["/bin/sh", str(script), *args],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+
+
+def _calls(path: Path) -> list[list[str]]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def _install_fake_docker(bin_dir: Path) -> None:
+    _executable(
+        bin_dir / "docker",
+        r"""
+        import json
+        import os
+        from pathlib import Path
+        import sys
+
+        args = sys.argv[1:]
+        with Path(os.environ["CALL_LOG"]).open("a") as stream:
+            stream.write(json.dumps(args) + "\n")
+
+        if "ps" in args:
+            print("fake-neo4j-id")
+        if "stop" in args and os.environ.get("FAIL_STOP") == "1":
+            raise SystemExit(7)
+        if "run" in args and "database" in args and "dump" in args:
+            if os.environ.get("FAIL_DUMP") == "1":
+                raise SystemExit(9)
+            mount = args[args.index("-v") + 1]
+            host_dir = Path(mount.rsplit(":/backup", 1)[0])
+            database = args[args.index("dump") + 1]
+            (host_dir / f"{database}.dump").write_bytes(b"valid dump")
+        """,
+    )
+
+
+def _call_index(calls: list[list[str]], *tokens: str) -> int:
+    return next(index for index, call in enumerate(calls) if all(token in call for token in tokens))
+
+
+def test_backup_honors_env_directory_and_runs_offline(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_docker(bin_dir)
+    call_log = tmp_path / "docker-calls"
+    backup_dir = tmp_path / "backup folder"
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(f"SERVER_BACKUP_DIR={backup_dir}\n")
+
+    result = _run_script(
+        BACKUP,
+        env_file=env_file,
+        bin_dir=bin_dir,
+        extra_env={"BACKUP_STAMP": "unit", "CALL_LOG": str(call_log)},
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (backup_dir / "neo4j-unit.dump").read_bytes() == b"valid dump"
+    assert (backup_dir / "neo4j-unit.dump").stat().st_mode & 0o777 == 0o600
+    calls = _calls(call_log)
+    assert _call_index(calls, "stop", "neo4j") < _call_index(calls, "database", "dump")
+    assert _call_index(calls, "database", "dump") < _call_index(calls, "up", "neo4j")
+
+
+def test_backup_failure_restarts_neo4j(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_docker(bin_dir)
+    call_log = tmp_path / "docker-calls"
+    backup_dir = tmp_path / "backups"
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(f"SERVER_BACKUP_DIR={backup_dir}\n")
+
+    result = _run_script(
+        BACKUP,
+        env_file=env_file,
+        bin_dir=bin_dir,
+        extra_env={
+            "BACKUP_STAMP": "unit",
+            "CALL_LOG": str(call_log),
+            "FAIL_DUMP": "1",
+        },
+    )
+
+    assert result.returncode != 0
+    calls = _calls(call_log)
+    assert _call_index(calls, "database", "dump") < _call_index(calls, "up", "neo4j")
+
+
+def test_backup_failed_stop_still_attempts_neo4j_recovery(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_docker(bin_dir)
+    call_log = tmp_path / "docker-calls"
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(f"SERVER_BACKUP_DIR={tmp_path / 'backups'}\n")
+
+    result = _run_script(
+        BACKUP,
+        env_file=env_file,
+        bin_dir=bin_dir,
+        extra_env={
+            "BACKUP_STAMP": "unit",
+            "CALL_LOG": str(call_log),
+            "FAIL_STOP": "1",
+        },
+    )
+
+    assert result.returncode != 0
+    calls = _calls(call_log)
+    assert _call_index(calls, "stop", "neo4j") < _call_index(calls, "up", "neo4j")
+
+
+def test_backup_refuses_concurrent_operation(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_docker(bin_dir)
+    backup_dir = tmp_path / "backups"
+    backup_dir.mkdir()
+    (backup_dir / ".neo4j-backup.lock").mkdir()
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(f"SERVER_BACKUP_DIR={backup_dir}\n")
+
+    result = _run_script(
+        BACKUP,
+        env_file=env_file,
+        bin_dir=bin_dir,
+        extra_env={"BACKUP_STAMP": "unit", "CALL_LOG": str(tmp_path / "calls")},
+    )
+
+    assert result.returncode != 0
+    assert "lock" in (result.stdout + result.stderr).lower()
+
+
+def test_backup_refuses_missing_external_volume(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_docker(bin_dir)
+    missing = f"/Volumes/sbir-test-not-mounted-{os.getpid()}/backups"
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(f"SERVER_BACKUP_DIR={missing}\n")
+
+    result = _run_script(
+        BACKUP,
+        env_file=env_file,
+        bin_dir=bin_dir,
+        extra_env={"BACKUP_STAMP": "unit", "CALL_LOG": str(tmp_path / "calls")},
+    )
+
+    assert result.returncode != 0
+    assert "actively mounted" in (result.stdout + result.stderr)
+
+
+def _install_fake_tailscale(bin_dir: Path) -> None:
+    _executable(
+        bin_dir / "tailscale",
+        r"""
+        import json
+        import os
+        from pathlib import Path
+        import sys
+        import time
+
+        args = sys.argv[1:]
+        state_path = Path(os.environ["STATE_FILE"])
+        with Path(os.environ["CALL_LOG"]).open("a") as stream:
+            stream.write(json.dumps(args) + "\n")
+
+        if args == ["status"]:
+            raise SystemExit(0)
+        if args == ["status", "--json"]:
+            print(json.dumps({"Self": {"DNSName": "node.test.ts.net."}}))
+            raise SystemExit(0)
+        if args[:2] == ["serve", "status"]:
+            print(state_path.read_text())
+            raise SystemExit(0)
+
+        port_arg = next(item for item in args if item.startswith("--https="))
+        port = port_arg.split("=", 1)[1]
+        if port == "443" and os.environ.get("HANG_443") == "1" and "off" not in args:
+            print("Serve is not enabled on your tailnet: https://example.test/consent", flush=True)
+            time.sleep(60)
+        if port == "8443" and os.environ.get("FAIL_8443") == "1" and "off" not in args:
+            print("forced failure", file=sys.stderr)
+            raise SystemExit(8)
+
+        state = json.loads(state_path.read_text())
+        host_key = f"node.test.ts.net:{port}"
+        if "off" in args:
+            state.get("TCP", {}).pop(port, None)
+            state.get("Web", {}).pop(host_key, None)
+            state.get("AllowFunnel", {}).pop(host_key, None)
+        else:
+            target = args[-1]
+            state.setdefault("TCP", {})[port] = {"HTTPS": True}
+            state.setdefault("Web", {})[host_key] = {
+                "Handlers": {"/": {"Proxy": target}}
+            }
+        state_path.write_text(json.dumps(state))
+        if (
+            port == "8443"
+            and os.environ.get("APPLY_THEN_FAIL_8443") == "1"
+            and "off" not in args
+        ):
+            print("forced late failure", file=sys.stderr)
+            raise SystemExit(8)
+        """,
+    )
+
+
+def _serve_state(port: str, target: str) -> dict[str, object]:
+    host_key = f"node.test.ts.net:{port}"
+    return {
+        "TCP": {port: {"HTTPS": True}},
+        "Web": {host_key: {"Handlers": {"/": {"Proxy": target}}}},
+    }
+
+
+def _run_tailscale(
+    tmp_path: Path,
+    command: str,
+    state: dict[str, object],
+    *,
+    fail_8443: bool = False,
+    apply_then_fail_8443: bool = False,
+    hang_443: bool = False,
+) -> tuple[subprocess.CompletedProcess[str], dict[str, object], list[list[str]]]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _install_fake_tailscale(bin_dir)
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps(state))
+    call_log = tmp_path / "tailscale-calls"
+    env_file = tmp_path / ".env.server"
+    env_file.write_text("DAGSTER_PORT=3000\nSBIR_ANALYTICS_API_PORT=8010\n")
+    extra = {"CALL_LOG": str(call_log), "STATE_FILE": str(state_file)}
+    if fail_8443:
+        extra["FAIL_8443"] = "1"
+    if apply_then_fail_8443:
+        extra["APPLY_THEN_FAIL_8443"] = "1"
+    if hang_443:
+        extra["HANG_443"] = "1"
+        extra["TAILSCALE_SERVE_TIMEOUT"] = "1"
+    result = _run_script(
+        TAILSCALE,
+        command,
+        env_file=env_file,
+        bin_dir=bin_dir,
+        extra_env=extra,
+    )
+    return result, json.loads(state_file.read_text()), _calls(call_log)
+
+
+def test_tailscale_down_removes_only_owned_route(tmp_path):
+    result, state, calls = _run_tailscale(
+        tmp_path,
+        "down",
+        _serve_state("443", "http://127.0.0.1:3000"),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert state.get("TCP", {}) == {}
+    assert any("--https=443" in call and "off" in call for call in calls)
+
+
+def test_tailscale_down_refuses_foreign_route(tmp_path):
+    original = _serve_state("443", "http://127.0.0.1:9999")
+    result, state, calls = _run_tailscale(tmp_path, "down", original)
+
+    assert result.returncode != 0
+    assert state == original
+    assert not any("off" in call for call in calls)
+
+
+def test_tailscale_down_refuses_funnel_enabled_route(tmp_path):
+    original = _serve_state("443", "http://127.0.0.1:3000")
+    original["AllowFunnel"] = {"node.test.ts.net:443": True}
+
+    result, state, calls = _run_tailscale(tmp_path, "down", original)
+
+    assert result.returncode != 0
+    assert state == original
+    assert not any("off" in call for call in calls)
+
+
+def test_tailscale_up_rolls_back_new_route_if_second_fails(tmp_path):
+    result, state, calls = _run_tailscale(tmp_path, "up", {}, fail_8443=True)
+
+    assert result.returncode != 0
+    assert state.get("TCP", {}) == {}
+    configure_443 = _call_index(calls, "serve", "--yes", "--https=443")
+    configure_8443 = _call_index(calls, "serve", "--yes", "--https=8443")
+    remove_443 = next(
+        index for index, call in enumerate(calls) if "--https=443" in call and "off" in call
+    )
+    assert configure_443 < configure_8443 < remove_443
+
+
+def test_tailscale_disabled_consent_times_out_without_mutation(tmp_path):
+    result, state, _calls = _run_tailscale(tmp_path, "up", {}, hang_443=True)
+
+    assert result.returncode != 0
+    assert state == {}
+    assert "consent" in (result.stdout + result.stderr).lower()
+
+
+def test_tailscale_up_rolls_back_route_applied_before_cli_failure(tmp_path):
+    result, state, calls = _run_tailscale(
+        tmp_path,
+        "up",
+        {},
+        apply_then_fail_8443=True,
+    )
+
+    assert result.returncode != 0
+    assert state.get("TCP", {}) == {}
+    assert any("--https=8443" in call and "off" in call for call in calls)
+    assert any("--https=443" in call and "off" in call for call in calls)
+
+
+def test_server_up_runs_preflight_and_native_base_fallback_first(tmp_path):
+    result = subprocess.run(
+        ["make", "-n", "server-up", f"SERVER_ENV_FILE={tmp_path / '.env.server'}"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    output = result.stdout
+    assert output.index("check-prerequisites.sh") < output.index("docker pull")
+    assert output.index("docker pull") < output.index("Dockerfile.python-base")
+    assert output.index("Dockerfile.python-base") < output.index("--profile server up -d --build")
+    assert "--wait --wait-timeout 300" in output

--- a/tests/unit/test_server_prerequisites.py
+++ b/tests/unit/test_server_prerequisites.py
@@ -13,14 +13,7 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "server" / "check-prerequisites.sh"
 
-pytestmark = [
-    pytest.mark.fast,
-    pytest.mark.unit,
-    pytest.mark.skipif(
-        not SCRIPT.is_file(),
-        reason="server prerequisite script not present in this environment",
-    ),
-]
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
 
 GOOD_ENV = """
 SERVER_LOOPBACK=127.0.0.1
@@ -71,3 +64,28 @@ def test_rejects_missing_api_token(tmp_path):
     env_file.write_text("SERVER_LOOPBACK=127.0.0.1\nNEO4J_PASSWORD=a-real-password\n")
     result = _run(env_file)
     assert result.returncode == 1
+
+
+def test_env_file_is_parsed_as_data_not_executed(tmp_path):
+    marker = tmp_path / "executed"
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(
+        GOOD_ENV
+        + f"DAGSTER_PORT=$(touch {marker})\n"
+        + "SBIR_ETL__DAGSTER__SCHEDULES__WEEKLY_CORE_REFRESH_JOB=15 3 * * *\n"
+    )
+
+    result = _run(env_file)
+
+    assert result.returncode != 0
+    assert not marker.exists()
+
+
+def test_rejects_duplicate_allowlisted_key(tmp_path):
+    env_file = tmp_path / ".env.server"
+    env_file.write_text(GOOD_ENV + "NEO4J_PASSWORD=change_me\n")
+
+    result = _run(env_file)
+
+    assert result.returncode != 0
+    assert "defined more than once" in (result.stdout + result.stderr)

--- a/tests/unit/test_server_prerequisites.py
+++ b/tests/unit/test_server_prerequisites.py
@@ -89,3 +89,30 @@ def test_rejects_duplicate_allowlisted_key(tmp_path):
 
     assert result.returncode != 0
     assert "defined more than once" in (result.stdout + result.stderr)
+
+
+def test_missing_env_in_full_mode_reports_summary_without_undefined_helpers(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    for command in ("docker", "tailscale"):
+        executable = bin_dir / command
+        executable.write_text("#!/bin/sh\nexit 1\n")
+        executable.chmod(0o755)
+
+    missing_env = tmp_path / ".env.server"
+    result = subprocess.run(
+        ["sh", str(SCRIPT)],
+        cwd=tmp_path,
+        env={
+            "SERVER_ENV_FILE": str(missing_env),
+            "PATH": f"{bin_dir}:/usr/bin:/bin",
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 1
+    assert f"{missing_env} not found" in output
+    assert "error(s)" in output
+    assert "path_has_active_external_volume: not found" not in output

--- a/tests/unit/test_server_runtime_contract.py
+++ b/tests/unit/test_server_runtime_contract.py
@@ -1,0 +1,119 @@
+"""Regression tests for the server container runtime contract."""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_COMPOSE = REPO_ROOT / "docker-compose.server.yml"
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+SERVER_WORKSPACE = REPO_ROOT / "workspace.server.yaml"
+DAGSTER_HEALTHCHECK = REPO_ROOT / "scripts" / "docker" / "healthcheck" / "dagster.sh"
+DAEMON_HEALTHCHECK = REPO_ROOT / "scripts" / "docker" / "healthcheck" / "daemon.sh"
+ENTRYPOINT = REPO_ROOT / "scripts" / "docker" / "entrypoint.sh"
+
+
+def test_server_ports_are_unconditionally_loopback_only():
+    compose = SERVER_COMPOSE.read_text()
+    assert "${SERVER_LOOPBACK" not in compose
+    assert '"127.0.0.1:${NEO4J_HTTP_PORT:-7474}:7474"' in compose
+    assert '"127.0.0.1:${NEO4J_BOLT_PORT:-7687}:7687"' in compose
+    assert '"127.0.0.1:${DAGSTER_PORT:-3000}:3000"' in compose
+    assert '"127.0.0.1:${SBIR_ANALYTICS_API_PORT:-8010}' in compose
+
+
+def test_neo4j_runtime_uses_valid_plugin_and_neutral_health_variables():
+    compose = SERVER_COMPOSE.read_text()
+    assert "'NEO4J_PLUGINS=${NEO4J_PLUGINS:-[\"apoc\"]}'" in compose
+    assert "SBIR_SERVER_NEO4J_USER=${NEO4J_USER:-neo4j}" in compose
+    assert "SBIR_SERVER_NEO4J_PASSWORD=${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}" in compose
+    assert "$${NEO4J_PASSWORD}" not in compose
+
+
+def test_dagster_daemon_waits_on_webserver_container():
+    compose = SERVER_COMPOSE.read_text()
+    daemon = compose.split("  dagster-daemon:", 1)[1].split("\nvolumes:", 1)[0]
+    assert "DAGSTER_HOST: dagster-webserver" in daemon
+    assert "HEALTHCHECK_PORT: 3000" in daemon
+    assert "dagster-daemon run -w /app/workspace.server.yaml" in daemon
+
+
+def test_dagster_uses_shared_internal_code_server():
+    compose = SERVER_COMPOSE.read_text()
+    workspace = SERVER_WORKSPACE.read_text()
+    code_server = compose.split("  dagster-code-server:", 1)[1].split("\n  analytics-api:", 1)[0]
+
+    assert "host: dagster-code-server" in workspace
+    assert "port: 4000" in workspace
+    assert "COPY workspace.server.yaml /app/workspace.server.yaml" in DOCKERFILE.read_text()
+    assert "\n    ports:" not in code_server
+    assert 'expose:\n      - "4000"' in code_server
+    assert "grpc-health-check" in code_server
+
+
+def test_dagster_execution_memory_belongs_to_code_server():
+    compose = SERVER_COMPOSE.read_text()
+    code_server = compose.split("  dagster-code-server:", 1)[1].split("\n  analytics-api:", 1)[0]
+    daemon = compose.split("  dagster-daemon:", 1)[1].split("\nvolumes:", 1)[0]
+
+    assert "memory: 3G" in code_server
+    assert "memory: 768M" in daemon
+
+
+def test_dagster_healthcheck_preserves_path_and_calls_configured_url(tmp_path):
+    calls = tmp_path / "curl-calls"
+    fake_curl = tmp_path / "curl"
+    fake_curl.write_text('#!/bin/sh\nprintf "%s\\n" "$*" > "$CURL_CALLS"\n')
+    fake_curl.chmod(0o755)
+
+    result = subprocess.run(
+        ["/bin/bash", str(DAGSTER_HEALTHCHECK)],
+        env={
+            "PATH": str(tmp_path),
+            "CURL_CALLS": str(calls),
+            "HEALTHCHECK_HOST": "dagster.test",
+            "HEALTHCHECK_PORT": "4321",
+            "HEALTHCHECK_PATH": "/ready",
+        },
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "http://dagster.test:4321/ready" in calls.read_text()
+
+
+def test_entrypoint_has_python_tcp_probe_fallback():
+    entrypoint = ENTRYPOINT.read_text()
+    neo4j_wait = entrypoint.split("wait_for_neo4j()", 1)[1].split("wait_for_dagster_web()", 1)[0]
+    assert "socket.create_connection" in entrypoint
+    assert 'probe_tcp "$HOST" "$PORT"' in neo4j_wait
+    assert "WAIT_SCRIPT=" not in neo4j_wait
+
+
+def test_entrypoint_only_drops_privileges_when_sbir_user_exists():
+    entrypoint = ENTRYPOINT.read_text()
+    prefix_function = entrypoint.split("_make_exec_prefix()", 1)[1].split("probe_tcp()", 1)[0]
+    assert "id sbir" in prefix_function
+    assert "continuing as root" in prefix_function
+
+
+def test_daemon_healthcheck_uses_heartbeat_liveness_without_procps(tmp_path):
+    calls = tmp_path / "daemon-calls"
+    fake_daemon = tmp_path / "dagster-daemon"
+    fake_daemon.write_text(f'#!/bin/sh\nprintf "%s\\n" "$*" > "{calls}"\n')
+    fake_daemon.chmod(0o755)
+
+    result = subprocess.run(
+        ["/bin/bash", str(DAEMON_HEALTHCHECK)],
+        env={"PATH": f"{tmp_path}:/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert calls.read_text().strip() == "liveness-check"

--- a/tests/unit/test_server_schedule_gating.py
+++ b/tests/unit/test_server_schedule_gating.py
@@ -85,13 +85,19 @@ def test_daily_all_assets_running_by_default(monkeypatch):
     assert daily.default_status == DefaultScheduleStatus.RUNNING
 
 
-def test_server_definitions_resolve_without_heavy_assets(monkeypatch):
-    """Every registered server job must resolve against the gated asset graph."""
+@pytest.mark.parametrize(
+    ("load_heavy", "heavy_jobs_present"),
+    [("false", False), ("true", True)],
+)
+def test_definitions_are_loadable_with_matching_jobs(monkeypatch, load_heavy, heavy_jobs_present):
+    defs = _reload_definitions(monkeypatch, DAGSTER_LOAD_HEAVY_ASSETS=load_heavy)
 
-    defs = _reload_definitions(monkeypatch, DAGSTER_LOAD_HEAVY_ASSETS="false")
-
-    defs.defs.get_repository_def().load_all_definitions()
-    assert "fiscal_returns_mvp_job" not in defs.auto_jobs
-    assert "cet_full_pipeline_job" not in defs.auto_jobs
-    assert "modernbert_job" not in defs.auto_jobs
-    assert "uspto_ai_extraction_job" not in defs.auto_jobs
+    dagster.Definitions.validate_loadable(defs.defs)
+    job_names = set(defs.auto_jobs)
+    for job_name in (
+        "cet_full_pipeline_job",
+        "fiscal_returns_mvp_job",
+        "modernbert_job",
+        "uspto_ai_extraction_job",
+    ):
+        assert (job_name in job_names) is heavy_jobs_present

--- a/workspace.server.yaml
+++ b/workspace.server.yaml
@@ -1,0 +1,5 @@
+load_from:
+  - grpc_server:
+      host: dagster-code-server
+      port: 4000
+      location_name: sbir-analytics-production


### PR DESCRIPTION
Follow-up to #440.

## Summary

- Run Dagster webserver and daemon against one stable internal gRPC code server, with memory limits applied to the processes that actually execute ETL work.
- Bind every host-published service to loopback and harden Tailscale Serve setup with route ownership checks, bounded consent handling, and rollback.
- Make server startup, environment parsing, SSD validation, and offline Neo4j backups fail safely.
- Add multi-architecture image builds, lightweight Dagster asset discovery, deployment documentation, and regression coverage.

## Validation

- Full unit suite: 4,702 passed, 7 skipped.
- Focused server-runtime suite: 52 passed.
- Ruff check and format check passed.
- Mypy passed for the four changed Python modules.
- Shell syntax and Docker Compose configuration checks passed.
- Live five-service Docker smoke test passed: all services healthy, loopback-only host ports, Dagster and API endpoints responsive.
- Stable code server soaked for more than one hour without heartbeat respawn.
- Live offline Neo4j backup completed successfully, restored service health, and produced a mode-0600 archive.
- Tailscale Serve consent path timed out at the configured 15 seconds without mutating route state.

## Deployment notes

- Tailscale Serve still requires the one-time tailnet administrator consent flow before this node can publish routes.
- The test device Docker VM exposed 7,994 MiB while the recommended allocation is 8,192 MiB, so preflight reports a warning.