### PR TITLE
docs: restructure research-questions.md for readability

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -28,9 +28,21 @@ Each question is written in a fixed shape:
   Deps / Refs / Spec: what it needs, what it benchmarks against, where it is specified.
 ```
 
+The **title**, **question**, and **Status** slots are written for an outside
+reader — a congressional staffer or program officer who arrived from
+[Where to start, by audience](#where-to-start-by-audience). Keep them in plain
+language. The *Deps*, *Spec*, and implementation notes are for maintainers and
+may use pipeline shorthand freely.
+
 **Status** appears only where answerability is contested or partial. A question
 with no status line has no special caveat attached — check the linked spec and
 the *Spec* slot to see whether it is built.
+
+**Lower-bound proxy** marks a question whose answer can only ever undercount.
+It appears wherever we detect ownership or capital through public filings: SEC
+EDGAR shows disclosed, structured ownership and disclosed private capital, so
+anything held privately or beneath a corporate layer is invisible to us. A
+"zero" on such a question means *we found none*, never *there are none*.
 
 **Spec** links point at spec directories and design docs. A `(PR #…)` tag means
 the work landed in that pull request. A `(branch: …)` tag means it is in
@@ -126,20 +138,24 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   DLA), phase, and vintage?
   *Deps: none · Refs: [L18]*
 
-- **Capability density & choke-point concentration map** (cap/vuln) (A-CP1 concentration map, A-CP2 supplier-base thickness, A-CP3 geographic distribution)
-  For each CET area, how many distinct awardees are there, how much award volume
-  do they hold, and how concentrated is that volume (awardee **HHI**) across
-  NAICS sector and geography (state, congressional district)?
-  High density reads as capability. The same HHI inverted is the choke-point
-  concentration map, flagging single- and thin-supplier clusters and
-  geographically narrow bases. GAO's program-wide Phase II HHI of ~11 [L14] is
-  the diffuse baseline that area-level concentration is measured against.
+- **Supplier base size and concentration per CET area** (cap/vuln) (A-CP1 concentration map, A-CP2 supplier-base thickness, A-CP3 geographic distribution)
+  In each CET area, how many distinct firms hold awards, how much award money do
+  they hold, and how much of that money is concentrated in a few of them —
+  measured by **HHI** (the Herfindahl-Hirschman Index, the standard antitrust
+  measure of market concentration; higher means fewer, larger players) and broken
+  out by NAICS sector and by geography (state, congressional district)?
+  Many independent firms in an area means a healthy supplier base. Few firms
+  means a choke point. It is the same number read two ways, and the second
+  reading also flags areas whose suppliers are clustered in one part of the
+  country. GAO's program-wide Phase II HHI of ~11 [L14] is the diffuse baseline
+  that area-level concentration is measured against.
   **Status:** Answerable now for the classified DoD subset.
   *Deps: CET, ER, NAICS · Refs: [L14], [L16], [L29] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md) (reproducible baseline and its limitations)*
 
-- **Whitespace** (cap)
-  Which CET subfields show DoD demand signals but sparse SBIR coverage?
-  Surfaced via semantic search over award and solicitation text.
+- **Coverage gaps** (cap) (house shorthand: *whitespace*)
+  Which CET subfields does DoD appear to want work in, but few SBIR awards
+  cover?
+  Found by semantic search over award and solicitation text.
   **Status:** Answerable now.
   *Deps: CET*
 
@@ -153,8 +169,7 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   What share of awardees — and of award dollars — in each CET area sit under
   disclosed foreign ownership, control, or influence, when screened against the
   eight Pub. L. 119-83 restricted-entity lists?
-  *Lower-bound proxy:* EDGAR Exhibit 21 / 8-K plus entity resolution detect only
-  disclosed, structured ownership — not private beneficial ownership.
+  *Lower-bound proxy* — ownership is read from EDGAR Exhibit 21 and 8-K filings.
   **Status:** Answerable now for the SEC-filer subset; the private majority needs
   data acquisition.
   *Deps: ER, SEC EDGAR, M&A signals · Refs: [L26] (screening lists), [L30] (foreign-supplier dependence), [L17] (foreign-acquisition risk)*
@@ -173,10 +188,10 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   historically incomplete [L14].
   *Deps: ER, ID, CET, transitions · Refs: [L1], [L14] · Spec: [../specs/ot-consortium-subaward-attribution/](../specs/ot-consortium-subaward-attribution/) (FFATA/FSRS sub-award T1 recovery)*
 
-- **Awardee-as-IP-chokepoint** (cap/vuln) (A-CP6)
+- **Awardees that control the key patents** (cap/vuln) (A-CP6)
   Within a CET area, do patent assignment chains (`ASSIGNED_VIA/FROM/TO`) show a
-  small number of awardees as the dominant source of enabling IP flowing to
-  primes — i.e. a knowledge-supply-chain choke point?
+  handful of awardees supplying most of the patents that primes go on to rely on
+  — a choke point in knowledge rather than in manufacturing?
   Builds on the [C2](#c2-relational-tier-2) patent-linkage work. The
   citation-centrality "who-depends-on-whom" variant needs patent-citation edge
   ingestion; a `PatentCitation` model exists but citations are not yet graph
@@ -192,19 +207,21 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   due-diligence data.
   *Deps: ER*
 
-- **Concentration vs. transition-thinness** (vuln) (A-CP5)
-  Do the most concentrated (thin-base) CET areas also show the thinnest Phase
-  II→III transition pipelines — concentrated *and* failing to graduate?
+- **Concentrated areas that also fail to graduate firms** (vuln) (A-CP5)
+  Do the CET areas served by the fewest firms also have the fewest firms
+  reaching Phase III — few suppliers *and* no pipeline replacing them?
   *Caveat:* the FPDS Phase III undercount [L14] bounds confidence.
   **Status:** Research target — not yet scoped.
   *Deps: ER, ID, CET, transitions · Refs: [L14]*
 
 - **New-entrant vs. repeat-winner mix per CET area** (vuln) (A-CP7)
-  What share of awards in each CET area go to first-time versus repeat winners,
-  as a read on entrant-pipeline health and graduation?
-  The DoD classified-subset baseline now reports first-observed entrants against
-  the complete retained FY2012+ DoD award history; pre-FY2012 activity remains
-  left-censored.
+  What share of awards in each CET area go to first-time winners versus repeat
+  winners — that is, are new firms still entering the program, and do they go on
+  to win again?
+  The DoD classified-subset baseline reports first-observed entrants against the
+  complete retained FY2012+ DoD award history. It cannot see earlier activity, so
+  a firm that first won in 2009 can still look like a new entrant
+  (*left-censoring*).
   **Status:** Partially answerable for the classified DoD subset.
   *Deps: ER, ID, CET · Refs: [L32] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md)*
 
@@ -241,32 +258,33 @@ NASEM calls this quantity the *leverage ratio*.
 
 #### Concentration & choke-point inference
 
