### PR TITLE
fix(ci): synth CDK without AWS credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,15 +228,12 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # BatchStack uses `ec2.Vpc.from_lookup(is_default=True)`, which forces CDK
-    # to call AWS at synth time. Pull requests don't have AWS credentials and
-    # the cdk.context.json stub written inline below is consistently ignored by
-    # the CDK CLI in CI (works locally), so restrict to push/scheduled/manual
-    # runs where credentials are available. Matches the existing pattern for
-    # Run Transition MVP.
+    # validation_app.py injects placeholder VPC attributes, so synthesis is
+    # deterministic and credential-free. Validate every push, but avoid adding
+    # this job to unrelated pull requests.
     if: |
       needs.detect-changes.outputs.docs-only != 'true' &&
-      github.event_name != 'pull_request'
+      (github.event_name != 'pull_request' || needs.detect-changes.outputs.infrastructure == 'true')
     steps:
       - uses: actions/checkout@v7
 
@@ -248,7 +245,7 @@ jobs:
       - name: Setup Node.js (for CDK CLI)
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install CDK dependencies
         working-directory: infrastructure/cdk
@@ -268,47 +265,10 @@ jobs:
           echo "## 🏗️ CDK Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # BatchStack uses `ec2.Vpc.from_lookup(is_default=True)`, which forces
-          # CDK to call AWS at synth time. CI has no AWS credentials, so seed
-          # cdk.context.json with the same stub VPC used by
-          # tests/test_batch_stack.py to keep synth offline. Use python to write
-          # the file rather than a YAML heredoc (heredoc indentation + JSON
-          # special chars are too fragile across runners).
-          python <<'PYEOF'
-          import json
-          ctx = {
-              "vpc-provider:account=123456789012:filter.isDefault=true:region=us-east-2:returnAsymmetricSubnets=true": {
-                  "vpcId": "vpc-12345",
-                  "vpcCidrBlock": "172.31.0.0/16",
-                  "ownerAccountId": "123456789012",
-                  "availabilityZones": [],
-                  "subnetGroups": [
-                      {
-                          "name": "Public",
-                          "type": "Public",
-                          "subnets": [
-                              {
-                                  "subnetId": "subnet-aaa",
-                                  "cidr": "172.31.0.0/20",
-                                  "availabilityZone": "us-east-2a",
-                                  "routeTableId": "rtb-aaa",
-                              }
-                          ],
-                      }
-                  ],
-              }
-          }
-          with open("cdk.context.json", "w") as f:
-              json.dump(ctx, f, indent=2)
-          PYEOF
-          echo "--- cdk.context.json written: ---"
-          ls -la cdk.context.json
-          echo "--- contents: ---"
-          cat cdk.context.json
-          echo "--- (end) ---"
-
-          # Run CDK synth with python directly (bypass cdk.json's uv command)
-          if cdk synth --app "python app.py" --quiet 2>&1; then
+          # Use explicit placeholder VPC attributes instead of an account
+          # lookup. Production deploys continue to use app.py and the real
+          # default-VPC lookup.
+          if cdk synth --app "python validation_app.py" --quiet 2>&1; then
             echo "✅ CDK synth successful" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ CDK synth failed" >> $GITHUB_STEP_SUMMARY
@@ -1125,7 +1085,7 @@ jobs:
 
   ci-summary:
     name: CI Summary
-    needs: [detect-changes, code-quality, verify-setup-script, test, container-build-test, performance-check, e2e-docker, transition-mvp, test-s3-integration]
+    needs: [detect-changes, code-quality, verify-setup-script, infrastructure-validate, test, container-build-test, performance-check, e2e-docker, transition-mvp, test-s3-integration]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1141,6 +1101,7 @@ jobs:
           echo "| 🔍 Detect Changes | ${{ needs.detect-changes.result == 'success' && '✅' || '❌' }} ${{ needs.detect-changes.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🧹 Code Quality | ${{ needs.code-quality.result == 'success' && '✅' || needs.code-quality.result == 'skipped' && '⏭️' || '❌' }} ${{ needs.code-quality.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| ✅ Verify Setup | ${{ needs.verify-setup-script.result == 'success' && '✅' || needs.verify-setup-script.result == 'skipped' && '⏭️' || '❌' }} ${{ needs.verify-setup-script.result }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| 🏗️ CDK Infrastructure | ${{ needs.infrastructure-validate.result == 'success' && '✅' || needs.infrastructure-validate.result == 'skipped' && '⏭️' || '❌' }} ${{ needs.infrastructure-validate.result }} |" >> $GITHUB_STEP_SUMMARY
           echo "| 🧪 Tests (3 suites) | ${{ needs.test.result == 'success' && '✅' || needs.test.result == 'skipped' && '⏭️' || '❌' }} ${{ needs.test.result }} |" >> $GITHUB_STEP_SUMMARY
 
           # Conditional jobs
