### PR TITLE
fix(transition): arm the fusion corpus-hash guard

### DIFF
--- a/packages/sbir-ml/sbir_ml/transition/detection/fusion_model.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/fusion_model.py
@@ -4,17 +4,18 @@ The award-grain transition-ranker fusion was refit and frozen offline
 (``fusion_coefficients.json``; specs/phase3-notice-corpus-fusion) at
 leakage-scrubbed AUC 0.847 [0.792, 0.898], reproducing the study's 0.844 within
 CI. Production scores with these constants — it never fits — and the loader
-refuses a coefficient set whose corpus hash does not match the caller's
-expectation, so scores can never silently drift from the corpus they were fit on.
+refuses a coefficient set whose declared corpus hash does not match the caller's
+expectation. This is a metadata-consistency check: it does not authenticate the
+coefficient values or prove that they were produced from the declared corpus.
 
-That guarantee only holds when a caller actually states its expectation.
+That check only runs when a caller actually states its expectation.
 :data:`FROZEN_CORPUS_FRAME_HASH` is that expectation, pinned in code so the
 production path can arm the check without reading anything outside the installed
-package. It is the frame hash of the award-grain corpus the shipped coefficients
-were fit on, and `tests/unit/transition/detection/test_fusion_model.py` asserts
-it still matches both the coefficients file and the committed provenance record
-(`specs/phase3-notice-corpus-fusion/corpus.manifest.json`) — the corpus parquet
-itself is gitignored, so the manifest is the only in-repo witness to what was fit.
+package. It is the corpus frame hash declared by the shipped coefficients, and
+`tests/unit/transition/detection/test_fusion_model.py` asserts that the same hash
+appears in the coefficients file and the committed provenance record
+(`specs/phase3-notice-corpus-fusion/corpus.manifest.json`). The corpus parquet is
+gitignored, so the manifest is the only in-repo witness to that corpus's contents.
 """
 
 from __future__ import annotations
@@ -28,9 +29,9 @@ from pathlib import Path
 
 DEFAULT_COEFFICIENTS_PATH = Path(__file__).with_name("fusion_coefficients.json")
 
-#: Frame hash of the award-grain notice corpus the shipped coefficients were fit
-#: on (828 rows, 138 positives, 101 firms). Changing the coefficients without
-#: changing this constant is the drift this pin exists to stop.
+#: Frame hash declared for the award-grain notice corpus used by the shipped fit
+#: (828 rows, 138 positives, 101 firms). The pin rejects coefficient artifacts
+#: that declare a different corpus; it does not authenticate coefficient values.
 FROZEN_CORPUS_FRAME_HASH = "4c4064f04d04ca2f0c4c96e50ce3be8b6169bfd7ff3d4c51b2a6c804782a7b84"
 
 
@@ -67,13 +68,13 @@ def load_fusion_coefficients(
     *,
     expected_corpus_hash: str | None = None,
 ) -> FusionCoefficients:
-    """Load frozen coefficients; refuse a corpus-hash mismatch."""
+    """Load frozen coefficients; refuse a declared corpus-hash mismatch."""
 
     data = json.loads(Path(path).read_text(encoding="utf-8"))
     corpus_hash = str(data["corpus_frame_hash"])
     if expected_corpus_hash is not None and corpus_hash != expected_corpus_hash:
         raise ValueError(
-            "fusion coefficients were fit on a different corpus "
+            "fusion coefficients declare a different corpus "
             f"(embedded {corpus_hash!r} != expected {expected_corpus_hash!r})"
         )
     return FusionCoefficients(

--- a/packages/sbir-ml/sbir_ml/transition/detection/fusion_model.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/fusion_model.py
@@ -6,6 +6,15 @@ leakage-scrubbed AUC 0.847 [0.792, 0.898], reproducing the study's 0.844 within
 CI. Production scores with these constants — it never fits — and the loader
 refuses a coefficient set whose corpus hash does not match the caller's
 expectation, so scores can never silently drift from the corpus they were fit on.
+
+That guarantee only holds when a caller actually states its expectation.
+:data:`FROZEN_CORPUS_FRAME_HASH` is that expectation, pinned in code so the
+production path can arm the check without reading anything outside the installed
+package. It is the frame hash of the award-grain corpus the shipped coefficients
+were fit on, and `tests/unit/transition/detection/test_fusion_model.py` asserts
+it still matches both the coefficients file and the committed provenance record
+(`specs/phase3-notice-corpus-fusion/corpus.manifest.json`) — the corpus parquet
+itself is gitignored, so the manifest is the only in-repo witness to what was fit.
 """
 
 from __future__ import annotations
