### PR TITLE
Add Phase III control and placebo foundation

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/__init__.py
@@ -1,0 +1,22 @@
+"""Pure Phase III negative-control and placebo mechanics."""
+
+from .methods import (
+    CONTROL_STATUS_LABEL,
+    PLACEBO_SEED,
+    NegativeControlInputError,
+    audit_exact_identifier_eligibility,
+    build_placebo_census_tables,
+    flag_identifier_free_name_stress_set,
+    permute_prior_end_dates,
+)
+
+
+__all__ = [
+    "CONTROL_STATUS_LABEL",
+    "PLACEBO_SEED",
+    "NegativeControlInputError",
+    "audit_exact_identifier_eligibility",
+    "build_placebo_census_tables",
+    "flag_identifier_free_name_stress_set",
+    "permute_prior_end_dates",
+]

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/__init__.py
@@ -3,10 +3,11 @@
 from .methods import (
     CONTROL_STATUS_LABEL,
     PLACEBO_SEED,
+    UNSCREENABLE_STATUS_LABEL,
     NegativeControlInputError,
     audit_exact_identifier_eligibility,
     build_placebo_census_tables,
-    flag_identifier_free_name_stress_set,
+    flag_identifier_unreachable_name_stress_set,
     permute_prior_end_dates,
 )
 
