### PR TITLE
refactor(reporting): centralize analyzer lifecycle

### DIFF
--- a/sbir_etl/utils/reporting/analyzers/base_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/base_analyzer.py
@@ -4,9 +4,10 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import Any
 
+from loguru import logger
 from pydantic import BaseModel
 
-from sbir_etl.models.quality import ModuleReport
+from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics, ModuleReport
 
 
 class AnalysisInsight(BaseModel):
@@ -25,6 +26,16 @@ class AnalysisInsight(BaseModel):
 class ModuleAnalyzer(ABC):
     """Base class for module-specific statistical analyzers."""
 
+    stage = ""
+    primary_data_key = ""
+    total_data_key: str | None = None
+    processing_keys = ("", "", "")
+    duration_data_key: str | None = None
+    analysis_label = ""
+    start_analysis_label: str | None = None
+    missing_data_warning = ""
+    missing_data_error = ""
+
     def __init__(self, module_name: str, config: dict[str, Any] | None = None):
         """Initialize the analyzer.
 
@@ -36,9 +47,8 @@ class ModuleAnalyzer(ABC):
         self.config = config or {}
         self.insights: list[AnalysisInsight] = []
 
-    @abstractmethod
     def analyze(self, module_data: dict[str, Any]) -> ModuleReport:
-        """Analyze module data and generate a comprehensive report.
+        """Run the shared analyzer lifecycle around domain-specific calculations.
 
         Args:
             module_data: Module-specific data to analyze
@@ -46,7 +56,82 @@ class ModuleAnalyzer(ABC):
         Returns:
             ModuleReport with analysis results
         """
-        pass
+        start_label = self.start_analysis_label or self.analysis_label
+        logger.info(f"Starting {start_label} analysis")
+
+        primary_data = module_data.get(self.primary_data_key)
+        run_context = module_data.get("run_context", {})
+
+        if primary_data is None:
+            logger.warning(self.missing_data_warning)
+            return self._create_empty_report(run_context)
+
+        key_metrics = self.get_key_metrics(module_data)
+        insights = self.generate_insights(module_data)
+        data_hygiene = self._calculate_report_data_hygiene(module_data)
+        changes_summary = self._calculate_report_changes_summary(module_data)
+
+        total_records = self._get_total_records(module_data)
+        records_processed, records_failed, duration_seconds = self._get_processing_metrics(
+            module_data, total_records
+        )
+
+        report = self.create_module_report(
+            run_id=run_context.get("run_id", "unknown"),
+            stage=self.stage,
+            total_records=total_records,
+            records_processed=records_processed,
+            records_failed=records_failed,
+            duration_seconds=duration_seconds,
+            module_metrics=key_metrics,
+            data_hygiene=data_hygiene,
+            changes_summary=changes_summary,
+        )
+
+        logger.info(f"{self.analysis_label} analysis complete: {len(insights)} insights generated")
+        return report
+
+    def _get_total_records(self, module_data: dict[str, Any]) -> int:
+        """Return the domain's report denominator."""
+        total_data = module_data.get(self.total_data_key or self.primary_data_key)
+        return len(total_data) if total_data is not None else 0
+
+    def _get_processing_metrics(
+        self, module_data: dict[str, Any], total_records: int
+    ) -> tuple[int, int, float]:
+        """Read shared processing counts while preserving domain-specific keys."""
+        results_key, processed_key, failed_key = self.processing_keys
+        processing_results = module_data.get(results_key, {})
+        duration_results = module_data.get(self.duration_data_key or results_key, {})
+        return (
+            processing_results.get(processed_key, total_records),
+            processing_results.get(failed_key, 0),
+            duration_results.get("duration_seconds", 0.0),
+        )
+
+    def _calculate_report_data_hygiene(
+        self, module_data: dict[str, Any]
+    ) -> DataHygieneMetrics | None:
+        """Calculate domain-specific hygiene for the shared lifecycle."""
+        raise NotImplementedError
+
+    def _calculate_report_changes_summary(
+        self, module_data: dict[str, Any]
+    ) -> ChangesSummary | None:
+        """Calculate domain-specific changes for the shared lifecycle."""
+        raise NotImplementedError
+
+    def _create_empty_report(self, run_context: dict[str, Any]) -> ModuleReport:
+        """Create a standardized report when the primary input is missing."""
+        return self.create_module_report(
+            run_id=run_context.get("run_id", "unknown"),
+            stage=self.stage,
+            total_records=0,
+            records_processed=0,
+            records_failed=0,
+            duration_seconds=0.0,
+            module_metrics={"error": self.missing_data_error},
+        )
 
     @abstractmethod
     def get_key_metrics(self, module_data: dict[str, Any]) -> dict[str, Any]:

--- a/sbir_etl/utils/reporting/analyzers/base_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/base_analyzer.py
@@ -109,17 +109,17 @@ class ModuleAnalyzer(ABC):
             duration_results.get("duration_seconds", 0.0),
         )
 
+    @abstractmethod
     def _calculate_report_data_hygiene(
         self, module_data: dict[str, Any]
     ) -> DataHygieneMetrics | None:
         """Calculate domain-specific hygiene for the shared lifecycle."""
-        raise NotImplementedError
 
