### PR TITLE
refactor(uspto): centralize identifier normalization

### DIFF
--- a/sbir_etl/models/uspto_models.py
+++ b/sbir_etl/models/uspto_models.py
@@ -30,17 +30,7 @@ from pydantic import BaseModel, Field, field_validator
 # ---- Utilities ----
 # Use centralized date parsing utility
 from sbir_etl.utils.date_utils import parse_date as _parse_date
-
-
-def _normalize_identifier(val: str | None) -> str | None:
-    if val is None:
-        return None
-    v = str(val).strip()
-    if v == "":
-        return None
-    # Remove common punctuation and whitespace collapse
-    v = re.sub(r"[^\w\-]", "", v).upper()
-    return v
+from sbir_etl.utils.identifiers import normalize_uspto_identifier
 
 
 def _normalize_name(name: str | None) -> str | None:
@@ -83,17 +73,17 @@ class PatentDocument(BaseModel):
     @field_validator("application_number", mode="before")
     @classmethod
     def _norm_application_number(cls, v):
-        return _normalize_identifier(v)
+        return normalize_uspto_identifier(v)
 
     @field_validator("publication_number", mode="before")
     @classmethod
     def _norm_publication_number(cls, v):
-        return _normalize_identifier(v)
+        return normalize_uspto_identifier(v)
 
     @field_validator("grant_number", mode="before")
     @classmethod
     def _norm_grant_number(cls, v):
-        return _normalize_identifier(v)
+        return normalize_uspto_identifier(v)
 
     @field_validator("filing_date", "publication_date", "grant_date", mode="before")
     @classmethod
@@ -139,7 +129,7 @@ class PatentAssignee(BaseModel):
     @field_validator("uei", "cage", "duns", mode="before")
     @classmethod
     def _normalize_ids(cls, v):
-        return _normalize_identifier(v)
+        return normalize_uspto_identifier(v)
 
 
 class PatentAssignor(BaseModel):

--- a/sbir_etl/transformers/patent_transformer.py
+++ b/sbir_etl/transformers/patent_transformer.py
@@ -32,6 +32,8 @@ from typing import Any
 
 from loguru import logger
 
+from sbir_etl.utils.identifiers import normalize_uspto_identifier
+
 
 # Try to use rapidfuzz for fuzzy matching; fallback to difflib
 try:
@@ -107,16 +109,7 @@ class PatentAssignmentTransformer:
     # ------------------------
     # Normalization helpers
     # ------------------------
-    @staticmethod
-    def _normalize_identifier(val: Any | None) -> str | None:
-        if val is None:
-            return None
-        s = str(val).strip()
-        if not s:
-            return None
-        # remove non-alphanumeric (retain dashes/underscores)
-        s = re.sub(r"[^\w\-]", "", s)
-        return s.upper()
+    _normalize_identifier = staticmethod(normalize_uspto_identifier)
 
     @staticmethod
     def _normalize_name(name: Any | None) -> str | None:

--- a/sbir_etl/utils/identifiers.py
+++ b/sbir_etl/utils/identifiers.py
@@ -1,10 +1,28 @@
-"""Canonical identifier normalizers for UEI, DUNS, and CAGE codes."""
+"""Canonical domain identifier normalizers."""
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from sbir_etl.utils.coercion import _blank
+
+
+def normalize_uspto_identifier(value: Any) -> str | None:
+    """Normalize an identifier carried by a USPTO record.
+
+    This preserves the permissive USPTO ingestion contract: trim surrounding
+    whitespace, remove characters other than Unicode word characters and
+    hyphens, and uppercase the result. It does not validate identifier type or
+    length; use the UEI, DUNS, and CAGE normalizers below when validation is
+    required.
+    """
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+    return re.sub(r"[^\w\-]", "", normalized).upper()
 
 
 def normalize_uei(v: Any) -> str | None:

--- a/tests/unit/utils/test_identifiers.py
+++ b/tests/unit/utils/test_identifiers.py
@@ -1,0 +1,26 @@
+"""Tests for canonical domain identifier normalization."""
+
+import pytest
+
+from sbir_etl.utils.identifiers import normalize_uspto_identifier
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("us123", "US123"),
+        ("  US 123  ", "US123"),
+        ("US-123.456/789", "US-123456789"),
+        ("app_123", "APP_123"),
+        (12345, "12345"),
+        (".", ""),
+    ],
+)
+def test_normalize_uspto_identifier_preserves_ingestion_contract(value, expected) -> None:
+    assert normalize_uspto_identifier(value) == expected


### PR DESCRIPTION
## What

- Add one domain-specific `normalize_uspto_identifier` utility for identifiers carried by USPTO records.
- Replace the byte-for-byte-equivalent model and transformer implementations with that shared function.
- Preserve the transformer's existing private static callable and the current permissive ingestion behavior, including Unicode word characters, underscores, hyphens, numeric coercion, and punctuation-only input.
- Add contract tests for the legacy normalization edge cases.

## Why

USPTO models and the patent assignment transformer maintained the same normalization algorithm independently. Centralizing it removes a drift point while keeping field selection and domain behavior unchanged.

## Scope

This PR intentionally does **not**:

- introduce a universal identifier normalizer;
- tighten UEI, DUNS, or CAGE validation;
- change Patent or Neo4j keys;
- change extractor field-alias selection;
- overlap company-identity or schema-authority work.

## Validation

- 153 focused USPTO/model/transformer tests passed
- 33 USPTO integration tests passed
- Full unit suite: 4,826 passed, 7 skipped
- Ruff check and format check passed
- MyPy passed for all changed production modules
- Independent review found no blockers
