### PR TITLE
ci: gate S3 integration tests

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -32,6 +32,9 @@ outputs:
   infrastructure:
     description: Whether infrastructure/CDK files changed
     value: ${{ steps.filter.outputs.infrastructure }}
+  s3:
+    description: Whether S3 integration-related files changed
+    value: ${{ steps.filter.outputs.s3 }}
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       docker: ${{ steps.detect.outputs.docker }}
       workflows: ${{ steps.detect.outputs.workflows }}
       infrastructure: ${{ steps.detect.outputs.infrastructure }}
+      s3: ${{ steps.detect.outputs.s3 }}
       docs-only: ${{ steps.detect.outputs.docs-only }}
     steps:
       - uses: actions/checkout@v7
@@ -94,6 +95,12 @@ jobs:
               - '.github/actions/**'
             infrastructure:
               - 'infrastructure/cdk/**'
+            s3:
+              - 'sbir_etl/utils/cloud_storage.py'
+              - 'tests/integration/test_s3_operations.py'
+              - 'tests/conftest.py'
+              - '.github/workflows/ci.yml'
+              - '.github/actions/detect-changes/**'
 
   code-quality:
     name: Code Quality (Lint + Type Check)
@@ -1083,27 +1090,49 @@ jobs:
 
   test-s3-integration:
     name: S3 Integration Tests
-    needs: [detect-changes, test]
+    needs: [detect-changes]
     if: |
-      needs.detect-changes.outputs.docs-only != 'true' &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-cloud-tests')
+      !contains(github.event.pull_request.labels.*.name, 'skip-cloud-tests') &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          needs.detect-changes.outputs.docs-only != 'true' &&
+          needs.detect-changes.outputs.s3 == 'true'
+        )
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       id-token: write
       contents: read
+    outputs:
+      tests-ran: ${{ steps.s3-tests.outcome == 'success' }}
     steps:
-      - uses: actions/checkout@v7
+      - name: Check AWS test role configuration
+        id: aws-role
+        env:
+          AWS_TEST_ROLE_ARN: ${{ secrets.AWS_TEST_ROLE_ARN }}
+        run: |
+          if [ -n "$AWS_TEST_ROLE_ARN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::AWS_TEST_ROLE_ARN is unavailable; skipping S3 integration tests"
+          fi
 
       - name: Configure AWS credentials
-        continue-on-error: true
+        if: steps.aws-role.outputs.available == 'true'
         id: aws-creds
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_TEST_ROLE_ARN }}
           aws-region: us-east-2
 
+      - uses: actions/checkout@v7
+        if: steps.aws-creds.outcome == 'success'
+
       - name: Setup Python and UV
+        if: steps.aws-creds.outcome == 'success'
         uses: ./.github/actions/setup-python-uv
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -1111,6 +1140,7 @@ jobs:
           cache-venv: "true"
 
       - name: Run S3 integration tests
+        id: s3-tests
         if: steps.aws-creds.outcome == 'success'
         env:
           TEST_S3_BUCKET: sbir-analytics-test
@@ -1118,10 +1148,16 @@ jobs:
           uv run pytest tests/integration/test_s3_operations.py -v -m s3
 
       - name: Skip S3 tests (no credentials)
-        if: steps.aws-creds.outcome != 'success'
+        if: |
+          always() &&
+          (steps.aws-role.outputs.available != 'true' || steps.aws-creds.outcome != 'success')
         run: |
-          echo "⚠️ AWS credentials not available, skipping S3 integration tests"
-          echo "This is expected for external PRs"
+          if [ "${{ steps.aws-role.outputs.available }}" != "true" ]; then
+            echo "⚠️ AWS_TEST_ROLE_ARN is unavailable; S3 integration tests were skipped"
+            echo "This is expected for external pull requests"
+          else
+            echo "⚠️ AWS credential configuration failed; S3 integration tests were skipped"
+          fi
 
   ci-summary:
     name: CI Summary
@@ -1153,7 +1189,11 @@ jobs:
           fi
 
           if [ "${{ needs.test-s3-integration.result }}" != "skipped" ]; then
-            echo "| ☁️ S3 Integration | ${{ needs.test-s3-integration.result == 'success' && '✅' || '❌' }} ${{ needs.test-s3-integration.result }} |" >> $GITHUB_STEP_SUMMARY
+            if [ "${{ needs.test-s3-integration.result }}" = "success" ] && [ "${{ needs.test-s3-integration.outputs.tests-ran }}" != "true" ]; then
+              echo "| ☁️ S3 Integration | ⏭️ skipped (AWS credentials unavailable) |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| ☁️ S3 Integration | ${{ needs.test-s3-integration.result == 'success' && '✅' || '❌' }} ${{ needs.test-s3-integration.result }} |" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
           if [ "${{ needs.e2e-docker.result }}" != "skipped" ]; then


### PR DESCRIPTION
## What changed

- add an S3-specific change-detection output
- run the S3 integration job only for relevant changes or manual dispatches
- check for `AWS_TEST_ROLE_ARN` before checkout or environment setup
- fail when a configured AWS role cannot be assumed
- report credential-unavailable skips accurately in the CI summary

## Why

The S3 follow-on ran after every non-doc test suite. When the AWS test role was unavailable, credential retries plus Python setup delayed CI by roughly two minutes even though no S3 test ran.

This keeps real S3 coverage for storage-related changes while removing the no-op follow-on from unrelated pull requests.

## Validation

- workflow YAML and structural assertions
- `git diff --check`
- `pytest tests/unit/utils/test_cloud_storage.py` — 34 passed