+    @abstractmethod
     def _calculate_report_changes_summary(
         self, module_data: dict[str, Any]
     ) -> ChangesSummary | None:
         """Calculate domain-specific changes for the shared lifecycle."""
-        raise NotImplementedError
 
     def _create_empty_report(self, run_context: dict[str, Any]) -> ModuleReport:
         """Create a standardized report when the primary input is missing."""

--- a/sbir_etl/utils/reporting/analyzers/base_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/base_analyzer.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any
+from typing import Any, ClassVar
 
 from loguru import logger
 from pydantic import BaseModel
@@ -26,15 +26,15 @@ class AnalysisInsight(BaseModel):
 class ModuleAnalyzer(ABC):
     """Base class for module-specific statistical analyzers."""
 
-    stage = ""
-    primary_data_key = ""
-    total_data_key: str | None = None
-    processing_keys = ("", "", "")
-    duration_data_key: str | None = None
-    analysis_label = ""
-    start_analysis_label: str | None = None
-    missing_data_warning = ""
-    missing_data_error = ""
+    stage: ClassVar[str]
+    primary_data_key: ClassVar[str]
+    total_data_key: ClassVar[str | None] = None
+    processing_keys: ClassVar[tuple[str, str, str]]
+    duration_data_key: ClassVar[str | None] = None
+    analysis_label: ClassVar[str]
+    start_analysis_label: ClassVar[str | None] = None
+    missing_data_warning: ClassVar[str]
+    missing_data_error: ClassVar[str]
 
     def __init__(self, module_name: str, config: dict[str, Any] | None = None):
         """Initialize the analyzer.

--- a/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
@@ -9,14 +9,20 @@ across CET taxonomy areas.
 from typing import Any
 
 import pandas as pd
-from loguru import logger
 
-from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics, ModuleReport
+from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics
 from sbir_etl.utils.reporting.analyzers.base_analyzer import AnalysisInsight, ModuleAnalyzer
 
 
 class CetClassificationAnalyzer(ModuleAnalyzer):
     """Analyzer for CET classification operations and taxonomy coverage."""
+
+    stage = "transform"
+    primary_data_key = "classified_df"
+    processing_keys = ("classification_results", "classified_records", "failed_records")
+    analysis_label = "CET classification"
+    missing_data_warning = "No classified DataFrame provided for CET analysis"
+    missing_data_error = "No classified DataFrame available"
 
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize CET classification analyzer.
@@ -64,64 +70,6 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
 
         # Classification confidence bands
         self.confidence_bands = {"high": (70, 100), "medium": (40, 69), "low": (0, 39)}
-
-    def analyze(self, module_data: dict[str, Any]) -> ModuleReport:
-        """Analyze CET classification data and generate comprehensive report.
-
-        Args:
-            module_data: Dictionary containing:
-                - classified_df: CET classified DataFrame
-                - classification_results: Classification operation results
-                - taxonomy_data: CET taxonomy information
-                - run_context: Pipeline run context
-
-        Returns:
-            ModuleReport with CET classification analysis
-        """
-        logger.info("Starting CET classification analysis")
-
-        classified_df = module_data.get("classified_df")
-        classification_results = module_data.get("classification_results", {})
-        module_data.get("taxonomy_data", {})
-        run_context = module_data.get("run_context", {})
-
-        if classified_df is None:
-            logger.warning("No classified DataFrame provided for CET analysis")
-            return self._create_empty_report(run_context)
-
-        # Calculate key metrics
-        key_metrics = self.get_key_metrics(module_data)
-
-        # Generate insights
-        insights = self.generate_insights(module_data)
-
-        # Calculate data hygiene metrics
-        data_hygiene = self._calculate_data_hygiene(classified_df, classification_results)
-
-        # Calculate changes summary
-        changes_summary = self._calculate_changes_summary(classified_df, classification_results)
-
-        # Extract processing metrics
-        total_records = len(classified_df) if classified_df is not None else 0
-        records_processed = classification_results.get("classified_records", total_records)
-        records_failed = classification_results.get("failed_records", 0)
-        duration_seconds = classification_results.get("duration_seconds", 0.0)
-
-        # Create module report
-        report = self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="transform",
-            total_records=total_records,
-            records_processed=records_processed,
-            records_failed=records_failed,
-            duration_seconds=duration_seconds,
-            module_metrics=key_metrics,
-            data_hygiene=data_hygiene,
-            changes_summary=changes_summary,
-        )
-
-        logger.info(f"CET classification analysis complete: {len(insights)} insights generated")
-        return report
 
     def get_key_metrics(self, module_data: dict[str, Any]) -> dict[str, Any]:
         """Extract key metrics from CET classification data.
@@ -729,21 +677,14 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
             enrichment_sources={"cet_classification": classified_records},
         )
 
-    def _create_empty_report(self, run_context: dict[str, Any]) -> ModuleReport:
-        """Create an empty report when no data is available.
+    def _calculate_report_data_hygiene(self, module_data: dict[str, Any]) -> DataHygieneMetrics:
+        """Calculate hygiene from classifications and their results."""
+        return self._calculate_data_hygiene(
+            module_data[self.primary_data_key], module_data.get("classification_results", {})
+        )
 
-        Args:
-            run_context: Pipeline run context
-
-        Returns:
-            Empty ModuleReport
-        """
-        return self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="transform",
-            total_records=0,
-            records_processed=0,
-            records_failed=0,
-            duration_seconds=0.0,
-            module_metrics={"error": "No classified DataFrame available"},
+    def _calculate_report_changes_summary(self, module_data: dict[str, Any]) -> ChangesSummary:
+        """Calculate classification changes for the shared lifecycle."""
+        return self._calculate_changes_summary(
+            module_data[self.primary_data_key], module_data.get("classification_results", {})
         )

