### PR TITLE
fix(container): include frozen census specs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -85,8 +85,12 @@ test-results*.json
 # OpenSpec
 openspec/
 
-# Specs (not needed in container)
-specs/
+# Specs (only frozen Phase III census inputs are needed in container)
+specs/*
+!specs/phase-iii-census/
+specs/phase-iii-census/*
+!specs/phase-iii-census/design.md
+!specs/phase-iii-census/amendments.md
 
 # Archive (not needed in container)
 archive/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY packages/sbir-graph/sbir_graph/ /app/sbir_graph/
 COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY scripts/ /app/scripts/
 COPY config/ /app/config/
+COPY specs/phase-iii-census/ /app/specs/phase-iii-census/
 COPY workspace.server.yaml /app/workspace.server.yaml
 COPY data/reference/ /app/data/reference/
 COPY pyproject.toml /app/

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -34,6 +34,7 @@ COPY packages/sbir-analytics/sbir_analytics/ /app/sbir_analytics/
 COPY packages/sbir-graph/sbir_graph/ /app/sbir_graph/
 COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY config/ /app/config/
+COPY specs/phase-iii-census/ /app/specs/phase-iii-census/
 COPY data/reference/ /app/data/reference/
 COPY scripts/ /app/scripts/
 COPY pyproject.toml /app/

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/assets.py
@@ -95,7 +95,21 @@ PHASE_II_OUTPUT_ENV = "SBIR_ETL__PHASE_TRANSITION__PHASE_II_OUTPUT_PATH"
 FROZEN_SPEC_REVISION = "phase-0-r4"
 FROZEN_SPEC_RELATIVE_PATH = Path("specs/phase-iii-census/design.md")
 AMENDMENTS_LOG_RELATIVE_PATH = Path("specs/phase-iii-census/amendments.md")
-_REPOSITORY_ROOT = Path(__file__).resolve().parents[5]
+
+
+def _find_resource_root() -> Path:
+    """Find the checkout or container root that holds the frozen census inputs."""
+
+    for root in Path(__file__).resolve().parents:
+        if all(
+            (root / relative_path).is_file()
+            for relative_path in (FROZEN_SPEC_RELATIVE_PATH, AMENDMENTS_LOG_RELATIVE_PATH)
+        ):
+            return root
+    raise RuntimeError("Phase III census frozen specification files are not installed")
+
+
+_REPOSITORY_ROOT = _find_resource_root()
 FROZEN_SPEC_PATH = _REPOSITORY_ROOT / FROZEN_SPEC_RELATIVE_PATH
 AMENDMENTS_LOG_PATH = _REPOSITORY_ROOT / AMENDMENTS_LOG_RELATIVE_PATH
 FROZEN_SPEC_SHA256 = "b1cce1e75af840f13223ecfc543b6d801e63cc3329f65f7c0a5b9037c0e9fc48"

--- a/tests/unit/phase_iii_census/test_import_isolation.py
+++ b/tests/unit/phase_iii_census/test_import_isolation.py
@@ -1,5 +1,11 @@
+import os
+import shutil
 import subprocess
 import sys
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_census_import_does_not_load_scoring_path() -> None:
@@ -24,3 +30,49 @@ if loaded:
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_census_import_and_freeze_verification_work_in_shallow_container_layout(
+    tmp_path: Path,
+) -> None:
+    install_root = tmp_path / "app"
+    shutil.copytree(
+        REPOSITORY_ROOT / "packages/sbir-analytics/sbir_analytics",
+        install_root / "sbir_analytics",
+    )
+    shutil.copytree(
+        REPOSITORY_ROOT / "specs/phase-iii-census",
+        install_root / "specs/phase-iii-census",
+    )
+    script = """
+import sys
+from pathlib import Path
+from sbir_analytics.assets.phase_iii_census import assets
+
+install_root = Path(sys.argv[1]).resolve()
+assert Path(assets.__file__).resolve().is_relative_to(install_root)
+assert assets.FROZEN_SPEC_PATH == install_root / "specs/phase-iii-census/design.md"
+assert assets.AMENDMENTS_LOG_PATH == install_root / "specs/phase-iii-census/amendments.md"
+record = assets.verify_frozen_spec()
+assert record["spec_sha256"] == assets.FROZEN_SPEC_SHA256
+assert record["amendments_sha256"] == assets.AMENDMENTS_LOG_SHA256
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(install_root)
+
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(install_root)],
+        cwd=install_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    docker_copy = "COPY specs/phase-iii-census/ /app/specs/phase-iii-census/"
+    for dockerfile in (REPOSITORY_ROOT / "Dockerfile", REPOSITORY_ROOT / "Dockerfile.full"):
+        assert docker_copy in dockerfile.read_text(encoding="utf-8")
+    dockerignore = (REPOSITORY_ROOT / ".dockerignore").read_text(encoding="utf-8")
+    assert "!specs/phase-iii-census/design.md" in dockerignore
+    assert "!specs/phase-iii-census/amendments.md" in dockerignore


### PR DESCRIPTION
## Summary

- locate the frozen Phase III census files by scanning the actual runtime layout instead of assuming a source-checkout depth
- copy the frozen census design and amendment log into both runtime image variants
- expose only those two Markdown files through `.dockerignore`
- add a shallow `/app`-layout regression that imports the asset and verifies both frozen hashes

## Root cause

The post-merge main container run failed because `assets.py` used `Path(__file__).resolve().parents[5]`. In the image, the module lives at `/app/sbir_analytics/...`, so that index does not exist. The images also did not include the frozen spec files that the asset verifies.

## Verification

- 71 focused census and asset-discovery tests passed
- updated regression subset: 18 passed
- Ruff check and format check passed
- `git diff --check` passed
- runtime Docker image built successfully
- inside the built image, the census asset was discovered and `verify_frozen_spec()` validated both files at `/app/specs/phase-iii-census/`

Fixes the container failure in main run 30713061566.