-- **Concentration-as-fragility** (vuln)
-  Where single-firm or thin-base dominance exists within a CET cluster, does it
-  read as risk rather than capability? Has the base for a given area thinned or
-  thickened over time, and which sole-supplier firms would — if acquired or lost
-  — remove a capability with no in-program substitute?
-  This is the [A1](#a1-descriptive-tier-1) HHI inverted, including
-  geographically narrow bases.
+- **When concentration becomes fragility** (vuln)
+  Where one firm or a handful of firms dominate a CET area, should that be read
+  as risk rather than as strength? Has the number of firms serving an area grown
+  or shrunk over time, and which single-supplier firms would — if acquired or
+  lost — take a capability with them that no other firm in the program can
+  supply?
+  Same measure as [A1](#a1-descriptive-tier-1), read for risk instead of health,
+  and including areas whose suppliers sit in one part of the country.
   *Caveat:* the DoD classified-subset baseline supports concentration screening
   but not physical sole-source conclusions.
   **Status:** Answerable now for the classified DoD subset.
   *Deps: ER, CET · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md)*
 
-- **Composite fragility per CET area** (vuln) (A-CP10)
-  Which CET areas are concentrated, failing to graduate, *and* starved of new
-  entrants at once?
-  Combines concentration (A-CP1/A-CP2), geographic narrowness (A-CP3),
-  transition-thinness (A-CP5), and new-entrant deficit (A-CP7) into a per-area
-  fragility judgment.
+- **Areas fragile on every measure at once** (vuln) (A-CP10)
+  Which CET areas are served by few firms, graduating few of them to Phase III,
+  *and* attracting few new entrants — all at the same time?
+  Combines few suppliers (A-CP1/A-CP2), suppliers clustered in one region
+  (A-CP3), few firms reaching Phase III (A-CP5), and few new entrants (A-CP7)
+  into a single per-area judgment.
   **Status:** Research target — not yet scoped.
   *Deps: CET, ER, ID, NAICS, transitions · Refs: [L28], [L30]*
 
 - **Program leverage at choke points** (vuln) (A-CP11)
-  When the DoD follow-on multiplier and the private-to-SBIR leverage ratio
-  ([F3](#f3-inferential-tier-3)) are sliced to choke-point firms, does thin-base
-  concentration coincide with low or with high leverage?
-  *Lower-bound proxy:* EDGAR captures only disclosed private capital.
+  Narrow the DoD follow-on multiplier and the private-to-SBIR leverage ratio
+  ([F3](#f3-inferential-tier-3)) to firms at choke points: do the areas with the
+  fewest suppliers attract more follow-on money per SBIR dollar, or less?
+  *Lower-bound proxy.*
   *Anchor:* the verifiable DoD SBIR Fast Track match of up to four SBIR dollars
   per outside-investor dollar [L33]. NSF's reported portfolio leverage carries a
   `[TODO: verify NSF primary source for the ~18:1 figure]` — found only in trade
@@ -275,12 +293,11 @@ NASEM calls this quantity the *leverage ratio*.
   **Status:** Research target — not yet scoped.
   *Deps: ER, ID, SEC EDGAR, CET · Refs: [L33]*
 
-- **Foreign-acquisition-pathway inference** (vuln) (A-CP12)
-  From disclosed ownership structure and M&A signals, which choke-point firms
-  sit on a plausible foreign-acquisition pathway when screened against the
-  restricted-entity lists?
-  *Lower-bound proxy:* only disclosed/structured ownership and M&A signals are
-  detectable, not private beneficial ownership.
+- **Firms on a plausible path to foreign acquisition** (vuln) (A-CP12)
+  Judging from disclosed ownership structure and past M&A activity, which
+  choke-point firms look like plausible foreign acquisition targets when screened
+  against the restricted-entity lists?
+  *Lower-bound proxy.*
   **Status:** Research target — not yet scoped.
   *Deps: ER, SEC EDGAR, M&A signals, CET · Refs: [L26], [L30]*
 
@@ -310,11 +327,10 @@ NASEM calls this quantity the *leverage ratio*.
 
 #### Choke-point monitoring & prediction
 
-- **Acquisition-erosion of thin bases** (vuln) (A-CP8)
-  Do M&A events remove sole- or dominant-supplier firms from already-thin CET
-  bases, eroding capability through consolidation?
-  *Lower-bound proxy:* the foreign-acquisition component detects only disclosed
-  ownership.
+- **Acquisitions that thin an already-small supplier base** (vuln) (A-CP8)
+  Do acquisitions pull sole or dominant suppliers out of CET areas that already
+  had few firms, so that consolidation costs the program a capability?
+  *Lower-bound proxy* for the foreign-acquisition component.
   **Status:** Research target — not yet scoped.
   *Deps: ER, M&A signals, CET · Refs: [L31] (defense-sector consolidation), [L17] (foreign-acquisition risk)*
 
@@ -330,24 +346,22 @@ NASEM calls this quantity the *leverage ratio*.
   Which CET areas — and which individual sole- or dominant-supplier firms within
   them — would, if acquired or lost, remove a capability with no in-program
   substitute?
-  A composite, forward-looking watchlist fusing every signal above:
-  concentration (A-CP1/A-CP2), geographic narrowness (A-CP3), FOCI (A-CP4),
-  transition-thinness (A-CP5), IP-flow position (A-CP6), new-entrant deficit
-  (A-CP7), acquisition-erosion (A-CP8), UCC-1 distress (A-CP9), and composite
-  fragility (A-CP10).
-  *Lower-bound proxy:* the FOCI and foreign-acquisition inputs detect only
-  disclosed ownership.
+  A forward-looking watchlist combining every signal above: few suppliers
+  (A-CP1/A-CP2), suppliers clustered in one region (A-CP3), foreign ownership
+  (A-CP4), few firms reaching Phase III (A-CP5), position in the IP chain
+  (A-CP6), few new entrants (A-CP7), acquisitions thinning the base (A-CP8),
+  secured-debt distress (A-CP9), and the combined per-area judgment (A-CP10).
+  *Lower-bound proxy* for the foreign-ownership and foreign-acquisition inputs.
   **Status:** Research target — flagship; not yet scoped or implemented.
   *Deps: CET, ER, ID, transitions, M&A signals, UCC-1, SEC EDGAR · Refs: [L28] (NDIS supply-chain resilience), [L31] (priority sectors), [L30] (sub-tier-visibility gap)*
 
-- **Predictive erosion / early warning** (vuln) (A-CP14)
-  What is the forward probability that a given choke-point firm exits — through
-  M&A or financial distress — within a set horizon?
+- **Early warning before a supplier is lost** (vuln) (A-CP14)
+  How likely is a given choke-point firm to disappear — through acquisition or
+  financial failure — within the next few years?
   Feeds the continuous-monitoring loop
-  ([E6](#e6-continuous-monitoring--rolling-analytics-tier-4-capstone)) so a
-  fragility flag is raised before the capability is lost.
-  *Lower-bound proxy:* the foreign-acquisition component detects only disclosed
-  ownership.
+  ([E6](#e6-continuous-monitoring--rolling-analytics-tier-4-capstone)) so the
+  flag is raised while the capability can still be preserved.
+  *Lower-bound proxy* for the foreign-acquisition component.
   **Status:** Research target — not yet scoped.
   *Deps: ER, M&A signals, UCC-1, CET, transitions · Refs: [L30], [L31]*
 
@@ -460,15 +474,17 @@ statutory goal is Phase III commercialization.*
   Did this SBIR-funded research result in a federal contract?
   *Deps: ER, ID · Refs: [L1], [L2] (NASEM DoD), [L12] (Link & Scott, ~50% commercialization probability), [L3], [L4], [L6] (NASEM program reviews) · Spec: [transition/overview.md](transition/overview.md), [../specs/archive/completed-features/transition_detection/](../specs/archive/completed-features/transition_detection/)*
 
-- **Uncoded-follow-on proxy census**
-  How many exact-UEI, post-completion contract actions survive a pre-registered,
-  label-free uncoded-follow-on proxy, and how do the audit counts change across
-  its frozen clauses and agency/window cells?
-  **Status:** Implementation complete, materialization paused — the criteria are
-  frozen and the schema-verified source layer is a separately reviewed
-  prerequisite. Production tables and matched controls have not been
-  materialized, and the result remains a proxy rather than proof of statutory
-  Phase III.
+- **Follow-on contracts that were never labelled Phase III**
+  When a firm wins a federal contract after its SBIR award ends — the same firm
+  by exact UEI, with no Phase III label required — how many of those contracts
+  hold up as likely follow-on work? And how does that count shift as we vary the
+  matching rules, the agency, and the time window?
+  *Method:* the matching rules were written down and frozen before the counts
+  were run, so the result cannot be tuned after the fact.
+  **Status:** Built, but not yet run in production. The production tables and the
+  matched comparison group have not been created, and the schema-verified source
+  layer it depends on is under separate review. Until then the count is a
+  plausible proxy, not proof of statutory Phase III.
   *Deps: ER, ID, NAICS/PSC · Spec: [../specs/phase-iii-census/](../specs/phase-iii-census/)*
 
 - **Research-to-procurement transitions**
@@ -495,8 +511,8 @@ statutory goal is Phase III commercialization.*
   *Deps: ER, ID · Refs: [L14] · Spec: [phase-transition-latency.md](phase-transition-latency.md)*
 
 - **Phase II → III survival probability**
-  What is the Phase II → III survival probability by agency, firm size, and
-  vintage?
+  What share of Phase II awardees go on to win Phase III work, and how does that
+  share vary by agency, firm size, and award vintage?
   *Deps: ER, ID*
 
 - **Latency by technology area**
@@ -504,22 +520,24 @@ statutory goal is Phase III commercialization.*
   *Deps: ER, ID, CET*
 
 - **Transition effectiveness rate**
-  What is the transition effectiveness rate by CET area, agency, and firm size?
+  What share of awards reach a federal contract, broken out by CET area, agency,
+  and firm size — and how does that compare to the published baselines?
   *Deps: ER, ID, CET · Refs: [L12], [L1], [L3], [L4]*
 
-- **Phase III coding undercount**
-  How much undercount exists in Phase III coding, by agency?
+- **How much Phase III work goes unrecorded**
+  How many Phase III contracts does each agency fail to code as Phase III?
   Corroborated by GAO [L14] and NASEM [L1], [L3]. The protocol depends on
-  award-grade identity/grain (issue #447 / PR #449); production source lifecycle
-  belongs to issue #442.
-  **Status:** Partially answerable — the deterministic audit and its source/grain
-  validation are implemented in separate stacked changes, but production tables
-  have not been materialized. Matched negative controls and labeled validation
-  are still required before interpreting the proxy as undercount.
+  award-grade identity and record granularity (issue #447 / PR #449); production
+  source lifecycle belongs to issue #442.
+  **Status:** Partially answerable. The audit and its source/granularity checks
+  are built, across two separate changes, but have not been run in production.
+  Before the gap can be called an undercount, it still needs a matched comparison
+  group and a hand-labelled sample to check the result against.
   *Deps: ID · Refs: [L14], [L1], [L3] · Spec: [../specs/phase3-match-benchmark/](../specs/phase3-match-benchmark/) (protocol and current evidence limits), [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/) (solicitation monitoring)*
 
 - **Categorization vs. transition likelihood**
-  How does company categorization relate to transition likelihood?
+  Are product firms, service firms, or mixed-mode firms (as categorized in
+  [B1](#b1-descriptive-tier-1)) more likely to reach a federal contract?
   *Deps: ER, ID · Refs: [L12]*
 
 - **Statutory Commercialization Benchmark**
@@ -698,10 +716,11 @@ Foundational — most questions in A–D depend on work here.*
 
 - **SBIR.gov ↔ USAspending/FPDS reconciliation**
   How does SBIR.gov data reconcile with federal USAspending/FPDS records?
-  **Status:** Partially answerable now — Phase II federal transactions collapse
-  on generated award IDs and reconcile to SBIR.gov only through exact normalized
-  raw PIID/source identifiers, with ambiguity and taxonomy-conflict failures.
-  Broader cross-source completeness remains unvalidated.
+  **Status:** Partially answerable. Federal Phase II transactions are grouped
+  under generated award IDs, so they match SBIR.gov only where a raw PIID or
+  source identifier matches exactly after normalization. Some records match more
+  than one award, and some disagree on how the award is categorized. Coverage
+  beyond that exact-match path has not been validated.
   *Deps: none · Refs: [L14], [L1], [L3] (tracking-data limits)*
 
 ### E2. Entity resolution (foundation, Tier 1–2)
@@ -847,8 +866,9 @@ the NVCA Yearbook [L25] — rather than NASEM and GAO.
   *Deps: ER, SEC EDGAR · Spec: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/) (PR #286 merged)*
 
 - **Debt vs. equity composition**
-  What is the debt-versus-equity composition and offering fill rate of SBIR-firm
-  Form D filings?
+  In SBIR-firm Form D filings, how much of the money raised is debt versus
+  equity, and what share of each announced offering actually sells (the fill
+  rate)?
   *Deps: ER, SEC EDGAR · Spec: (PR #286 merged)*
 
 - **Secured-debt activity**
@@ -1081,7 +1101,36 @@ so Section A opens on questions rather than on ten lines of framing. Converted
 the dependency-tag glossary to a table and added a
 [How to read this document](#how-to-read-this-document) key. **No questions,
 citations, status labels, `A-CP#` identifiers, PR/branch tags, or spec links
-were added, removed, or changed in substance** — this pass is presentation only.
+were added, removed, or changed in substance** — that pass was presentation only.
+
+A second pass then rewrote the wording of the **title**, **question**, and
+**Status** slots in plain language, per the rule now stated in
+[How to read this document](#how-to-read-this-document). Three kinds of change:
+
+1. **House shorthand translated.** The thick/thin/dense metaphor family
+   (*capability density*, *supplier-base thickness*, *transition-thinness*,
+   *thin bases*) and the nominalized compounds (*Concentration-as-fragility*,
+   *Acquisition-erosion*, *Predictive erosion*) were invented here and could not
+   be looked up by an outside reader; they now say how many firms there are and
+   what is happening to them. *Whitespace* became *Coverage gaps*, keeping the
+   house term parenthetically.
+2. **Pipeline vocabulary removed from audience-facing slots.** *Materialized* /
+   *materialization* is Dagster's word for "computed and stored" and read as
+   hedging in a Status line; it is now "built" / "run in production". Same for
+   *stacked changes* and *grain*. The maintainer-facing implementation notes keep
+   the original vocabulary.
+3. **Terms of art kept, but glossed.** HHI, left-censoring, survival
+   probability, fill rate, and crowd-in/crowd-out are the correct words and were
+   not replaced — they gained a short in-line gloss on first use. *Lower-bound
+   proxy* is now defined once in the reading key and used bare thereafter,
+   instead of six slightly different restatements.
+
+The heaviest rewrite is B2's follow-on census question, which previously stacked
+five invented modifiers before its verb; its methodology terms
+(*pre-registered*, *frozen criteria*) moved to a *Method* line, where they answer
+a reviewer's concern rather than blocking a scanner's.
+
+**No question changed meaning, and no status label changed what it asserts.**
 
 **Prior review:** 2026-06-27 — **consolidated Section A** into a single
 complexity-tier ladder (A1 Descriptive → A4 Risk/monitoring/prediction)

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -1,10 +1,11 @@
 # Research Questions Inventory
 
-The SBIR ETL pipeline is designed to answer a broad set of questions about the
-SBIR/STTR program. Questions are organized by **policy area** (what audience /
-statutory goal the answer serves), then within each area by **complexity tier**
-(descriptive → relational → inferential → predictive), with **dependency order**
-respected so foundational work appears before dependents.
+This is the canonical list of what the SBIR ETL pipeline exists to answer.
+
+Questions are grouped by **policy area** (which audience or statutory goal the
+answer serves), then by **complexity tier** (descriptive → relational →
+inferential → predictive). Within a tier, foundational work comes before the
+work that depends on it.
 
 **Policy areas:**
 
@@ -15,335 +16,999 @@ respected so foundational work appears before dependents.
 - [E. Program management & data infrastructure](#e-program-management--data-infrastructure)
 - [F. Capital formation & entrepreneurial finance](#f-capital-formation--entrepreneurial-finance)
 
-**Where to start, by audience:**
+## How to read this document
 
-- **Policymakers** (Congress, OMB, agency leadership, congressional defense committees): start with the **DoD follow-on funding multiplier** question (Section **A3**, inferential tier; reproduces NASEM's ~4:1 benchmark — NASEM calls this quantity the *leverage ratio*), **D2** (Treasury ROI / tax receipts from SBIR spending), and **F3** (private-to-SBIR leverage as the private-side mirror to the DoD follow-on funding multiplier).
-- **SBIR program managers** (NSF, NIH, DoD, DOE, SBA program offices): start with **B** (transitions, Phase II→III latency, company performance), **C1** (cross-agency CET portfolio composition), and **E6** (rolling quarterly snapshots / continuous monitoring).
-- **Investors** (VC, PE, angels, family offices, corporate VC): start with **F1** (Form D fundraising profile, M&A exit rate by funding agency, capital-event timeline) and **F2** (cohort outcomes vs. published VC/PE baselines, acquirer-type concentration).
-- **OSTP / congressional oversight** (OSTP, armed-services / science / small-business committees): start with the **choke-point fragility watchlist** (Section **A4**, A-CP13 — the flagship composite) and the **capability density & choke-point concentration map** (Section **A1**, A-CP1/A-CP2/A-CP3). The choke-point questions are research targets, not yet scoped or implemented — see their inline status labels.
+Each question is written in a fixed shape:
 
-Each pointer above lands inside a section that mixes implemented and spec-only
-work — see status banners in the linked specs, and the inline *(PR #)* /
-*(branch: …)* tags on individual questions, to tell what's answerable today
-from what's a research target.
+```text
+- **Short title** (lens tags, legacy IDs)
+  The question itself, as a question.
+  Caveat — a stated limit on what the answer can support, when one applies.
+  Status: whether we can answer it today.
+  Deps / Refs / Spec: what it needs, what it benchmarks against, where it is specified.
+```
 
-**Dependency tags** used in parentheses after each question:
+**Status** appears only where answerability is contested or partial. A question
+with no status line has no special caveat attached — check the linked spec and
+the *Spec* slot to see whether it is built.
 
-- `ER` — entity resolution (UEI/CAGE/DUNS/fuzzy-name cascade)
-- `ID` — SBIR/STTR identification classifier
-- `CET` — CET technology classifier
-- `PATLINK` — patent-to-award linkage
-- `IMP` — imputed fields for missing data
-- `M&A signals` — M&A event detection (8-K/Form D parsing, ownership-change signals)
-- `SEC EDGAR` — SEC EDGAR filings (Form D Reg D, Form 8-K) for SBIR-firm transactions
-- `UCC-1` — UCC-1 financing-statement filings (state-level secured-debt registry; captures equipment finance, depository-bank loans, and venture debt as distinct sub-channels)
-- `NAICS` — industry classification derived from NAICS codes
-- `fiscal model` — fiscal-impact modeling inputs and assumptions
-- `BEA I-O` — BEA input-output tables for economic-impact estimation
-- `transitions` — commercialization/phase-transition outcome definitions
-- `NIPA rate provider` — BEA NIPA-derived effective tax rates (Tables 3.2/3.3)
-- `state rate provider` — state-specific effective tax rates for jurisdiction decomposition
+**Spec** links point at spec directories and design docs. A `(PR #…)` tag means
+the work landed in that pull request. A `(branch: …)` tag means it is in
+progress on a feature branch and **not** yet merged to `main`.
 
-Items marked *(branch: …)* are in-progress on a feature branch and not yet
-merged to `main`. Public-study citations appear as `[L#]` — see
-[Prior literature & benchmarks](#prior-literature--benchmarks) at the bottom.
+**Refs** are public studies and statutes, cited as `[L#]` and listed under
+[Prior literature & benchmarks](#prior-literature--benchmarks).
+
+**Deps** are the pipeline capabilities a question needs before it can be answered:
+
+| Tag | Meaning |
+|-----|---------|
+| `ER` | Entity resolution (UEI/CAGE/DUNS/fuzzy-name cascade) |
+| `ID` | SBIR/STTR identification classifier |
+| `CET` | CET technology classifier |
+| `PATLINK` | Patent-to-award linkage |
+| `IMP` | Imputed fields for missing data |
+| `M&A signals` | M&A event detection (8-K/Form D parsing, ownership-change signals) |
+| `SEC EDGAR` | SEC EDGAR filings (Form D Reg D, Form 8-K) for SBIR-firm transactions |
+| `UCC-1` | UCC-1 financing statements (state secured-debt registries; separates equipment finance, depository-bank loans, and venture debt) |
+| `NAICS` | Industry classification derived from NAICS codes |
+| `fiscal model` | Fiscal-impact modeling inputs and assumptions |
+| `BEA I-O` | BEA input-output tables for economic-impact estimation |
+| `transitions` | Commercialization / phase-transition outcome definitions |
+| `NIPA rate provider` | BEA NIPA-derived effective tax rates (Tables 3.2/3.3) |
+| `state rate provider` | State-specific effective tax rates for jurisdiction decomposition |
+
+## Where to start, by audience
+
+Every pointer below lands in a section that mixes implemented and spec-only
+work. Use the per-question *Status* and *Spec* slots to tell what is answerable
+today from what is still a research target.
+
+- **Policymakers** — Congress, OMB, agency leadership, congressional defense
+  committees. Start with the **DoD follow-on funding multiplier** ([A3](#a3-inferential-tier-3);
+  reproduces NASEM's ~4:1 benchmark, which NASEM calls the *leverage ratio*),
+  then **[D2](#d2-relational-tier-2)** (Treasury ROI and tax receipts from SBIR
+  spending) and **[F3](#f3-inferential-tier-3)** (private-to-SBIR leverage, the
+  private-side mirror of the DoD multiplier).
+- **SBIR program managers** — NSF, NIH, DoD, DOE, SBA program offices. Start
+  with **[B](#b-technology-commercialization--entrepreneurship)** (transitions,
+  Phase II→III latency, company performance), **[C1](#c1-descriptive-tier-1)**
+  (cross-agency CET portfolio composition), and **[E6](#e6-continuous-monitoring--rolling-analytics-tier-4-capstone)**
+  (rolling quarterly snapshots).
+- **Investors** — VC, PE, angels, family offices, corporate VC. Start with
+  **[F1](#f1-descriptive-tier-1)** (Form D fundraising profile, M&A exit rate by
+  funding agency, capital-event timeline) and **[F2](#f2-relational-tier-2)**
+  (cohort outcomes vs. published VC/PE baselines, acquirer-type concentration).
+- **OSTP / congressional oversight** — OSTP, armed-services, science, and
+  small-business committees. Start with the **choke-point fragility watchlist**
+  ([A4](#a4-risk-monitoring--prediction-tier-4), A-CP13 — the flagship composite)
+  and the **capability density & choke-point concentration map**
+  ([A1](#a1-descriptive-tier-1), A-CP1/A-CP2/A-CP3). Note that the choke-point
+  questions are research targets, not yet scoped or implemented.
 
 ## A. National security, industrial base, and supply chain
 
-*Audience: DoD acquisition leadership, congressional defense / armed-services committees, OSTP, congressional science / small-business committees, CSIS-style industrial-base analysts. This section merges three previously-separate framings — the defense-industrial-base questions, the supply-chain / technology choke-point set, and the former standalone "industrial-base resilience" section — into one complexity-tier ladder. They serve the same audience and statutory goal and draw on the same `CET`, `NAICS`, `ER`, `SEC EDGAR`, and `M&A signals` data. For SBIR-firm capital structure and exit analysis from an entrepreneurial-finance perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-formation--entrepreneurial-finance).*
+*Audience: DoD acquisition leadership, congressional defense / armed-services
+committees, OSTP, congressional science / small-business committees, CSIS-style
+industrial-base analysts.*
 
-### The master question: industrial capability vs. vulnerability
+**Master question:** Across the CET areas, where does SBIR/STTR build domestic
+industrial capability that strengthens the defense industrial base, and where
+are awardees exposed to adversary ownership/control or capability concentration
+that creates vulnerability?
 
-**Master question:** Across the CET areas, where does SBIR/STTR build domestic industrial capability that strengthens the DIB, and where are awardees exposed to adversary ownership/control or capability concentration that creates vulnerability?
+Two lenses run through every tier. Questions are tagged for the lens they read:
 
-Two lenses run through every tier below — **capability** (does SBIR/STTR build domestic industrial capability?) and **vulnerability / choke-point exposure** (are awardees exposed to adversary control or capability concentration?). The framing is only honest because award data answers the capability side **well** and the vulnerability / choke-point side **only weakly**: strong capability metrics must not lend false confidence to weak vulnerability inferences, so every question keeps its own answerability label and weak ones are not allowed to free-ride. Questions are tagged **(cap)**, **(vuln)**, or **(cap/vuln)** for the lens(es) they read; the supply-chain choke-point questions carry their original `A-CP#` identifiers inline so prior references still resolve. Physical / sub-tier supply-chain questions that award data cannot answer are listed in the **Out of scope** appendix at the end of the section, stated explicitly rather than as graded metrics.
+- **(cap)** — capability. Does SBIR/STTR build domestic industrial capability?
+- **(vuln)** — vulnerability. Are awardees exposed to adversary control or to
+  capability concentration?
+- **(cap/vuln)** — the question reads both.
 
-**CET spine.** The organizing spine is the repo's **21-area `NSTC-2025Q1`** taxonomy defined in `config/cet/taxonomy.yaml`; `packages/sbir-ml/sbir_ml/ml/config/taxonomy_loader.py` expects exactly 21 areas and logs a warning on any mismatch (a soft check, not a hard-failing validation). This is *not* the external 18-area Feb-2024 NSTC Critical and Emerging Technologies list [L29], nor DoD's 14 Critical Technology Areas — both are narrower external frameworks, and the repo's 21-area set already blends NSTC CET areas with several DoD critical-technology areas (Hypersonics, Directed Energy, Advanced Gas Turbine Engine Technologies, Integrated Network Systems-of-Systems). **Crosswalk note:** for DoD-facing outputs each CET area should also carry a **DoD-14** and an **NDIS-8** (National Defense Industrial Strategy supply-chain-priority) tag where a mapping exists, so results speak to both NSTC and DoD audiences. (Two other, divergent CET taxonomies exist in code — a 10-area transition-system set and a 19-area reporting-analyzer set — and are not yet reconciled to the canonical 21; see Maintenance.)
+Award data answers the capability side well and the vulnerability side only
+weakly, so each question carries its own status and the strong capability
+metrics are not allowed to lend confidence to the weak vulnerability inferences.
+Choke-point questions keep their original `A-CP#` identifiers so prior
+references still resolve. Physical and sub-tier supply-chain questions that
+award data cannot answer are listed in
+[Out of scope](#out-of-scope--physical--sub-tier-supply-chain) rather than
+graded as metrics.
 
-**Statutory grounding.** The vulnerability lens maps to the risk-based due-diligence factors of the SBIR/STTR reauthorization, **Pub. L. 119-83** (signed April 13, 2026), and its eight restricted-entity screening lists — the UFLPA Entity List, the Non-SDN Chinese Military-Industrial Complex Companies (NS-CMIC) List, the Section 889 Prohibition List, the 1260H list, the Military End-User (MEU) List, the BIS Entity List, the FCC Covered List, and the CBP WRO/Findings List [L26]; the FY2026 NDAA [L27] carries related DIB authorities. The capability lens maps to the same law's Strategic Breakthrough Allocation and Phase III provisions. The choke-point questions are framed by the DoD National Defense Industrial Strategy [L28] and the DoD State of Competition report [L31]. (Statutes linked, not reproduced.)
+Background on the CET taxonomy and the statutory basis for both lenses is in
+[Section A framing notes](#section-a-framing-notes) at the end of the section.
+
+For SBIR-firm capital structure and exit analysis from an entrepreneurial-finance
+perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-formation--entrepreneurial-finance).
 
 ### A1. Descriptive (Tier 1)
 
-- Portfolio composition by DoD component (Army/Navy/AF/DARPA/DLA), phase, and vintage — SBA annual reports [L18]. *(deps: —)*
-- **(cap/vuln) Capability density & choke-point concentration map per CET area** *(A-CP1 concentration map / A-CP2 supplier-base thickness / A-CP3 geographic distribution)* — distinct awardee counts, award volume, and an awardee **HHI** per CET area, read across NAICS sector and geography (state / congressional district). High density reads as capability; the same HHI inverted is the choke-point concentration map, flagging single-/thin-supplier clusters and geographically narrow bases. GAO's program-wide Phase II HHI of ~11 [L14] is the diffuse baseline that area-level concentration is measured against. CSIS Center for the Industrial Base [L16]; cross-read against the external NSTC CET list [L29]. The reproducible DoD classified-subset baseline and its limitations are documented in [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md). **[Answerable now for the classified DoD subset]** *(deps: CET, ER, NAICS)*
-- **(cap) Whitespace** — CET subfields with DoD demand signals but sparse SBIR coverage, surfaced via semantic search over award and solicitation text. **[Answerable now]** *(deps: CET)*
-- **(cap) Capital formation / firm health per CET area** — Form D raises and follow-on funding as a proxy for awardee financial health by technology area (the defense-CET slice of F1). **[Partial — SEC/Form D filers only]** *(deps: ER, CET, SEC EDGAR)*
-- **(vuln) Foreign ownership / control (FOCI) exposure share per CET area** *(A-CP4; LOWER-BOUND proxy — EDGAR Exhibit 21 / 8-K plus entity resolution detect only disclosed/structured ownership, not private beneficial ownership)* — share of awardees and award volume per CET area under disclosed foreign ownership / control / influence, screened against the eight Pub. L. 119-83 restricted-entity lists [L26] and read alongside GAO's foreign-supplier-dependence findings [L30]. Foreign-acquisition risk flagged by CSIS [L17]. **[Now for the SEC-filer subset; needs data acquisition for the private majority]** *(deps: ER, SEC EDGAR, M&A signals)*
+- **Portfolio composition by DoD component**
+  How do DoD SBIR awards break down by component (Army, Navy, Air Force, DARPA,
+  DLA), phase, and vintage?
+  *Deps: none · Refs: [L18]*
+
+- **Capability density & choke-point concentration map** (cap/vuln) (A-CP1 concentration map, A-CP2 supplier-base thickness, A-CP3 geographic distribution)
+  For each CET area, how many distinct awardees are there, how much award volume
+  do they hold, and how concentrated is that volume (awardee **HHI**) across
+  NAICS sector and geography (state, congressional district)?
+  High density reads as capability. The same HHI inverted is the choke-point
+  concentration map, flagging single- and thin-supplier clusters and
+  geographically narrow bases. GAO's program-wide Phase II HHI of ~11 [L14] is
+  the diffuse baseline that area-level concentration is measured against.
+  **Status:** Answerable now for the classified DoD subset.
+  *Deps: CET, ER, NAICS · Refs: [L14], [L16], [L29] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md) (reproducible baseline and its limitations)*
+
+- **Whitespace** (cap)
+  Which CET subfields show DoD demand signals but sparse SBIR coverage?
+  Surfaced via semantic search over award and solicitation text.
+  **Status:** Answerable now.
+  *Deps: CET*
+
+- **Capital formation / firm health per CET area** (cap)
+  How healthy are awardees financially in each technology area, proxied by Form D
+  raises and follow-on funding? (The defense-CET slice of [F1](#f1-descriptive-tier-1).)
+  **Status:** Partial — SEC/Form D filers only.
+  *Deps: ER, CET, SEC EDGAR*
+
+- **Foreign ownership / control (FOCI) exposure per CET area** (vuln) (A-CP4)
+  What share of awardees — and of award dollars — in each CET area sit under
+  disclosed foreign ownership, control, or influence, when screened against the
+  eight Pub. L. 119-83 restricted-entity lists?
+  *Lower-bound proxy:* EDGAR Exhibit 21 / 8-K plus entity resolution detect only
+  disclosed, structured ownership — not private beneficial ownership.
+  **Status:** Answerable now for the SEC-filer subset; the private majority needs
+  data acquisition.
+  *Deps: ER, SEC EDGAR, M&A signals · Refs: [L26] (screening lists), [L30] (foreign-supplier dependence), [L17] (foreign-acquisition risk)*
 
 ### A2. Relational (Tier 2)
 
-- Do firms show higher transition rates within the same awarding agency (agency continuity signal)? *(deps: ER, ID)*
-- **(cap) DIB integration** — Phase II→III transition rate per CET area via FPDS, plus SAM.gov subaward links to prime contractors — [../specs/ot-consortium-subaward-attribution/](../specs/ot-consortium-subaward-attribution/) (FFATA/FSRS sub-award T1 recovery). Aligns with NASEM's "knowledge transfer to primes" finding [L1]. **[Answerable now, moderate confidence — FPDS Phase III tagging is historically incomplete; GAO [L14]]** *(deps: ER, ID, CET, transitions)*
-- **(cap/vuln) Awardee-as-IP-chokepoint** *(A-CP6)* — within a CET area, do patent assignment chains (`ASSIGNED_VIA/FROM/TO`) show a small number of awardees as the dominant source of enabling IP flowing to primes (knowledge-supply-chain position)? Builds on the C2 patent-linkage work; the citation-centrality "who-depends-on-whom" variant needs patent-citation edge ingestion (a `PatentCitation` model exists but citations are not yet graph relationships). Aligns with NASEM's knowledge-transfer-to-primes finding [L1]. **[Partial — assignment-chain lens buildable now; citation-centrality needs ingestion]** *(deps: ER, PATLINK, CET)*
-- **(vuln) Adversary-affiliation screening** — entity resolution of awardees and key personnel against the named restricted-entity lists and foreign-country-of-concern ties. **[Partial via public lists; full coverage needs agency-held due-diligence data]** *(deps: ER)*
-- **(vuln) Concentration vs. transition-thinness** *(A-CP5)* — do the most concentrated (thin-base) CET areas also show the thinnest Phase II→III transition pipelines, compounding fragility (concentrated AND failing to graduate)? FPDS Phase III undercount [L14] bounds confidence. **[Research target — not yet scoped]** *(deps: ER, ID, CET, transitions)*
-- **(vuln) New-entrant vs. repeat-winner mix per CET area** *(A-CP7)* — share of awards going to first-time vs. repeat winners, as a read on entrant-pipeline health and graduation (CSIS new-entrant / small-business-graduation analysis [L32]). The [DoD classified-subset baseline](research/dod_supply_chain_initial_analysis.md) now reports first-observed entrants against the complete retained FY2012+ DoD award history; pre-FY2012 activity remains left-censored. **[Partially answerable for the classified DoD subset]** *(deps: ER, ID, CET)*
+- **Agency continuity signal**
+  Do firms show higher transition rates within the same awarding agency?
+  *Deps: ER, ID*
 
-*The SBIR-vs-non-SBIR identification question and the underlying patent-to-award linkage are foundational and live at their canonical homes — see **E1** and **C2** — rather than being restated here.*
+- **DIB integration** (cap)
+  What is the Phase II→III transition rate per CET area via FPDS, and how do
+  SAM.gov subaward links connect awardees to prime contractors?
+  Aligns with NASEM's "knowledge transfer to primes" finding [L1].
+  **Status:** Answerable now, moderate confidence — FPDS Phase III tagging is
+  historically incomplete [L14].
+  *Deps: ER, ID, CET, transitions · Refs: [L1], [L14] · Spec: [../specs/ot-consortium-subaward-attribution/](../specs/ot-consortium-subaward-attribution/) (FFATA/FSRS sub-award T1 recovery)*
+
+- **Awardee-as-IP-chokepoint** (cap/vuln) (A-CP6)
+  Within a CET area, do patent assignment chains (`ASSIGNED_VIA/FROM/TO`) show a
+  small number of awardees as the dominant source of enabling IP flowing to
+  primes — i.e. a knowledge-supply-chain choke point?
+  Builds on the [C2](#c2-relational-tier-2) patent-linkage work. The
+  citation-centrality "who-depends-on-whom" variant needs patent-citation edge
+  ingestion; a `PatentCitation` model exists but citations are not yet graph
+  relationships.
+  **Status:** Partial — the assignment-chain lens is buildable now;
+  citation-centrality needs ingestion.
+  *Deps: ER, PATLINK, CET · Refs: [L1]*
+
+- **Adversary-affiliation screening** (vuln)
+  Do awardees or their key personnel resolve to entities on the named
+  restricted-entity lists, or to foreign countries of concern?
+  **Status:** Partial via public lists; full coverage needs agency-held
+  due-diligence data.
+  *Deps: ER*
+
+- **Concentration vs. transition-thinness** (vuln) (A-CP5)
+  Do the most concentrated (thin-base) CET areas also show the thinnest Phase
+  II→III transition pipelines — concentrated *and* failing to graduate?
+  *Caveat:* the FPDS Phase III undercount [L14] bounds confidence.
+  **Status:** Research target — not yet scoped.
+  *Deps: ER, ID, CET, transitions · Refs: [L14]*
+
+- **New-entrant vs. repeat-winner mix per CET area** (vuln) (A-CP7)
+  What share of awards in each CET area go to first-time versus repeat winners,
+  as a read on entrant-pipeline health and graduation?
+  The DoD classified-subset baseline now reports first-observed entrants against
+  the complete retained FY2012+ DoD award history; pre-FY2012 activity remains
+  left-censored.
+  **Status:** Partially answerable for the classified DoD subset.
+  *Deps: ER, ID, CET · Refs: [L32] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md)*
+
+*The SBIR-vs-non-SBIR identification question and the underlying patent-to-award
+linkage are foundational and live at their canonical homes —
+see [E1](#e1-sbir-identification-foundation-tier-12) and
+[C2](#c2-relational-tier-2) — rather than being restated here.*
 
 ### A3. Inferential (Tier 3)
 
-**DoD follow-on funding multiplier** (NASEM calls this the *leverage ratio*).
+#### DoD follow-on funding multiplier
 
-- What is the aggregate follow-on funding multiplier (non-SBIR DoD obligations ÷ SBIR/STTR obligations) for DoD SBIR firms? **Target: reproduce NASEM's ~4:1 for 2012–2020** [L1][L2] — [../specs/archive/completed-features/follow-on-multiplier-analysis/](../specs/archive/completed-features/follow-on-multiplier-analysis/) (FPDS contract-node ingestion: [../specs/archive/completed-features/load-contract-nodes/](../specs/archive/completed-features/load-contract-nodes/)). *(deps: ER, ID)*
-- How does the multiplier stratify by award vintage, firm size, technology area, and firm experience (new vs. repeat)? NASEM reports SBIR firms = ~1/3 of DoD's extramural R&D base [L1]. *(deps: ER, ID, CET)*
-- How is the multiplier changing over time? *(deps: ER, ID)*
-- What is the multiplier for civilian agencies (e.g., DOE)? Myers & Lanahan [L9] and NASEM DOE [L5] supply baselines. *(deps: ER, ID)*
+NASEM calls this quantity the *leverage ratio*.
 
-**Concentration & choke-point inference.**
+- **Aggregate multiplier**
+  What is the aggregate follow-on funding multiplier — non-SBIR DoD obligations
+  ÷ SBIR/STTR obligations — for DoD SBIR firms?
+  **Target:** reproduce NASEM's ~4:1 for 2012–2020.
+  *Deps: ER, ID · Refs: [L1], [L2] · Spec: [../specs/archive/completed-features/follow-on-multiplier-analysis/](../specs/archive/completed-features/follow-on-multiplier-analysis/), [../specs/archive/completed-features/load-contract-nodes/](../specs/archive/completed-features/load-contract-nodes/) (FPDS contract-node ingestion)*
 
-- **(vuln) Concentration-as-fragility** — single-firm or thin-base dominance within a CET cluster, read as risk rather than capability (the A1 HHI inverted, including geographically narrow bases). Has the base for a given area thinned or thickened over time, and which sole-supplier firms would, if acquired or lost, remove a capability with no in-program substitute? The [DoD classified-subset baseline](research/dod_supply_chain_initial_analysis.md) supports concentration screening, but not physical sole-source conclusions. **[Answerable now for the classified DoD subset]** *(deps: ER, CET)*
-- **(vuln) Composite fragility inference per CET area** *(A-CP10)* — combine concentration (A-CP1/A-CP2), geographic narrowness (A-CP3), transition-thinness (A-CP5), and new-entrant deficit (A-CP7) into a per-area fragility judgment that flags areas concentrated, failing to graduate, and starved of new entrants at once [L28][L30]. **[Research target — not yet scoped]** *(deps: CET, ER, ID, NAICS, transitions)*
-- **(vuln) Program leverage at choke points** *(A-CP11; LOWER-BOUND proxy — EDGAR captures only disclosed private capital)* — the DoD follow-on funding multiplier above and the private-to-SBIR leverage ratio (**F3**) sliced to choke-point firms: does thin-base concentration coincide with low or high leverage? Anchor to the verifiable DoD SBIR Fast Track match of up to four SBIR dollars per outside-investor dollar [L33] and NSF's reported portfolio leverage [TODO: verify NSF primary source for the ~18:1 figure — found only in trade press, not confirmed against an NSF publication; do not state as fact until verified]. **[Research target — not yet scoped]** *(deps: ER, ID, SEC EDGAR, CET)*
-- **(vuln) Foreign-acquisition-pathway inference** *(A-CP12; LOWER-BOUND proxy — only disclosed/structured ownership and M&A signals are detectable, not private beneficial ownership)* — from disclosed ownership structure and M&A signals, infer which choke-point firms sit on a plausible foreign-acquisition pathway, screened against the restricted-entity lists [L26] and GAO's foreign-dependence findings [L30]. **[Research target — not yet scoped]** *(deps: ER, SEC EDGAR, M&A signals, CET)*
+- **Multiplier stratification**
+  How does the multiplier vary by award vintage, firm size, technology area, and
+  firm experience (new vs. repeat winner)?
+  NASEM reports SBIR firms as ~1/3 of DoD's extramural R&D base [L1].
+  *Deps: ER, ID, CET · Refs: [L1]*
+
+- **Multiplier over time**
+  How is the multiplier changing over time?
+  *Deps: ER, ID*
+
+- **Civilian-agency multiplier**
+  What is the multiplier for civilian agencies such as DOE?
+  *Deps: ER, ID · Refs: [L9], [L5] (baselines)*
+
+#### Concentration & choke-point inference
+
+- **Concentration-as-fragility** (vuln)
+  Where single-firm or thin-base dominance exists within a CET cluster, does it
+  read as risk rather than capability? Has the base for a given area thinned or
+  thickened over time, and which sole-supplier firms would — if acquired or lost
+  — remove a capability with no in-program substitute?
+  This is the [A1](#a1-descriptive-tier-1) HHI inverted, including
+  geographically narrow bases.
+  *Caveat:* the DoD classified-subset baseline supports concentration screening
+  but not physical sole-source conclusions.
+  **Status:** Answerable now for the classified DoD subset.
+  *Deps: ER, CET · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md)*
+
+- **Composite fragility per CET area** (vuln) (A-CP10)
+  Which CET areas are concentrated, failing to graduate, *and* starved of new
+  entrants at once?
+  Combines concentration (A-CP1/A-CP2), geographic narrowness (A-CP3),
+  transition-thinness (A-CP5), and new-entrant deficit (A-CP7) into a per-area
+  fragility judgment.
+  **Status:** Research target — not yet scoped.
+  *Deps: CET, ER, ID, NAICS, transitions · Refs: [L28], [L30]*
+
+- **Program leverage at choke points** (vuln) (A-CP11)
+  When the DoD follow-on multiplier and the private-to-SBIR leverage ratio
+  ([F3](#f3-inferential-tier-3)) are sliced to choke-point firms, does thin-base
+  concentration coincide with low or with high leverage?
+  *Lower-bound proxy:* EDGAR captures only disclosed private capital.
+  *Anchor:* the verifiable DoD SBIR Fast Track match of up to four SBIR dollars
+  per outside-investor dollar [L33]. NSF's reported portfolio leverage carries a
+  `[TODO: verify NSF primary source for the ~18:1 figure]` — found only in trade
+  press, not confirmed against an NSF publication; **do not state as fact until
+  verified**.
+  **Status:** Research target — not yet scoped.
+  *Deps: ER, ID, SEC EDGAR, CET · Refs: [L33]*
+
+- **Foreign-acquisition-pathway inference** (vuln) (A-CP12)
+  From disclosed ownership structure and M&A signals, which choke-point firms
+  sit on a plausible foreign-acquisition pathway when screened against the
+  restricted-entity lists?
+  *Lower-bound proxy:* only disclosed/structured ownership and M&A signals are
+  detectable, not private beneficial ownership.
+  **Status:** Research target — not yet scoped.
+  *Deps: ER, SEC EDGAR, M&A signals, CET · Refs: [L26], [L30]*
 
 ### A4. Risk, monitoring & prediction (Tier 4)
 
-**M&A detection & transition pathways.**
+#### M&A detection & transition pathways
 
-- Did a defense-funded SBIR company undergo M&A activity, especially involving a foreign acquirer? — [../specs/archive/completed-features/merger_acquisition_detection/](../specs/archive/completed-features/merger_acquisition_detection/). *(deps: ER, M&A signals)*
-- For SBIR firms acquired by public companies, can inbound M&A be detected via 8-K full-text search? *(PR #286)* *(deps: ER, SEC EDGAR)*
-- Which defense primes concentrate SBIR-firm acquisitions (e.g., Titan, Teledyne, Ametek, Kratos), and are any of those acquirers themselves foreign-owned or under CFIUS review? *(deps: ER, M&A signals)*
-- How does M&A activity affect Phase III / federal-contract transition pathways? *(deps: ER, M&A signals, transitions)*
+- **Foreign-acquirer M&A detection**
+  Did a defense-funded SBIR company undergo M&A activity, particularly involving
+  a foreign acquirer?
+  *Deps: ER, M&A signals · Spec: [../specs/archive/completed-features/merger_acquisition_detection/](../specs/archive/completed-features/merger_acquisition_detection/)*
 
-**Choke-point monitoring & prediction.**
+- **Inbound M&A via 8-K full-text search**
+  For SBIR firms acquired by public companies, can inbound M&A be detected
+  through 8-K full-text search?
+  *Deps: ER, SEC EDGAR · Spec: (PR #286)*
 
-- **(vuln) Acquisition-erosion of thin bases** *(A-CP8; foreign-acquisition component is a LOWER-BOUND proxy)* — do M&A events remove sole- or dominant-supplier firms from already-thin CET bases, eroding capability through consolidation? Defense-sector consolidation [L31] and foreign-acquisition risk [L17] frame the concern. **[Research target — not yet scoped]** *(deps: ER, M&A signals, CET)*
-- **(vuln) UCC-1 financial-distress signal** *(A-CP9)* — do shifts in UCC-1 secured-debt filing patterns (lapses, new liens, lender churn) flag financial distress among choke-point firms ahead of exit or capability loss? No external benchmark; novel signal. **[Research target — not yet scoped]** *(deps: ER, UCC-1, CET)*
-- **(vuln) Choke-point fragility watchlist** *(A-CP13 — flagship).* A composite, forward-looking watchlist ranking CET areas — and the individual sole-/dominant-supplier firms within them — whose acquisition or loss would remove a capability with no in-program substitute. It fuses every signal above: concentration (A-CP1/A-CP2), geographic narrowness (A-CP3), FOCI (A-CP4), transition-thinness (A-CP5), IP-flow position (A-CP6), new-entrant deficit (A-CP7), composite fragility (A-CP10), acquisition-erosion (A-CP8), and UCC-1 distress (A-CP9); the FOCI and foreign-acquisition inputs are LOWER-BOUND proxies. Grounded in the NDIS supply-chain-resilience priority [L28], the State of Competition priority-sector framing [L31], and GAO-25-107283's sub-tier-visibility gap [L30]. **[Research target — flagship; not yet scoped or implemented]** *(deps: CET, ER, ID, transitions, M&A signals, UCC-1, SEC EDGAR)*
-- **(vuln) Predictive erosion / early warning** *(A-CP14; foreign-acquisition component is a LOWER-BOUND proxy)* — forward probability that a given choke-point firm exits (M&A or financial distress) within a horizon, feeding the continuous-monitoring loop (**E6**) so a fragility flag is raised before the capability is lost [L30][L31]. **[Research target — not yet scoped]** *(deps: ER, M&A signals, UCC-1, CET, transitions)*
+- **Acquirer concentration among defense primes**
+  Which defense primes concentrate SBIR-firm acquisitions (e.g. Titan, Teledyne,
+  Ametek, Kratos), and are any of those acquirers themselves foreign-owned or
+  under CFIUS review?
+  *Deps: ER, M&A signals*
 
-*Implementation note: M&A event detection runs as a CLI script
-(`scripts/archive/data/detect_sbir_ma_events.py`), not as a Dagster asset. The script
-merges two signals: Form D filings (entity_type-based business-combination
-heuristics) and SEC EDGAR full-text mention scan across multiple filing types
-(operationally: 8-K, 10-K, DEFM14A, PREM14A, SC TO-T, SC 14D9 — see
-`scripts/archive/data/refine_ma_medium_tier.py`). The orchestrated graph has no
-continuous M&A-event materialization; rerunning the script is how the M&A
-signal that feeds the vulnerability (A1/A3/A4) and F-area questions gets
-refreshed. The previously-existing
-`packages/sbir-analytics/sbir_analytics/assets/ma_detection.py` stub was a
-placeholder, never wired into the M&A pipeline, and was removed in PR #317.*
+- **M&A effect on transition pathways**
+  How does M&A activity affect Phase III / federal-contract transition pathways?
+  *Deps: ER, M&A signals, transitions*
 
-### Out of scope — physical & sub-tier supply chain (data the project does not ingest)
+#### Choke-point monitoring & prediction
 
-*Listed for visibility, these choke-point questions are **not answerable** with award-type data and are **not research targets** for this pipeline. Each requires bill-of-materials, customs, contractual country-of-origin, or sub-tier supplier data the pipeline does not ingest. Stated explicitly, not as graded metrics. GAO-25-107283 documents exactly this sub-tier-visibility gap [L30].*
+- **Acquisition-erosion of thin bases** (vuln) (A-CP8)
+  Do M&A events remove sole- or dominant-supplier firms from already-thin CET
+  bases, eroding capability through consolidation?
+  *Lower-bound proxy:* the foreign-acquisition component detects only disclosed
+  ownership.
+  **Status:** Research target — not yet scoped.
+  *Deps: ER, M&A signals, CET · Refs: [L31] (defense-sector consolidation), [L17] (foreign-acquisition risk)*
 
-- **Physical input chokepoints** — dependence on contested physical inputs (rare earths, castings, advanced chips, APIs); sole-source inputs, foreign-content percentages, and surge capacity. *(deps: — / out of scope)*
-- **Tiered BoM / supplier-tier maps** — sub-tier (Tier 2/3/N) supplier-dependency mapping for a CET capability. *(deps: — / out of scope)*
-- **Critical-mineral dependency** — exposure of a CET area to contested minerals/materials (rare earths, gallium, etc.). *(deps: — / out of scope)*
-- **Allied-supplier substitution** — whether an allied or partner-nation supplier could substitute for a domestic choke point. *(deps: — / out of scope)*
-- **Customs / trade-flow dependency** — import-dependence and trade-flow chokepoints for inputs to a CET capability. *(deps: — / out of scope)*
-- **Sub-tier foreign integration** — foreign content or foreign-owned sub-tier suppliers buried below the prime/awardee tier. *(deps: — / out of scope)*
+- **UCC-1 financial-distress signal** (vuln) (A-CP9)
+  Do shifts in UCC-1 secured-debt filing patterns — lapses, new liens, lender
+  churn — flag financial distress among choke-point firms ahead of exit or
+  capability loss?
+  *Caveat:* no external benchmark exists; this is a novel signal.
+  **Status:** Research target — not yet scoped.
+  *Deps: ER, UCC-1, CET*
+
+- **Choke-point fragility watchlist** (vuln) (A-CP13 — flagship)
+  Which CET areas — and which individual sole- or dominant-supplier firms within
+  them — would, if acquired or lost, remove a capability with no in-program
+  substitute?
+  A composite, forward-looking watchlist fusing every signal above:
+  concentration (A-CP1/A-CP2), geographic narrowness (A-CP3), FOCI (A-CP4),
+  transition-thinness (A-CP5), IP-flow position (A-CP6), new-entrant deficit
+  (A-CP7), acquisition-erosion (A-CP8), UCC-1 distress (A-CP9), and composite
+  fragility (A-CP10).
+  *Lower-bound proxy:* the FOCI and foreign-acquisition inputs detect only
+  disclosed ownership.
+  **Status:** Research target — flagship; not yet scoped or implemented.
+  *Deps: CET, ER, ID, transitions, M&A signals, UCC-1, SEC EDGAR · Refs: [L28] (NDIS supply-chain resilience), [L31] (priority sectors), [L30] (sub-tier-visibility gap)*
+
+- **Predictive erosion / early warning** (vuln) (A-CP14)
+  What is the forward probability that a given choke-point firm exits — through
+  M&A or financial distress — within a set horizon?
+  Feeds the continuous-monitoring loop
+  ([E6](#e6-continuous-monitoring--rolling-analytics-tier-4-capstone)) so a
+  fragility flag is raised before the capability is lost.
+  *Lower-bound proxy:* the foreign-acquisition component detects only disclosed
+  ownership.
+  **Status:** Research target — not yet scoped.
+  *Deps: ER, M&A signals, UCC-1, CET, transitions · Refs: [L30], [L31]*
+
+> **Implementation note — M&A detection is script-driven, not orchestrated.**
+> M&A event detection runs as a CLI script
+> (`scripts/archive/data/detect_sbir_ma_events.py`), not as a Dagster asset. The
+> script merges two signals: Form D filings (entity_type-based
+> business-combination heuristics) and an SEC EDGAR full-text mention scan across
+> multiple filing types — operationally 8-K, 10-K, DEFM14A, PREM14A, SC TO-T, and
+> SC 14D9 (see `scripts/archive/data/refine_ma_medium_tier.py`).
+>
+> The orchestrated graph has no continuous M&A-event materialization. Rerunning
+> the script is how the M&A signal feeding the vulnerability (A1/A3/A4) and
+> F-area questions gets refreshed. The former
+> `packages/sbir-analytics/sbir_analytics/assets/ma_detection.py` stub was a
+> placeholder, never wired into the M&A pipeline, and was removed in PR #317.
+
+### Out of scope — physical & sub-tier supply chain
+
+*These choke-point questions are **not answerable** with award-type data and are
+**not research targets** for this pipeline. Each needs bill-of-materials,
+customs, contractual country-of-origin, or sub-tier supplier data the pipeline
+does not ingest. They are listed for visibility, stated explicitly rather than
+graded as metrics. GAO-25-107283 [L30] documents exactly this
+sub-tier-visibility gap.*
+
+- **Physical input chokepoints** — dependence on contested physical inputs (rare
+  earths, castings, advanced chips, APIs); sole-source inputs, foreign-content
+  percentages, and surge capacity.
+- **Tiered BoM / supplier-tier maps** — sub-tier (Tier 2/3/N) supplier-dependency
+  mapping for a CET capability.
+- **Critical-mineral dependency** — exposure of a CET area to contested minerals
+  and materials (rare earths, gallium, etc.).
+- **Allied-supplier substitution** — whether an allied or partner-nation supplier
+  could substitute for a domestic choke point.
+- **Customs / trade-flow dependency** — import dependence and trade-flow
+  chokepoints for inputs to a CET capability.
+- **Sub-tier foreign integration** — foreign content or foreign-owned sub-tier
+  suppliers buried below the prime/awardee tier.
+
+### Section A framing notes
+
+**Scope consolidation.** This section merges three previously separate framings —
+the defense-industrial-base questions, the supply-chain / technology choke-point
+set, and the former standalone "industrial-base resilience" section — into one
+complexity-tier ladder. They serve the same audience and statutory goal and draw
+on the same `CET`, `NAICS`, `ER`, `SEC EDGAR`, and `M&A signals` data.
+
+**CET spine.** The organizing spine is the repo's **21-area `NSTC-2025Q1`**
+taxonomy in `config/cet/taxonomy.yaml`.
+`packages/sbir-ml/sbir_ml/ml/config/taxonomy_loader.py` expects exactly 21 areas
+and logs a warning on any mismatch — a soft check, not a hard-failing
+validation.
+
+This is *not* the external 18-area Feb-2024 NSTC Critical and Emerging
+Technologies list [L29], nor DoD's 14 Critical Technology Areas. Both are
+narrower external frameworks, and the repo's 21-area set already blends NSTC CET
+areas with several DoD critical-technology areas (Hypersonics, Directed Energy,
+Advanced Gas Turbine Engine Technologies, Integrated Network
+Systems-of-Systems).
+
+*Crosswalk note:* for DoD-facing outputs, each CET area should also carry a
+**DoD-14** tag and an **NDIS-8** (National Defense Industrial Strategy
+supply-chain-priority) tag where a mapping exists, so results speak to both NSTC
+and DoD audiences.
+
+Two other, divergent CET taxonomies exist in code — a 10-area transition-system
+set and a 19-area reporting-analyzer set — and are not yet reconciled to the
+canonical 21. See [Maintenance](#maintenance).
+
+**Statutory grounding.** The vulnerability lens maps to the risk-based
+due-diligence factors of the SBIR/STTR reauthorization, **Pub. L. 119-83**
+(signed April 13, 2026), and its eight restricted-entity screening lists — the
+UFLPA Entity List, the Non-SDN Chinese Military-Industrial Complex Companies
+(NS-CMIC) List, the Section 889 Prohibition List, the 1260H list, the Military
+End-User (MEU) List, the BIS Entity List, the FCC Covered List, and the CBP
+WRO/Findings List [L26]. The FY2026 NDAA [L27] carries related DIB authorities.
+
+The capability lens maps to the same law's Strategic Breakthrough Allocation and
+Phase III provisions. The choke-point questions are framed by the DoD National
+Defense Industrial Strategy [L28] and the DoD State of Competition report [L31].
+(Statutes are linked, not reproduced.)
 
 ## B. Technology commercialization & entrepreneurship
 
-*Audience: SBA oversight, agency program offices, awardee firms. Core statutory goal is Phase III commercialization.*
+*Audience: SBA oversight, agency program offices, awardee firms. The core
+statutory goal is Phase III commercialization.*
 
 ### B1. Descriptive (Tier 1)
 
-- Is this SBIR company primarily a product, service, or mixed-mode firm (based on full federal contract portfolio)? — [../specs/company-categorization/](../specs/company-categorization/). *(deps: ER)*
-- What percentage of a company's revenue comes from product vs. service contracts? *(deps: ER)*
-- Which SBIR companies show the highest transition success rate, and which are consistent repeat performers? — [queries/transition-queries.md](queries/transition-queries.md). Lerner [L10] found growth concentrated in high-VC zip codes. *(deps: ER)*
+- **Firm mode: product, service, or mixed**
+  Is this SBIR company primarily a product, service, or mixed-mode firm, judged
+  from its full federal contract portfolio?
+  *Deps: ER · Spec: [../specs/company-categorization/](../specs/company-categorization/)*
+
+- **Product vs. service revenue split**
+  What percentage of a company's revenue comes from product contracts versus
+  service contracts?
+  *Deps: ER*
+
+- **Top and repeat transition performers**
+  Which SBIR companies show the highest transition success rate, and which are
+  consistent repeat performers?
+  Lerner [L10] found growth concentrated in high-VC zip codes.
+  *Deps: ER · Refs: [L10] · Spec: [queries/transition-queries.md](queries/transition-queries.md)*
 
 ### B2. Relational (Tier 2)
 
-- Did this SBIR-funded research result in a federal contract? — [transition/overview.md](transition/overview.md), [../specs/archive/completed-features/transition_detection/](../specs/archive/completed-features/transition_detection/). Baselines: NASEM DoD [L1][L2]; Link & Scott ~50% commercialization probability [L12]; NASEM program reviews [L3][L4][L6]. *(deps: ER, ID)*
-- How many exact-UEI, post-completion contract actions survive a pre-registered,
-  label-free uncoded-follow-on proxy, and how do the audit counts change across its
-  frozen clauses and agency/window cells? —
-  [../specs/phase-iii-census/](../specs/phase-iii-census/). **[Implementation complete,
-  materialization paused — criteria are frozen and the schema-verified source layer is a
-  separately reviewed prerequisite; production tables and matched controls have not yet
-  been materialized, and the result remains a proxy rather than proof of statutory
-  Phase III]** *(deps: ER, ID, NAICS/PSC)*
-- Which SBIR-funded companies transitioned research into federal procurements? — [transition/detection-algorithm.md](transition/detection-algorithm.md). *(deps: ER, ID)*
-- What is the average time from award to transition by technology area? *(deps: ER, ID, CET)*
-- Which SBIR awards transitioned with patent backing, and what share of transitions are patent-enabled? Related to Lerner [L10] and Howell [L11]. *(deps: ER, ID, PATLINK)*
+- **Award-to-contract transition**
+  Did this SBIR-funded research result in a federal contract?
+  *Deps: ER, ID · Refs: [L1], [L2] (NASEM DoD), [L12] (Link & Scott, ~50% commercialization probability), [L3], [L4], [L6] (NASEM program reviews) · Spec: [transition/overview.md](transition/overview.md), [../specs/archive/completed-features/transition_detection/](../specs/archive/completed-features/transition_detection/)*
+
+- **Uncoded-follow-on proxy census**
+  How many exact-UEI, post-completion contract actions survive a pre-registered,
+  label-free uncoded-follow-on proxy, and how do the audit counts change across
+  its frozen clauses and agency/window cells?
+  **Status:** Implementation complete, materialization paused — the criteria are
+  frozen and the schema-verified source layer is a separately reviewed
+  prerequisite. Production tables and matched controls have not been
+  materialized, and the result remains a proxy rather than proof of statutory
+  Phase III.
+  *Deps: ER, ID, NAICS/PSC · Spec: [../specs/phase-iii-census/](../specs/phase-iii-census/)*
+
+- **Research-to-procurement transitions**
+  Which SBIR-funded companies transitioned research into federal procurements?
+  *Deps: ER, ID · Spec: [transition/detection-algorithm.md](transition/detection-algorithm.md)*
+
+- **Time to transition by technology area**
+  What is the average time from award to transition, by technology area?
+  *Deps: ER, ID, CET*
+
+- **Patent-enabled transitions**
+  Which SBIR awards transitioned with patent backing, and what share of all
+  transitions are patent-enabled?
+  *Deps: ER, ID, PATLINK · Refs: [L10], [L11]*
 
 ### B3. Inferential (Tier 3)
 
-- What is the elapsed time between Phase II completion and first Phase III contract? — [phase-transition-latency.md](phase-transition-latency.md). GAO documents the newer §638(qq)(3) performance-standard framework and notes that commercialization progress is measured from multiple SBA data sources [L14]. *(deps: ER, ID)*
-- Phase II → III survival probability by agency, firm size, and vintage. *(deps: ER, ID)*
-- Does Phase II → III latency vary by technology area? *(deps: ER, ID, CET)*
-- Transition effectiveness rate by CET area, agency, and firm size — compare to Link & Scott [L12] and NASEM [L1][L3][L4]. *(deps: ER, ID, CET)*
-- How much undercount exists in Phase III coding by agency? Corroborated by GAO [L14]
-  and NASEM [L1][L3]. The research protocol and its current evidence limits are
-  documented in [the Phase III match benchmark](../specs/phase3-match-benchmark/); it
-  depends on award-grade identity/grain (issue #447 / PR #449), while production source
-  lifecycle belongs to issue #442. Phase III solicitation monitoring:
-  [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/).
-  **[Partially answerable — the deterministic audit and its source/grain validation are
-  implemented in separate stacked changes, but production tables have not been
-  materialized; matched negative controls and labeled validation are still required
-  before interpreting the proxy as undercount]** *(deps: ID)*
-- How does company categorization relate to transition likelihood? Baseline: Link & Scott commercialization-probability econometrics [L12]. *(deps: ER, ID)*
-- Which Phase II awardees subject to §638(qq)(3) Increased Performance Standards meet the **statutory Commercialization Benchmark** (sales + private investment over the 10-FY covered period ÷ SBIR funding ≥ specified ratio)? Pub. L. 117-183 SBIR/STTR Extension Act of 2022 §638(qq)(3). Implementation on main: `scripts/run_benchmark.py` (evaluate / sensitivity / company-level CLI) backed by `sbir_etl/models/benchmark_models.py`, with tests in `tests/unit/test_benchmark_evaluator.py`. Spec: [../specs/archive/completed-features/commercialization-benchmark/](../specs/archive/completed-features/commercialization-benchmark/). Additional per-firm audit infrastructure and a more comprehensive methodology doc exist as local-only / uncommitted work — see "Output products" section below for the in-progress status. *(deps: ER, ID, transitions, SEC EDGAR)*
+- **Phase II → III latency**
+  What is the elapsed time between Phase II completion and the first Phase III
+  contract?
+  GAO documents the newer §638(qq)(3) performance-standard framework and notes
+  that commercialization progress is measured from multiple SBA data sources
+  [L14].
+  *Deps: ER, ID · Refs: [L14] · Spec: [phase-transition-latency.md](phase-transition-latency.md)*
+
+- **Phase II → III survival probability**
+  What is the Phase II → III survival probability by agency, firm size, and
+  vintage?
+  *Deps: ER, ID*
+
+- **Latency by technology area**
+  Does Phase II → III latency vary by technology area?
+  *Deps: ER, ID, CET*
+
+- **Transition effectiveness rate**
+  What is the transition effectiveness rate by CET area, agency, and firm size?
+  *Deps: ER, ID, CET · Refs: [L12], [L1], [L3], [L4]*
+
+- **Phase III coding undercount**
+  How much undercount exists in Phase III coding, by agency?
+  Corroborated by GAO [L14] and NASEM [L1], [L3]. The protocol depends on
+  award-grade identity/grain (issue #447 / PR #449); production source lifecycle
+  belongs to issue #442.
+  **Status:** Partially answerable — the deterministic audit and its source/grain
+  validation are implemented in separate stacked changes, but production tables
+  have not been materialized. Matched negative controls and labeled validation
+  are still required before interpreting the proxy as undercount.
+  *Deps: ID · Refs: [L14], [L1], [L3] · Spec: [../specs/phase3-match-benchmark/](../specs/phase3-match-benchmark/) (protocol and current evidence limits), [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/) (solicitation monitoring)*
+
+- **Categorization vs. transition likelihood**
+  How does company categorization relate to transition likelihood?
+  *Deps: ER, ID · Refs: [L12]*
+
+- **Statutory Commercialization Benchmark**
+  Which Phase II awardees subject to §638(qq)(3) Increased Performance Standards
+  meet the statutory Commercialization Benchmark — sales plus private investment
+  over the 10-FY covered period ÷ SBIR funding ≥ the specified ratio?
+  Grounded in Pub. L. 117-183, the SBIR/STTR Extension Act of 2022, §638(qq)(3).
+  Implementation on `main`: `scripts/run_benchmark.py` (evaluate / sensitivity /
+  company-level CLI) backed by `sbir_etl/models/benchmark_models.py`, with tests
+  in `tests/unit/test_benchmark_evaluator.py`.
+  *Caveat:* additional per-firm audit infrastructure and a fuller methodology doc
+  exist as local-only, uncommitted work — see
+  [Output products](#commercialization-benchmark-methodology-in-progress-not-yet-committed).
+  *Deps: ER, ID, transitions, SEC EDGAR · Spec: [../specs/archive/completed-features/commercialization-benchmark/](../specs/archive/completed-features/commercialization-benchmark/)*
 
 ### B4. Predictive (Tier 4)
 
-- Forward-looking transition probabilities for Phase II awards nearing completion. Per-firm **Phase III prospect digest** builder exists at commit [`4470b921`](https://github.com/hollomancer/sbir-analytics/commit/4470b921) (not on `main`; was developed on a since-removed feature branch — re-introduce as needed). Surfaces top candidates for outreach using B1-B3 features as scoring inputs. *(deps: all of B1–B3)*
+- **Forward transition probability**
+  What is the forward-looking transition probability for Phase II awards nearing
+  completion, and which firms are the top candidates for outreach?
+  A per-firm **Phase III prospect digest** builder exists at commit
+  [`4470b921`](https://github.com/hollomancer/sbir-analytics/commit/4470b921).
+  It is not on `main` — it was developed on a since-removed feature branch, and
+  should be re-introduced as needed. Uses B1–B3 features as scoring inputs.
+  *Deps: all of B1–B3*
 
 ## C. Innovation & knowledge generation (R&D policy)
 
-*Audience: OSTP, agency R&D directors, innovation researchers. Does federal SBIR spending produce measurable new knowledge?*
+*Audience: OSTP, agency R&D directors, innovation researchers. Does federal SBIR
+spending produce measurable new knowledge?*
 
 ### C1. Descriptive (Tier 1)
 
-- Federal SBIR portfolio composition across all 11 agencies by technology area — [../specs/cross-agency-taxonomy/](../specs/cross-agency-taxonomy/). CSIS [L16]. *(deps: CET)*
-- Which CET areas are funded by multiple agencies? Cross-agency overlap. *(deps: CET)*
-- How does the SBIR technology mix shift over time by agency? SBA [L18]. *(deps: CET)*
-- Which SBIR awards align with each CET area, and with what calibrated probability? — [ml/cet-classifier.md](ml/cet-classifier.md). *(deps: —)*
+- **Cross-agency portfolio composition**
+  How does the federal SBIR portfolio compose across all 11 agencies by
+  technology area?
+  *Deps: CET · Refs: [L16] · Spec: [../specs/cross-agency-taxonomy/](../specs/cross-agency-taxonomy/)*
+
+- **Cross-agency CET overlap**
+  Which CET areas are funded by multiple agencies?
+  *Deps: CET*
+
+- **Technology mix over time**
+  How does the SBIR technology mix shift over time, by agency?
+  *Deps: CET · Refs: [L18]*
+
+- **CET alignment per award**
+  Which SBIR awards align with each CET area, and with what calibrated
+  probability?
+  *Deps: none · Spec: [ml/cet-classifier.md](ml/cet-classifier.md)*
 
 ### C2. Relational (Tier 2)
 
-- Which USPTO patents are linked to specific SBIR awards, and with what confidence? — [transition/vendor-matching.md](transition/vendor-matching.md). Parallels Jaffe-Trajtenberg-Henderson [L13]. *(deps: ER, PATLINK)*
-- Which patents are semantically similar to specific SBIR awards (ModernBERT-Embed)? — [../specs/modernbert_analysis_layer/](../specs/modernbert_analysis_layer/). *(deps: PATLINK)*
-- Do SBIR awards and resulting contracts share the same technology focus (CET alignment signal)? *(deps: ER, ID, CET)*
-- How many patents are linked to each award, and what is the matching confidence distribution? *(deps: PATLINK)*
+- **Patent-to-award linkage**
+  Which USPTO patents are linked to specific SBIR awards, and with what
+  confidence?
+  Parallels Jaffe-Trajtenberg-Henderson [L13].
+  *Deps: ER, PATLINK · Refs: [L13] · Spec: [transition/vendor-matching.md](transition/vendor-matching.md)*
+
+- **Semantic patent similarity**
+  Which patents are semantically similar to specific SBIR awards
+  (ModernBERT-Embed)?
+  *Deps: PATLINK · Spec: [../specs/modernbert_analysis_layer/](../specs/modernbert_analysis_layer/)*
+
+- **Award-contract technology alignment**
+  Do SBIR awards and the contracts that result from them share the same
+  technology focus?
+  *Deps: ER, ID, CET*
+
+- **Patent linkage distribution**
+  How many patents are linked to each award, and what does the matching-confidence
+  distribution look like?
+  *Deps: PATLINK*
 
 ### C3. Inferential (Tier 3)
 
-- What is the marginal cost per patent by agency (award $ ÷ linked patents)? Compare against NIH/NSF figures in NASEM reviews [L3][L4][L6] — [../specs/patent-cost-spillover/](../specs/patent-cost-spillover/). *(deps: ER, PATLINK)*
-- What is the spillover multiplier (non-SBIR patent citations to SBIR patents)? **Target: reproduce Myers & Lanahan ~3× for DOE, ~60% U.S.-retained** [L9][L5]. *(deps: PATLINK)*
-- How do patent cost and spillover vary by technology area, firm size, and award vintage? *(deps: ER, PATLINK, CET)*
+- **Marginal cost per patent**
+  What is the marginal cost per patent by agency (award dollars ÷ linked
+  patents)?
+  Compare against the NIH/NSF figures in NASEM reviews.
+  *Deps: ER, PATLINK · Refs: [L3], [L4], [L6] · Spec: [../specs/patent-cost-spillover/](../specs/patent-cost-spillover/)*
+
+- **Spillover multiplier**
+  What is the spillover multiplier — non-SBIR patent citations to SBIR patents?
+  **Target:** reproduce Myers & Lanahan's ~3× for DOE, with ~60% U.S.-retained.
+  *Deps: PATLINK · Refs: [L9], [L5]*
+
+- **Cost and spillover variation**
+  How do patent cost and spillover vary by technology area, firm size, and award
+  vintage?
+  *Deps: ER, PATLINK, CET*
 
 ## D. Economic & fiscal impact
 
-*Audience: Treasury, OMB, JCT, state economic-development offices. What is the dollar return on the SBIR program?*
+*Audience: Treasury, OMB, JCT, state economic-development offices. What is the
+dollar return on the SBIR program?*
 
 ### D1. Descriptive (Tier 1)
 
-- Award totals by state, agency, and phase — SBA annual reports [L18]. *(deps: —)*
-- NAICS-sector coverage and fallback usage — [../specs/naics-enricher-consolidation/](../specs/naics-enricher-consolidation/). *(deps: IMP for NAICS)*
+- **Award totals**
+  What are award totals by state, agency, and phase?
+  *Deps: none · Refs: [L18]*
+
+- **NAICS coverage and fallback usage**
+  What is NAICS-sector coverage across awards, and how often is the fallback
+  used?
+  *Deps: IMP for NAICS · Spec: [../specs/naics-enricher-consolidation/](../specs/naics-enricher-consolidation/)*
 
 ### D2. Relational (Tier 2)
 
-- What are federal fiscal returns (tax receipts) from SBIR program spending? — [fiscal/](fiscal/) ([../specs/fiscal-tax-impact-v2.md](../specs/fiscal-tax-impact-v2.md)). TechLink's DoD-wide 1995–2018 study reports ~22:1 total-output ROI, 8.4:1 sales ROI, $39.4B tax revenue [L19]; Air Force ~12:1, Navy ~19.5:1 [L19]; NCI published a separate economic-impact study [L20]. *(deps: ER, ID, NAICS, BEA I-O)*
-- What are employment, wage, proprietor-income, and production impacts by award? *(deps: fiscal model)*
-- How do fiscal returns stratify by state and NAICS sector? *(deps: ER, NAICS)*
-- Which NAICS sectors show the highest fiscal return multipliers? *(deps: fiscal model)*
-- What is the payback period for Treasury investment recovery? *(deps: fiscal model)*
-- Decomposed by jurisdiction: federal income, payroll, corporate, and excise vs. state/local income, sales, and property — what share of total tax impact accrues where? *(deps: fiscal model with state rates)*
+- **Federal fiscal returns**
+  What are the federal fiscal returns (tax receipts) from SBIR program spending?
+  TechLink's DoD-wide 1995–2018 study reports ~22:1 total-output ROI, 8.4:1 sales
+  ROI, and $39.4B in tax revenue; Air Force ~12:1 and Navy ~19.5:1 [L19]. NCI
+  published a separate economic-impact study [L20].
+  *Deps: ER, ID, NAICS, BEA I-O · Refs: [L19], [L20] · Spec: [fiscal/](fiscal/), [../specs/fiscal-tax-impact-v2.md](../specs/fiscal-tax-impact-v2.md)*
+
+- **Employment and income impacts**
+  What are the employment, wage, proprietor-income, and production impacts per
+  award?
+  *Deps: fiscal model*
+
+- **Returns by state and sector**
+  How do fiscal returns stratify by state and NAICS sector?
+  *Deps: ER, NAICS*
+
+- **Highest-multiplier sectors**
+  Which NAICS sectors show the highest fiscal return multipliers?
+  *Deps: fiscal model*
+
+- **Treasury payback period**
+  What is the payback period for Treasury investment recovery?
+  *Deps: fiscal model*
+
+- **Jurisdiction decomposition**
+  What share of total tax impact accrues where, decomposed into federal income,
+  payroll, corporate, and excise versus state/local income, sales, and property?
+  *Deps: fiscal model with state rates*
 
 ### D3. Uncertainty & reconciliation (Tier 3)
 
-- How robust are fiscal return estimates to parameter uncertainty (sensitivity bands)? *(deps: full fiscal model)*
-- What are match rates and entity-resolution coverage needed to reconcile to NASEM follow-on funding multiplier and impact figures [L1][L2]? *(deps: ER, ID)*
-- Are tax-impact estimates more credible when derived from BEA NIPA tables [L22] than from hardcoded effective rates? Does state-specific variation (e.g., TX with no income tax vs. CA at 13.3%) materially change state-by-state ROI estimates? *(deps: NIPA rate provider, state rate provider)*
+- **Sensitivity of fiscal estimates**
+  How robust are fiscal return estimates to parameter uncertainty (sensitivity
+  bands)?
+  *Deps: full fiscal model*
+
+- **Reconciliation to NASEM figures**
+  What match rates and entity-resolution coverage are needed to reconcile to the
+  NASEM follow-on funding multiplier and impact figures?
+  *Deps: ER, ID · Refs: [L1], [L2]*
+
+- **NIPA-derived vs. hardcoded tax rates**
+  Are tax-impact estimates more credible when derived from BEA NIPA tables [L22]
+  than from hardcoded effective rates? Does state-specific variation — Texas with
+  no income tax versus California at 13.3% — materially change state-by-state ROI
+  estimates?
+  *Deps: NIPA rate provider, state rate provider · Refs: [L22]*
 
 ## E. Program management & data infrastructure
 
-*Audience: SBA, agency program managers, GAO, internal pipeline engineers. Foundational — most questions in A–D depend on work here.*
+*Audience: SBA, agency program managers, GAO, internal pipeline engineers.
+Foundational — most questions in A–D depend on work here.*
 
 ### E1. SBIR identification (foundation, Tier 1–2)
 
-- Which federal awards are SBIR/STTR vs. non-SBIR, and with what confidence? Three-tier classifier (FPDS research field 1.0 → ALN 0.8–1.0 → description parsing 0.5–0.7) — [sbir-identification-methodology.md](sbir-identification-methodology.md), [../specs/archive/completed-features/sbir-identification/](../specs/archive/completed-features/sbir-identification/). CRS [L15], GAO [L14]. *(deps: —)*
-- What are false-positive rates for shared-ALN grant identification (e.g., NIH ~20%)? *(deps: ID)*
-- How does SBIR.gov data reconcile with federal USAspending/FPDS records? GAO [L14] and
-  NASEM [L1][L3] flag tracking-data limits. **[Partially answerable now — Phase II
-  federal transactions collapse on generated award IDs and reconcile to SBIR.gov only
-  through exact normalized raw PIID/source identifiers, with ambiguity and taxonomy
-  conflict failures; broader cross-source completeness remains unvalidated]** *(deps: —)*
+- **SBIR vs. non-SBIR classification**
+  Which federal awards are SBIR/STTR versus non-SBIR, and with what confidence?
+  A three-tier classifier: FPDS research field (1.0) → ALN (0.8–1.0) →
+  description parsing (0.5–0.7).
+  *Deps: none · Refs: [L15], [L14] · Spec: [sbir-identification-methodology.md](sbir-identification-methodology.md), [../specs/archive/completed-features/sbir-identification/](../specs/archive/completed-features/sbir-identification/)*
+
+- **Shared-ALN false positives**
+  What are the false-positive rates for shared-ALN grant identification (e.g.
+  NIH at ~20%)?
+  *Deps: ID*
+
+- **SBIR.gov ↔ USAspending/FPDS reconciliation**
+  How does SBIR.gov data reconcile with federal USAspending/FPDS records?
+  **Status:** Partially answerable now — Phase II federal transactions collapse
+  on generated award IDs and reconcile to SBIR.gov only through exact normalized
+  raw PIID/source identifiers, with ambiguity and taxonomy-conflict failures.
+  Broader cross-source completeness remains unvalidated.
+  *Deps: none · Refs: [L14], [L1], [L3] (tracking-data limits)*
 
 ### E2. Entity resolution (foundation, Tier 1–2)
 
-- Is this SBIR recipient the same entity that won the federal contract? UEI → CAGE → DUNS → fuzzy-name cascade — [transition/vendor-matching.md](transition/vendor-matching.md). Graph schema: [../specs/archive/completed-features/unify-graph-node-labels/](../specs/archive/completed-features/unify-graph-node-labels/) (Phase 1, `:Award`→`:FinancialTransaction`) and [../specs/archive/completed-features/unify-company-into-organization/](../specs/archive/completed-features/unify-company-into-organization/) (Phase 2, `:Company`→`:Organization`). *(deps: —)*
-- What is the entity-resolution match rate, and what is the exact-vs-fuzzy share? *(deps: ER)*
-- Have companies undergone acquisitions or rebrandings that break matching? *(deps: ER)*
+- **Recipient ↔ contractor identity**
+  Is this SBIR recipient the same entity that won the federal contract?
+  Resolved through a UEI → CAGE → DUNS → fuzzy-name cascade.
+  *Deps: none · Spec: [transition/vendor-matching.md](transition/vendor-matching.md); graph schema in [../specs/archive/completed-features/unify-graph-node-labels/](../specs/archive/completed-features/unify-graph-node-labels/) (Phase 1, `:Award`→`:FinancialTransaction`) and [../specs/archive/completed-features/unify-company-into-organization/](../specs/archive/completed-features/unify-company-into-organization/) (Phase 2, `:Company`→`:Organization`)*
+
+- **Match rate and match quality**
+  What is the entity-resolution match rate, and what is the exact-versus-fuzzy
+  share?
+  *Deps: ER*
+
+- **Identity breaks from corporate change**
+  Have companies undergone acquisitions or rebrandings that break matching?
+  *Deps: ER*
 
 ### E3. Data quality & completeness (Tier 1)
 
-- What percentage of awards have valid NAICS codes, and what is the fallback usage rate? — [../specs/naics-enricher-consolidation/](../specs/naics-enricher-consolidation/). *(deps: —)*
-- How many awards lack UEI/DUNS identifiers? *(deps: —)*
-- What is the data-freshness lag for SBIR.gov, USAspending, USPTO, and BEA I-O sources? — [../specs/iterative_api_enrichment/](../specs/iterative_api_enrichment/). *(deps: —)*
-- Which awards have missing or null critical fields (amount, dates, recipient)? *(deps: —)*
+- **NAICS validity and fallback rate**
+  What percentage of awards have valid NAICS codes, and what is the fallback
+  usage rate?
+  *Deps: none · Spec: [../specs/naics-enricher-consolidation/](../specs/naics-enricher-consolidation/)*
 
-### E4. Data imputation (Tier 2–3) *(spec merged via PR #277; implementation not yet started)*
+- **Missing firm identifiers**
+  How many awards lack UEI/DUNS identifiers?
+  *Deps: none*
 
-- Why is `award_date` missing on ~50% of records, and can it be recovered non-destructively? — [../specs/data-imputation/](../specs/data-imputation/). *(deps: E3)*
-- For each imputable field (award date, amount, contract dates, NAICS, identifiers), which methods are available and at what confidence tier (high ≥90%, medium 75–90%, low <75%)? *(deps: E3)*
-- What is per-method backtest accuracy / MAE against ground-truth holdouts? *(deps: IMP)*
-- Can solicitation topics be mapped to NAICS (agency-topic crosswalk top-1 accuracy ≥75%)? *(deps: IMP, CET)*
-- Does the phase-transition precision benchmark remain ≥85% when imputed values are included? *(deps: IMP + transition detection)*
-- Which downstream consumers (Neo4j, CET, transition detection) should use raw vs. effective values? *(deps: IMP)*
+- **Source freshness lag**
+  What is the data-freshness lag for SBIR.gov, USAspending, USPTO, and BEA I-O
+  sources?
+  *Deps: none · Spec: [../specs/iterative_api_enrichment/](../specs/iterative_api_enrichment/)*
 
-### E5. External data source evaluation (Tier 2) *(branch: claude/procurement-data-sources-eval)*
+- **Missing critical fields**
+  Which awards have missing or null critical fields (amount, dates, recipient)?
+  *Deps: none*
 
-- Does SAM.gov Entity Extracts materially improve UEI backfill recall? — `specs/procurement-data-sources-eval/` *(branch)*. *(deps: ER)*
-- Does the SAM.gov Opportunities API replace agency-page scraping for solicitation ceilings and periods of performance? — [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/). *(deps: E3)*
-- Does FSCPSC NAICS prediction beat our abstract-nearest-neighbor baseline? *(deps: IMP)*
-- Does the PSC Selection Tool provide the NAICS ↔ PSC crosswalk needed for topic-derived NAICS? *(deps: IMP)*
-- Do DIIG CSIS lookup tables feed our NAICS hierarchy or agency normalization? *(deps: —)*
-- Should we adopt third-party procurement-tools clients (e.g., `makegov/procurement-tools`, `tandemgov/fpds`)? — `docs/decisions/procurement-tools-evaluation.md` *(branch)*. *(deps: —)*
+### E4. Data imputation (Tier 2–3)
+
+*Spec merged via PR #277; implementation not yet started.*
+
+- **Missing `award_date`**
+  Why is `award_date` missing on ~50% of records, and can it be recovered
+  non-destructively?
+  *Deps: E3 · Spec: [../specs/data-imputation/](../specs/data-imputation/)*
+
+- **Imputation methods and confidence tiers**
+  For each imputable field (award date, amount, contract dates, NAICS,
+  identifiers), which methods are available, and at what confidence tier — high
+  ≥90%, medium 75–90%, low <75%?
+  *Deps: E3*
+
+- **Backtest accuracy**
+  What is per-method backtest accuracy / MAE against ground-truth holdouts?
+  *Deps: IMP*
+
+- **Topic → NAICS crosswalk**
+  Can solicitation topics be mapped to NAICS with agency-topic crosswalk top-1
+  accuracy ≥75%?
+  *Deps: IMP, CET*
+
+- **Imputation effect on transition precision**
+  Does the phase-transition precision benchmark remain ≥85% when imputed values
+  are included?
+  *Deps: IMP + transition detection*
+
+- **Raw vs. effective values downstream**
+  Which downstream consumers (Neo4j, CET, transition detection) should use raw
+  versus effective values?
+  *Deps: IMP*
+
+### E5. External data source evaluation (Tier 2)
+
+*(branch: `claude/procurement-data-sources-eval`)*
+
+- **SAM.gov Entity Extracts for UEI backfill**
+  Does SAM.gov Entity Extracts materially improve UEI backfill recall?
+  *Deps: ER · Spec: `specs/procurement-data-sources-eval/` (branch)*
+
+- **SAM.gov Opportunities API vs. scraping**
+  Does the SAM.gov Opportunities API replace agency-page scraping for
+  solicitation ceilings and periods of performance?
+  *Deps: E3 · Spec: [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/)*
+
+- **FSCPSC NAICS prediction**
+  Does FSCPSC NAICS prediction beat our abstract-nearest-neighbor baseline?
+  *Deps: IMP*
+
+- **PSC Selection Tool crosswalk**
+  Does the PSC Selection Tool provide the NAICS ↔ PSC crosswalk needed for
+  topic-derived NAICS?
+  *Deps: IMP*
+
+- **DIIG CSIS lookup tables**
+  Do DIIG CSIS lookup tables feed our NAICS hierarchy or agency normalization?
+  *Deps: none*
+
+- **Third-party procurement clients**
+  Should we adopt third-party procurement-tools clients such as
+  `makegov/procurement-tools` or `tandemgov/fpds`?
+  *Deps: none · Spec: `docs/decisions/procurement-tools-evaluation.md` (branch)*
 
 ### E6. Continuous monitoring & rolling analytics (Tier 4, capstone)
 
-- What are current-quarter SBIR metrics and trends (weekly snapshots)? — [research-plan-alignment.md](research-plan-alignment.md), [../specs/weekly-awards-report-refactor/](../specs/weekly-awards-report-refactor/). Fills the gap between point-in-time NASEM reviews [L1][L3][L4][L5]. *(deps: E1–E5 + A–D pipelines)*
-- Can typed, optimized LM programs improve weekly award-narrative schema reliability, solicitation grounding, and operator cost beyond the current prompt and provider-native structured output? — [DSPy evaluation](decisions/dspy-evaluation.md), [prototype spec](../specs/dspy-weekly-awards-prototype/). *(deps: weekly-awards-report-refactor)*
-- How have transition rates, patent output, and fiscal returns changed quarter-over-quarter? *(deps: all)*
-- Which agencies are under-performing on transitions vs. historical baseline? *(deps: all)*
+- **Current-quarter metrics**
+  What are the current-quarter SBIR metrics and trends, on weekly snapshots?
+  Fills the gap between point-in-time NASEM reviews.
+  *Deps: E1–E5 plus the A–D pipelines · Refs: [L1], [L3], [L4], [L5] · Spec: [research-plan-alignment.md](research-plan-alignment.md), [../specs/weekly-awards-report-refactor/](../specs/weekly-awards-report-refactor/)*
+
+- **Typed LM programs for weekly narratives**
+  Can typed, optimized LM programs improve weekly award-narrative schema
+  reliability, solicitation grounding, and operator cost beyond the current
+  prompt and provider-native structured output?
+  *Deps: weekly-awards-report-refactor · Spec: [DSPy evaluation](decisions/dspy-evaluation.md), [prototype spec](../specs/dspy-weekly-awards-prototype/)*
+
+- **Quarter-over-quarter change**
+  How have transition rates, patent output, and fiscal returns changed
+  quarter-over-quarter?
+  *Deps: all*
+
+- **Underperforming agencies**
+  Which agencies are under-performing on transitions versus historical baseline?
+  *Deps: all*
 
 ## F. Capital formation & entrepreneurial finance
 
-*Audience: NVCA, Kauffman Foundation, NBER entrepreneurship researchers, VC/PE analysts, agencies (NSF, NIH) running founder-track programs. Does SBIR funding substitute for, complement, or seed private capital?*
+*Audience: NVCA, Kauffman Foundation, NBER entrepreneurship researchers, VC/PE
+analysts, and agencies (NSF, NIH) running founder-track programs. Does SBIR
+funding substitute for, complement, or seed private capital?*
 
-This area treats the SBIR awardee as a **firm with a capital history**, not as a federal-contract counterparty. Data comes from SEC EDGAR (Form D, 8-K), state UCC-1 financing-statement registries, and the unified capital-event timeline. The literature is Lerner [L10], Howell [L11], Kortum & Lerner [L24], and the NVCA Yearbook [L25] rather than NASEM and GAO.
+This area treats the SBIR awardee as a **firm with a capital history**, not as a
+federal-contract counterparty. Data comes from SEC EDGAR (Form D, 8-K), state
+UCC-1 financing-statement registries, and the unified capital-event timeline.
+The relevant literature is Lerner [L10], Howell [L11], Kortum & Lerner [L24], and
+the NVCA Yearbook [L25] — rather than NASEM and GAO.
 
 ### F1. Descriptive (Tier 1)
 
-- What is the Form D [L23] private-placement fundraising profile of SBIR awardees? *(PR #286 merged)* — [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/). *(deps: ER, SEC EDGAR)*
-- What is the debt-vs-equity composition and offering fill rate of SBIR-firm Form D filings? *(PR #286 merged)* *(deps: ER, SEC EDGAR)*
-- What fraction of SBIR awardees show secured-debt activity (UCC-1 filings), and what mix of equipment finance, depository-bank lending, and venture debt do those filings represent by lender? UCC-1 complements Form D's equity view — [../specs/ucc1-financing-analysis/](../specs/ucc1-financing-analysis/) *(PRs #303 / #305 merged, CA-only pilot found equipment + community-bank patterns and an absence of venture-debt lenders in the CA channel)*. *(deps: ER, UCC-1)*
-- Unified capital-event timeline: federal awards, private placements, M&A, and patent events on a single firm history *(PR #307 merged)*. *(deps: ER, SEC EDGAR, UCC-1, M&A signals)*
-- What is the SBIR-firm M&A exit rate, and how does it stratify by funding agency (HHS biotech ~9.3% vs. DoD defense ~5.8%)? *(PR #286 merged)* *(deps: ER, M&A signals)*
-- What is the median time from first SBIR award to M&A exit (~15 years per PR #286)? *(deps: ER, M&A signals)*
+- **Form D fundraising profile**
+  What is the Form D [L23] private-placement fundraising profile of SBIR
+  awardees?
+  *Deps: ER, SEC EDGAR · Spec: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/) (PR #286 merged)*
+
+- **Debt vs. equity composition**
+  What is the debt-versus-equity composition and offering fill rate of SBIR-firm
+  Form D filings?
+  *Deps: ER, SEC EDGAR · Spec: (PR #286 merged)*
+
+- **Secured-debt activity**
+  What fraction of SBIR awardees show secured-debt activity (UCC-1 filings), and
+  what mix of equipment finance, depository-bank lending, and venture debt do
+  those filings represent, by lender?
+  UCC-1 complements Form D's equity view. The CA-only pilot found equipment and
+  community-bank patterns, and an absence of venture-debt lenders in the CA
+  channel.
+  *Deps: ER, UCC-1 · Spec: [../specs/ucc1-financing-analysis/](../specs/ucc1-financing-analysis/) (PRs #303 / #305 merged)*
+
+- **Unified capital-event timeline**
+  What does a single firm history look like when federal awards, private
+  placements, M&A, and patent events are placed on one timeline?
+  *Deps: ER, SEC EDGAR, UCC-1, M&A signals · Spec: (PR #307 merged)*
+
+- **M&A exit rate by agency**
+  What is the SBIR-firm M&A exit rate, and how does it stratify by funding agency
+  (HHS biotech ~9.3% vs. DoD defense ~5.8%)?
+  *Deps: ER, M&A signals · Spec: (PR #286 merged)*
+
+- **Time to exit**
+  What is the median time from first SBIR award to M&A exit?
+  Roughly 15 years, per PR #286.
+  *Deps: ER, M&A signals*
 
 ### F2. Relational (Tier 2)
 
-- Among acquirers of SBIR firms, what share are life-sciences consolidators (Bruker, Ligand, Thermo Fisher) vs. defense primes vs. financial sponsors? What fraction of acquirers are serial (3+ SBIR-firm targets)? *(deps: ER, M&A signals)*
-- Do Form D filers and non-filers differ on transition, patent, and exit outcomes — controlling for vintage, agency, and CET area? *(PR #314)* *(deps: ER, ID, CET, SEC EDGAR)*
-- What is the SBIR ↔ M&A-event match rate by fiscal year, and how is coverage trending? *(PR #313)* — [../specs/sbir_ma_match_rate_by_fy/](../specs/sbir_ma_match_rate_by_fy/). *(deps: ER, M&A signals)*
-- How does SBIR-firm capital structure benchmark against the NVCA Yearbook [L25] cohort of comparable-stage VC-backed startups? *(deps: ER, SEC EDGAR)*
+- **Acquirer-type concentration**
+  Among acquirers of SBIR firms, what share are life-sciences consolidators
+  (Bruker, Ligand, Thermo Fisher) versus defense primes versus financial
+  sponsors? What fraction of acquirers are serial buyers with 3+ SBIR-firm
+  targets?
+  *Deps: ER, M&A signals*
+
+- **Filers vs. non-filers**
+  Do Form D filers and non-filers differ on transition, patent, and exit
+  outcomes, controlling for vintage, agency, and CET area?
+  *Deps: ER, ID, CET, SEC EDGAR · Spec: (PR #314)*
+
+- **SBIR ↔ M&A match rate by fiscal year**
+  What is the SBIR ↔ M&A-event match rate by fiscal year, and how is coverage
+  trending?
+  *Deps: ER, M&A signals · Spec: [../specs/sbir_ma_match_rate_by_fy/](../specs/sbir_ma_match_rate_by_fy/) (PR #313)*
+
+- **Capital structure vs. NVCA cohort**
+  How does SBIR-firm capital structure benchmark against the NVCA Yearbook [L25]
+  cohort of comparable-stage VC-backed startups?
+  *Deps: ER, SEC EDGAR · Refs: [L25]*
 
 ### F3. Inferential (Tier 3)
 
-- What is the **private-to-SBIR leverage ratio** (private capital raised ÷ SBIR funding) by agency, vintage, and firm size? The private-side mirror to NASEM's 4:1 DoD follow-on funding multiplier [L1] — [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/), [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/). *(deps: ER, ID, SEC EDGAR)*
-- For Phase II awardees of any agency, do follow-on funding and exit outcomes match the published private-capital-backed-startup baselines from the NVCA Yearbook [L25]? *(PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, terminology changed from "VC" to "private capital")* *(deps: ER, SEC EDGAR)*
-- Does SBIR funding crowd in or crowd out subsequent private capital? **Target: reproduce or extend Howell's finding that an early-stage DOE SBIR grant roughly doubles the probability of subsequent VC** [L11]. Compare against Kortum & Lerner [L24] on VC's contribution to innovation. *(deps: ER, ID, SEC EDGAR)*
-- Does the Lerner [L10] finding — SBIR growth effects concentrated in VC-rich zip codes — still hold post-2010 and across all eleven agencies? *(deps: ER, ID, SEC EDGAR)*
+- **Private-to-SBIR leverage ratio**
+  What is the private-to-SBIR leverage ratio (private capital raised ÷ SBIR
+  funding) by agency, vintage, and firm size?
+  The private-side mirror of NASEM's 4:1 DoD follow-on funding multiplier [L1].
+  *Deps: ER, ID, SEC EDGAR · Refs: [L1] · Spec: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/), [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/)*
+
+- **Outcomes vs. private-capital baselines**
+  For Phase II awardees of any agency, do follow-on funding and exit outcomes
+  match the published private-capital-backed-startup baselines from the NVCA
+  Yearbook [L25]?
+  *Deps: ER, SEC EDGAR · Refs: [L25] · Spec: (PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, with terminology changed from "VC" to "private capital")*
+
+- **Crowd-in vs. crowd-out**
+  Does SBIR funding crowd in or crowd out subsequent private capital?
+  **Target:** reproduce or extend Howell's finding that an early-stage DOE SBIR
+  grant roughly doubles the probability of subsequent VC [L11]. Compare against
+  Kortum & Lerner [L24] on VC's contribution to innovation.
+  *Deps: ER, ID, SEC EDGAR · Refs: [L11], [L24]*
+
+- **Geographic concentration of effects**
+  Does Lerner's finding [L10] — that SBIR growth effects concentrate in VC-rich
+  zip codes — still hold post-2010 and across all eleven agencies?
+  *Deps: ER, ID, SEC EDGAR · Refs: [L10]*
 
 ### F4. Predictive (Tier 4)
 
-- Forward-looking probability of an exit event (M&A or IPO) for a given SBIR firm, conditional on capital-event history and CET area. *(deps: all of F1–F3)*
+- **Forward exit probability**
+  What is the forward-looking probability of an exit event (M&A or IPO) for a
+  given SBIR firm, conditional on its capital-event history and CET area?
+  *Deps: all of F1–F3*
 
 ## Output products & audiences
 
-Documents and reports the question inventory has produced for specific audiences. Each is a synthesis of A-F questions for a particular reader, not a new research question itself.
+Documents and reports this inventory has produced for specific readers. Each is
+a synthesis of A–F questions for a particular audience, not a new research
+question.
 
 ### Congressional district success-story briefings
 
-**Audience:** members of Congress and their staff, for constituent-facing communication.
-**Format:** per-district briefing identifying 3-5 SBIR firms within the member's district that represent the strongest success stories (FDA-cleared products, defense supplier roles, follow-on capital raises, M&A exits) with political-safety vetting.
-**Districts covered to date** (in conversation; not yet committed as repo artifacts): KY-3 (McGarvey), NJ-10 (McIver), NY-16 (Latimer), NH-2 (Goodlander), MT-2 (Downing), TX-6 (Ellzey), and a CNMI null finding for King-Hinds. Vetting depth includes press review, SEC Form D filings, M&A history, and any political-sensitivity factors (foreign ownership, classified work exposure, recent acquisition).
-**Supporting code:** `sbir_etl/enrichers/congressional_district_resolver.py` (UEI → district resolver), `scripts/setup_congressional_districts.py` (district reference data).
-**Pulls from:** Section A (portfolio composition; A1 foreign-ownership / A4 acquisition screens), B1-B3 (commercialization signals), F1-F2 (capital events, M&A). (Classified-work exposure remains a manual political-sensitivity vetting factor, not an automated pipeline screen — there is no vulnerability signal for it.)
+**Audience:** members of Congress and their staff, for constituent-facing
+communication.
+
+**Format:** a per-district briefing identifying 3–5 SBIR firms within the
+member's district that represent the strongest success stories — FDA-cleared
+products, defense supplier roles, follow-on capital raises, M&A exits — with
+political-safety vetting. Vetting depth covers press review, SEC Form D filings,
+M&A history, and political-sensitivity factors (foreign ownership, classified
+work exposure, recent acquisition).
+
+**Districts covered to date** (in conversation; not yet committed as repo
+artifacts): KY-3 (McGarvey), NJ-10 (McIver), NY-16 (Latimer), NH-2 (Goodlander),
+MT-2 (Downing), TX-6 (Ellzey), plus a CNMI null finding for King-Hinds.
+
+**Supporting code:** `sbir_etl/enrichers/congressional_district_resolver.py`
+(UEI → district resolver), `scripts/setup_congressional_districts.py` (district
+reference data).
+
+**Pulls from:** Section A (portfolio composition; A1 foreign-ownership and A4
+acquisition screens), B1–B3 (commercialization signals), F1–F2 (capital events,
+M&A). Classified-work exposure remains a manual political-sensitivity vetting
+factor, not an automated pipeline screen — there is no vulnerability signal for
+it.
 
 ### Form D fundraising analysis (published)
 
-**Audience:** F-area analysts, investor researchers, policy staff studying program-wide private-capital leverage.
-**Format:** `docs/research/sbir-form-d-fundraising-analysis.md` (canonical, on main; now includes Appendix A — firm-level bootstrap CIs, PR #338 — and Appendix B — PIF cross-link integrity audit, PR #341); `docs/research/dod-form-d-leverage.md` (DoD Branch decomposition + per-firm/time-series/acquirer-type follow-ups + Form D vs. FPDS substitution test, PRs #342/#343/#350); `docs/research/form-d-data-dictionary.md` (field reference).
-**Pulls from:** F1 (Form D profile), F3 (private-to-SBIR leverage), A1/A4 (DoD-specific firm-health and acquisition decomposition).
+**Audience:** F-area analysts, investor researchers, and policy staff studying
+program-wide private-capital leverage.
+
+**Format:**
+
+- `docs/research/sbir-form-d-fundraising-analysis.md` — canonical, on `main`.
+  Includes Appendix A (firm-level bootstrap CIs, PR #338) and Appendix B (PIF
+  cross-link integrity audit, PR #341).
+- `docs/research/dod-form-d-leverage.md` — DoD Branch decomposition, per-firm and
+  time-series and acquirer-type follow-ups, and the Form D vs. FPDS substitution
+  test (PRs #342 / #343 / #350).
+- `docs/research/form-d-data-dictionary.md` — field reference.
+
+**Pulls from:** F1 (Form D profile), F3 (private-to-SBIR leverage), A1/A4
+(DoD-specific firm-health and acquisition decomposition).
 
 ### Commercialization-benchmark methodology (in progress, not yet committed)
 
 **Audience:** SBA program oversight, statutory compliance reviewers, GAO.
-**Format:** `docs/commercialization-benchmark-methodology.md` (locally present but **not committed** to the repo) documenting the §638(qq)(3) statutory framework, the FY2026 evaluation methodology, the data-source provenance (FPDS/USAspending contracts, SEC Form D investment, SBIR.gov FABS grants), and the per-firm audit protocol. The methodology doc pairs with a per-firm audit harness (`scripts/archive/data/run_commercialization_benchmark.py` and `scripts/data/audit_one_firm.py`) and an FY2026 audited cohort CSV — all of which are **local-only / uncommitted** on the author's machine. The shippable counterpart on main is `scripts/run_benchmark.py` + `sbir_etl/models/benchmark_models.py`, which implements the same statutory framework via a different CLI shape. **The methodology doc + audit harness should be committed once stabilized** — the untracked status is itself a coverage gap worth closing.
-**Pulls from:** B3 (transition effectiveness + new §638(qq) benchmark question), F1 (Form D investment signal), F2 (NVCA-baseline comparison).
+
+**Format:** `docs/commercialization-benchmark-methodology.md` — locally present
+but **not committed** to the repo. Documents the §638(qq)(3) statutory
+framework, the FY2026 evaluation methodology, the data-source provenance
+(FPDS/USAspending contracts, SEC Form D investment, SBIR.gov FABS grants), and
+the per-firm audit protocol.
+
+The methodology doc pairs with a per-firm audit harness
+(`scripts/archive/data/run_commercialization_benchmark.py` and
+`scripts/data/audit_one_firm.py`) and an FY2026 audited cohort CSV — all of which
+are **local-only / uncommitted** on the author's machine. The shippable
+counterpart on `main` is `scripts/run_benchmark.py` plus
+`sbir_etl/models/benchmark_models.py`, which implements the same statutory
+framework through a different CLI shape.
+
+**The methodology doc and audit harness should be committed once stabilized** —
+the untracked status is itself a coverage gap worth closing.
+
+**Pulls from:** B3 (transition effectiveness and the §638(qq) benchmark
+question), F1 (Form D investment signal), F2 (NVCA-baseline comparison).
 
 ## Prior literature & benchmarks
 
-Public studies the inventory draws from or benchmarks against.
+Public studies this inventory draws from or benchmarks against.
 
 **NASEM reviews (congressionally mandated):**
 
@@ -397,7 +1062,7 @@ Public studies the inventory draws from or benchmarks against.
 
 - **[L28]** DoD. *National Defense Industrial Strategy (NDIS)* (released January 11, 2024). First-ever DoD industrial strategy; four priorities (supply-chain resilience, workforce readiness, flexible acquisition, economic deterrence) and ten systemic challenges including sub-tier supplier fragility. <https://www.businessdefense.gov/docs/ndis/2023-NDIS.pdf>
 - **[L29]** OSTP / NSTC. *Critical and Emerging Technologies List — 2024 Update* (February 2024). NSTC interagency CET list; external reference framework distinct from the repo's 21-area `NSTC-2025Q1` spine. <https://bidenwhitehouse.archives.gov/wp-content/uploads/2024/02/Critical-and-Emerging-Technologies-List-2024-Update.pdf>
-- **[L30]** GAO-25-107283 (2025). *Defense Industrial Base: Actions Needed to Address Risks Posed by Dependence on Foreign Suppliers.* Finds DoD relies on 200,000+ suppliers with little visibility past the prime-contractor tier — the documented sub-tier-visibility gap behind the out-of-boundary choke-point questions. <https://www.gao.gov/products/gao-25-107283>
+- **[L30]** GAO-25-107283 (2025). *Defense Industrial Base: Actions Needed to Address Risks Posed by Dependence on Foreign Suppliers.* Finds DoD relies on 200,000+ suppliers with little visibility past the prime-contractor tier — the documented sub-tier-visibility gap behind the out-of-scope choke-point questions. <https://www.gao.gov/products/gao-25-107283>
 - **[L31]** DoD. *State of Competition within the Defense Industrial Base* (February 15, 2022). Documents defense-sector consolidation (prime contractors 51→5 since the 1990s; small businesses in the DIB down >40% over a decade) and five priority sectors (microelectronics, missiles & munitions, high-capacity batteries, castings & forgings, critical minerals & materials). <https://media.defense.gov/2022/Feb/15/2002939087/-1/-1/1/STATE-OF-COMPETITION-WITHIN-THE-DEFENSE-INDUSTRIAL-BASE.PDF>
 - **[L32]** CSIS Center for the Industrial Base. *New Entrants and Small Business Graduation in the Market for Federal Contracts.* FPDS-based analysis (2001–2016) of entrant, exit, and small-business graduation rates in federal contracting. <https://www.csis.org/analysis/new-entrants-and-small-business-graduation-market-federal-contracts>
 - **[L33]** DoD SBIR/STTR Fast Track. Match mechanism of up to four SBIR/STTR dollars per outside-investor dollar (1:1 to 1:4), contingent on Phase II selection. Verified leverage anchor for A-CP11. <https://www.sbir.gov/tutorials/individual-agency-requirements/DOD-services>
@@ -406,20 +1071,71 @@ Public studies the inventory draws from or benchmarks against.
 
 ## Maintenance
 
-**Last reviewed:** 2026-06-27 — **consolidated Section A** into a single complexity-tier ladder (A1 Descriptive → A4 Risk/monitoring/prediction) following a holistic overlap/redundancy review. This collapsed the three previously-coexisting sub-structures (the Axis A / Axis B "capability vs. vulnerability" split, the separately-tiered "Supporting DIB questions," and the interleaved A-CP1–A-CP9 choke-point extensions) and folded in the former **Section G** (Industrial-base resilience), which was removed as a standalone policy area because its audience and content fully overlapped Section A. Each question now appears once at its highest tier; the capability/vulnerability distinction is preserved as inline **(cap)** / **(vuln)** tags and per-question answerability labels; the choke-point questions retain their `A-CP#` identifiers inline so prior references resolve. Fixes the prior `A1–A4` / `B1–B4` label collision (Axis B's `B1–B4` had clashed with Section B). The out-of-scope physical / sub-tier supply-chain questions (former B4 + Section G's G3 list) are merged into one **Out of scope** appendix at the end of Section A. De-duplicated the foundational SBIR-identification and patent-flow bullets out of Section A (they live at E1 / C2). No questions were dropped and no citations changed; the choke-point citation set (L27–L33, GAO-24-106398/L14 reuse) and the open `[TODO: verify]` items below carry over from the prior choke-point addition.
+**Last reviewed:** 2026-08-02 — **readability pass.** Reformatted every question
+into a fixed shape (title → question → caveat → status → deps/refs/spec),
+rewrote noun-phrase entries as actual questions, and broke multi-clause
+sentences apart. Moved the Section A framing material (CET spine, statutory
+grounding, scope-consolidation history) from the section preamble into
+[Section A framing notes](#section-a-framing-notes) at the end of the section,
+so Section A opens on questions rather than on ten lines of framing. Converted
+the dependency-tag glossary to a table and added a
+[How to read this document](#how-to-read-this-document) key. **No questions,
+citations, status labels, `A-CP#` identifiers, PR/branch tags, or spec links
+were added, removed, or changed in substance** — this pass is presentation only.
 
-**Open [TODO: verify] items from the choke-point set (resolve before relying on the figures):**
+**Prior review:** 2026-06-27 — **consolidated Section A** into a single
+complexity-tier ladder (A1 Descriptive → A4 Risk/monitoring/prediction)
+following a holistic overlap/redundancy review. This collapsed the three
+previously-coexisting sub-structures (the Axis A / Axis B "capability vs.
+vulnerability" split, the separately-tiered "Supporting DIB questions," and the
+interleaved A-CP1–A-CP9 choke-point extensions) and folded in the former
+**Section G** (Industrial-base resilience), removed as a standalone policy area
+because its audience and content fully overlapped Section A. Each question now
+appears once at its highest tier; the capability/vulnerability distinction is
+preserved as inline **(cap)** / **(vuln)** tags and per-question answerability
+labels; the choke-point questions retain their `A-CP#` identifiers so prior
+references resolve. Fixes the prior `A1–A4` / `B1–B4` label collision (Axis B's
+`B1–B4` had clashed with Section B). The out-of-scope physical / sub-tier
+supply-chain questions (former B4 plus Section G's G3 list) are merged into one
+**Out of scope** appendix at the end of Section A. De-duplicated the foundational
+SBIR-identification and patent-flow bullets out of Section A (they live at E1 /
+C2). No questions were dropped and no citations changed.
 
-- **A-CP11 / NSF ~18:1 portfolio leverage** — the ~18:1 private-to-public figure was found only in trade press, not confirmed against an NSF publication (NSF primary pages returned 403 during the review; a separate NSF page cites "$6.5B private investment since 2015," which does not reconcile). Marked `[TODO: verify]` inline and **not stated as fact**. The DoD Fast Track 1:4 anchor [L33] is verified.
-- **A3 / "4:1 NASEM" multiplier attribution** — the existing A3 (Inferential — DoD follow-on funding multiplier) "~4:1" figure and its NASEM attribution [L1][L2] were left untouched in this pass per scope. `[TODO: verify A3 4:1 attribution against NASEM source]` before the next citation audit relies on it.
+**Open `[TODO: verify]` items from the choke-point set** (resolve before relying
+on the figures):
 
-When this doc is reviewed next, the audit should cover:
+- **A-CP11 / NSF ~18:1 portfolio leverage** — the ~18:1 private-to-public figure
+  was found only in trade press, not confirmed against an NSF publication (NSF
+  primary pages returned 403 during the review; a separate NSF page cites "$6.5B
+  private investment since 2015," which does not reconcile). Marked
+  `[TODO: verify]` inline and **not stated as fact**. The DoD Fast Track 1:4
+  anchor [L33] is verified.
+- **A3 / "4:1 NASEM" multiplier attribution** — the A3 "~4:1" figure and its
+  NASEM attribution [L1], [L2] were left untouched per scope.
+  `[TODO: verify A3 4:1 attribution against NASEM source]` before the next
+  citation audit relies on it.
 
-- All `*(PR #...)*` references resolve to merged or otherwise tracked PRs (closed-without-merge PRs need explicit successor links — PR #311 → #321 was the prior failure mode)
-- All `*(branch: ...)*` tags point at branches that still exist on origin (`claude/sbir-data-imputation-strategy` was the prior failure mode — branch deleted, work landed under a different name)
-- Internal links to `../specs/` and `docs/` directories resolve
-- Each "deps:" tag accurately reflects current pipeline structure (M&A signals are script-driven, not orchestrated — flagged in the M&A implementation note under Section A → A4)
-- Coverage gaps: cross-reference recent merged feature PRs against the question inventory to surface work not yet documented here
-- CET taxonomy consistency: the canonical spine is the 21-area `NSTC-2025Q1` set (`config/cet/taxonomy.yaml`, validated by `taxonomy_loader.py`). Two divergent code-level taxonomies remain unreconciled — a 10-area transition-system set (`docs/transition/cet-integration.md`, code in transition CET inference) and a 19-area hardcoded reporting set (`sbir_etl/utils/reporting/analyzers/cet_analyzer.py`). Reconciling these to the 21-area spine is a code change with test/precision-benchmark risk and should be scoped separately.
+**Next audit should cover:**
+
+- All `(PR #…)` references resolve to merged or otherwise tracked PRs
+  (closed-without-merge PRs need explicit successor links — PR #311 → #321 was
+  the prior failure mode).
+- All `(branch: …)` tags point at branches that still exist on origin
+  (`claude/sbir-data-imputation-strategy` was the prior failure mode — branch
+  deleted, work landed under a different name).
+- Internal links to `../specs/` and `docs/` directories resolve.
+- Each *Deps* slot accurately reflects current pipeline structure (M&A signals
+  are script-driven, not orchestrated — flagged in the implementation note under
+  [A4](#a4-risk-monitoring--prediction-tier-4)).
+- Coverage gaps: cross-reference recent merged feature PRs against this
+  inventory to surface work not yet documented here.
+- CET taxonomy consistency: the canonical spine is the 21-area `NSTC-2025Q1` set
+  (`config/cet/taxonomy.yaml`, validated by `taxonomy_loader.py`). Two divergent
+  code-level taxonomies remain unreconciled — a 10-area transition-system set
+  (`docs/transition/cet-integration.md`, code in transition CET inference) and a
+  19-area hardcoded reporting set
+  (`sbir_etl/utils/reporting/analyzers/cet_analyzer.py`). Reconciling these to
+  the 21-area spine is a code change with test/precision-benchmark risk and
+  should be scoped separately.
 
 Update this footer with the new review date when the audit completes.

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -104,6 +104,8 @@ today from what is still a research target.
 committees, OSTP, congressional science / small-business committees, CSIS-style
 industrial-base analysts.*
 
+<a id="the-master-question-industrial-capability-vs-vulnerability"></a>
+
 **Master question:** Across the CET areas, where does SBIR/STTR build domestic
 industrial capability that strengthens the defense industrial base, and where
 are awardees exposed to adversary ownership/control or capability concentration
@@ -142,13 +144,16 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   In each CET area, how many distinct firms hold awards, how much award money do
   they hold, and how much of that money is concentrated in a few of them —
   measured by **HHI** (the Herfindahl-Hirschman Index, the standard antitrust
-  measure of market concentration; higher means fewer, larger players) and broken
-  out by NAICS sector and by geography (state, congressional district)?
-  Many independent firms in an area means a healthy supplier base. Few firms
-  means a choke point. It is the same number read two ways, and the second
-  reading also flags areas whose suppliers are clustered in one part of the
-  country. GAO's program-wide Phase II HHI of ~11 [L14] is the diffuse baseline
-  that area-level concentration is measured against.
+  measure of market concentration; higher means award dollars are concentrated
+  among fewer or larger firms) and broken out by NAICS sector and by geography
+  (state, congressional district)?
+  More independent awardees suggest a broader in-program supplier base. Fewer
+  awardees and a higher HHI flag potential concentration for review; these
+  award-data signals do not by themselves establish supplier health or a
+  physical choke point. The geographic view also flags areas whose suppliers
+  are clustered in one part of the country. GAO's program-wide Phase II HHI of
+  ~11 [L14] is the diffuse baseline that area-level concentration is measured
+  against.
   **Status:** Answerable now for the classified DoD subset.
   *Deps: CET, ER, NAICS · Refs: [L14], [L16], [L29] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md) (reproducible baseline and its limitations)*
 
@@ -379,6 +384,8 @@ NASEM calls this quantity the *leverage ratio*.
 > `packages/sbir-analytics/sbir_analytics/assets/ma_detection.py` stub was a
 > placeholder, never wired into the M&A pipeline, and was removed in PR #317.
 
+<a id="out-of-scope--physical--sub-tier-supply-chain-data-the-project-does-not-ingest"></a>
+
 ### Out of scope — physical & sub-tier supply chain
 
 *These choke-point questions are **not answerable** with award-type data and are
@@ -511,8 +518,11 @@ statutory goal is Phase III commercialization.*
   *Deps: ER, ID · Refs: [L14] · Spec: [phase-transition-latency.md](phase-transition-latency.md)*
 
 - **Phase II → III survival probability**
-  What share of Phase II awardees go on to win Phase III work, and how does that
-  share vary by agency, firm size, and award vintage?
+  What is the probability that a Phase II awardee wins Phase III work within a
+  defined follow-up period, and how does it vary by agency, firm size, and award
+  vintage?
+  Awardees whose follow-up period is not yet complete are still under observation
+  (*right-censored*), not counted as failures.
   *Deps: ER, ID*
 
 - **Latency by technology area**
@@ -759,6 +769,8 @@ Foundational — most questions in A–D depend on work here.*
   Which awards have missing or null critical fields (amount, dates, recipient)?
   *Deps: none*
 
+<a id="e4-data-imputation-tier-23-spec-merged-via-pr-277-implementation-not-yet-started"></a>
+
 ### E4. Data imputation (Tier 2–3)
 
 *Spec merged via PR #277; implementation not yet started.*
@@ -792,6 +804,8 @@ Foundational — most questions in A–D depend on work here.*
   Which downstream consumers (Neo4j, CET, transition detection) should use raw
   versus effective values?
   *Deps: IMP*
+
+<a id="e5-external-data-source-evaluation-tier-2-branch-claudeprocurement-data-sources-eval"></a>
 
 ### E5. External data source evaluation (Tier 2)
 


### PR DESCRIPTION
## Description

`docs/research-questions.md` is the canonical inventory of what this repo exists to answer, but it had become hard to read. Two commits: a structural pass, then a plain-language pass over the reader-facing text.

---

## Commit 1 — structural pass (presentation only)

No questions, citations, status labels, `A-CP#` identifiers, PR/branch tags, or spec links added, removed, or changed in substance.

### What was making it hard to read

1. **Five orthogonal axes crammed into single prose bullets.** The A-CP4 FOCI question carried a lens tag, a legacy ID, a lower-bound caveat, the question, two citations, an answerability label, and a deps list — in one 90-word sentence. Finding the question meant parsing the metadata wrapped around it.
2. **Many "questions" were noun phrases.** *"Capability density & choke-point concentration map per CET area"*, *"Concentration-as-fragility"* — the reader had to reverse-engineer what was being asked.
3. **Sentence length.** Several single sentences ran 3–6 lines with nested em-dashes and parentheticals.

### Changes

- **Fixed shape for every question:** bold title (plus lens/ID tags) → the question, as a question → caveat if one applies → `Status:` if answerability is contested → a trailing `Deps / Refs / Spec` line.
- Rewrote noun-phrase entries as interrogatives; split the long sentences.
- **Moved Section A's framing** (CET spine, statutory grounding, scope-consolidation history) into a `Section A framing notes` subsection at the end, so Section A opens on questions rather than ten lines of framing. Easy to revert if you'd rather it stayed up top.
- Promoted the bolded sub-groupings in A3/A4 to real headings.
- Dep glossary → table; added a `How to read this document` key; added cross-section anchor links.

---

## Commit 2 — plain-language pass

Commit 1 deliberately left wording alone. This one applies a bounded rule, now stated in the reading key: **the title, question, and Status slots are written for an outside reader and stay in plain language; Deps, Spec, and the implementation notes are maintainer-facing and keep pipeline shorthand.** Those three slots are exactly where the audience pointers send external readers.

Three kinds of change:

**1. House shorthand translated.** The thick/thin/dense metaphor family (*capability density*, *supplier-base thickness*, *transition-thinness*, *thin bases*) and the nominalized compounds (*Concentration-as-fragility*, *Acquisition-erosion*, *Predictive erosion*) were invented in this repo — they look like terms of art but cannot be looked up. They now say how many firms there are and what is happening to them. *Whitespace* → *Coverage gaps*, keeping the house term parenthetically so existing readers still find it.

**2. Pipeline vocabulary out of audience-facing slots.** *Materialized* / *materialization* is Dagster's word for "computed and stored"; in a Status line read by an oversight staffer it looks like hedging. Now "built" / "run in production". Same for *stacked changes* and *grain*. The M&A implementation note keeps the original vocabulary, per the rule.

**3. Terms of art kept, but glossed.** HHI, left-censoring, survival probability, fill rate, and crowd-in/crowd-out are the correct words for this audience and were **not** replaced — each gained a short in-line gloss on first use. *Lower-bound proxy* is now defined once in the reading key and used bare thereafter, replacing six slightly different restatements.

The heaviest rewrite is B2's follow-on census question, which stacked five invented modifiers before reaching a verb:

> **Before:** How many exact-UEI, post-completion contract actions survive a pre-registered, label-free uncoded-follow-on proxy, and how do the audit counts change across its frozen clauses and agency/window cells?

> **After:** When a firm wins a federal contract after its SBIR award ends — the same firm by exact UEI, with no Phase III label required — how many of those contracts hold up as likely follow-on work? And how does that count shift as we vary the matching rules, the agency, and the time window?

Its methodology terms (*pre-registered*, *frozen criteria*) moved to a `Method:` line, where they answer a reviewer's concern about post-hoc tuning rather than blocking a scanner.

Also de-circularized three questions that restated their own titles (transition effectiveness rate, survival probability, categorization vs. transition likelihood) and unpacked E1's reconciliation status line.

**No question changed meaning and no status label changed what it asserts.**

## Type of Change

- [x] Documentation update

## Testing

No code changed, so no unit or integration tests apply. Content preservation was verified mechanically against the pre-change file after **both** commits:

- **Citations** — all 33 `[L#]` entries present; only additions (citations pulled into explicit `Refs` slots), zero removals.
- **Identifiers** — all 37 `A-CP#` occurrences preserved exactly.
- **PR / issue refs** — all 15 PR refs and both issue refs preserved.
- **Links** — every link target and `<https://…>` URL from the original present; all relative links resolve on disk; all internal anchors resolve to real headings.
- **Question counts** — unchanged in every section. Net +3 bullets, all from splitting the Form D "Format:" run-on into a list.
- **Status labels** — every answerability label preserved; commit 2 rewords some but changes none of their assertions.
- **Inbound links** — no other file in the repo links to an anchor inside this doc, so heading changes break nothing.
- **markdownlint** — clean under `.markdownlint.yaml`. Also fixes two pre-existing MD052 adjacent-reference errors (`[L1][L3]` → `[L1], [L3]`).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

The Maintenance footer records both passes and the prior 2026-06-27 review. The open `[TODO: verify]` items (NSF ~18:1, A3 4:1 NASEM attribution) carry over untouched, as does the next-audit checklist.