@@ -18,6 +27,11 @@ from pathlib import Path
 
 
 DEFAULT_COEFFICIENTS_PATH = Path(__file__).with_name("fusion_coefficients.json")
+
+#: Frame hash of the award-grain notice corpus the shipped coefficients were fit
+#: on (828 rows, 138 positives, 101 firms). Changing the coefficients without
+#: changing this constant is the drift this pin exists to stop.
+FROZEN_CORPUS_FRAME_HASH = "4c4064f04d04ca2f0c4c96e50ce3be8b6169bfd7ff3d4c51b2a6c804782a7b84"
 
 
 @dataclass(frozen=True)
@@ -72,4 +86,8 @@ def load_fusion_coefficients(
     )
 
 
-__all__ = ["FusionCoefficients", "load_fusion_coefficients"]
+__all__ = [
+    "FROZEN_CORPUS_FRAME_HASH",
+    "FusionCoefficients",
+    "load_fusion_coefficients",
+]

--- a/packages/sbir-ml/sbir_ml/transition/detection/fusion_scoring.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/fusion_scoring.py
@@ -130,14 +130,15 @@ def score_pairs_with_fusion(
     identity-scrubbed and both cosines are inflated relative to the fit.
 
     The corpus-hash check is **armed by default**: the loaded coefficients must
-    have been fit on :data:`~fusion_model.FROZEN_CORPUS_FRAME_HASH`. Pass
-    ``expected_corpus_hash=None`` to score with a deliberately different
-    coefficient set (a refit under evaluation, or a test fixture) — that is the
-    only way to opt out, so a swapped file cannot pass unnoticed.
+    declare :data:`~fusion_model.FROZEN_CORPUS_FRAME_HASH`. Pass
+    ``expected_corpus_hash=None`` to score with a coefficient set that declares
+    a different corpus (a refit under evaluation, or a test fixture). This is an
+    explicit opt-out from the metadata check; the hash does not authenticate the
+    coefficient values or the feature-extraction implementation.
 
     Raises :class:`ValueError` if the sequences disagree in length, if the loaded
-    coefficients were fit on a different corpus, or if they put non-zero weight on
-    a placeholder feature (see :data:`PLACEHOLDER_FEATURES`).
+    coefficients declare a different corpus, or if they put non-zero weight on a
+    placeholder feature (see :data:`PLACEHOLDER_FEATURES`).
     """
 
     n = len(award_texts)

--- a/packages/sbir-ml/sbir_ml/transition/detection/fusion_scoring.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/fusion_scoring.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 from sbir_ml.transition.detection.fusion_model import (
     DEFAULT_COEFFICIENTS_PATH,
+    FROZEN_CORPUS_FRAME_HASH,
     FusionCoefficients,
     load_fusion_coefficients,
 )
@@ -120,6 +121,7 @@ def score_pairs_with_fusion(
     *,
     firm_names: Sequence[object] | None = None,
     coefficients_path: str | Path = DEFAULT_COEFFICIENTS_PATH,
+    expected_corpus_hash: str | None = FROZEN_CORPUS_FRAME_HASH,
 ) -> list[float]:
     """Frozen-fusion score per (award, target) pair, TF-IDF fitted over the run.
 
@@ -127,9 +129,15 @@ def score_pairs_with_fusion(
     is optional but should be supplied: without it the target text is not
     identity-scrubbed and both cosines are inflated relative to the fit.
 
-    Raises :class:`ValueError` if the sequences disagree in length, or if the
-    loaded coefficients put non-zero weight on a placeholder feature (see
-    :data:`PLACEHOLDER_FEATURES`).
+    The corpus-hash check is **armed by default**: the loaded coefficients must
+    have been fit on :data:`~fusion_model.FROZEN_CORPUS_FRAME_HASH`. Pass
+    ``expected_corpus_hash=None`` to score with a deliberately different
+    coefficient set (a refit under evaluation, or a test fixture) — that is the
+    only way to opt out, so a swapped file cannot pass unnoticed.
+
+    Raises :class:`ValueError` if the sequences disagree in length, if the loaded
+    coefficients were fit on a different corpus, or if they put non-zero weight on
+    a placeholder feature (see :data:`PLACEHOLDER_FEATURES`).
     """
 
     n = len(award_texts)
@@ -140,7 +148,7 @@ def score_pairs_with_fusion(
     if n == 0:
         return []
 
-    model = load_fusion_coefficients(coefficients_path)
+    model = load_fusion_coefficients(coefficients_path, expected_corpus_hash=expected_corpus_hash)
     neutral = _placeholder_values(model)
 
     names = ["" for _ in range(n)] if firm_names is None else [str(v or "") for v in firm_names]

--- a/tests/unit/transition/detection/test_fusion_model.py
+++ b/tests/unit/transition/detection/test_fusion_model.py
@@ -71,12 +71,12 @@ def test_score_handles_zero_variance_feature_without_dividing_by_zero():
 
 
 def test_frozen_hash_matches_the_shipped_coefficients():
-    """The pinned hash must describe the coefficients that actually ship.
+    """The pinned hash must match the declaration in the artifact that ships.
 
     Without this, `FROZEN_CORPUS_FRAME_HASH` could drift from the file it guards
     and the armed check in `score_pairs_with_fusion` would reject the repo's own
     coefficients — or, worse, a swapped file could be accompanied by an updated
-    constant and pass silently.
+    constant and pass this metadata check.
     """
 
     shipped = json.loads(DEFAULT_COEFFICIENTS_PATH.read_text(encoding="utf-8"))
@@ -84,13 +84,13 @@ def test_frozen_hash_matches_the_shipped_coefficients():
 
 
 def test_frozen_hash_matches_the_committed_provenance_record():
-    """The pin must agree with the only in-repo witness to what was fit.
+    """The pin must agree with the only in-repo witness to the corpus metadata.
 
     The corpus parquet is gitignored (`*.parquet`), so `corpus.manifest.json` is
-    the sole committed record of the frame the coefficients were fit on. If the
-    coefficients are ever refit, this test fails until the manifest is updated
-    too — which is the point: the artifact and its provenance move together or
-    not at all.
+    the sole committed record of the frame named by the artifact. If a refit
+    declares a new corpus, this test fails until the pin and manifest are updated
+    too — which is the point: the three corpus-hash declarations move together or
+    not at all. This does not authenticate the coefficient values.
     """
 
     repo_root = Path(__file__).resolve().parents[4]
@@ -101,15 +101,15 @@ def test_frozen_hash_matches_the_committed_provenance_record():
     assert manifest["frame_hash"] == FROZEN_CORPUS_FRAME_HASH
 
 
-def test_production_scoring_refuses_coefficients_from_another_corpus(tmp_path):
-    """The armed guard must actually reject a swapped coefficient set."""
+def test_production_scoring_refuses_artifact_declaring_another_corpus(tmp_path):
+    """The armed guard must reject an artifact declaring another corpus."""
 
     from sbir_ml.transition.detection.fusion_scoring import score_pairs_with_fusion
 
     shipped = json.loads(DEFAULT_COEFFICIENTS_PATH.read_text(encoding="utf-8"))
-    impostor = dict(shipped, corpus_frame_hash="0" * 64)
+    mismatched = dict(shipped, corpus_frame_hash="0" * 64)
     path = tmp_path / "fusion_coefficients.json"
-    path.write_text(json.dumps(impostor), encoding="utf-8")
+    path.write_text(json.dumps(mismatched), encoding="utf-8")
 
     with pytest.raises(ValueError, match="different corpus"):
         score_pairs_with_fusion(

--- a/tests/unit/transition/detection/test_fusion_model.py
+++ b/tests/unit/transition/detection/test_fusion_model.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from sbir_ml.transition.detection.fusion_model import (
     DEFAULT_COEFFICIENTS_PATH,
+    FROZEN_CORPUS_FRAME_HASH,
     FusionCoefficients,
     load_fusion_coefficients,
 )
@@ -66,3 +68,65 @@ def test_score_handles_zero_variance_feature_without_dividing_by_zero():
         corpus_frame_hash="x",
     )
     assert 0.0 <= coefficients.score([2.0, 5.0]) <= 1.0
+
+
+def test_frozen_hash_matches_the_shipped_coefficients():
+    """The pinned hash must describe the coefficients that actually ship.
+
+    Without this, `FROZEN_CORPUS_FRAME_HASH` could drift from the file it guards
+    and the armed check in `score_pairs_with_fusion` would reject the repo's own
+    coefficients — or, worse, a swapped file could be accompanied by an updated
+    constant and pass silently.
+    """
+
+    shipped = json.loads(DEFAULT_COEFFICIENTS_PATH.read_text(encoding="utf-8"))
+    assert shipped["corpus_frame_hash"] == FROZEN_CORPUS_FRAME_HASH
+
+
+def test_frozen_hash_matches_the_committed_provenance_record():
+    """The pin must agree with the only in-repo witness to what was fit.
+
+    The corpus parquet is gitignored (`*.parquet`), so `corpus.manifest.json` is
+    the sole committed record of the frame the coefficients were fit on. If the
+    coefficients are ever refit, this test fails until the manifest is updated
+    too — which is the point: the artifact and its provenance move together or
+    not at all.
+    """
+
+    repo_root = Path(__file__).resolve().parents[4]
+    manifest_path = repo_root / "specs" / "phase3-notice-corpus-fusion" / "corpus.manifest.json"
+    assert manifest_path.is_file(), f"provenance record missing: {manifest_path}"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["frame_hash"] == FROZEN_CORPUS_FRAME_HASH
+
+
+def test_production_scoring_refuses_coefficients_from_another_corpus(tmp_path):
+    """The armed guard must actually reject a swapped coefficient set."""
+
+    from sbir_ml.transition.detection.fusion_scoring import score_pairs_with_fusion
+
+    shipped = json.loads(DEFAULT_COEFFICIENTS_PATH.read_text(encoding="utf-8"))
+    impostor = dict(shipped, corpus_frame_hash="0" * 64)
+    path = tmp_path / "fusion_coefficients.json"
+    path.write_text(json.dumps(impostor), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="different corpus"):
+        score_pairs_with_fusion(
+            ["autonomous ground robot lidar"],
+            ["autonomous ground vehicle lidar integration"],
+            ["541715"],
+            ["Solicitation"],
+            coefficients_path=path,
+        )
+
+    # Opting out is possible, but only explicitly.
+    scores = score_pairs_with_fusion(
+        ["autonomous ground robot lidar"],
+        ["autonomous ground vehicle lidar integration"],
+        ["541715"],
+        ["Solicitation"],
+        coefficients_path=path,
+        expected_corpus_hash=None,
+    )
+    assert len(scores) == 1


### PR DESCRIPTION
## Description

`load_fusion_coefficients` already accepted `expected_corpus_hash` and rejected a declared-corpus mismatch, but the production scorer never supplied that expectation. No test also kept the hash declaration in `fusion_coefficients.json` aligned with the committed provenance manifest.

This PR arms that metadata check by default. `score_pairs_with_fusion` supplies `FROZEN_CORPUS_FRAME_HASH`, pinned inside `sbir-ml`, so production does not need to read a repository-only spec file at runtime. Passing `expected_corpus_hash=None` is an explicit opt-out for a refit under evaluation or a test fixture.

The guarantee is intentionally narrow: this checks agreement among declared corpus hashes. It does **not** authenticate coefficient values, prove that a fit used the declared corpus, fingerprint feature-extraction code, or make the fit reproducible. A same-corpus refit can legitimately produce different weights while retaining the same frame hash. The run-fitted TF-IDF train/serve difference documented in `fusion_scoring.py` is also unchanged.

The corpus parquet remains gitignored, so `corpus.manifest.json` is the only committed witness to that corpus content. Freezing the corpus or a durable equivalent remains a separate decision.

Related: #467 introduced the frozen coefficients and production scorer.

## Type of Change

- [x] Bug fix: arm an existing declared-corpus consistency check
- [x] Documentation correction: state exactly what the check does and does not prove
- [ ] New feature
- [ ] Breaking change

## Testing

| Test | Asserts |
|---|---|
| `test_frozen_hash_matches_the_shipped_coefficients` | the code pin matches the artifact declaration |
| `test_frozen_hash_matches_the_committed_provenance_record` | the code pin matches the manifest declaration |
| `test_production_scoring_refuses_artifact_declaring_another_corpus` | production rejects an artifact that declares a different corpus, while the explicit opt-out remains available |

Verified locally:

- 12 focused fusion model/scoring tests passed
- Ruff check and format check passed for all changed files
- MyPy passed for all 41 `sbir-ml` source files
- `sbir-ml` sdist and wheel built successfully
- the built wheel contains `fusion_coefficients.json`, and its packaged loader accepts the pinned declaration

## Checklist

- [x] Current review feedback addressed
- [x] Runtime behavior remains package-local
- [x] The limitation of a self-declared corpus hash is explicit
- [x] Focused tests, lint, type checking, and package build pass