--- a/sbir_etl/utils/reporting/analyzers/patent_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/patent_analyzer.py
@@ -8,14 +8,22 @@ established), and data quality scores for patent records.
 from typing import Any
 
 import pandas as pd
-from loguru import logger
 
-from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics, ModuleReport
+from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics
 from sbir_etl.utils.reporting.analyzers.base_analyzer import AnalysisInsight, ModuleAnalyzer
 
 
 class PatentAnalysisAnalyzer(ModuleAnalyzer):
     """Analyzer for patent validation and loading operations."""
+
+    stage = "load"
+    primary_data_key = "patent_df"
+    processing_keys = ("validation_results", "valid_records", "invalid_records")
+    duration_data_key = "loading_results"
+    analysis_label = "Patent"
+    start_analysis_label = "patent"
+    missing_data_warning = "No patent DataFrame provided for analysis"
+    missing_data_error = "No patent DataFrame available"
 
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize patent analysis analyzer.
@@ -50,66 +58,6 @@ class PatentAnalysisAnalyzer(ModuleAnalyzer):
         # (org_patent_*) and :Individual (ind_patent_*) nodes, not :PatentEntity/:Company.
         self.node_types = ["Patent", "PatentAssignment", "Organization", "Individual"]
         self.relationship_types = ["ASSIGNED_VIA", "ASSIGNED_FROM", "ASSIGNED_TO", "OWNS"]
-
-    def analyze(self, module_data: dict[str, Any]) -> ModuleReport:
-        """Analyze patent data and generate comprehensive report.
-
-        Args:
-            module_data: Dictionary containing:
-                - patent_df: Patent DataFrame
-                - validation_results: Patent validation results
-                - loading_results: Neo4j loading results
-                - neo4j_stats: Neo4j database statistics
-                - run_context: Pipeline run context
-
-        Returns:
-            ModuleReport with patent analysis results
-        """
-        logger.info("Starting patent analysis")
-
-        patent_df = module_data.get("patent_df")
-        validation_results = module_data.get("validation_results", {})
-        loading_results = module_data.get("loading_results", {})
-        neo4j_stats = module_data.get("neo4j_stats", {})
-        run_context = module_data.get("run_context", {})
-
-        if patent_df is None:
-            logger.warning("No patent DataFrame provided for analysis")
-            return self._create_empty_report(run_context)
-
-        # Calculate key metrics
-        key_metrics = self.get_key_metrics(module_data)
-
-        # Generate insights
-        insights = self.generate_insights(module_data)
-
-        # Calculate data hygiene metrics
-        data_hygiene = self._calculate_data_hygiene(patent_df, validation_results)
-
-        # Calculate changes summary (for loading operations)
-        changes_summary = self._calculate_changes_summary(loading_results, neo4j_stats)
-
-        # Extract processing metrics
-        total_records = len(patent_df) if patent_df is not None else 0
-        records_processed = validation_results.get("valid_records", total_records)
-        records_failed = validation_results.get("invalid_records", 0)
-        duration_seconds = loading_results.get("duration_seconds", 0.0)
-
-        # Create module report
-        report = self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="load",
-            total_records=total_records,
-            records_processed=records_processed,
-            records_failed=records_failed,
-            duration_seconds=duration_seconds,
-            module_metrics=key_metrics,
-            data_hygiene=data_hygiene,
-            changes_summary=changes_summary,
-        )
-
-        logger.info(f"Patent analysis complete: {len(insights)} insights generated")
-        return report
 
     def get_key_metrics(self, module_data: dict[str, Any]) -> dict[str, Any]:
         """Extract key metrics from patent analysis data.
@@ -657,21 +605,14 @@ class PatentAnalysisAnalyzer(ModuleAnalyzer):
             enrichment_sources={"neo4j_loading": total_operations},
         )
 
-    def _create_empty_report(self, run_context: dict[str, Any]) -> ModuleReport:
-        """Create an empty report when no data is available.
+    def _calculate_report_data_hygiene(self, module_data: dict[str, Any]) -> DataHygieneMetrics:
+        """Calculate hygiene from patents and validation results."""
+        return self._calculate_data_hygiene(
+            module_data[self.primary_data_key], module_data.get("validation_results", {})
+        )
 