@@ -1167,6 +1128,7 @@ jobs:
       - name: Check for failures
         if: |
           needs.code-quality.result == 'failure' ||
+          needs.infrastructure-validate.result == 'failure' ||
           needs.test.result == 'failure' ||
           needs.container-build-test.result == 'failure' ||
           needs.performance-check.result == 'failure' ||

--- a/infrastructure/cdk/README.md
+++ b/infrastructure/cdk/README.md
@@ -51,6 +51,11 @@ The account is taken from `CDK_DEFAULT_ACCOUNT` and the region from
 `--context notification_email=you@example.com` to subscribe an address to its
 SNS job notifications.
 
+CI synthesizes `validation_app.py`, which imports syntactically valid placeholder
+VPC attributes so template validation remains credential-free. Production synth
+and deploy commands continue to use `app.py` and look up the account's default
+VPC; do not deploy the validation app.
+
 ## Outputs
 
 - `FoundationStack`: `BucketName`, `BucketArn`, `GitHubActionsRoleArn`

--- a/infrastructure/cdk/app.py
+++ b/infrastructure/cdk/app.py
@@ -5,24 +5,31 @@ import os
 
 import aws_cdk as cdk
 
-from stacks.batch import BatchStack
+from stacks.batch import BatchStack, VpcConfig
 from stacks.foundation import FoundationStack
 
-app = cdk.App()
 
-env = cdk.Environment(
-    account=os.environ.get("CDK_DEFAULT_ACCOUNT"),
-    region=os.environ.get("CDK_DEFAULT_REGION", "us-east-2"),
-)
+def build_app(*, batch_vpc_config: VpcConfig | None = None) -> cdk.App:
+    """Build the CDK app, optionally importing explicit VPC attributes."""
+    app = cdk.App()
 
-foundation = FoundationStack(app, "sbir-analytics-foundation", env=env)
+    env = cdk.Environment(
+        account=os.environ.get("CDK_DEFAULT_ACCOUNT"),
+        region=os.environ.get("CDK_DEFAULT_REGION", "us-east-2"),
+    )
 
-BatchStack(
-    app,
-    "sbir-analytics-batch",
-    env=env,
-    bucket=foundation.bucket,
-    neo4j_secret=foundation.neo4j_secret,
-)
+    foundation = FoundationStack(app, "sbir-analytics-foundation", env=env)
 
-app.synth()
+    BatchStack(
+        app,
+        "sbir-analytics-batch",
+        env=env,
+        bucket=foundation.bucket,
+        neo4j_secret=foundation.neo4j_secret,
+        vpc_config=batch_vpc_config,
+    )
+    return app
+
+
+if __name__ == "__main__":
+    build_app().synth()

--- a/infrastructure/cdk/stacks/batch.py
+++ b/infrastructure/cdk/stacks/batch.py
@@ -50,6 +50,16 @@ class JobConfig:
         return self.log_prefix or self.name.split("-")[-1]
 
 
+@dataclass(frozen=True)
+class VpcConfig:
+    """Attributes for importing a VPC without an AWS environment lookup."""
+
+    vpc_id: str
+    availability_zones: tuple[str, ...]
+    public_subnet_ids: tuple[str, ...]
+    public_subnet_route_table_ids: tuple[str, ...]
+
+
 _DAGSTER_ENV = [
     {"name": "DAGSTER_LOAD_HEAVY_ASSETS", "value": "true"},
     {"name": "DAGSTER_HOME", "value": "/tmp/dagster_home"},
@@ -156,6 +166,7 @@ class BatchStack(Stack):
         construct_id: str,
         bucket: s3.IBucket,
         neo4j_secret: secretsmanager.ISecret,
+        vpc_config: VpcConfig | None = None,
         **kwargs,
     ) -> None:
         super().__init__(scope, construct_id, **kwargs)
@@ -168,7 +179,17 @@ class BatchStack(Stack):
             removal_policy=RemovalPolicy.DESTROY,
         )
 