@@ -14,9 +15,10 @@ from .methods import (
 __all__ = [
     "CONTROL_STATUS_LABEL",
     "PLACEBO_SEED",
+    "UNSCREENABLE_STATUS_LABEL",
     "NegativeControlInputError",
     "audit_exact_identifier_eligibility",
     "build_placebo_census_tables",
-    "flag_identifier_free_name_stress_set",
+    "flag_identifier_unreachable_name_stress_set",
     "permute_prior_end_dates",
 ]

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/methods.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/methods.py
@@ -22,6 +22,7 @@ from ..phase_iii_census.criteria import build_dropoff_ladder, build_sensitivity_
 
 PLACEBO_SEED = 20260801
 CONTROL_STATUS_LABEL = "no observed exact-identifier SBIR/STTR match"
+UNSCREENABLE_STATUS_LABEL = "no usable identifier; not screenable"
 
 EXACT_UEI_EXCLUSION_REASON = "observed_exact_uei_sbir_sttr_match"
 EXACT_DUNS_EXCLUSION_REASON = "observed_exact_duns_sbir_sttr_match"
@@ -30,6 +31,7 @@ _CANDIDATE_IDENTIFIER_COLUMNS = frozenset({"entity_id", "uei", "duns"})
 _HISTORY_IDENTIFIER_COLUMNS = frozenset({"uei", "duns"})
 _ELIGIBILITY_AUDIT_COLUMNS = frozenset(
     {
+        "has_usable_identifier",
         "passes_exact_identifier_screen",
         "control_status_label",
     }
@@ -92,6 +94,12 @@ def _validate_history(
         )
 
 
+def _control_status_label(passed: bool, screenable: bool) -> str | None:
+    if not passed:
+        return None
+    return CONTROL_STATUS_LABEL if screenable else UNSCREENABLE_STATUS_LABEL
+
+
 def audit_exact_identifier_eligibility(
     candidate_entities: pd.DataFrame,
     complete_award_history: pd.DataFrame,
@@ -101,6 +109,14 @@ def audit_exact_identifier_eligibility(
     Passing this screen means only that no exact usable identifier was observed in
     the supplied history. It does not certify that an entity never received an
     SBIR/STTR award.
+
+    Passing is three-valued in substance and the output says so rather than leaving
+    it to be reconstructed from the normalized identifier columns. An entity that
+    was screened and matched nothing carries `has_usable_identifier` true and the
+    approved control label; an entity whose identifiers are absent or malformed
+    carries `has_usable_identifier` false and `UNSCREENABLE_STATUS_LABEL`, because
+    nothing about it was screened at all. Selecting on
+    `passes_exact_identifier_screen` alone silently mixes the two.
     """
 
     _require_columns(
@@ -127,6 +143,7 @@ def audit_exact_identifier_eligibility(
     normalized_duns = output["duns"].map(normalize_duns)
     exact_uei_match = normalized_uei.isin(history_ueis)
     exact_duns_match = normalized_duns.isin(history_duns)
+    has_usable_identifier = normalized_uei.notna() | normalized_duns.notna()
     passes = ~(exact_uei_match | exact_duns_match)
 
     reasons = [
@@ -148,20 +165,37 @@ def audit_exact_identifier_eligibility(
     output["exclusion_reason"] = pd.Series(reasons, index=output.index, dtype="string").mask(
         lambda series: series.eq("")
     )
+    output["has_usable_identifier"] = has_usable_identifier.astype(bool)
     output["passes_exact_identifier_screen"] = passes.astype(bool)
     output["control_status_label"] = pd.Series(
-        [CONTROL_STATUS_LABEL if passed else pd.NA for passed in passes],
+        [
+            _control_status_label(bool(passed), bool(screenable))
+            for passed, screenable in zip(passes, has_usable_identifier, strict=True)
+        ],
         index=output.index,
         dtype="string",
     )
     return output
 
 
-def flag_identifier_free_name_stress_set(
+def flag_identifier_unreachable_name_stress_set(
     eligibility_audit: pd.DataFrame,
     complete_award_history: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Flag exact normalized names found on identifier-free award rows.
+    """Flag exact normalized names on award rows the identifier screen could not reach.
+
+    Which award rows are unreachable is a property of the *candidate*, not of the
+    history alone. A candidate with a usable identifier was compared against every
+    identifier-carrying award row, so only identifier-free award rows remain
+    unreachable for it. A candidate with no usable identifier was compared against
+    nothing, so the whole history remains unreachable for it — including award rows
+    that do carry identifiers.
+
+    Restricting the reference set to identifier-free award rows for every candidate
+    drops exactly the worst case this flag exists to surface: an unscreenable
+    candidate whose normalized name equals that of an identifier-carrying awardee.
+    That case would be reported as clean by the eligibility audit and absent here,
+    and it understates stress in the direction that flatters the control arm.
 
     The flag is for worst-case stress reporting only. It is not an eligibility
     rule, contamination estimate, upper bound, fuzzy match, or alias screen.
@@ -183,11 +217,12 @@ def flag_identifier_free_name_stress_set(
     history_duns = complete_award_history["duns"].map(normalize_duns)
     history_names = complete_award_history["company_name"].map(_normalized_company_name)
     identifier_free = history_uei.isna() & history_duns.isna()
-    reference_names = {
+    identifier_free_names = {
         normalized
         for normalized in history_names.loc[identifier_free]
         if isinstance(normalized, str)
     }
+    every_award_name = {normalized for normalized in history_names if isinstance(normalized, str)}
 
     output = eligibility_audit.copy()
     normalized_entity_name = output["entity_name"].map(_normalized_company_name)
@@ -196,8 +231,13 @@ def flag_identifier_free_name_stress_set(
         index=output.index,
         dtype="string",
     )
-    output["identifier_free_award_exact_name_match"] = (
-        normalized_entity_name.notna() & normalized_entity_name.isin(reference_names)
+    screenable = output["has_usable_identifier"].astype(bool)
+    unreachable_name_match = normalized_entity_name.isin(identifier_free_names).where(
+        screenable,
+        normalized_entity_name.isin(every_award_name),
+    )
+    output["identifier_unreachable_award_exact_name_match"] = (
+        normalized_entity_name.notna() & unreachable_name_match
     ).astype(bool)
     return output
 

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/methods.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/methods.py
@@ -1,0 +1,296 @@
+"""Approved pure mechanics for Phase III controls and the fixed placebo.
+
+This module does not choose a control population, match firms, materialize an
+artifact, or change the frozen census criteria. Its inputs are already-canonical
+frames supplied by a future, separately approved orchestration layer.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import date
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from sbir_etl.utils.identifiers import normalize_duns, normalize_uei
+from sbir_etl.utils.text_normalization import normalize_company_name
+
+from ..phase_iii_census.criteria import build_dropoff_ladder, build_sensitivity_grid
+
+
+PLACEBO_SEED = 20260801
+CONTROL_STATUS_LABEL = "no observed exact-identifier SBIR/STTR match"
+
+EXACT_UEI_EXCLUSION_REASON = "observed_exact_uei_sbir_sttr_match"
+EXACT_DUNS_EXCLUSION_REASON = "observed_exact_duns_sbir_sttr_match"
+
+_CANDIDATE_IDENTIFIER_COLUMNS = frozenset({"entity_id", "uei", "duns"})
+_HISTORY_IDENTIFIER_COLUMNS = frozenset({"uei", "duns"})
+_ELIGIBILITY_AUDIT_COLUMNS = frozenset(
+    {
+        "passes_exact_identifier_screen",
+        "control_status_label",
+    }
+)
+_NULL_TEXT = frozenset({"", "<NA>", "NAN", "NAT", "NONE", "NULL", r"\N"})
+
+
+class NegativeControlInputError(ValueError):
+    """Raised when an input cannot support the approved audit or placebo."""
+
+
+def _require_columns(frame: pd.DataFrame, required: frozenset[str], *, label: str) -> None:
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        raise NegativeControlInputError(f"{label} is missing required columns: {missing}")
+
+
+def _normalized_record_key(value: Any) -> str:
+    if value is None or value is pd.NA or value is pd.NaT:
+        return ""
+    try:
+        if bool(pd.isna(value)):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    normalized = str(value).strip().upper()
+    return "" if normalized in _NULL_TEXT else normalized
+
+
+def _normalized_company_name(value: Any) -> str | None:
+    if _normalized_record_key(value) == "":
+        return None
+    normalized = normalize_company_name(str(value))
+    return normalized or None
+
+
+def _validated_entity_keys(candidate_entities: pd.DataFrame) -> pd.Series:
+    keys = candidate_entities["entity_id"].map(_normalized_record_key)
+    if keys.eq("").any():
+        raise NegativeControlInputError("Every candidate entity must have a nonblank entity_id")
+    if keys.duplicated().any():
+        raise NegativeControlInputError(
+            "Candidate entity_id values must be unique after case/whitespace normalization"
+        )
+    return keys
+
+
+def _validate_history(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> None:
+    _require_columns(
+        complete_award_history,
+        _HISTORY_IDENTIFIER_COLUMNS,
+        label="complete SBIR/STTR award history",
+    )
+    if not candidate_entities.empty and complete_award_history.empty:
+        raise NegativeControlInputError(
+            "A nonempty candidate frame cannot be screened against empty SBIR/STTR history"
+        )
+
+
+def audit_exact_identifier_eligibility(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> pd.DataFrame:
+    """Audit exact UEI/DUNS exclusions against supplied complete award history.
+
+    Passing this screen means only that no exact usable identifier was observed in
+    the supplied history. It does not certify that an entity never received an
+    SBIR/STTR award.
+    """
+
+    _require_columns(
+        candidate_entities,
+        _CANDIDATE_IDENTIFIER_COLUMNS,
+        label="candidate entity frame",
+    )
+    _validate_history(candidate_entities, complete_award_history)
+    _validated_entity_keys(candidate_entities)
+
+    history_ueis = {
+        normalized
+        for normalized in complete_award_history["uei"].map(normalize_uei)
+        if isinstance(normalized, str)
+    }
+    history_duns = {
+        normalized
+        for normalized in complete_award_history["duns"].map(normalize_duns)
+        if isinstance(normalized, str)
+    }
+
+    output = candidate_entities.copy()
+    normalized_uei = output["uei"].map(normalize_uei)
+    normalized_duns = output["duns"].map(normalize_duns)
+    exact_uei_match = normalized_uei.isin(history_ueis)
+    exact_duns_match = normalized_duns.isin(history_duns)
+    passes = ~(exact_uei_match | exact_duns_match)
+
+    reasons = [
+        ";".join(
+            reason
+            for matched, reason in (
+                (uei_match, EXACT_UEI_EXCLUSION_REASON),
+                (duns_match, EXACT_DUNS_EXCLUSION_REASON),
+            )
+            if matched
+        )
+        for uei_match, duns_match in zip(exact_uei_match, exact_duns_match, strict=True)
+    ]
+
+    output["normalized_uei"] = pd.Series(normalized_uei, index=output.index, dtype="string")
+    output["normalized_duns"] = pd.Series(normalized_duns, index=output.index, dtype="string")
+    output["exact_uei_sbir_sttr_match"] = exact_uei_match.astype(bool)
+    output["exact_duns_sbir_sttr_match"] = exact_duns_match.astype(bool)
+    output["exclusion_reason"] = pd.Series(reasons, index=output.index, dtype="string").mask(
+        lambda series: series.eq("")
+    )
+    output["passes_exact_identifier_screen"] = passes.astype(bool)
+    output["control_status_label"] = pd.Series(
+        [CONTROL_STATUS_LABEL if passed else pd.NA for passed in passes],
+        index=output.index,
+        dtype="string",
+    )
+    return output
+
+
+def flag_identifier_free_name_stress_set(
+    eligibility_audit: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> pd.DataFrame:
+    """Flag exact normalized names found on identifier-free award rows.
+
+    The flag is for worst-case stress reporting only. It is not an eligibility
+    rule, contamination estimate, upper bound, fuzzy match, or alias screen.
+    """
+
+    _require_columns(
+        eligibility_audit,
+        frozenset({"entity_name", *_ELIGIBILITY_AUDIT_COLUMNS}),
+        label="eligibility audit",
+    )
+    _validate_history(eligibility_audit, complete_award_history)
+    _require_columns(
+        complete_award_history,
+        frozenset({"company_name"}),
+        label="complete SBIR/STTR award history",
+    )
+
+    history_uei = complete_award_history["uei"].map(normalize_uei)
+    history_duns = complete_award_history["duns"].map(normalize_duns)
+    history_names = complete_award_history["company_name"].map(_normalized_company_name)
+    identifier_free = history_uei.isna() & history_duns.isna()
+    reference_names = {
+        normalized
+        for normalized in history_names.loc[identifier_free]
+        if isinstance(normalized, str)
+    }
+
+    output = eligibility_audit.copy()
+    normalized_entity_name = output["entity_name"].map(_normalized_company_name)
+    output["normalized_entity_name"] = pd.Series(
+        normalized_entity_name,
+        index=output.index,
+        dtype="string",
+    )
+    output["identifier_free_award_exact_name_match"] = (
+        normalized_entity_name.notna() & normalized_entity_name.isin(reference_names)
+    ).astype(bool)
+    return output
+
+
+def _parse_prior_end_dates(values: pd.Series) -> pd.Series:
+    present = values.map(_normalized_record_key).ne("")
+    parsed = pd.to_datetime(values, errors="coerce", utc=True, format="mixed")
+    parsed = parsed.dt.tz_localize(None).dt.normalize()
+    if (present & parsed.isna()).any():
+        raise NegativeControlInputError(
+            "prior_period_of_performance_end contains an unparsable nonblank value"
+        )
+    return parsed
+
+
+def _date_multiset(values: pd.Series) -> Counter[int | None]:
+    return Counter(None if pd.isna(value) else int(pd.Timestamp(value).value) for value in values)
+
+
+def permute_prior_end_dates(pairs: pd.DataFrame) -> pd.DataFrame:
+    """Apply the one fixed placebo permutation at unique prior-award grain."""
+
+    required = frozenset({"prior_award_id", "prior_period_of_performance_end"})
+    _require_columns(pairs, required, label="placebo pair frame")
+    if pairs.empty:
+        return pairs.copy()
+
+    prior_keys = pairs["prior_award_id"].map(_normalized_record_key)
+    if prior_keys.eq("").any():
+        raise NegativeControlInputError("Every placebo pair row must have a prior_award_id")
+
+    prior_dates = _parse_prior_end_dates(pairs["prior_period_of_performance_end"])
+    award_rows = pd.DataFrame(
+        {"_prior_key": prior_keys, "_prior_end": prior_dates},
+        index=pairs.index,
+    )
+    date_variants = award_rows.groupby("_prior_key", sort=False)["_prior_end"].nunique(dropna=False)
+    if date_variants.gt(1).any():
+        raise NegativeControlInputError(
+            "Each prior_award_id must map to exactly one prior_period_of_performance_end"
+        )
+
+    unique_awards = (
+        award_rows.drop_duplicates("_prior_key", keep="first")
+        .sort_values("_prior_key", kind="stable")
+        .reset_index(drop=True)
+    )
+    donor_order = np.random.default_rng(PLACEBO_SEED).permutation(len(unique_awards))
+    shuffled_dates = unique_awards["_prior_end"].iloc[donor_order].reset_index(drop=True)
+    date_by_award = dict(zip(unique_awards["_prior_key"], shuffled_dates, strict=True))
+
+    output = pairs.copy()
+    output_dates = prior_keys.map(date_by_award)
+    output["prior_period_of_performance_end"] = pd.to_datetime(output_dates)
+
+    if len(output) != len(pairs) or not output.index.equals(pairs.index):
+        raise NegativeControlInputError("Placebo permutation changed pair row count or order")
+    for column in pairs.columns:
+        if column == "prior_period_of_performance_end":
+            continue
+        if not output[column].equals(pairs[column]):
+            raise NegativeControlInputError(
+                f"Placebo permutation changed prohibited non-date column: {column}"
+            )
+
+    output_award_dates = pd.DataFrame(
+        {"_prior_key": prior_keys, "_prior_end": output["prior_period_of_performance_end"]}
+    )
+    output_variants = output_award_dates.groupby("_prior_key", sort=False)["_prior_end"].nunique(
+        dropna=False
+    )
+    if output_variants.gt(1).any():
+        raise NegativeControlInputError(
+            "Placebo date was not propagated consistently across prior-award fan-out"
+        )
+    output_unique_dates = output_award_dates.drop_duplicates("_prior_key", keep="first")[
+        "_prior_end"
+    ]
+    if _date_multiset(output_unique_dates) != _date_multiset(unique_awards["_prior_end"]):
+        raise NegativeControlInputError(
+            "Placebo permutation did not preserve the award-grain date distribution"
+        )
+    return output
+
+
+def build_placebo_census_tables(
+    pairs: pd.DataFrame,
+    data_cut_date: date,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Run one permuted frame through both unchanged frozen census helpers."""
+
+    placebo_pairs = permute_prior_end_dates(pairs)
+    return (
+        build_dropoff_ladder(placebo_pairs, data_cut_date),
+        build_sensitivity_grid(placebo_pairs, data_cut_date),
+    )

--- a/specs/phase-iii-negative-controls/design.md
+++ b/specs/phase-iii-negative-controls/design.md
@@ -15,12 +15,14 @@ materialization can be approved.
 The following decisions were approved on **2026-08-02 with no result visibility**:
 
 1. Retained controls are labeled **“no observed exact-identifier SBIR/STTR match,”** not
-   certified SBIR-negative.
+   certified SBIR-negative. A candidate with no usable identifier was not screened at
+   all and carries the distinct label **“no usable identifier; not screenable”** —
+   see the correction below.
 2. The core eligibility exclusion is exact strict-normalized UEI/DUNS against the
    complete available SBIR/STTR history.
-3. An exact normalized-name match to an identifier-free award recipient is only a
-   worst-case stress-set/reporting flag. It is neither an upper bound nor an
-   inclusion/exclusion rule, and exact names do not bound aliases.
+3. An exact normalized-name match to an award recipient the identifier screen could not
+   reach is only a worst-case stress-set/reporting flag. It is neither an upper bound
+   nor an inclusion/exclusion rule, and exact names do not bound aliases.
 4. Employee count is omitted, without a proxy or new bands. The limitation must be
    prominent in eventual methods and results.
 5. The single placebo uses seed `20260801`. It shuffles
@@ -29,6 +31,33 @@ The following decisions were approved on **2026-08-02 with no result visibility*
 6. Every remaining methodological choice is an explicit question to resolve before the
    corresponding implementation or materialization. No result may answer a design
    question retrospectively.
+
+### Correction (2026-08-03): unscreenable candidates, pending sign-off
+
+Decisions 1 and 3 as first written left the same missingness unhandled on both sides of
+the screen, and the two helpers composed into a hole rather than a bound.
+
+A candidate whose UEI and DUNS are absent or malformed cannot match anything, so it
+passed the eligibility screen and received the retained-control label without having been
+compared to a single award row. The same candidate was then compared, in the stress flag,
+only against *identifier-free* award rows — so a candidate with no identifiers whose
+normalized name equals that of an identifier-carrying awardee was reported clean by the
+audit and absent from the stress set. That is the single most likely undetected recipient
+in the frame, and it fell through both outputs.
+
+Two changes, both strictly conservative — they can only move rows *into* the
+unscreenable or stressed populations, never out:
+
+- the audit emits `has_usable_identifier` and labels unscreenable passing rows
+  `“no usable identifier; not screenable”`, so screened-clean and not-screenable are
+  distinguishable in the output rather than only in prose;
+- the stress reference set is chosen per candidate: identifier-free award rows for a
+  screenable candidate, the **entire** history for an unscreenable one, since no identifier
+  join could have reached any award row on its behalf.
+
+This changes approved wording and is recorded here **pending repository-owner sign-off**.
+No result exists or has been viewed, so nothing here is a retrospective answer to a design
+question.
 
 ## Bounded architecture
 
@@ -39,7 +68,7 @@ canonical candidate rows + complete available SBIR/STTR history
                     |
                     +--> exact UEI/DUNS audit --> retained-label + exclusion reasons
                     |
-                    +--> identifier-free exact-name reporting flag
+                    +--> identifier-unreachable exact-name reporting flag
 
 existing exact-UEI pair frame
                     |
@@ -63,8 +92,11 @@ and appends:
 - exact UEI and DUNS match booleans;
 - a deterministic semicolon-separated exclusion reason containing every applicable
   match reason;
-- `passes_exact_identifier_screen`; and
-- the approved control label only for rows that pass.
+- `passes_exact_identifier_screen`;
+- `has_usable_identifier`, false when both strict normalizers reject the candidate's
+  identifiers; and
+- a status label for rows that pass: the approved control label when the row was
+  screenable, `“no usable identifier; not screenable”` when it was not.
 
 Candidate `entity_id` is an interface key, not a decision about which registered-entity
 population supplies candidates. It must be unique and nonblank so every exclusion is
@@ -72,11 +104,13 @@ auditable. A nonempty candidate frame with an empty history fails closed. The he
 not assert that the caller supplied complete history; provenance verification belongs to
 the future materialization.
 
-`flag_identifier_free_name_stress_set(audit, complete_award_history)` expects an
-`entity_name` in the audit and a `company_name` in history. Award rows enter the reference
-set only when both strict identifier normalizers return no usable identifier. The helper
-uses the existing `normalize_company_name` function and exact nonblank equality. It
-appends a reporting flag and does not change the eligibility fields.
+`flag_identifier_unreachable_name_stress_set(audit, complete_award_history)` expects an
+`entity_name` and `has_usable_identifier` in the audit and a `company_name` in history.
+The reference set is per candidate: for a screenable candidate, award rows enter it only
+when both strict identifier normalizers return no usable identifier; for an unscreenable
+candidate, every award row enters it, because the identifier screen reached none of them.
+The helper uses the existing `normalize_company_name` function and exact nonblank
+equality. It appends a reporting flag and does not change the eligibility fields.
 
 `permute_prior_end_dates(pairs)` has no seed argument: exposing one would invite repeated
 runs and favorable selection. It validates the prior-award/date relationship, sorts the
@@ -100,7 +134,8 @@ Future control construction must likewise call the existing
   normalization.
 - DUNS values are exact only after the repository's strict nine-digit normalization.
 - A missing or malformed identifier is unusable exact-linkage evidence. It does not
-  become evidence of nonparticipation.
+  become evidence of nonparticipation, and the audit says so in a column rather than
+  leaving it to be inferred from two null identifier fields.
 - Both exact reasons are retained when both identifiers match, even if they point to
   different history rows.
 - Company names use the repository's existing punctuation, whitespace, Unicode, and

--- a/specs/phase-iii-negative-controls/design.md
+++ b/specs/phase-iii-negative-controls/design.md
@@ -1,0 +1,52 @@
+# Phase III Negative Controls and Placebo — Dependency Scaffold
+
+**Status:** **BLOCKED — dependency scaffold only.**
+
+**Base dependency:**
+[Phase III census PR #475](https://github.com/hollomancer/sbir-analytics/pull/475).
+
+PR #475 implements frozen, auditable Phase 1 census tables. Those tables are
+implementation outputs, not validated Phase III results. No production census count,
+negative-control result, or placebo result has been materialized or quoted.
+
+This stub makes the validation dependency visible before a count can acquire the
+appearance of a finished result. It adds no control implementation, resolution method,
+new numeric cutoff, or result.
+
+## Inherited design
+
+The control and SBIR arms must use the identical frozen census filter and pseudo-index
+design from [`../phase-iii-census/design.md`](../phase-iii-census/design.md). The filter
+must not branch on arm membership; an `if is_control:` inclusion path is a design failure.
+
+## Required work before this gate can close
+
+1. **Full-history eligibility:** certify that every control firm received no SBIR/STTR
+   award anywhere in the complete award history, and report every exclusion with its
+   reason.
+2. **Matching:** match each SBIR firm to one through three controls on primary NAICS,
+   employee-count band, state, year of first federal contract, and PSC family.
+3. **Balance:** report standardized mean differences for every matched covariate and stop
+   for review when a key covariate exceeds the pre-registered `0.1` balance limit.
+4. **Arm-blind evaluation:** run the same census filter implementation on both arms with
+   no arm-specific criterion or threshold.
+5. **Distributional reporting:** publish the full per-firm distribution of criteria-met
+   counts for both arms, their overlap coefficient, and the ratio of firms in each arm
+   clearing the complete criteria set.
+6. **Placebo:** permute `prior_period_of_performance_end` across real SBIR firms with a
+   fixed, recorded seed, rerun the census, and report the unpermuted and permuted tables
+   without selecting a favorable result.
+
+## Current blockers
+
+- The full-history SBIR.gov record has a material population without reliable UEI or
+  DUNS linkage. Exact identifier exclusion therefore cannot yet certify that a SAM entity
+  is SBIR/STTR-negative across the entire history; a replacement method has not been
+  approved.
+- The available SAM public entity extract does not provide the required employee-count
+  covariate. No employee-band construction or substitute covariate has been approved.
+
+Until both blockers are resolved and evidence-backed control and placebo artifacts exist,
+the release gate in `tests/unit/phase_iii_negative_controls/test_release_gate.py` must
+remain deliberately failing. Removing, skipping, or marking it expected-to-fail is not a
+resolution.

--- a/specs/phase-iii-negative-controls/design.md
+++ b/specs/phase-iii-negative-controls/design.md
@@ -21,11 +21,35 @@ must not branch on arm membership; an `if is_control:` inclusion path is a desig
 
 ## Required work before this gate can close
 
-1. **Full-history eligibility:** certify that every control firm received no SBIR/STTR
-   award anywhere in the complete award history, and report every exclusion with its
-   reason.
+1. **Full-history eligibility — bound the contamination, do not certify its absence.**
+   Exact-identifier exclusion against the complete award history, reporting every
+   exclusion with its reason. That screen cannot clear the population with no reliable
+   UEI/DUNS, and no future work will: the identifiers are absent from the source record,
+   which is a permanent property of it, not a dependency waiting to resolve. A
+   requirement to *certify* a negative over that population would therefore never be
+   satisfiable, and the gate would be permanent rather than blocking. What is required
+   instead, following the standard matched-control treatment:
+   - **estimate an upper bound** on the share of retained "controls" that are undetected
+     SBIR/STTR recipients — a name-based screen over the unlinkable population yields a
+     rate even where it cannot adjudicate any individual firm;
+   - **pre-register that bound** as a reported quantity alongside the headline contrast;
+   - **show the contrast survives the worst case** — assume every unlinkable,
+     name-similar firm is SBIR-positive, and report whether the conclusion holds.
+
+   The gate closes on a measured and disclosed contamination bound, not on proof of
+   zero contamination.
 2. **Matching:** match each SBIR firm to one through three controls on primary NAICS,
-   employee-count band, state, year of first federal contract, and PSC family.
+   state, year of first federal contract, and PSC family.
+
+   **Employee-count band is dropped**, and the drop is deliberate rather than deferred:
+   it was specified as a required covariate while simultaneously appearing in the
+   blockers below as unavailable in the SAM public entity extract, which left the
+   matching design not executable as written. Resolution: match without it, and report
+   the cost — firm size is the covariate most plausibly correlated with both SBIR
+   participation and contract outcomes, so its omission is the largest known threat to
+   balance and **must be named in the results, not just here**. If an approved
+   employee-count source later exists, reinstating it is a strict improvement; adding it
+   back is not a precondition for closing the gate.
 3. **Balance:** report standardized mean differences for every matched covariate and stop
    for review when a key covariate exceeds the pre-registered `0.1` balance limit.
 4. **Arm-blind evaluation:** run the same census filter implementation on both arms with
@@ -40,13 +64,29 @@ must not branch on arm membership; an `if is_control:` inclusion path is a desig
 ## Current blockers
 
 - The full-history SBIR.gov record has a material population without reliable UEI or
-  DUNS linkage. Exact identifier exclusion therefore cannot yet certify that a SAM entity
-  is SBIR/STTR-negative across the entire history; a replacement method has not been
-  approved.
-- The available SAM public entity extract does not provide the required employee-count
-  covariate. No employee-band construction or substitute covariate has been approved.
+  DUNS linkage, so exact-identifier exclusion cannot certify that a SAM entity is
+  SBIR/STTR-negative across the entire history. This is a **permanent property of the
+  source**, not a pending dependency — requirement 1 is written to bound the resulting
+  contamination rather than wait for it to close. The remaining work is to *build* that
+  bound (the name-based screen and the worst-case robustness check), which is not done.
+- The available SAM public entity extract does not provide an employee-count covariate.
+  This is **no longer a blocker**: requirement 2 drops the covariate and requires the
+  resulting balance cost to be reported. It is recorded here as a known limitation, and
+  as the reason a size-band substitute would be worth approving later.
 
-Until both blockers are resolved and evidence-backed control and placebo artifacts exist,
-the release gate in `tests/unit/phase_iii_negative_controls/test_release_gate.py` must
-remain deliberately failing. Removing, skipping, or marking it expected-to-fail is not a
-resolution.
+Until evidence-backed control and placebo artifacts exist — including the contamination
+bound required by requirement 1 — the release gate in
+`tests/unit/phase_iii_negative_controls/test_release_gate.py` must remain deliberately
+failing. Removing, skipping, or marking it expected-to-fail is not a resolution.
+
+**This branch is therefore not intended to merge while the gate is closed.** `unit-fast`
+is a required check, so merging a deliberately failing test would turn `main` red for
+every unrelated PR in the repo. The draft status is what enforces that today; it should
+stay a draft until the gate can close.
+
+One requirement here *can* be pinned by a green test today, with none of the blocked
+data: requirement 4's arm-blindness. A test asserting that the census filter's call
+signature takes no arm/label argument — or that the filter module never references the
+arm column — would pass now, could live on `main`, and would go red the moment someone
+adds the `if is_control:` branch this design calls a failure. That test is not blocked on
+SAM or SBIR.gov and should land independently of this gate.

--- a/specs/phase-iii-negative-controls/design.md
+++ b/specs/phase-iii-negative-controls/design.md
@@ -1,92 +1,196 @@
-# Phase III Negative Controls and Placebo — Dependency Scaffold
+# Phase III Negative Controls and Placebo — Design
 
-**Status:** **BLOCKED — dependency scaffold only.**
+> **Status (2026-08-02):** Approved bounded foundation; empirical study and release gate
+> remain blocked. The repository owner approved the decisions recorded below before any
+> census, negative-control, or placebo result had been computed or seen.
 
-**Base dependency:**
-[Phase III census PR #475](https://github.com/hollomancer/sbir-analytics/pull/475).
+This is a post-Phase-0 companion to the frozen
+[`phase-iii-census`](../phase-iii-census/design.md) design. It does not amend that design,
+its amendments, or its frozen constants. It adds only the data-independent control audit,
+name stress flag, and one placebo permutation needed before a future matched-control
+materialization can be approved.
 
-PR #475 implements frozen, auditable Phase 1 census tables. Those tables are
-implementation outputs, not validated Phase III results. No production census count,
-negative-control result, or placebo result has been materialized or quoted.
+## Approved decisions
 
-This stub makes the validation dependency visible before a count can acquire the
-appearance of a finished result. It adds no control implementation, resolution method,
-new numeric cutoff, or result.
+The following decisions were approved on **2026-08-02 with no result visibility**:
 
-## Inherited design
+1. Retained controls are labeled **“no observed exact-identifier SBIR/STTR match,”** not
+   certified SBIR-negative.
+2. The core eligibility exclusion is exact strict-normalized UEI/DUNS against the
+   complete available SBIR/STTR history.
+3. An exact normalized-name match to an identifier-free award recipient is only a
+   worst-case stress-set/reporting flag. It is neither an upper bound nor an
+   inclusion/exclusion rule, and exact names do not bound aliases.
+4. Employee count is omitted, without a proxy or new bands. The limitation must be
+   prominent in eventual methods and results.
+5. The single placebo uses seed `20260801`. It shuffles
+   `prior_period_of_performance_end` once at unique prior-award grain and propagates the
+   assigned date to all fan-out pair rows for that award.
+6. Every remaining methodological choice is an explicit question to resolve before the
+   corresponding implementation or materialization. No result may answer a design
+   question retrospectively.
 
-The control and SBIR arms must use the identical frozen census filter and pseudo-index
-design from [`../phase-iii-census/design.md`](../phase-iii-census/design.md). The filter
-must not branch on arm membership; an `if is_control:` inclusion path is a design failure.
+## Bounded architecture
 
-## Required work before this gate can close
+The implemented layer is deliberately pure and additive:
 
-1. **Full-history eligibility — bound the contamination, do not certify its absence.**
-   Exact-identifier exclusion against the complete award history, reporting every
-   exclusion with its reason. That screen cannot clear the population with no reliable
-   UEI/DUNS, and no future work will: the identifiers are absent from the source record,
-   which is a permanent property of it, not a dependency waiting to resolve. A
-   requirement to *certify* a negative over that population would therefore never be
-   satisfiable, and the gate would be permanent rather than blocking. What is required
-   instead, following the standard matched-control treatment:
-   - **estimate an upper bound** on the share of retained "controls" that are undetected
-     SBIR/STTR recipients — a name-based screen over the unlinkable population yields a
-     rate even where it cannot adjudicate any individual firm;
-   - **pre-register that bound** as a reported quantity alongside the headline contrast;
-   - **show the contrast survives the worst case** — assume every unlinkable,
-     name-similar firm is SBIR-positive, and report whether the conclusion holds.
+```text
+canonical candidate rows + complete available SBIR/STTR history
+                    |
+                    +--> exact UEI/DUNS audit --> retained-label + exclusion reasons
+                    |
+                    +--> identifier-free exact-name reporting flag
 
-   The gate closes on a measured and disclosed contamination bound, not on proof of
-   zero contamination.
-2. **Matching:** match each SBIR firm to one through three controls on primary NAICS,
-   state, year of first federal contract, and PSC family.
+existing exact-UEI pair frame
+                    |
+                    +--> fixed award-grain date permutation
+                    |
+                    +--> existing frozen census helpers (unchanged)
+```
 
-   **Employee-count band is dropped**, and the drop is deliberate rather than deferred:
-   it was specified as a required covariate while simultaneously appearing in the
-   blockers below as unavailable in the SAM public entity extract, which left the
-   matching design not executable as written. Resolution: match without it, and report
-   the cost — firm size is the covariate most plausibly correlated with both SBIR
-   participation and contract outcomes, so its omission is the largest known threat to
-   balance and **must be named in the results, not just here**. If an approved
-   employee-count source later exists, reinstating it is a strict improvement; adding it
-   back is not a precondition for closing the gate.
-3. **Balance:** report standardized mean differences for every matched covariate and stop
-   for review when a key covariate exceeds the pre-registered `0.1` balance limit.
-4. **Arm-blind evaluation:** run the same census filter implementation on both arms with
-   no arm-specific criterion or threshold.
-5. **Distributional reporting:** publish the full per-firm distribution of criteria-met
-   counts for both arms, their overlap coefficient, and the ratio of firms in each arm
-   clearing the complete criteria set.
-6. **Placebo:** permute `prior_period_of_performance_end` across real SBIR firms with a
-   fixed, recorded seed, rerun the census, and report the unpermuted and permuted tables
-   without selecting a favorable result.
+There is no source reader, matcher, Dagster asset, artifact writer, config object, or
+generic study framework here. Those boundaries would force answers to unresolved
+questions.
 
-## Current blockers
+### Pure interfaces
 
-- The full-history SBIR.gov record has a material population without reliable UEI or
-  DUNS linkage, so exact-identifier exclusion cannot certify that a SAM entity is
-  SBIR/STTR-negative across the entire history. This is a **permanent property of the
-  source**, not a pending dependency — requirement 1 is written to bound the resulting
-  contamination rather than wait for it to close. The remaining work is to *build* that
-  bound (the name-based screen and the worst-case robustness check), which is not done.
-- The available SAM public entity extract does not provide an employee-count covariate.
-  This is **no longer a blocker**: requirement 2 drops the covariate and requires the
-  resulting balance cost to be reported. It is recorded here as a known limitation, and
-  as the reason a size-band substitute would be worth approving later.
+`audit_exact_identifier_eligibility(candidate_entities, complete_award_history)` expects
+an already-canonical candidate frame with `entity_id`, `uei`, and `duns`, plus a complete
+available SBIR/STTR history frame with `uei` and `duns`. It preserves candidate columns
+and appends:
 
-Until evidence-backed control and placebo artifacts exist — including the contamination
-bound required by requirement 1 — the release gate in
-`tests/unit/phase_iii_negative_controls/test_release_gate.py` must remain deliberately
-failing. Removing, skipping, or marking it expected-to-fail is not a resolution.
+- strict normalized identifiers;
+- exact UEI and DUNS match booleans;
+- a deterministic semicolon-separated exclusion reason containing every applicable
+  match reason;
+- `passes_exact_identifier_screen`; and
+- the approved control label only for rows that pass.
 
-**This branch is therefore not intended to merge while the gate is closed.** `unit-fast`
-is a required check, so merging a deliberately failing test would turn `main` red for
-every unrelated PR in the repo. The draft status is what enforces that today; it should
-stay a draft until the gate can close.
+Candidate `entity_id` is an interface key, not a decision about which registered-entity
+population supplies candidates. It must be unique and nonblank so every exclusion is
+auditable. A nonempty candidate frame with an empty history fails closed. The helper does
+not assert that the caller supplied complete history; provenance verification belongs to
+the future materialization.
 
-One requirement here *can* be pinned by a green test today, with none of the blocked
-data: requirement 4's arm-blindness. A test asserting that the census filter's call
-signature takes no arm/label argument — or that the filter module never references the
-arm column — would pass now, could live on `main`, and would go red the moment someone
-adds the `if is_control:` branch this design calls a failure. That test is not blocked on
-SAM or SBIR.gov and should land independently of this gate.
+`flag_identifier_free_name_stress_set(audit, complete_award_history)` expects an
+`entity_name` in the audit and a `company_name` in history. Award rows enter the reference
+set only when both strict identifier normalizers return no usable identifier. The helper
+uses the existing `normalize_company_name` function and exact nonblank equality. It
+appends a reporting flag and does not change the eligibility fields.
+
+`permute_prior_end_dates(pairs)` has no seed argument: exposing one would invite repeated
+runs and favorable selection. It validates the prior-award/date relationship, sorts the
+unique normalized prior-award keys to make the mapping independent of pair-row order,
+uses the fixed seed once, maps donor dates at award grain, and propagates the result back
+to the original rows. It verifies the award-grain date multiset and fan-out invariant
+before returning.
+
+`build_placebo_census_tables(pairs, data_cut_date)` is intentionally a thin composition:
+it permutes the one approved field exactly once, then passes that same in-memory frame to
+the existing `build_dropoff_ladder` and `build_sensitivity_grid`. It returns both tables,
+has no arm parameter, and has no alternative criterion path.
+
+Future control construction must likewise call the existing
+`phase_iii_candidates.pairing.build_uei_pairs` for pseudo-index rows, then the existing
+`phase_iii_census.criteria` helpers. This spec does not copy either implementation.
+
+## Exact identifier and name semantics
+
+- UEIs are exact only after the repository's strict 12-character alphanumeric
+  normalization.
+- DUNS values are exact only after the repository's strict nine-digit normalization.
+- A missing or malformed identifier is unusable exact-linkage evidence. It does not
+  become evidence of nonparticipation.
+- Both exact reasons are retained when both identifiers match, even if they point to
+  different history rows.
+- Company names use the repository's existing punctuation, whitespace, Unicode, and
+  suffix normalization. No fuzzy score, alias list, DBA expansion, substring rule, or
+  crosswalk is used.
+- The name stress flag can miss true identity relationships and can flag unrelated firms.
+  Its size is therefore not a contamination rate or upper bound.
+
+## Employee count is deliberately absent
+
+Employee count is not deferred inside the matcher and is not replaced. GSA's official
+[Entity Management API documentation](https://open.gsa.gov/api/entity-api/) classifies
+`assertions.sizeMetrics.averageNumberOfEmployees` as FOUO, while public entity data
+includes fields such as UEI, name, NAICS, and PSC. GSA separately describes the
+[public entity extracts](https://open.gsa.gov/api/sam-entity-extracts-api/) as the
+unclassified public tier and requires FOUO permissions for FOUO extracts.
+
+Consequently the public-input study omits employee count. Firm size can be associated
+with both SBIR/STTR participation and procurement outcomes, so residual size imbalance is
+a major known limitation. Every eventual methods and results artifact must say this
+prominently. Revenue, small-business flags, award volume, or any other size proxy would
+be a new design choice and is prohibited here.
+
+## Arm blindness and inherited criteria
+
+The census filter sees only pair fields. It cannot accept or inspect an arm label. SBIR
+pairs, future control pseudo-index pairs, and placebo pairs all run through the same
+frozen core clauses. The only placebo mutation is the pre-registered prior end date.
+
+The implementation does not import or call a scorer, weights, thresholds, similarity,
+embeddings, or ML. It does not modify `phase_iii_candidates/assets.py`,
+`TransitionScorer`, or anything under `packages/sbir-ml/sbir_ml/transition/detection/`.
+
+## Questions to resolve before any empirical implementation
+
+Every item below is intentionally unanswered. The answer must be approved and recorded
+before its code is written and before any result is viewed.
+
+1. **SAM acquisition and provenance:** Which dated SAM public snapshot will be acquired,
+   by which API/extract route, and which URL, file name, checksum, extract layout,
+   registration-status scope, generation date, and acquisition timestamp must its
+   manifest bind?
+2. **Registered-entity candidate frame:** Which public SAM entities enter the candidate
+   frame—active only, active plus recently expired, all-awards registrations, procurement
+   registrations, domestic entities, firms with a federal-contract history, or another
+   pre-declared population—and how are duplicate or successor registrations handled?
+3. **SBIR/STTR history provenance:** Which exact full-history snapshot and manifest define
+   “complete available history,” and which program/phase fields establish that every
+   supplied row is in SBIR or STTR scope?
+4. **Canonical candidate name:** Does the staged `entity_name` use legal business name
+   only, DBA only, or a separately reported flag for each? How are missing names handled
+   without turning alias expansion into an inclusion rule?
+5. **Primary NAICS and state:** Which snapshot fields and missing-value rules define
+   primary NAICS and state, and is state physical address or incorporation state?
+6. **First federal contract year:** Which contract corpus, transaction/award grain,
+   identifier resolution, date field, and observation-window rule derive first-contract
+   year?
+7. **PSC family:** Which authoritative taxonomy/version and deterministic mapping derive
+   PSC family, which contract history supplies a firm's PSCs, and how are multiple or
+   missing families handled?
+8. **Matching algorithm:** Are covariates exact strata, distance terms, calipers, or a
+   staged combination; what happens when fewer than the target one-to-three controls are
+   available?
+9. **Control reuse and tie-breaking:** May a control be reused across treated firms or
+   pseudo-index assignments, what reuse cap applies, and what deterministic ordering or
+   random seed breaks otherwise equal matches?
+10. **Multiple identifiers and organizations:** How are multiple UEIs/DUNS, corporate
+    parents, acquisitions, successor entities, and identifier changes represented without
+    introducing an unapproved identity method?
+11. **Categorical and temporal SMD encoding:** Are NAICS, PSC family, and state expanded as
+    indicator variables; is first-contract year continuous, categorical, or binned; how
+    are pooled variance, zero-variance cells, missingness, and weighting handled?
+12. **Key-covariate review:** Which encoded balance rows are “key” for the absolute `0.1`
+    stop rule, and what action follows a failure without post-result rematching?
+13. **Per-firm distribution grain:** Is a firm keyed by staged entity ID or UEI; how are
+    multiple real Phase II indices, copied pseudo-indices, reused controls, and multiple
+    target transactions collapsed into criteria-met counts?
+14. **Control pseudo-index artifact:** What exact mapping schema binds each control to its
+    matched SBIR firm and copied prior-award row, and how are provenance and one-to-many
+    fan-out verified before `build_uei_pairs`?
+15. **Output contracts:** What artifact paths, schemas, manifests, hashes, data-cut
+    bindings, and review metadata are required for eligibility, matches, balance,
+    per-firm distributions, stress-set reporting, and placebo outputs?
+16. **Release evidence:** Which concrete artifact checks and reviewer sign-off replace the
+    sentinel once—and only once—the negative-control and placebo evidence exists?
+
+## Release discipline
+
+The release sentinel remains deliberately failing. Green fixture tests prove only that
+the approved pure mechanics behave as specified. They do not establish source
+provenance, match quality, balance, or an empirical result, and they cannot close the
+gate. This branch must not compute, materialize, or quote real census, control, or placebo
+results.

--- a/specs/phase-iii-negative-controls/requirements.md
+++ b/specs/phase-iii-negative-controls/requirements.md
@@ -1,0 +1,127 @@
+# Phase III Negative Controls and Placebo — Requirements
+
+> **Status (2026-08-02):** The bounded, data-independent methods are approved and
+> implemented. Matching, balance, reporting, artifact materialization, and release remain
+> gated on the questions in [`design.md`](design.md). No census, control, or placebo result
+> had been computed or seen when these requirements were approved.
+
+**Research-question anchors:** B2 and B3 in
+[`docs/research-questions.md`](../../docs/research-questions.md)
+
+## Done when
+
+The study is done only when an analyst can compare the frozen Phase III census proxy for
+SBIR firms with a pre-registered matched-control arm and the single fixed placebo, while
+showing exact-identifier exclusions, the normalized-name stress set, covariate balance,
+and full per-firm distributions. The comparison must use the same pair builder and census
+criteria in every arm. It must prominently state that employee count was unavailable and
+omitted, and it must describe retained controls as **“no observed exact-identifier
+SBIR/STTR match,”** never as certified SBIR-negative.
+
+No such result or artifact exists yet. The deliberately failing release sentinel remains
+closed until all release evidence exists.
+
+## Requirements
+
+### Requirement 1 — Exact-identifier eligibility audit
+
+1. The control-candidate audit **SHALL** compare strict normalized UEI and DUNS values
+   against the complete available SBIR/STTR award history supplied to the audit.
+2. A candidate with an observed exact UEI match, exact DUNS match, or both **SHALL** fail
+   the screen. Every failed row **SHALL** record each applicable exclusion reason.
+3. A retained candidate **SHALL** be labeled exactly **“no observed exact-identifier
+   SBIR/STTR match.”** The label **SHALL NOT** be shortened to “non-SBIR,”
+   “SBIR-negative,” or any equivalent certification.
+4. The audit **SHALL** use the existing strict `normalize_uei` and `normalize_duns`
+   functions. Missing or malformed values do not match; they also do not establish that
+   the entity never received an award.
+5. The pure audit helper **SHALL NOT** claim that its input history is complete. A future
+   materialization must verify and record the history snapshot's provenance and
+   completeness before calling it.
+
+### Requirement 2 — Identifier-free exact-name stress set
+
+1. The reporting stress flag **SHALL** consider only SBIR/STTR history rows for which
+   neither UEI nor DUNS yields a usable strict normalized identifier.
+2. Candidate and award-recipient names **SHALL** use the existing deterministic company-
+   name normalizer. Only equality of the resulting nonblank normalized names is a match.
+3. The name flag **SHALL NOT** change exact-identifier eligibility, matching inclusion,
+   census criteria, weights, or thresholds.
+4. The flagged set **SHALL** be reported as a worst-case stress set. It **SHALL NOT** be
+   called a contamination estimate or upper bound: exact names do not cover aliases,
+   rebrandings, acquisitions, spelling changes, or other identity variation, and exact
+   normalization can also create false positives.
+
+### Requirement 3 — Matching and the employee-count limitation
+
+1. A future approved matcher **SHALL** select one through three controls using primary
+   NAICS, state, year of first federal contract, and PSC family.
+2. Employee count **SHALL BE OMITTED**. No employee proxy, size band, revenue band, or new
+   band boundary may be introduced under this spec.
+3. Every eventual result and methods artifact **SHALL** prominently state that omitting
+   firm size is a major known threat to balance because size may relate to both SBIR/STTR
+   participation and contracting outcomes.
+4. Matching **SHALL NOT** be implemented until the candidate frame, PSC-family
+   derivation, reuse, tie-breaking, and missing-covariate questions in the design are
+   resolved before results are viewed.
+
+### Requirement 4 — Balance and distributional reporting
+
+1. A future balance artifact **SHALL** report standardized mean differences for every
+   matched covariate and stop for review when an approved key-covariate encoding exceeds
+   the pre-registered absolute `0.1` limit.
+2. The encoding of categorical and temporal covariates **SHALL** be resolved before the
+   balance calculation is implemented.
+3. Arm results **SHALL** include the full per-firm distribution of criteria-met counts,
+   the overlap coefficient, and the ratio of firms clearing the complete criteria set.
+4. The per-firm grain and the treatment of multiple pseudo-index rows **SHALL** be
+   resolved before those distributions are implemented.
+
+### Requirement 5 — Arm-blind census evaluation
+
+1. SBIR, control, and placebo pair frames **SHALL** be evaluated with the existing
+   `apply_core_clauses`, `build_dropoff_ladder`, and `build_sensitivity_grid` helpers and
+   their frozen criteria.
+2. Pair construction for SBIR and future pseudo-index control rows **SHALL** reuse the
+   existing normalized exact-UEI `build_uei_pairs` boundary.
+3. No filter function may accept or inspect an arm, cohort, treatment, control, or placebo
+   label. There **SHALL NOT** be an `if is_control:` inclusion path.
+4. No scorer, similarity, model, weight, rank, or threshold may affect inclusion.
+
+### Requirement 6 — One fixed placebo
+
+1. There **SHALL** be one pre-registered placebo using seed `20260801`.
+2. `prior_period_of_performance_end` **SHALL** be permuted once at unique
+   `prior_award_id` grain, not independently at pair-row grain.
+3. The shuffled date assigned to a prior award **SHALL** propagate to every fan-out pair
+   row for that award.
+4. The permutation **SHALL** preserve the award-grain marginal multiset of dates, row
+   count, pair order, and every non-date column.
+5. Conflicting dates within a prior award, blank prior-award identifiers, or unparsable
+   nonblank dates **SHALL** fail before permutation.
+6. The placebo frame **SHALL** run through the identical frozen census helper without
+   selecting a favorable seed or changing a criterion after comparison.
+7. One evaluation call **SHALL** permute once and pass that same in-memory pair frame to
+   both the drop-off ladder and sensitivity grid; the two tables may not be based on
+   separate permutations.
+
+### Requirement 7 — Release gate
+
+1. The sentinel in
+   `tests/unit/phase_iii_negative_controls/test_release_gate.py` **SHALL** remain a
+   deliberate failure until real, provenance-backed negative-control and placebo
+   artifacts exist and their pre-registered checks pass.
+2. The sentinel **SHALL NOT** be removed, skipped, xfailed, or weakened to make CI green.
+3. Pure helper tests do not close the gate and are not empirical evidence.
+4. No production census, negative-control, or placebo count may be quoted from this
+   implementation branch.
+
+## Prohibited scope
+
+- No modification to `phase_iii_candidates/assets.py`, `TransitionScorer`, or any file
+  under `packages/sbir-ml/sbir_ml/transition/detection/`.
+- No modification to the frozen census design, amendment log, criteria, constants,
+  weights, or thresholds.
+- No Dagster asset, new configuration tree, generic matching framework, or dependency.
+- No name similarity, fuzzy matching, alias expansion, embedding, model, or classifier.
+- No silent answer to any question listed in the design.

--- a/specs/phase-iii-negative-controls/tasks.md
+++ b/specs/phase-iii-negative-controls/tasks.md
@@ -1,0 +1,74 @@
+# Phase III Negative Controls and Placebo — Tasks
+
+> **Status (2026-08-02):** Bounded pure mechanics implemented; empirical phases gated.
+> Approval was recorded before any census, negative-control, or placebo result was
+> computed or seen.
+
+## Phase 0 — Approved data-independent foundation
+
+- [x] 0.1 Replace the dependency scaffold with requirements, design, tasks, approval
+      date, result-visibility statement, and explicit unresolved questions.
+- [x] 0.2 Implement a strict exact-UEI/DUNS candidate audit with row-level match flags,
+      every applicable exclusion reason, and the approved retained-control label.
+- [x] 0.3 Implement the exact normalized-name reporting flag over identifier-free
+      SBIR/STTR award rows without changing eligibility or claiming an upper bound.
+- [x] 0.4 Implement the one seed-`20260801` prior-award-grain end-date permutation with
+      fan-out propagation and fail-closed integrity checks.
+- [x] 0.5 Compose one placebo permutation with both existing frozen census table helpers;
+      pass the same in-memory frame to both and add no arm-specific filter, scorer,
+      threshold, similarity, ML, or copied criteria.
+- [x] 0.6 Add fixture-based unit tests for the approved mechanics. Arm blindness is
+      enforced independently by the broader suite merged from PR #480.
+- [x] 0.7 Keep the release sentinel deliberately failing and clarify that pure helper
+      tests do not constitute release evidence.
+
+## Phase 1 — Resolve source and cohort questions before coding
+
+- [ ] 1.1 Answer and approve the SAM snapshot acquisition/provenance question.
+- [ ] 1.2 Answer and approve the registered-entity candidate-frame question.
+- [ ] 1.3 Answer and approve the complete SBIR/STTR history provenance/scope question.
+- [ ] 1.4 Answer and approve the canonical candidate-name, primary-NAICS, state, and
+      missingness questions.
+- [ ] 1.5 Materialize no cohort until tasks 1.1–1.4 are recorded in the design.
+
+## Phase 2 — Resolve and implement matching
+
+- [ ] 2.1 Answer and approve first-contract-year and PSC-family derivations.
+- [ ] 2.2 Answer and approve the matching algorithm, one-to-three availability rule,
+      control reuse, and deterministic tie-breaking.
+- [ ] 2.3 Answer and approve multiple-identifier, successor-entity, and parent handling.
+- [ ] 2.4 Implement the smallest matcher consistent with the approved answers. Do not add
+      employee count, a size proxy, or new bands.
+- [ ] 2.5 Emit a row-level match audit and pseudo-index provenance artifact using the
+      approved schema.
+
+## Phase 3 — Resolve and implement balance/reporting
+
+- [ ] 3.1 Answer and approve categorical/temporal SMD encoding, weighting, missingness,
+      zero-variance handling, and the key-covariate review set.
+- [ ] 3.2 Answer and approve the per-firm distribution grain and multi-index collapse.
+- [ ] 3.3 Implement balance tables, the absolute `0.1` review stop, full per-firm
+      distributions, overlap coefficient, and complete-criteria ratios.
+- [ ] 3.4 Make the employee-count omission and its residual-confounding risk prominent in
+      every methods and result artifact.
+
+## Phase 4 — Materialization and release evidence
+
+- [ ] 4.1 Answer and approve output paths, schemas, manifests, hash/data-cut bindings,
+      artifact checks, and reviewer sign-off.
+- [ ] 4.2 Materialize the real exact-identifier audit and exact-name stress-set artifact.
+- [ ] 4.3 Materialize the matched-control, balance, distributional, and single-placebo
+      artifacts through the shared exact-UEI builder and frozen criteria.
+- [ ] 4.4 Verify that no arm-specific branch, scorer, similarity, weight, model, threshold,
+      alternate seed, or post-result criterion change entered the run.
+- [ ] 4.5 Replace the deliberately failing sentinel only with evidence-backed release
+      tests after all required artifacts and approvals exist.
+
+## Explicit non-tasks
+
+- Certifying any retained entity as SBIR-negative.
+- Treating the exact-name flag as a contamination estimate or upper bound.
+- Employee-count proxies, size bands, or new matching covariates.
+- Changes to the frozen census design/amendments, freeze constants,
+  `phase_iii_candidates/assets.py`, `TransitionScorer`, or transition-detection ML.
+- Computing, materializing, or quoting real results on this implementation branch.

--- a/tests/unit/phase_iii_negative_controls/test_methods.py
+++ b/tests/unit/phase_iii_negative_controls/test_methods.py
@@ -1,0 +1,332 @@
+from datetime import date
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.phase_iii_census.criteria import (
+    build_dropoff_ladder,
+    build_sensitivity_grid,
+)
+from sbir_analytics.assets.phase_iii_negative_controls import methods as methods_module
+from sbir_analytics.assets.phase_iii_negative_controls.methods import (
+    CONTROL_STATUS_LABEL,
+    EXACT_DUNS_EXCLUSION_REASON,
+    EXACT_UEI_EXCLUSION_REASON,
+    PLACEBO_SEED,
+    NegativeControlInputError,
+    audit_exact_identifier_eligibility,
+    build_placebo_census_tables,
+    flag_identifier_free_name_stress_set,
+    permute_prior_end_dates,
+)
+
+
+pytestmark = pytest.mark.fast
+DATA_CUT = date(2025, 12, 31)
+
+
+@pytest.fixture
+def complete_award_history() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "award_id": "AWARD-UEI",
+                "uei": "UEI000000001",
+                "duns": None,
+                "company_name": "UEI Recipient LLC",
+            },
+            {
+                "award_id": "AWARD-DUNS",
+                "uei": None,
+                "duns": "123456789",
+                "company_name": "DUNS Recipient LLC",
+            },
+            {
+                "award_id": "AWARD-BOTH",
+                "uei": "UEI000000003",
+                "duns": "333333333",
+                "company_name": "Both Recipient LLC",
+            },
+            {
+                "award_id": "AWARD-NAME-ONLY",
+                "uei": None,
+                "duns": None,
+                "company_name": "Acme Incorporated",
+            },
+            {
+                "award_id": "AWARD-NAME-WITH-ID",
+                "uei": "UEI000000005",
+                "duns": None,
+                "company_name": "Identifier Backed LLC",
+            },
+        ]
+    )
+
+
+@pytest.fixture
+def candidate_entities() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "entity_id": "ENTITY-UEI",
+                "uei": " uei-000-000-001 ",
+                "duns": None,
+                "entity_name": "UEI Recipient LLC",
+            },
+            {
+                "entity_id": "ENTITY-DUNS",
+                "uei": None,
+                "duns": "123-456-789",
+                "entity_name": "DUNS Recipient LLC",
+            },
+            {
+                "entity_id": "ENTITY-BOTH",
+                "uei": "UEI000000003",
+                "duns": "33-333-3333",
+                "entity_name": "Both Recipient LLC",
+            },
+            {
+                "entity_id": "ENTITY-NAME-STRESS",
+                "uei": None,
+                "duns": None,
+                "entity_name": "Acme, Inc.",
+            },
+            {
+                "entity_id": "ENTITY-ID-BACKED-NAME",
+                "uei": "malformed",
+                "duns": "12",
+                "entity_name": "Identifier Backed LLC",
+            },
+        ]
+    )
+
+
+def _pair(prior: int, target: int, prior_end: object) -> dict[str, object]:
+    uei = f"UEI-{prior}"
+    return {
+        "prior_award_id": f"PRIOR-{prior}",
+        "prior_recipient_uei": uei,
+        "prior_agency": "DEPARTMENT A",
+        "prior_sub_agency": "COMPONENT A",
+        "prior_naics_code": "541715",
+        "prior_psc_code": "AC13",
+        "prior_period_of_performance_end": prior_end,
+        "target_id": f"TARGET-{target}",
+        "target_recipient_uei": uei,
+        "target_agency": "DEPARTMENT A",
+        "target_sub_agency": "COMPONENT A",
+        "target_naics_code": "541715",
+        "target_psc_code": "AC13",
+        "target_action_date": "2024-01-15",
+        "target_competition_type": "FULL AND OPEN COMPETITION",
+        "target_obligated_amount": 100.0,
+        "target_research": None,
+        "target_sbir_phase": None,
+        "target_transaction_id": f"TRANSACTION-{target}",
+        "target_contract_key": f"CONTRACT-{target}",
+        "agency_match_level": "office",
+    }
+
+
+@pytest.fixture
+def fanout_pairs() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            _pair(1, 1, "2018-01-31"),
+            _pair(1, 2, "2018-01-31"),
+            _pair(1, 3, "2018-01-31"),
+            _pair(2, 4, "2019-02-28"),
+            _pair(3, 5, "2020-03-31"),
+            _pair(3, 6, "2020-03-31"),
+            _pair(4, 7, "2021-04-30"),
+        ]
+    )
+
+
+def test_exact_identifier_audit_labels_retained_rows_and_records_every_reason(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> None:
+    audit = audit_exact_identifier_eligibility(candidate_entities, complete_award_history)
+    by_id = audit.set_index("entity_id")
+
+    assert by_id.loc["ENTITY-UEI", "exclusion_reason"] == EXACT_UEI_EXCLUSION_REASON
+    assert by_id.loc["ENTITY-DUNS", "exclusion_reason"] == EXACT_DUNS_EXCLUSION_REASON
+    assert by_id.loc["ENTITY-BOTH", "exclusion_reason"] == (
+        f"{EXACT_UEI_EXCLUSION_REASON};{EXACT_DUNS_EXCLUSION_REASON}"
+    )
+    assert not bool(by_id.loc["ENTITY-BOTH", "passes_exact_identifier_screen"])
+
+    for entity_id in ("ENTITY-NAME-STRESS", "ENTITY-ID-BACKED-NAME"):
+        assert bool(by_id.loc[entity_id, "passes_exact_identifier_screen"])
+        assert by_id.loc[entity_id, "control_status_label"] == CONTROL_STATUS_LABEL
+        assert pd.isna(by_id.loc[entity_id, "exclusion_reason"])
+
+    assert pd.isna(by_id.loc["ENTITY-UEI", "control_status_label"])
+    assert pd.isna(by_id.loc["ENTITY-ID-BACKED-NAME", "normalized_uei"])
+    assert pd.isna(by_id.loc["ENTITY-ID-BACKED-NAME", "normalized_duns"])
+
+
+def test_exact_identifier_audit_fails_closed_on_empty_history(
+    candidate_entities: pd.DataFrame,
+) -> None:
+    empty_history = pd.DataFrame(columns=["uei", "duns"])
+
+    with pytest.raises(NegativeControlInputError, match="cannot be screened against empty"):
+        audit_exact_identifier_eligibility(candidate_entities, empty_history)
+
+
+def test_exact_identifier_audit_requires_unique_nonblank_entity_keys(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> None:
+    invalid = candidate_entities.iloc[[0, 0]].copy()
+    invalid.loc[invalid.index[1], "entity_id"] = " entity-uei "
+
+    with pytest.raises(NegativeControlInputError, match="must be unique"):
+        audit_exact_identifier_eligibility(invalid, complete_award_history)
+
+
+def test_identifier_free_name_match_is_only_a_reporting_flag(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> None:
+    audit = audit_exact_identifier_eligibility(candidate_entities, complete_award_history)
+    original_screen = audit["passes_exact_identifier_screen"].copy()
+
+    flagged = flag_identifier_free_name_stress_set(audit, complete_award_history)
+    by_id = flagged.set_index("entity_id")
+
+    assert bool(by_id.loc["ENTITY-NAME-STRESS", "identifier_free_award_exact_name_match"])
+    assert not bool(by_id.loc["ENTITY-ID-BACKED-NAME", "identifier_free_award_exact_name_match"])
+    assert by_id.loc["ENTITY-NAME-STRESS", "normalized_entity_name"] == "acme inc"
+    pd.testing.assert_series_equal(
+        flagged["passes_exact_identifier_screen"],
+        original_screen,
+    )
+
+
+def test_placebo_is_fixed_at_unique_prior_award_grain_and_preserves_fanout(
+    fanout_pairs: pd.DataFrame,
+) -> None:
+    assert PLACEBO_SEED == 20260801
+
+    first = permute_prior_end_dates(fanout_pairs)
+    second = permute_prior_end_dates(fanout_pairs)
+
+    pd.testing.assert_frame_equal(first, second)
+    assert not first["prior_period_of_performance_end"].equals(
+        pd.to_datetime(fanout_pairs["prior_period_of_performance_end"])
+    )
+    assert first.groupby("prior_award_id")["prior_period_of_performance_end"].nunique().eq(1).all()
+
+    before = (
+        fanout_pairs.drop_duplicates("prior_award_id")["prior_period_of_performance_end"]
+        .pipe(pd.to_datetime)
+        .sort_values()
+        .reset_index(drop=True)
+    )
+    after = (
+        first.drop_duplicates("prior_award_id")["prior_period_of_performance_end"]
+        .sort_values()
+        .reset_index(drop=True)
+    )
+    pd.testing.assert_series_equal(after, before, check_names=False)
+    pd.testing.assert_frame_equal(
+        first.drop(columns="prior_period_of_performance_end"),
+        fanout_pairs.drop(columns="prior_period_of_performance_end"),
+    )
+
+
+def test_placebo_mapping_is_independent_of_pair_row_order(fanout_pairs: pd.DataFrame) -> None:
+    baseline = permute_prior_end_dates(fanout_pairs).set_index("target_transaction_id")
+    reordered = fanout_pairs.sample(frac=1, random_state=17)
+    permuted_reordered = permute_prior_end_dates(reordered).set_index("target_transaction_id")
+
+    pd.testing.assert_series_equal(
+        baseline["prior_period_of_performance_end"].sort_index(),
+        permuted_reordered["prior_period_of_performance_end"].sort_index(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("column", "value", "message"),
+    [
+        ("prior_award_id", " ", "must have a prior_award_id"),
+        (
+            "prior_period_of_performance_end",
+            "not-a-date",
+            "unparsable nonblank value",
+        ),
+    ],
+)
+def test_placebo_rejects_invalid_award_keys_and_dates(
+    fanout_pairs: pd.DataFrame,
+    column: str,
+    value: str,
+    message: str,
+) -> None:
+    invalid = fanout_pairs.copy()
+    invalid.loc[0, column] = value
+
+    with pytest.raises(NegativeControlInputError, match=message):
+        permute_prior_end_dates(invalid)
+
+
+def test_placebo_rejects_conflicting_dates_within_prior_award(
+    fanout_pairs: pd.DataFrame,
+) -> None:
+    invalid = fanout_pairs.copy()
+    invalid.loc[1, "prior_period_of_performance_end"] = "2022-01-01"
+
+    with pytest.raises(NegativeControlInputError, match="map to exactly one"):
+        permute_prior_end_dates(invalid)
+
+
+def test_placebo_census_tables_delegate_to_both_existing_frozen_helpers(
+    fanout_pairs: pd.DataFrame,
+) -> None:
+    permuted = permute_prior_end_dates(fanout_pairs)
+    expected_dropoff = build_dropoff_ladder(permuted, DATA_CUT)
+    expected_sensitivity = build_sensitivity_grid(permuted, DATA_CUT)
+
+    actual_dropoff, actual_sensitivity = build_placebo_census_tables(fanout_pairs, DATA_CUT)
+
+    pd.testing.assert_frame_equal(actual_dropoff, expected_dropoff)
+    pd.testing.assert_frame_equal(actual_sensitivity, expected_sensitivity)
+
+
+def test_placebo_census_tables_permute_once_and_share_one_frame(
+    fanout_pairs: pd.DataFrame,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    permuted = permute_prior_end_dates(fanout_pairs)
+    permute_calls: list[pd.DataFrame] = []
+    helper_inputs: list[pd.DataFrame] = []
+
+    def fake_permute(pairs: pd.DataFrame) -> pd.DataFrame:
+        permute_calls.append(pairs)
+        return permuted
+
+    def fake_dropoff(pairs: pd.DataFrame, data_cut_date: date) -> pd.DataFrame:
+        assert data_cut_date == DATA_CUT
+        helper_inputs.append(pairs)
+        return pd.DataFrame({"table": ["dropoff"]})
+
+    def fake_sensitivity(pairs: pd.DataFrame, data_cut_date: date) -> pd.DataFrame:
+        assert data_cut_date == DATA_CUT
+        helper_inputs.append(pairs)
+        return pd.DataFrame({"table": ["sensitivity"]})
+
+    monkeypatch.setattr(methods_module, "permute_prior_end_dates", fake_permute)
+    monkeypatch.setattr(methods_module, "build_dropoff_ladder", fake_dropoff)
+    monkeypatch.setattr(methods_module, "build_sensitivity_grid", fake_sensitivity)
+
+    dropoff, sensitivity = build_placebo_census_tables(fanout_pairs, DATA_CUT)
+
+    assert len(permute_calls) == 1
+    assert permute_calls[0] is fanout_pairs
+    assert helper_inputs[0] is permuted
+    assert helper_inputs[1] is permuted
+    assert dropoff.loc[0, "table"] == "dropoff"
+    assert sensitivity.loc[0, "table"] == "sensitivity"

--- a/tests/unit/phase_iii_negative_controls/test_methods.py
+++ b/tests/unit/phase_iii_negative_controls/test_methods.py
@@ -13,10 +13,11 @@ from sbir_analytics.assets.phase_iii_negative_controls.methods import (
     EXACT_DUNS_EXCLUSION_REASON,
     EXACT_UEI_EXCLUSION_REASON,
     PLACEBO_SEED,
+    UNSCREENABLE_STATUS_LABEL,
     NegativeControlInputError,
     audit_exact_identifier_eligibility,
     build_placebo_census_tables,
-    flag_identifier_free_name_stress_set,
+    flag_identifier_unreachable_name_stress_set,
     permute_prior_end_dates,
 )
 
@@ -97,6 +98,12 @@ def candidate_entities() -> pd.DataFrame:
                 "duns": "12",
                 "entity_name": "Identifier Backed LLC",
             },
+            {
+                "entity_id": "ENTITY-CLEAN",
+                "uei": "UEI000000009",
+                "duns": None,
+                "entity_name": "Clean Candidate LLC",
+            },
         ]
     )
 
@@ -157,14 +164,41 @@ def test_exact_identifier_audit_labels_retained_rows_and_records_every_reason(
     )
     assert not bool(by_id.loc["ENTITY-BOTH", "passes_exact_identifier_screen"])
 
-    for entity_id in ("ENTITY-NAME-STRESS", "ENTITY-ID-BACKED-NAME"):
+    for entity_id in ("ENTITY-NAME-STRESS", "ENTITY-ID-BACKED-NAME", "ENTITY-CLEAN"):
         assert bool(by_id.loc[entity_id, "passes_exact_identifier_screen"])
-        assert by_id.loc[entity_id, "control_status_label"] == CONTROL_STATUS_LABEL
         assert pd.isna(by_id.loc[entity_id, "exclusion_reason"])
 
+    assert by_id.loc["ENTITY-CLEAN", "control_status_label"] == CONTROL_STATUS_LABEL
     assert pd.isna(by_id.loc["ENTITY-UEI", "control_status_label"])
     assert pd.isna(by_id.loc["ENTITY-ID-BACKED-NAME", "normalized_uei"])
     assert pd.isna(by_id.loc["ENTITY-ID-BACKED-NAME", "normalized_duns"])
+
+
+def test_exact_identifier_audit_separates_screened_clean_from_unscreenable(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> None:
+    """Passing the screen is three-valued, and the output must say which value.
+
+    `ENTITY-CLEAN` carries a usable UEI absent from history: screened, matched
+    nothing. `ENTITY-NAME-STRESS` has no identifiers and `ENTITY-ID-BACKED-NAME`
+    has malformed ones: neither was screened against anything. All three pass, so a
+    consumer selecting on `passes_exact_identifier_screen` alone would take an
+    unscreenable firm for a screened-clean one.
+    """
+
+    audit = audit_exact_identifier_eligibility(candidate_entities, complete_award_history)
+    by_id = audit.set_index("entity_id")
+
+    assert bool(by_id.loc["ENTITY-CLEAN", "has_usable_identifier"])
+    assert by_id.loc["ENTITY-CLEAN", "control_status_label"] == CONTROL_STATUS_LABEL
+
+    for entity_id in ("ENTITY-NAME-STRESS", "ENTITY-ID-BACKED-NAME"):
+        assert bool(by_id.loc[entity_id, "passes_exact_identifier_screen"])
+        assert not bool(by_id.loc[entity_id, "has_usable_identifier"])
+        assert by_id.loc[entity_id, "control_status_label"] == UNSCREENABLE_STATUS_LABEL
+
+    assert UNSCREENABLE_STATUS_LABEL != CONTROL_STATUS_LABEL
 
 
 def test_exact_identifier_audit_fails_closed_on_empty_history(
@@ -187,23 +221,48 @@ def test_exact_identifier_audit_requires_unique_nonblank_entity_keys(
         audit_exact_identifier_eligibility(invalid, complete_award_history)
 
 
-def test_identifier_free_name_match_is_only_a_reporting_flag(
+def test_identifier_unreachable_name_match_is_only_a_reporting_flag(
     candidate_entities: pd.DataFrame,
     complete_award_history: pd.DataFrame,
 ) -> None:
     audit = audit_exact_identifier_eligibility(candidate_entities, complete_award_history)
     original_screen = audit["passes_exact_identifier_screen"].copy()
 
-    flagged = flag_identifier_free_name_stress_set(audit, complete_award_history)
+    flagged = flag_identifier_unreachable_name_stress_set(audit, complete_award_history)
     by_id = flagged.set_index("entity_id")
 
-    assert bool(by_id.loc["ENTITY-NAME-STRESS", "identifier_free_award_exact_name_match"])
-    assert not bool(by_id.loc["ENTITY-ID-BACKED-NAME", "identifier_free_award_exact_name_match"])
+    assert bool(by_id.loc["ENTITY-NAME-STRESS", "identifier_unreachable_award_exact_name_match"])
+    assert not bool(by_id.loc["ENTITY-CLEAN", "identifier_unreachable_award_exact_name_match"])
     assert by_id.loc["ENTITY-NAME-STRESS", "normalized_entity_name"] == "acme inc"
     pd.testing.assert_series_equal(
         flagged["passes_exact_identifier_screen"],
         original_screen,
     )
+
+
+def test_unscreenable_candidate_is_stressed_against_the_whole_history(
+    candidate_entities: pd.DataFrame,
+    complete_award_history: pd.DataFrame,
+) -> None:
+    """The worst case is an unscreenable candidate named like an *identified* awardee.
+
+    `ENTITY-ID-BACKED-NAME` has malformed identifiers and normalizes to the same
+    name as `AWARD-NAME-WITH-ID`, which carries a UEI. No identifier join could ever
+    have reached that award row on this candidate's behalf, so it belongs in the
+    stress set. Restricting the reference names to identifier-free award rows for
+    every candidate dropped exactly this row from both outputs.
+
+    A candidate that *was* screenable keeps the narrow reference set: `ENTITY-UEI`
+    shares a name with the identifier-carrying `AWARD-UEI`, and the identifier
+    screen already adjudicated it, so a name flag there would be noise.
+    """
+
+    audit = audit_exact_identifier_eligibility(candidate_entities, complete_award_history)
+    flagged = flag_identifier_unreachable_name_stress_set(audit, complete_award_history)
+    by_id = flagged.set_index("entity_id")
+
+    assert bool(by_id.loc["ENTITY-ID-BACKED-NAME", "identifier_unreachable_award_exact_name_match"])
+    assert not bool(by_id.loc["ENTITY-UEI", "identifier_unreachable_award_exact_name_match"])
 
 
 def test_placebo_is_fixed_at_unique_prior_award_grain_and_preserves_fanout(

--- a/tests/unit/phase_iii_negative_controls/test_release_gate.py
+++ b/tests/unit/phase_iii_negative_controls/test_release_gate.py
@@ -7,8 +7,8 @@ count may be released as a validated result until evidence-backed
 negative-control and placebo artifacts exist.
 
 If you hit this while running the fast lane locally (`pytest -x` aborts the whole
-suite here), deselect it:
-``pytest --deselect tests/unit/phase_iii_negative_controls``.
+suite here), deselect this sentinel node only:
+``pytest --deselect tests/unit/phase_iii_negative_controls/test_release_gate.py::test_negative_controls_and_placebo_release_gate_is_closed``.
 
 **This branch is not intended to merge while the gate is closed.** ``unit-fast``
 is a required check, so merging would turn `main` red for every unrelated PR in
@@ -16,10 +16,9 @@ the repo, and the design doc forecloses the usual escapes — removing, skipping
 or xfailing the sentinel is not a resolution. The PR stays a draft until the gate
 can close.
 
-The one design requirement a test could pin *today*, with none of the blocked
-data — that the census filter takes no arm/label argument — belongs on `main` as a
-real green test rather than here. See the design doc's "Arm-blind evaluation"
-requirement.
+The green fixture tests beside this sentinel cover only the approved pure mechanics.
+They do not establish source provenance, matching quality, balance, or an empirical
+result and therefore cannot close this gate.
 """
 
 import pytest
@@ -30,6 +29,7 @@ pytestmark = pytest.mark.fast
 
 def test_negative_controls_and_placebo_release_gate_is_closed() -> None:
     pytest.fail(
-        "Release gate intentionally closed: replace this sentinel only with "
-        "evidence-backed tests after both negative-control and placebo artifacts exist."
+        "Release gate intentionally closed: replace this sentinel only after real, "
+        "provenance-backed negative-control and fixed-seed placebo artifacts exist; "
+        "pure helper tests are not release evidence."
     )

--- a/tests/unit/phase_iii_negative_controls/test_release_gate.py
+++ b/tests/unit/phase_iii_negative_controls/test_release_gate.py
@@ -1,3 +1,27 @@
+"""Release gate for the Phase III negative-control and placebo arms.
+
+This module contains a **deliberately failing** test. It is not broken, and it is
+not a work-in-progress to be fixed by making it pass — it is a commitment device
+described in `specs/phase-iii-negative-controls/design.md`: no Phase III census
+count may be released as a validated result until evidence-backed
+negative-control and placebo artifacts exist.
+
+If you hit this while running the fast lane locally (`pytest -x` aborts the whole
+suite here), deselect it:
+``pytest --deselect tests/unit/phase_iii_negative_controls``.
+
+**This branch is not intended to merge while the gate is closed.** ``unit-fast``
+is a required check, so merging would turn `main` red for every unrelated PR in
+the repo, and the design doc forecloses the usual escapes — removing, skipping,
+or xfailing the sentinel is not a resolution. The PR stays a draft until the gate
+can close.
+
+The one design requirement a test could pin *today*, with none of the blocked
+data — that the census filter takes no arm/label argument — belongs on `main` as a
+real green test rather than here. See the design doc's "Arm-blind evaluation"
+requirement.
+"""
+
 import pytest
 
 

--- a/tests/unit/phase_iii_negative_controls/test_release_gate.py
+++ b/tests/unit/phase_iii_negative_controls/test_release_gate.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_negative_controls_and_placebo_release_gate_is_closed() -> None:
+    pytest.fail(
+        "Release gate intentionally closed: replace this sentinel only with "
+        "evidence-backed tests after both negative-control and placebo artifacts exist."
+    )


### PR DESCRIPTION
## Purpose

This draft is the visible validation dependency for the frozen, label-free Phase III census. It adds only the approved data-independent control audit and placebo mechanics; it does not present the census proxy as a validated Phase III result.

## What changed

- Replaces the dependency stub with repository-convention requirements, design, and tasks documents.
- Audits exact strict-normalized UEI and DUNS matches against a caller-supplied complete available SBIR/STTR history, retaining every exclusion reason.
- Labels passing candidates exactly `no observed exact-identifier SBIR/STTR match`; it never certifies a firm as SBIR-negative.
- Flags exact normalized-name matches only against identifier-free award rows as a worst-case reporting stress set. The flag never changes eligibility and is not described as a contamination estimate or bound.
- Records that public inputs omit employee count, with no proxy or new band, and that this is a major residual-balance limitation.
- Implements the single seed-`20260801` placebo at unique prior-award grain, propagates each shuffled end date through pair fan-out, and passes one permuted frame to both unchanged census table builders.
- Keeps the evidence-backed release sentinel deliberately failing.

## Deferred by design

The spec leaves SAM and award-history provenance, candidate-frame scope, canonical names, NAICS/state fields, first-contract year, PSC family, matching/reuse/tie-breaking, organizational identity, SMD encoding, per-firm and pseudo-index grain, artifact contracts, and release sign-off as explicit questions. None is silently answered in code.

## Scope boundary

The PR contains no SAM reader, matcher, Dagster asset, empirical control/placebo artifact, result, scorer, weight, threshold, similarity method, embedding, classifier, or ML change. It does not modify the frozen census criteria or the transition-scoring path.

## Validation

- 81 focused controls, arm-blindness, census-criteria, and shared-pairing tests pass after integration with current `main`.
- Ruff check and format pass.
- Mypy passes for the new package.
- `git diff --check` passes.

## Expected CI state

This PR remains intentionally draft/red. The release sentinel may be replaced only after real, provenance-backed negative-control and fixed-seed placebo artifacts exist. Pure fixture tests are not release evidence.