-        Args:
-            run_context: Pipeline run context
-
-        Returns:
-            Empty ModuleReport
-        """
-        return self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="load",
-            total_records=0,
-            records_processed=0,
-            records_failed=0,
-            duration_seconds=0.0,
-            module_metrics={"error": "No patent DataFrame available"},
+    def _calculate_report_changes_summary(self, module_data: dict[str, Any]) -> ChangesSummary:
+        """Calculate graph changes from loading results and Neo4j statistics."""
+        return self._calculate_changes_summary(
+            module_data.get("loading_results", {}), module_data.get("neo4j_stats", {})
         )

--- a/sbir_etl/utils/reporting/analyzers/sbir_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/sbir_analyzer.py
@@ -8,14 +8,20 @@ comparisons of data completeness.
 from typing import Any
 
 import pandas as pd
-from loguru import logger
 
-from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics, ModuleReport
+from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics
 from sbir_etl.utils.reporting.analyzers.base_analyzer import AnalysisInsight, ModuleAnalyzer
 
 
 class SbirEnrichmentAnalyzer(ModuleAnalyzer):
     """Analyzer for SBIR enrichment operations and data quality."""
+
+    stage = "enrich"
+    primary_data_key = "enriched_df"
+    processing_keys = ("enrichment_metrics", "records_processed", "records_failed")
+    analysis_label = "SBIR enrichment"
+    missing_data_warning = "No enriched DataFrame provided for SBIR analysis"
+    missing_data_error = "No enriched DataFrame available"
 
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize SBIR enrichment analyzer.
@@ -53,64 +59,6 @@ class SbirEnrichmentAnalyzer(ModuleAnalyzer):
             "agency_default",
             "sector_fallback",
         ]
-
-    def analyze(self, module_data: dict[str, Any]) -> ModuleReport:
-        """Analyze SBIR enrichment data and generate comprehensive report.
-
-        Args:
-            module_data: Dictionary containing:
-                - enriched_df: Enriched SBIR DataFrame
-                - original_df: Original SBIR DataFrame (for comparison)
-                - enrichment_metrics: Enrichment operation metrics
-                - run_context: Pipeline run context
-
-        Returns:
-            ModuleReport with SBIR enrichment analysis
-        """
-        logger.info("Starting SBIR enrichment analysis")
-
-        enriched_df = module_data.get("enriched_df")
-        original_df = module_data.get("original_df")
-        enrichment_metrics = module_data.get("enrichment_metrics", {})
-        run_context = module_data.get("run_context", {})
-
-        if enriched_df is None:
-            logger.warning("No enriched DataFrame provided for SBIR analysis")
-            return self._create_empty_report(run_context)
-
-        # Calculate key metrics
-        key_metrics = self.get_key_metrics(module_data)
-
-        # Generate insights
-        insights = self.generate_insights(module_data)
-
-        # Calculate data hygiene metrics
-        data_hygiene = self._calculate_data_hygiene(enriched_df, original_df)
-
-        # Calculate changes summary
-        changes_summary = self._calculate_changes_summary(enriched_df, original_df)
-
-        # Extract processing metrics
-        total_records = len(enriched_df) if enriched_df is not None else 0
-        records_processed = enrichment_metrics.get("records_processed", total_records)
-        records_failed = enrichment_metrics.get("records_failed", 0)
-        duration_seconds = enrichment_metrics.get("duration_seconds", 0.0)
-
-        # Create module report
-        report = self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="enrich",
-            total_records=total_records,
-            records_processed=records_processed,
-            records_failed=records_failed,
-            duration_seconds=duration_seconds,
-            module_metrics=key_metrics,
-            data_hygiene=data_hygiene,
-            changes_summary=changes_summary,
-        )
-
-        logger.info(f"SBIR enrichment analysis complete: {len(insights)} insights generated")
-        return report
 
     def get_key_metrics(self, module_data: dict[str, Any]) -> dict[str, Any]:
         """Extract key metrics from SBIR enrichment data.
@@ -596,21 +544,16 @@ class SbirEnrichmentAnalyzer(ModuleAnalyzer):
             enrichment_sources=enrichment_sources,
         )
 
-    def _create_empty_report(self, run_context: dict[str, Any]) -> ModuleReport:
-        """Create an empty report when no data is available.
+    def _calculate_report_data_hygiene(self, module_data: dict[str, Any]) -> DataHygieneMetrics:
+        """Calculate hygiene from the enriched and original data."""
+        return self._calculate_data_hygiene(
+            module_data[self.primary_data_key], module_data.get("original_df")
+        )
 
-        Args:
-            run_context: Pipeline run context
-
-        Returns:
-            Empty ModuleReport
-        """
-        return self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="enrich",
-            total_records=0,
-            records_processed=0,
-            records_failed=0,
-            duration_seconds=0.0,
-            module_metrics={"error": "No enriched DataFrame available"},
+    def _calculate_report_changes_summary(
+        self, module_data: dict[str, Any]
+    ) -> ChangesSummary | None:
+        """Calculate enrichment changes from the original data."""
+        return self._calculate_changes_summary(
+            module_data[self.primary_data_key], module_data.get("original_df")
         )

--- a/sbir_etl/utils/reporting/analyzers/transition_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/transition_analyzer.py
@@ -8,14 +8,22 @@ and identifying high-impact transition examples for success stories.
 from typing import Any
 
 import pandas as pd
-from loguru import logger
 
-from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics, ModuleReport
+from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics
 from sbir_etl.utils.reporting.analyzers.base_analyzer import AnalysisInsight, ModuleAnalyzer
 
 
 class TransitionDetectionAnalyzer(ModuleAnalyzer):
     """Analyzer for transition detection operations and commercialization success."""