-        vpc = ec2.Vpc.from_lookup(self, "VPC", is_default=True)
+        if vpc_config is None:
+            vpc = ec2.Vpc.from_lookup(self, "VPC", is_default=True)
+        else:
+            vpc = ec2.Vpc.from_vpc_attributes(
+                self,
+                "VPC",
+                vpc_id=vpc_config.vpc_id,
+                availability_zones=list(vpc_config.availability_zones),
+                public_subnet_ids=list(vpc_config.public_subnet_ids),
+                public_subnet_route_table_ids=list(vpc_config.public_subnet_route_table_ids),
+            )
 
         security_group = ec2.SecurityGroup(
             self,

--- a/infrastructure/cdk/tests/test_batch_stack.py
+++ b/infrastructure/cdk/tests/test_batch_stack.py
@@ -3,38 +3,21 @@
 import aws_cdk as cdk
 from aws_cdk.assertions import Match, Template
 
-from stacks.batch import BatchStack
+from stacks.batch import BatchStack, VpcConfig
 from stacks.foundation import FoundationStack
 
 ENV = cdk.Environment(account="123456789012", region="us-east-2")
 
-# Minimal default-VPC context so Vpc.from_lookup doesn't hit AWS during synthesis
-VPC_CONTEXT = {
-    "vpc-provider:account=123456789012:filter.isDefault=true:region=us-east-2:returnAsymmetricSubnets=true": {
-        "vpcId": "vpc-12345",
-        "vpcCidrBlock": "172.31.0.0/16",
-        "ownerAccountId": "123456789012",
-        "availabilityZones": [],
-        "subnetGroups": [
-            {
-                "name": "Public",
-                "type": "Public",
-                "subnets": [
-                    {
-                        "subnetId": "subnet-aaa",
-                        "cidr": "172.31.0.0/20",
-                        "availabilityZone": "us-east-2a",
-                        "routeTableId": "rtb-aaa",
-                    }
-                ],
-            }
-        ],
-    }
-}
+TEST_VPC = VpcConfig(
+    vpc_id="vpc-00000000000000000",
+    availability_zones=("us-east-2a",),
+    public_subnet_ids=("subnet-00000000000000000",),
+    public_subnet_route_table_ids=("rtb-00000000000000000",),
+)
 
 
 def _template() -> Template:
-    app = cdk.App(context=VPC_CONTEXT)
+    app = cdk.App()
     foundation = FoundationStack(app, "TestFoundation", env=ENV)
     batch = BatchStack(
         app,
@@ -42,6 +25,7 @@ def _template() -> Template:
         env=ENV,
         bucket=foundation.bucket,
         neo4j_secret=foundation.neo4j_secret,
+        vpc_config=TEST_VPC,
     )
     return Template.from_stack(batch)
 
@@ -86,9 +70,9 @@ def test_job_queue_name_and_spot_preference():
     )
 
 
-def test_four_job_definitions():
+def test_five_job_definitions():
     template = _template()
-    template.resource_count_is("AWS::Batch::JobDefinition", 4)
+    template.resource_count_is("AWS::Batch::JobDefinition", 5)
 
 
 def test_usaspending_job_has_ephemeral_storage():
@@ -97,9 +81,7 @@ def test_usaspending_job_has_ephemeral_storage():
         "AWS::Batch::JobDefinition",
         {
             "JobDefinitionName": "sbir-analytics-usaspending-extract",
-            "ContainerProperties": Match.object_like(
-                {"EphemeralStorage": {"SizeInGiB": 200}}
-            ),
+            "ContainerProperties": Match.object_like({"EphemeralStorage": {"SizeInGiB": 200}}),
         },
     )
 

--- a/infrastructure/cdk/validation_app.py
+++ b/infrastructure/cdk/validation_app.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Credential-free CDK app entry point for CI template validation."""
+
+from app import build_app
+from stacks.batch import VpcConfig
+
+OFFLINE_VPC = VpcConfig(
+    vpc_id="vpc-00000000000000000",
+    availability_zones=("us-east-2a",),
+    public_subnet_ids=("subnet-00000000000000000",),
+    public_subnet_route_table_ids=("rtb-00000000000000000",),
+)
+
+build_app(batch_vpc_config=OFFLINE_VPC).synth()


### PR DESCRIPTION
## Summary

- synthesize the CDK app in CI with explicit placeholder VPC attributes instead of an AWS lookup
- keep production synth/deploy behavior unchanged: `app.py` still resolves the real default VPC
- run CDK validation for infrastructure-changing pull requests and every non-doc push
- include infrastructure validation in the aggregate CI result and move the job to Node 22

## Verification

- credential-stripped CDK synth passed under Node 22
- CDK unit tests: 16 passed
- Ruff lint and format checks passed for changed Python files
- combined workflow YAML parses successfully
- `git diff --check origin/main...HEAD` passed

This replaces the ignored `cdk.context.json` stub that caused main's CDK validation job to fail without AWS credentials.