+
+    stage = "detect"
+    primary_data_key = "transitions_df"
+    total_data_key = "awards_df"
+    processing_keys = ("detection_results", "awards_processed", "detection_failed")
+    analysis_label = "Transition detection"
+    start_analysis_label = "transition detection"
+    missing_data_warning = "No transitions DataFrame provided for analysis"
+    missing_data_error = "No transitions DataFrame available"
 
     def __init__(self, config: dict[str, Any] | None = None):
         """Initialize transition detection analyzer.
@@ -50,64 +58,6 @@ class TransitionDetectionAnalyzer(ModuleAnalyzer):
             "research",
             "other",
         ]
-
-    def analyze(self, module_data: dict[str, Any]) -> ModuleReport:
-        """Analyze transition detection data and generate comprehensive report.
-
-        Args:
-            module_data: Dictionary containing:
-                - transitions_df: DataFrame with detected transitions
-                - awards_df: Original awards DataFrame
-                - detection_results: Detection operation results
-                - run_context: Pipeline run context
-
-        Returns:
-            ModuleReport with transition detection analysis
-        """
-        logger.info("Starting transition detection analysis")
-
-        transitions_df = module_data.get("transitions_df")
-        awards_df = module_data.get("awards_df")
-        detection_results = module_data.get("detection_results", {})
-        run_context = module_data.get("run_context", {})
-
-        if transitions_df is None:
-            logger.warning("No transitions DataFrame provided for analysis")
-            return self._create_empty_report(run_context)
-
-        # Calculate key metrics
-        key_metrics = self.get_key_metrics(module_data)
-
-        # Generate insights
-        insights = self.generate_insights(module_data)
-
-        # Calculate data hygiene metrics
-        data_hygiene = self._calculate_data_hygiene(transitions_df, awards_df)
-
-        # Calculate changes summary
-        changes_summary = self._calculate_changes_summary(transitions_df, awards_df)
-
-        # Extract processing metrics
-        total_records = len(awards_df) if awards_df is not None else 0
-        records_processed = detection_results.get("awards_processed", total_records)
-        records_failed = detection_results.get("detection_failed", 0)
-        duration_seconds = detection_results.get("duration_seconds", 0.0)
-
-        # Create module report
-        report = self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="detect",
-            total_records=total_records,
-            records_processed=records_processed,
-            records_failed=records_failed,
-            duration_seconds=duration_seconds,
-            module_metrics=key_metrics,
-            data_hygiene=data_hygiene,
-            changes_summary=changes_summary,
-        )
-
-        logger.info(f"Transition detection analysis complete: {len(insights)} insights generated")
-        return report
 
     def get_key_metrics(self, module_data: dict[str, Any]) -> dict[str, Any]:
         """Extract key metrics from transition detection data.
@@ -757,21 +707,14 @@ class TransitionDetectionAnalyzer(ModuleAnalyzer):
             enrichment_sources={"transition_detection": total_transitions},
         )
 
-    def _create_empty_report(self, run_context: dict[str, Any]) -> ModuleReport:
-        """Create an empty report when no data is available.
+    def _calculate_report_data_hygiene(self, module_data: dict[str, Any]) -> DataHygieneMetrics:
+        """Calculate hygiene from transitions and their award population."""
+        return self._calculate_data_hygiene(
+            module_data[self.primary_data_key], module_data.get("awards_df")
+        )
 
-        Args:
-            run_context: Pipeline run context
-
-        Returns:
-            Empty ModuleReport
-        """
-        return self.create_module_report(
-            run_id=run_context.get("run_id", "unknown"),
-            stage="detect",
-            total_records=0,
-            records_processed=0,
-            records_failed=0,
-            duration_seconds=0.0,
-            module_metrics={"error": "No transitions DataFrame available"},
+    def _calculate_report_changes_summary(self, module_data: dict[str, Any]) -> ChangesSummary:
+        """Calculate transition changes against the award population."""
+        return self._calculate_changes_summary(
+            module_data[self.primary_data_key], module_data.get("awards_df")
         )

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -27,6 +27,19 @@ from sbir_etl.utils.reporting.analyzers.transition_analyzer import TransitionDet
 pytestmark = pytest.mark.fast
 
 
+def _stable_report_dump(report: ModuleReport) -> dict[str, Any]:
+    """Return the deterministic portion of a module report."""
+    return report.model_dump(exclude={"timestamp"})
+
+
+def _stub_domain_analysis(monkeypatch: pytest.MonkeyPatch, analyzer: ModuleAnalyzer) -> None:
+    """Isolate shared lifecycle behavior from domain calculations."""
+    monkeypatch.setattr(analyzer, "get_key_metrics", lambda _module_data: {"stub_metric": 1})
+    monkeypatch.setattr(analyzer, "generate_insights", lambda _module_data: [])
+    monkeypatch.setattr(analyzer, "_calculate_data_hygiene", lambda *_args: None)
+    monkeypatch.setattr(analyzer, "_calculate_changes_summary", lambda *_args: None)
+
+
 # =============================================================================
 # Base Analyzer Tests
 # =============================================================================
@@ -292,6 +305,239 @@ class TestModuleAnalyzer:
 
 
 # =============================================================================
+# Shared Analyzer Lifecycle Characterization
+# =============================================================================
+
+
+class TestAnalyzerLifecycleCharacterization:
+    """Pin behavior shared by all concrete analyzers before lifecycle consolidation."""
+
+    def test_shared_lifecycle_preserves_calculation_order(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        analyzer = SbirEnrichmentAnalyzer()
+        calls: list[str] = []
+        monkeypatch.setattr(
+            analyzer,
+            "get_key_metrics",
+            lambda _module_data: calls.append("metrics") or {},
+        )
+        monkeypatch.setattr(
+            analyzer,
+            "generate_insights",
+            lambda _module_data: calls.append("insights") or [],
+        )
+        monkeypatch.setattr(
+            analyzer,
+            "_calculate_report_data_hygiene",
+            lambda _module_data: calls.append("hygiene") or None,
+        )
+        monkeypatch.setattr(
+            analyzer,
+            "_calculate_report_changes_summary",
+            lambda _module_data: calls.append("changes") or None,
+        )
+        monkeypatch.setattr(
+            analyzer,
+            "_get_total_records",
+            lambda _module_data: calls.append("total") or 1,
+        )
+        monkeypatch.setattr(
+            analyzer,
+            "_get_processing_metrics",
+            lambda _module_data, _total: calls.append("processing") or (1, 0, 0.0),
+        )
+
+        analyzer.analyze({"enriched_df": pd.DataFrame({"award_id": [1]})})
+
+        assert calls == ["metrics", "insights", "hygiene", "changes", "total", "processing"]
+
+    def test_missing_primary_data_short_circuits_calculations(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        analyzer = SbirEnrichmentAnalyzer()
+
+        def fail_if_called(*_args, **_kwargs):
+            raise AssertionError("domain calculation should not run without primary data")
+
+        for method_name in (
+            "get_key_metrics",
+            "generate_insights",
+            "_calculate_report_data_hygiene",
+            "_calculate_report_changes_summary",
+            "_get_total_records",
+            "_get_processing_metrics",
+        ):
+            monkeypatch.setattr(analyzer, method_name, fail_if_called)
+
+        report = analyzer.analyze({"enriched_df": None})
+
+        assert report.module_metrics == {"error": "No enriched DataFrame available"}
+
+    @pytest.mark.parametrize(
+        ("analyzer_cls", "primary_key", "module_name", "stage", "error_message"),
+        [
+            (
+                SbirEnrichmentAnalyzer,
+                "enriched_df",
+                "sbir_enrichment",
+                "enrich",
+                "No enriched DataFrame available",
+            ),
+            (
+                CetClassificationAnalyzer,
+                "classified_df",
+                "cet_classification",
+                "transform",
+                "No classified DataFrame available",
+            ),
+            (
+                PatentAnalysisAnalyzer,
+                "patent_df",
+                "patent_analysis",
+                "load",
+                "No patent DataFrame available",
+            ),
+            (
+                TransitionDetectionAnalyzer,
+                "transitions_df",
+                "transition_detection",
+                "detect",
+                "No transitions DataFrame available",
+            ),
+        ],
+    )
+    def test_missing_primary_data_returns_exact_empty_report(
+        self,
+        analyzer_cls,
+        primary_key: str,
+        module_name: str,
+        stage: str,
+        error_message: str,
+    ):
+        analyzer = analyzer_cls()
+
+        report = analyzer.analyze(
+            {primary_key: None, "run_context": {"run_id": "missing-primary-run"}}
+        )
+
+        assert _stable_report_dump(report) == {
+            "module_name": module_name,
+            "run_id": "missing-primary-run",
+            "stage": stage,
+            "total_records": 0,
+            "records_processed": 0,
+            "records_failed": 0,
+            "success_rate": 0.0,
+            "duration_seconds": 0.0,
+            "throughput_records_per_second": 0.0,
+            "data_hygiene": None,
+            "changes_summary": None,
+            "module_metrics": {"error": error_message},
+        }
+
+    @pytest.mark.parametrize(
+        ("analyzer_cls", "primary_key", "module_name", "stage", "total_records"),
+        [
+            (SbirEnrichmentAnalyzer, "enriched_df", "sbir_enrichment", "enrich", 1),
+            (CetClassificationAnalyzer, "classified_df", "cet_classification", "transform", 1),
+            (PatentAnalysisAnalyzer, "patent_df", "patent_analysis", "load", 1),
+            (
+                TransitionDetectionAnalyzer,
+                "transitions_df",
+                "transition_detection",
+                "detect",
+                3,
+            ),
+        ],
+    )
+    def test_processing_metrics_default_to_successful_primary_population(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        analyzer_cls,
+        primary_key: str,
+        module_name: str,
+        stage: str,
+        total_records: int,
+    ):
+        analyzer = analyzer_cls()
+        _stub_domain_analysis(monkeypatch, analyzer)
+        module_data = {
+            primary_key: pd.DataFrame({"record_id": [1]}),
+            "run_context": {"run_id": "defaults-run"},
+        }
+        if analyzer_cls is TransitionDetectionAnalyzer:
+            module_data["awards_df"] = pd.DataFrame({"award_id": [1, 2, 3]})
+
+        report = analyzer.analyze(module_data)
+
+        assert _stable_report_dump(report) == {
+            "module_name": module_name,
+            "run_id": "defaults-run",
+            "stage": stage,
+            "total_records": total_records,
+            "records_processed": total_records,
+            "records_failed": 0,
+            "success_rate": 1.0,
+            "duration_seconds": 0.0,
+            "throughput_records_per_second": 0.0,
+            "data_hygiene": None,
+            "changes_summary": None,
+            "module_metrics": {"stub_metric": 1},
+        }
+
+    @pytest.mark.parametrize(
+        ("analyzer_cls", "primary_key", "module_name", "stage", "total_records"),
+        [
+            (SbirEnrichmentAnalyzer, "enriched_df", "sbir_enrichment", "enrich", 0),
+            (CetClassificationAnalyzer, "classified_df", "cet_classification", "transform", 0),
+            (PatentAnalysisAnalyzer, "patent_df", "patent_analysis", "load", 0),
+            (
+                TransitionDetectionAnalyzer,
+                "transitions_df",
+                "transition_detection",
+                "detect",
+                2,
+            ),
+        ],
+    )
+    def test_empty_dataframe_is_analyzed_instead_of_treated_as_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        analyzer_cls,
+        primary_key: str,
+        module_name: str,
+        stage: str,
+        total_records: int,
+    ):
+        analyzer = analyzer_cls()
+        _stub_domain_analysis(monkeypatch, analyzer)
+        module_data = {
+            primary_key: pd.DataFrame({"record_id": pd.Series(dtype=int)}),
+            "run_context": {"run_id": "empty-dataframe-run"},
+        }
+        if analyzer_cls is TransitionDetectionAnalyzer:
+            module_data["awards_df"] = pd.DataFrame({"award_id": [1, 2]})
+
+        report = analyzer.analyze(module_data)
+
+        assert _stable_report_dump(report) == {
+            "module_name": module_name,
+            "run_id": "empty-dataframe-run",
+            "stage": stage,
+            "total_records": total_records,
+            "records_processed": total_records,
+            "records_failed": 0,
+            "success_rate": 1.0 if total_records else 0.0,
+            "duration_seconds": 0.0,
+            "throughput_records_per_second": 0.0,
+            "data_hygiene": None,
+            "changes_summary": None,
+            "module_metrics": {"stub_metric": 1},
+        }
+
+
+# =============================================================================
 # CET Classification Analyzer Tests
 # =============================================================================
 
@@ -445,12 +691,29 @@ class TestCetClassificationAnalyzer:
             "run_context": {"run_id": "test_run_123"},
         }
 
+        expected_report = analyzer.create_module_report(
+            run_id="test_run_123",
+            stage="transform",
+            total_records=5,
+            records_processed=4,
+            records_failed=1,
+            duration_seconds=5.0,
+            module_metrics=analyzer.get_key_metrics(module_data),
+            data_hygiene=analyzer._calculate_data_hygiene(
+                sample_classified_df, module_data["classification_results"]
+            ),
+            changes_summary=analyzer._calculate_changes_summary(
+                sample_classified_df, module_data["classification_results"]
+            ),
+        )
+
         report = analyzer.analyze(module_data)
 
         assert isinstance(report, ModuleReport)
         assert report.module_name == "cet_classification"
         assert report.run_id == "test_run_123"
         assert report.total_records == 5
+        assert _stable_report_dump(report) == _stable_report_dump(expected_report)
 
     def test_analyze_with_no_data(self):
         """Test analysis with no data."""
@@ -615,12 +878,53 @@ class TestPatentAnalysisAnalyzer:
             "run_context": {"run_id": "patent_run_123"},
         }
 
+        expected_report = analyzer.create_module_report(
+            run_id="patent_run_123",
+            stage="load",
+            total_records=5,
+            records_processed=5,
+            records_failed=0,
+            duration_seconds=10.0,
+            module_metrics=analyzer.get_key_metrics(module_data),
+            data_hygiene=analyzer._calculate_data_hygiene(
+                sample_patent_df, module_data["validation_results"]
+            ),
+            changes_summary=analyzer._calculate_changes_summary(
+                module_data["loading_results"], module_data["neo4j_stats"]
+            ),
+        )
+
         report = analyzer.analyze(module_data)
 
         assert isinstance(report, ModuleReport)
         assert report.module_name == "patent_analysis"
         assert report.run_id == "patent_run_123"
         assert report.stage == "load"
+        assert _stable_report_dump(report) == _stable_report_dump(expected_report)
+
+    def test_analyze_uses_validation_counts_and_loading_duration(self, sample_patent_df):
+        """Patent processing counts and duration intentionally come from different sources."""
+        analyzer = PatentAnalysisAnalyzer()
+        module_data = {
+            "patent_df": sample_patent_df,
+            "validation_results": {"valid_records": 3, "invalid_records": 2},
+            "loading_results": {
+                "records_processed": 99,
+                "records_failed": 98,
+                "duration_seconds": 4.0,
+            },
+            "neo4j_stats": {},
+            "run_context": {"run_id": "patent-split-sources"},
+        }
+
+        report = analyzer.analyze(module_data)
+
+        assert report.total_records == 5
+        assert report.records_processed == 3
+        assert report.records_failed == 2
+        assert report.success_rate == 0.6
+        assert report.duration_seconds == 4.0
+        assert report.throughput_records_per_second == 0.75
 
 
 # =============================================================================
@@ -748,11 +1052,26 @@ class TestSbirEnrichmentAnalyzer:
             "run_context": {"run_id": "sbir_run_123"},
         }
 
+        expected_report = analyzer.create_module_report(
+            run_id="sbir_run_123",
+            stage="enrich",
+            total_records=5,
+            records_processed=5,
+            records_failed=0,
+            duration_seconds=8.0,
+            module_metrics=analyzer.get_key_metrics(module_data),
+            data_hygiene=analyzer._calculate_data_hygiene(sample_enriched_df, sample_original_df),
+            changes_summary=analyzer._calculate_changes_summary(
+                sample_enriched_df, sample_original_df
+            ),
+        )
+
         report = analyzer.analyze(module_data)
 
         assert isinstance(report, ModuleReport)
         assert report.module_name == "sbir_enrichment"
         assert report.stage == "enrich"
+        assert _stable_report_dump(report) == _stable_report_dump(expected_report)
 
 
 # =============================================================================
@@ -878,9 +1197,30 @@ class TestTransitionDetectionAnalyzer:
             "run_context": {"run_id": "transition_run_123"},
         }
 
+        expected_report = analyzer.create_module_report(
+            run_id="transition_run_123",
+            stage="detect",
+            total_records=100,
+            records_processed=100,
+            records_failed=0,
+            duration_seconds=20.0,
+            module_metrics=analyzer.get_key_metrics(module_data),
+            data_hygiene=analyzer._calculate_data_hygiene(sample_transitions_df, sample_awards_df),
+            changes_summary=analyzer._calculate_changes_summary(
+                sample_transitions_df, sample_awards_df
+            ),
+        )
+
         report = analyzer.analyze(module_data)
 
         assert isinstance(report, ModuleReport)
         assert report.module_name == "transition_detection"
         assert report.stage == "detect"
         assert report.total_records == 100
+        assert report.records_processed == 100
+        assert report.changes_summary is not None
+        assert report.changes_summary.total_records == 100
+        assert report.changes_summary.records_modified == 5
+        assert report.changes_summary.records_unchanged == 95
+        assert report.changes_summary.modification_rate == 0.05
+        assert _stable_report_dump(report) == _stable_report_dump(expected_report)

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -48,8 +48,15 @@ def _stub_domain_analysis(monkeypatch: pytest.MonkeyPatch, analyzer: ModuleAnaly
 class ConcreteAnalyzer(ModuleAnalyzer):
     """Concrete implementation of ModuleAnalyzer for testing."""
 
+    stage = "test"
+    primary_data_key = "records"
+    processing_keys = ("processing", "processed", "failed")
+    analysis_label = "Test"
+    missing_data_warning = "No test data"
+    missing_data_error = "No test data available"
+
     def analyze(self, module_data: dict[str, Any]) -> ModuleReport:
-        """Implement abstract analyze method."""
+        """Return a simple report for base utility tests."""
         return self.create_module_report(
             run_id="test_run",
             stage="test",
@@ -79,6 +86,13 @@ class ConcreteAnalyzer(ModuleAnalyzer):
 
 class TestModuleAnalyzer:
     """Tests for the base ModuleAnalyzer class."""
+
+    def test_domain_lifecycle_hooks_are_required(self):
+        """Require subclasses to implement both domain lifecycle hooks."""
+        assert {
+            "_calculate_report_data_hygiene",
+            "_calculate_report_changes_summary",
+        } <= ModuleAnalyzer.__abstractmethods__
 
     def test_initialization(self):
         """Test analyzer initialization with module name and config."""

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -68,6 +68,14 @@ class ConcreteAnalyzer(ModuleAnalyzer):
         """Implement abstract generate_insights method."""
         return []
 
+    def _calculate_report_data_hygiene(self, module_data: dict[str, Any]) -> None:
+        """Unused: this stub overrides the shared lifecycle in ``analyze``."""
+        return None
+
+    def _calculate_report_changes_summary(self, module_data: dict[str, Any]) -> None:
+        """Unused: this stub overrides the shared lifecycle in ``analyze``."""
+        return None
+
 
 class TestModuleAnalyzer:
     """Tests for the base ModuleAnalyzer class."""


### PR DESCRIPTION
## What

- move the common analyzer sequence and missing-input report construction into `ModuleAnalyzer`
- keep each analyzer's stage, primary input, denominator, count keys, duration source, and messages explicit
- require subclasses to declare lifecycle metadata and implement both domain report hooks
- retain small domain adapters for hygiene and change calculations
- add characterization coverage for exact report composition, call order, short-circuiting, defaults, and domain-specific metric sources

## Why

The SBIR, CET, Patent, and Transition analyzers duplicated the same lifecycle and empty-report construction across roughly 300 lines. Small but important differences—especially Patent's split validation/loading sources and Transition's award denominator—were buried inside those copies.

## Impact

Production analyzer code is 147 lines smaller. Domain hygiene, changes, insight logic, thresholds, confidence bands, and output models are unchanged. Missing `None` inputs remain distinct from empty DataFrames, and log/report messages retain their existing text. Missing subclass hooks now fail at instantiation instead of mid-report, and required lifecycle metadata no longer has silent empty defaults.

Refs #441 for context only. This internal legacy-analyzer cleanup neither implements nor constrains the modular analysis/report platform and does not partially close that issue.

## Checks

- 69 analyzer tests passed
- 120 related reporting/model tests passed
- Ruff check and format check passed
- MyPy passed for all analyzer modules
- fresh GitHub CI passed unit, integration, lint, type, and S3 checks
- independent review found no contract, API, or scope blockers
