### PR TITLE
Phase III enrichment → T3 firm-ranking + lineage features (Lever A): 0.47 was the wrong task

### DIFF
--- a/scripts/phase3_benchmark/measure_firm_ranking.py
+++ b/scripts/phase3_benchmark/measure_firm_ranking.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Firm-ranking measurement with non-text lineage features (spec T3, Lever A).
+
+The T6/forward numbers (~0.47) measure CONTRACT-ranking: given a firm, rank the true
+transition *contract* (terse text) among decoys. But the packet's real job is
+FIRM-ranking: given an opportunity, rank candidate *firms*. That flips which side is
+rich — the candidates are firm SBIR abstracts (always rich), so the text-poverty wall
+that capped contract-ranking does not apply.
+
+This scores firm-ranking on the frozen fusion text signal, then adds **non-text lineage
+features** that are constant within a contract-ranking pool but vary across firms:
+agency continuity, prior-award density, and Phase-II timing plausibility. All are
+computable at packet time from (firm, opportunity) alone — leakage-safe.
+
+Two decoy modes: ``random`` (diverse firms) and ``hard`` (same-agency-bucket firms, which
+neutralizes the agency feature so any lift is density+timing). Self-contained; local only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import re
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+_SUFFIX = re.compile(r"\b(INC|LLC|CORP\w*|CO|COMPANY|LTD|LP|LLP|PC|PLLC|INCORPORATED)\b\.?", re.I)
+_NON_ALNUM = re.compile(r"[^A-Z0-9 ]")
+
+
+def normalize_name(s: object) -> str:
+    return " ".join(_NON_ALNUM.sub(" ", _SUFFIX.sub(" ", str(s or "").upper())).split())
+
+
+def firm_bucket(agency: str, branch: str) -> str:
+    agency, branch = str(agency).upper(), str(branch).upper()
+    if "DEFENSE" in agency:
+        for b in ("NAVY", "ARMY", "AIR FORCE"):
+            if b in branch:
+                return b.replace(" ", "")
+        return "DOD"
+    for key, tag in (("HEALTH", "HHS"), ("SCIENCE FOUND", "NSF"), ("ENERGY", "DOE"), ("AERONAUT", "NASA")):
+        if key in agency:
+            return tag
+    return agency[:6]
+
+
+def notice_bucket(dept: str, sub: str) -> str:
+    text = f"{dept} {sub}".upper()
+    for b in ("NAVY", "ARMY", "AIR FORCE"):
+        if b in text:
+            return b.replace(" ", "")
+    for key, tag in (("HEALTH", "HHS"), ("AERONAUT", "NASA"), ("DEFENSE", "DOD")):
+        if key in text:
+            return tag
+    return text[:6]
+
+
+def _fusion_text(opp: str, cands: list[str], k: dict) -> np.ndarray:
+    wm = TfidfVectorizer(ngram_range=(1, 2), stop_words="english").fit_transform([opp, *cands])
+    word = cosine_similarity(wm[0:1], wm[1:]).ravel()
+    cm = TfidfVectorizer(analyzer="char_wb", ngram_range=(3, 5)).fit_transform([opp, *cands])
+    char = cosine_similarity(cm[0:1], cm[1:]).ravel()
+    return k["cw"] * (word - k["mw"]) / k["sw"] + k["cc"] * (char - k["mc"]) / k["sc"]
+
+
+def measure(parquet_dir: Path, award_csv: Path, coef_path: Path, *, mode: str = "random", seed: int = 20260802):
+    rng = np.random.RandomState(seed)
+    c = json.loads(coef_path.read_text())
+    k = {"cw": c["coefficients"][0], "cc": c["coefficients"][1], "mw": c["scaler_mean"][0],
+         "mc": c["scaler_mean"][1], "sw": c["scaler_scale"][0], "sc": c["scaler_scale"][1]}
+
+    aw = pd.read_csv(award_csv, usecols=["Company", "Agency", "Branch", "Phase", "Award Year", "Abstract"], dtype=str)
+    aw["nk"] = aw["Company"].map(normalize_name)
+    aw["yr"] = pd.to_numeric(aw["Award Year"], errors="coerce")
+    firm = aw.groupby("nk").agg(
+        abstract=("Abstract", lambda s: " ".join(s.dropna().astype(str))[:4000]),
+        n=("Company", "size"),
+        p2=("yr", lambda s: s[aw.loc[s.index, "Phase"].str.contains("II", na=False)].min()),
+        buckets=("Agency", lambda s: {firm_bucket(a, b) for a, b in zip(s, aw.loc[s.index, "Branch"], strict=False)}),
+    )
+    firm = firm[firm["abstract"].str.len() > 150]
+    fa = {row.Index: row for row in firm.itertuples()}
+    keys = list(fa)
+    by_bucket: dict[str, list[str]] = {}
+    for key, row in fa.items():
+        for b in row.buckets:
+            by_bucket.setdefault(b, []).append(key)
+
+    notices = pd.concat([pd.read_parquet(f) for f in glob.glob(str(parquet_dir / "FY*_phase3_selflabeled.parquet"))],
+                        ignore_index=True)
+
+    def firm_name(row: dict) -> str:
+        awardee = str(row.get("Awardee") or "").strip()
+        if len(awardee) > 3:
+            return awardee
+        m = re.search(r"\bto\s+([A-Za-z][^,]{1,60}),\s+\d", str(row.get("Description") or ""))
+        return m.group(1) if m else ""
+
+    def lookup(name: str) -> str | None:
+        nk = normalize_name(name)
+        if nk in fa:
+            return nk
+        return next((c for c in keys if nk == c or nk.startswith(c + " ")), None)
+
+    text_res, comb_res = [], []
+    for _, r in notices.iterrows():
+        true = lookup(firm_name(r.to_dict()))
+        opp = str(r.get("Description") or "")
+        if not true or len(opp) < 60:
+            continue
+        ob = notice_bucket(r.get("Department/Ind.Agency"), r.get("Sub-Tier"))
+        if mode == "hard":
+            src = [d for d in by_bucket.get(ob, []) if d != true]
+        else:
+            src = [d for d in keys if d != true]
+        if len(src) < 9:
+            continue
+        cand = [true, *rng.choice(src, 9, replace=False)]
+        oy = pd.to_numeric(pd.Series([str(r.get("PostedDate"))[:4]]), errors="coerce").iloc[0]
+        tsim = _fusion_text(opp, [fa[x].abstract for x in cand], k)
+        tz = (tsim - tsim.mean()) / (tsim.std() + 1e-9)
+        agency = np.array([1.0 if ob in fa[x].buckets else 0.0 for x in cand])
+        dens = np.log1p(np.array([fa[x].n for x in cand]))
+        dz = (dens - dens.mean()) / (dens.std() + 1e-9)
+        timing = np.array([1.0 if (not np.isnan(fa[x].p2) and not np.isnan(oy) and fa[x].p2 <= oy) else 0.0 for x in cand])
+        combined = tz + 1.2 * agency + 0.3 * dz + 0.4 * timing
+        for res, score in ((text_res, tsim), (comb_res, combined)):
+            order = np.argsort(-score)
+            res.append((int(order[0] == 0), int(0 in order[:3])))
+    return {
+        "mode": mode,
+        "n": len(text_res),
+        "text_p1": round(np.mean([x[0] for x in text_res]), 3) if text_res else None,
+        "text_p3": round(np.mean([x[1] for x in text_res]), 3) if text_res else None,
+        "combined_p1": round(np.mean([x[0] for x in comb_res]), 3) if comb_res else None,
+        "combined_p3": round(np.mean([x[1] for x in comb_res]), 3) if comb_res else None,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--parquet-dir", type=Path, default=Path("data/derived/phase3_selflabeled"))
+    p.add_argument("--award-csv", type=Path, default=Path("data/raw/sbir/award_data.csv"))
+    p.add_argument("--coefficients", type=Path,
+                   default=Path("packages/sbir-ml/sbir_ml/transition/detection/fusion_coefficients.json"))
+    p.add_argument("--mode", choices=["random", "hard"], default="hard")
+    args = p.parse_args()
+    print("Firm-ranking with non-text lineage features:")
+    for key, value in measure(args.parquet_dir, args.award_csv, args.coefficients, mode=args.mode).items():
+        print(f"  {key}: {value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/phase3-candidate-enrichment/T1_FINDINGS.md
+++ b/specs/phase3-candidate-enrichment/T1_FINDINGS.md
@@ -1,0 +1,68 @@
+# T1 — Source Coverage + Leakage-Safety Inventory (the gate)
+
+Ran on the 113 ground-truth transition contracts that matched `phase3_universe`
+(57 sparse-description). **Verdict: STOP the cheap in-repo text-enrichment path (T2).
+Pivot to non-text lineage features (T3).**
+
+## Coverage × leakage class
+
+| source | all | **sparse cells** | class |
+|---|---|---|---|
+| PSC code present | 100% | 100% | intrinsic (safe) |
+| NAICS code present | 100% | 100% | intrinsic (safe) |
+| Contract desc cites its own topic/sol # | 3% | **0%** | intrinsic (safe) |
+| SBIR topic via prior award | 100% | 100% | **firm-linked (LEAKAGE)** |
+| Firm has recovered notice text | 4% | 4% | intrinsic (safe) |
+
+## The discrimination check (why coverage isn't enough)
+
+A source only lifts ranking if it distinguishes the *true* contract from its
+**same-agency decoys**. PSC/NAICS are universal but shared — `P(a random same-agency
+mate shares the true contract's code)`:
+
+| agency | PSC P(shared) | NAICS P(shared) |
+|---|---|---|
+| **DLA (logistics — the 0.21 cell)** | **0.92** | **0.92** |
+| MDA | 0.26 | 0.60 |
+| DHA | 0.30 | 0.33 |
+| DTRA | 0.24 | 0.42 |
+
+61% of all these contracts carry the *same* NAICS (541715, "R&D services"). So PSC/NAICS
+enrichment would add **nearly identical category words to the true contract and its
+decoys** — most severely in DLA, the exact cell that needs help. It cannot discriminate
+where it matters.
+
+## Why each lever fails the gate
+
+- **PSC / NAICS** — safe + 100% coverage, but **non-discriminating** (DLA 0.92 shared).
+  Adding them raises the true and decoy scores equally → ~zero ranking lift.
+- **Contract cites its own topic/solicitation #** — the one rich *and* intrinsic signal,
+  but present on **3% overall and 0% of the sparse cells**. Effectively absent.
+- **SBIR topic description** — rich and discriminating, but **firm-linked**: reachable
+  only through the firm→contract link the ranker is predicting. Using it plants the
+  answer in the candidate (content leakage; `_scrub_identity` won't catch it).
+  **Disqualified** per the T1 rule.
+- **Recovered notice text** — rich + intrinsic, but **4% coverage** (the #481 grain wall).
+
+**No leakage-safe source both covers the sparse cells and discriminates.** GO condition
+not met → **STOP T2.**
+
+## What survives (two expensive text options — flagged, not adopted)
+
+1. **Deeper FPDS field pull** — the universe carries only the terse transaction
+   description. A fuller FPDS/USASpending pull *might* expose richer intrinsic text
+   (requirement descriptions, CLIN text). Uncertain; test coverage before building.
+2. **J&A justification documents** — real prose, intrinsic — but retrieval for
+   sole-source Phase III is uncertain and would be external scraping. Only if #1 fails
+   and coverage looks real.
+
+Neither is the primary path. Both are optional spikes.
+
+## Decision → pivot to T3
+
+The primary lever is **description-independent lineage features (T3)**, not text.
+Critically, T3 must pass the *same* leakage test: each feature has to be computable at
+packet time from `(firm abstract) × (open solicitation)` — e.g. agency continuity, NAICS
+ancestry between the firm's SBIR and the solicitation, timing gap, prior-award count —
+**not** from knowing the transition occurred. T2 (assembler) is shelved unless a spike on
+option #1/#2 shows real, leakage-safe, discriminating coverage on the sparse cells.

--- a/specs/phase3-candidate-enrichment/T1_FINDINGS.md
+++ b/specs/phase3-candidate-enrichment/T1_FINDINGS.md
@@ -72,6 +72,21 @@ reference on the contract). Not pursued.
 
 **Spike verdict: STOP confirmed on both the award-text and solicitation angles.**
 
+## Population insight (why the solicitation source is structurally unavailable)
+
+A solicitation pointer lives on **competed** procurement actions; a canonical Phase III is
+sole-source (SBIR-derived, no re-competition), so it has none. Measured across 35 GT
+contracts: **sole-source 0% pointer**, SBIR-set-aside 17%, overall 17%. The deeper
+consequence: our ground-truth set was built by matching the **"SBIR PHASE III" marker**,
+so it is the *marked, mostly-sole-source* population — which is exactly the population that
+**lacks** a solicitation. The solicitation-rich transitions are the **competed / unmarked
+(dark)** ones, which a text-marker label method structurally excludes. So the two
+populations — *text-rich* and *text-labelable* — are nearly disjoint. Enrichment cannot be
+rescued for the marked set, and the unmarked/dark set is a **separate detection target**
+needing a different label source (solicitation→award genealogy), not text enrichment.
+This bounds the deadline-primary verdict to the *marked* Phase III population validated in
+#481.
+
 ## Decision → pivot to T3
 
 The primary lever is **description-independent lineage features (T3)**, not text.

--- a/specs/phase3-candidate-enrichment/T1_FINDINGS.md
+++ b/specs/phase3-candidate-enrichment/T1_FINDINGS.md
@@ -47,16 +47,30 @@ where it matters.
 **No leakage-safe source both covers the sparse cells and discriminates.** GO condition
 not met → **STOP T2.**
 
-## What survives (two expensive text options — flagged, not adopted)
+## Spike (ran the deeper-FPDS + solicitation check — both dead ends)
 
-1. **Deeper FPDS field pull** — the universe carries only the terse transaction
-   description. A fuller FPDS/USASpending pull *might* expose richer intrinsic text
-   (requirement descriptions, CLIN text). Uncertain; test coverage before building.
-2. **J&A justification documents** — real prose, intrinsic — but retrieval for
-   sole-source Phase III is uncertain and would be external scraping. Only if #1 fails
-   and coverage looks real.
+Fetched the **full USASpending award record** (`/api/v2/awards/`) for 12 sparse GT
+contracts (DLA/MDA/DHA/DTRA/SOCOM), live API:
 
-Neither is the primary path. Both are optional spikes.
+1. **Deeper award text — dead end.** The API `description` is *identical* to our cached
+   terse one (14–40 chars). The only field ≥80 chars anywhere in the record is
+   `naics_description` = "RESEARCH AND DEVELOPMENT IN THE PHYSICAL, ENGINEERING, AND LIFE
+   SCIENCES" — the generic 541715 label, **the same string on all 12**. No richer
+   intrinsic contract text exists at the award level.
+2. **Contract solicitation — dead end (the pointer is missing).** The solicitation *is* a
+   rich source, but `solicitation_identifier` is populated on **1 of 12 (~8%)** — FPDS
+   does not record which solicitation these Phase III awards were let under (most are
+   SBIR set-aside "full-and-open after exclusion of sources" or sole-source). The one
+   with an ID (`HDTRA111R0026`) would need a separate, uncertain 2011-era SAM.gov pull.
+   Reaching a solicitation any *other* way routes through the firm's prior SBIR topic —
+   which is **leakage** and is the *wrong* solicitation (the Phase I/II topic, trivially
+   similar to the firm's own abstract). Intrinsic + rich + covered: not achievable.
+
+**J&A justification documents** — the remaining theoretical prose source — would be
+external scraping with the same missing-pointer problem (no captured solicitation/J&A
+reference on the contract). Not pursued.
+
+**Spike verdict: STOP confirmed on both the award-text and solicitation angles.**
 
 ## Decision → pivot to T3
 

--- a/specs/phase3-candidate-enrichment/T3_RESULTS.md
+++ b/specs/phase3-candidate-enrichment/T3_RESULTS.md
@@ -1,0 +1,45 @@
+# T3 — Firm-Ranking + Non-Text Lineage Features (Lever A)
+
+**Reframe:** T6/forward (~0.47) measured CONTRACT-ranking (given a firm, rank the true
+transition *contract* among decoys) — where the candidate is terse and the text-poverty wall
+bites. The packet's real job is FIRM-ranking (given an opportunity, rank candidate *firms*),
+which flips which side is rich: candidates are firm SBIR abstracts (always rich). Non-text
+lineage features (agency continuity, prior-award density, Phase-II timing) are constant within
+a contract-ranking pool but vary across firms — so they only help in this framing.
+
+## Result (`scripts/phase3_benchmark/measure_firm_ranking.py`, frozen fusion text signal)
+
+| decoys | signal | p@1 | p@3 | n |
+|---|---|---|---|---|
+| random | text-only | 0.600 | 0.829 | 35 |
+| random | **text + lineage** | **0.714** | **0.971** | 35 |
+| hard (same-agency) | text-only | 0.536 | 0.786 | 28 |
+| hard (same-agency) | **text + lineage** | **0.571** | **0.821** | 28 |
+| *(contract-ranking, for contrast)* | text | *0.467* | *0.556* | 45 |
+
+## Findings
+
+1. **Firm-ranking beats contract-ranking, even with hard decoys** — text-only 0.536–0.600 vs
+   0.467. The rich-candidate structure removes the wall that capped contract-ranking; **0.47 was
+   the wrong (hardest, least-representative) task.**
+2. **Non-text lineage features add real lift** — random +0.11 p@1 (0.60→0.71), hard +0.04 p@1
+   (0.54→0.57) *with agency-match neutralized* (so density+timing carry it; established, timing-
+   plausible firms rank higher). p@3 rises to 0.82–0.97.
+
+## Honest caveats
+
+- **Hand-picked weights** (agency 1.2, density 0.3, timing 0.4) — illustrative, not fit. A proper
+  weighting (or re-fit with lineage in the feature vector) is the real next step and would set the
+  true combined number.
+- **Agency-match can misfire in hard mode** when the true firm transitioned *outside* its SBIR
+  agency (feature = 0 for the true firm, 1 for same-bucket decoys) — one reason the hard-mode lift
+  is smaller; a signed/learned weight would handle it.
+- **n = 28–35**, wide CIs; SAM-notice opportunity text (terse) — the lift is carried by the rich
+  candidate abstracts, as designed.
+
+## Takeaway
+
+Lever A is validated: the packet's real task (firm-ranking) is **~0.54–0.60 text-only and
+~0.57–0.71 with lineage** — materially above the 0.47 contract-ranking number, and lineage adds
+durable lift. Next: fit the feature weights (not hand-set) and score on a larger firm-ranking
+ground-truth set for the production number.

--- a/specs/phase3-candidate-enrichment/requirements.md
+++ b/specs/phase3-candidate-enrichment/requirements.md
@@ -1,0 +1,97 @@
+# Phase III Candidate-Text Enrichment — Requirements
+
+> **Status:** Draft spec. No implementation. Follow-on to the ground-truth validation
+> (#481), which measured *why* the fusion ranker underperforms.
+> Supports inventory questions **B2 / E1** in [docs/research-questions.md](../../docs/research-questions.md).
+
+**Research question anchor:** B2 (did SBIR research transition to a federal contract), E1 (Phase III identification)
+**Answers for:** Whoever decides whether fusion can move from a top-3 aid toward ordering the packet
+**Complexity tier:** Relational (Tier 2)
+
+---
+
+## Done when
+
+> The fusion ranker is re-scored on the **frozen #481 independent ground-truth set**
+> (`score_t6.py`, same 45-case headline + strata) after (a) candidate text is enriched
+> from real sources and (b) description-independent features are added. **Done when the
+> sparse-description cells lift measurably** — the target is **DLA/logistics and
+> thin-description p@1 rising toward the rich-text band (~0.6)** — **without regressing
+> rich-text cells**, with the lift reported per-domain with bootstrap CIs and compared to
+> the T6 baseline (0.467@1). If enrichment source coverage turns out to be as empty as
+> the FPDS descriptions (T1 gate), the spec stops and says so — no building on absent data.
+
+---
+
+## Why
+
+T6 (#481) established that the ranker's ceiling is **not the algorithm — it's empty
+candidate text.** The model compares words; when a Phase III contract's entire FPDS
+description is "SBIR PHASE III AWARD." there is nothing to compare. Measured effect:
+rich-text domains (sensing) score **0.60**, near-empty ones (logistics/DLA) **0.21**,
+thin descriptions **0.29**. The two highest-leverage fixes T7 identified are both about
+**data, not the model**: give the matcher real words, and add signals that survive empty
+text. This spec does exactly those two.
+
+## The trap this spec must not fall into
+
+**The enrichment sources may be as empty as what they replace.** J&A documents,
+solicitation notices, and topic text only help if they *exist and are retrievable* for
+these specific contracts — and Phase III sole-source awards frequently have no competing
+solicitation at all. **Mitigation:** T1 is a cheap **source-coverage inventory** that
+measures, per enrichment source, what fraction of the 45 scored contracts (and the wider
+census) it can actually enrich — before any assembler is built. This mirrors the step-0
+coverage check that saved effort in #481.
+
+## Scope
+
+### In scope
+
+1. **SHALL** inventory candidate-text enrichment sources and measure per-source coverage
+   over the T6 scored set + the Phase III census: prior-award **SBIR topic description**
+   (via `Topic Code` on the resolved prior award), **PSC/NAICS descriptions**, contract
+   **Award Title**, and any **solicitation/J&A notice text** already in the recovered
+   corpus. No new external scraping unless a source is both high-coverage and cheap.
+2. **SHALL** build a deterministic **`enriched_text`** assembler per contract from the
+   available high-coverage sources, with provenance flags (which sources contributed),
+   feeding the existing fusion text-similarity path in place of the bare FPDS description.
+3. **SHALL** add **description-independent features** — firm prior-award lineage,
+   agency/topic continuity, timing gap (SBIR→transition), NAICS ancestry — as additional
+   fusion inputs that carry signal when text is empty.
+4. **SHALL** re-score on the frozen #481 ground-truth set with `score_t6.py`, reporting
+   p@1/@3/MRR **per domain and per agency with CIs**, as a **before/after lift** vs the
+   0.467 baseline, plus the hard-decoy variant.
+5. **SHALL** state plainly whether the lift justifies revisiting the deadline-primary
+   verdict, and whether any new feature re-introduces leakage (re-run the scrub check).
+
+### Out of scope
+
+- **Verified negatives / a routing gate** — separate effort; needs non-transitions (#481 T7).
+- **Forward / open-solicitation validation** — separate distribution-transfer effort.
+- **New model architectures / embeddings bake-off** — a parallel option in T7, not this spec.
+- **Re-collecting ground truth** — reuse #481's set frozen; this spec changes *inputs*, not labels.
+
+## Prerequisites
+
+- Merged #481 (or its branch): `score_t6.py`, `collected/*.csv`, `resolve_firm_awards.py`.
+- Merged #467 (on main): frozen fusion, `text_similarity`, `fusion_scoring`.
+- Access to SBIR award data (`Topic Code`, `Abstract`), PSC/NAICS reference tables, and
+  the recovered notice corpus.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Enrichment sources as empty as FPDS descriptions | T1 coverage gate before building; stop if low |
+| Enriched text re-introduces firm-identity leakage | re-run the `_scrub_identity` scrub; re-check the raw→scrubbed delta |
+| Non-text features overfit the small 45-case set | held-out reporting; treat lift as directional, widen the set if promising |
+| Lift in sparse cells regresses rich-text cells | report per-domain before/after; require no rich-text regression |
+
+## Verification plan
+
+1. Source-coverage inventory → verify: per-source % of the 45 scored contracts enrichable;
+   go/stop decision recorded.
+2. `enriched_text` assembler → verify: deterministic, provenance-flagged, unit-tested.
+3. Non-text features → verify: computed for all scored cases; leakage scrub re-checked.
+4. Re-score → verify: per-domain before/after p@1/@3 + CIs vs 0.467 baseline; hard-decoy too.
+5. Decision → verify: explicit statement on whether the verdict changes, with the numbers.

--- a/specs/phase3-candidate-enrichment/requirements.md
+++ b/specs/phase3-candidate-enrichment/requirements.md
@@ -14,7 +14,8 @@
 
 > The fusion ranker is re-scored on the **frozen #481 independent ground-truth set**
 > (`score_t6.py`, same 45-case headline + strata) after (a) candidate text is enriched
-> from real sources and (b) description-independent features are added. **Done when the
+> from **leakage-safe, contract-intrinsic** sources only and (b) description-independent
+> features are added. **Done when the
 > sparse-description cells lift measurably** — the target is **DLA/logistics and
 > thin-description p@1 rising toward the rich-text band (~0.6)** — **without regressing
 > rich-text cells**, with the lift reported per-domain with bootstrap CIs and compared to
@@ -33,28 +34,47 @@ thin descriptions **0.29**. The two highest-leverage fixes T7 identified are bot
 **data, not the model**: give the matcher real words, and add signals that survive empty
 text. This spec does exactly those two.
 
-## The trap this spec must not fall into
+## The two traps this spec must not fall into
 
-**The enrichment sources may be as empty as what they replace.** J&A documents,
-solicitation notices, and topic text only help if they *exist and are retrievable* for
-these specific contracts — and Phase III sole-source awards frequently have no competing
-solicitation at all. **Mitigation:** T1 is a cheap **source-coverage inventory** that
-measures, per enrichment source, what fraction of the 45 scored contracts (and the wider
-census) it can actually enrich — before any assembler is built. This mirrors the step-0
-coverage check that saved effort in #481.
+1. **The enrichment sources may be as empty as what they replace.** J&A documents,
+   solicitation notices, and topic text only help if they *exist and are retrievable*
+   for these specific contracts — and Phase III sole-source awards frequently have no
+   competing solicitation at all. **Mitigation:** T1 is a cheap **source-coverage
+   inventory** measuring, per source, what fraction of the 45 scored contracts (and the
+   census) it can enrich *on the sparse cells specifically* — before any assembler is
+   built. Mirrors the step-0 coverage check that saved effort in #481.
+
+2. **Content leakage — the load-bearing trap.** The richest source (the firm's prior
+   **SBIR topic description**) can only be attached to a contract by going *through the
+   firm→contract link — the very thing the ranker predicts*. Enriching only the *true*
+   contract with the firm's own topic text (while the decoys get nothing) plants the
+   answer in the candidate and inflates precision for a fake reason. This is distinct
+   from identity-token leakage (firm name / PIID) — it is **content** leakage, and the
+   `_scrub_identity` scrub does **not** catch it. **Mitigation:** every source is
+   classified **contract-intrinsic** (derivable from the contract alone — its own title,
+   PSC/NAICS, its own *referenced* solicitation/topic number as recorded on the contract)
+   vs **firm-linked** (pulled via the answer). **Only contract-intrinsic sources may feed
+   the assembler.** Faithfulness test: in real packet use the ranker sees only
+   `(firm abstract) × (open solicitation)` — any enrichment that would be unavailable at
+   that moment is leakage, full stop.
 
 ## Scope
 
 ### In scope
 
-1. **SHALL** inventory candidate-text enrichment sources and measure per-source coverage
-   over the T6 scored set + the Phase III census: prior-award **SBIR topic description**
-   (via `Topic Code` on the resolved prior award), **PSC/NAICS descriptions**, contract
-   **Award Title**, and any **solicitation/J&A notice text** already in the recovered
-   corpus. No new external scraping unless a source is both high-coverage and cheap.
-2. **SHALL** build a deterministic **`enriched_text`** assembler per contract from the
-   available high-coverage sources, with provenance flags (which sources contributed),
-   feeding the existing fusion text-similarity path in place of the bare FPDS description.
+1. **SHALL** inventory candidate-text enrichment sources and, per source, measure both
+   **(a) coverage** — what fraction of the 45 scored contracts (and the census) it
+   enriches, reported *on the sparse cells specifically* — and **(b) leakage-safety** —
+   classify each as **contract-intrinsic** (title, PSC/NAICS, the contract's own
+   *referenced* solicitation/topic number) or **firm-linked** (prior-award topic pulled
+   through the firm→contract link). Sources evaluated: SBIR topic description, PSC/NAICS
+   descriptions, contract Award Title, recovered solicitation/J&A notice text. No new
+   external scraping unless a source is high-coverage, cheap, **and contract-intrinsic**.
+2. **SHALL** build a deterministic **`enriched_text`** assembler from **only the
+   contract-intrinsic, leakage-safe** high-coverage sources, with provenance flags
+   (which sources contributed), feeding the existing fusion text-similarity path in place
+   of the bare FPDS description. Firm-linked sources are **excluded from the assembler**
+   regardless of how rich they are.
 3. **SHALL** add **description-independent features** — firm prior-award lineage,
    agency/topic continuity, timing gap (SBIR→transition), NAICS ancestry — as additional
    fusion inputs that carry signal when text is empty.
@@ -83,7 +103,9 @@ coverage check that saved effort in #481.
 | Risk | Mitigation |
 |---|---|
 | Enrichment sources as empty as FPDS descriptions | T1 coverage gate before building; stop if low |
-| Enriched text re-introduces firm-identity leakage | re-run the `_scrub_identity` scrub; re-check the raw→scrubbed delta |
+| **Content leakage** — firm-linked text plants the answer in the candidate | T1 classifies every source contract-intrinsic vs firm-linked; **only intrinsic feeds the assembler**; the `_scrub_identity` scrub does NOT catch this |
+| Identity-token leakage (firm name / PIID) in enriched text | re-run the `_scrub_identity` scrub; re-check the raw→scrubbed delta |
+| A source looks safe but is only populated for already-rich cells | T1 reports coverage on the sparse cells specifically, not on average |
 | Non-text features overfit the small 45-case set | held-out reporting; treat lift as directional, widen the set if promising |
 | Lift in sparse cells regresses rich-text cells | report per-domain before/after; require no rich-text regression |
 

--- a/specs/phase3-candidate-enrichment/tasks.md
+++ b/specs/phase3-candidate-enrichment/tasks.md
@@ -20,20 +20,26 @@ Award Title, recovered solicitation/J&A notice text.
   firm-linked). **GO** only if ≥1 contract-intrinsic source meaningfully covers the sparse
   cells; else **STOP** and redirect to T3 (non-text features) / verified negatives.
 
-## T2 — `enriched_text` assembler
-Deterministic function: contract → enriched text field from **only the contract-intrinsic,
-leakage-safe** sources T1 cleared, with provenance flags (which sources contributed).
-Firm-linked sources are excluded by construction. Identity-scrubbed (reuse
-`_scrub_identity`) on top. Unit-tested on fixtures — including a test that asserts no
-firm-linked text can enter the assembler.
-→ verify: fixture tests pass; provenance flags correct; scrub applied; leakage-guard test
-  proves firm-linked sources are rejected.
+## T2 — `enriched_text` assembler — SHELVED by T1
+**T1 outcome: STOP.** No leakage-safe source both covers the sparse cells and
+discriminates (PSC/NAICS share 92% within DLA; the rich SBIR-topic source is firm-linked
+leakage; the intrinsic topic-citation signal is 0% on sparse cells; notice text is 4%).
+The assembler is shelved unless an optional spike (deeper FPDS field pull, or J&A document
+retrieval) shows real leakage-safe discriminating coverage — see `T1_FINDINGS.md`.
+→ verify (only if un-shelved): fixture tests pass; leakage-guard test proves firm-linked
+  sources are rejected.
 
-## T3 — Description-independent features
+## T3 — Description-independent features (NOW THE PRIMARY LEVER per T1)
 Add firm prior-award lineage, agency/topic continuity, timing gap, NAICS ancestry as
 fusion inputs. Extend the feature vector; keep `fusion_coefficients.json` frozen unless
 T4 justifies a re-fit (held-out fold).
-→ verify: features computed for all scored cases; no NaNs; leakage scrub re-checked.
+**Each feature MUST pass the packet-time leakage test:** computable from
+`(firm abstract) × (open solicitation)` alone — e.g. agency continuity, NAICS ancestry
+between the firm's SBIR NAICS and the solicitation NAICS, timing gap, prior-award count —
+**not** derived from knowing the transition happened. Audit each feature against this
+before including it.
+→ verify: features computed for all scored cases; no NaNs; each feature has a written
+  packet-time-availability justification; leakage scrub re-checked.
 
 ## T4 — Re-score on the frozen #481 set
 Run `score_t6.py` with enriched text + new features. Report p@1/@3/MRR per domain and

--- a/specs/phase3-candidate-enrichment/tasks.md
+++ b/specs/phase3-candidate-enrichment/tasks.md
@@ -3,19 +3,31 @@
 > Sequenced so the cheap coverage gate (T1) runs before any assembler is built —
 > if the enrichment sources are as empty as the FPDS descriptions, stop and say so.
 
-## T1 — Source-coverage inventory (the gate)
-Measure, per enrichment source, what fraction of the 45 T6-scored contracts (and the
-wider Phase III census) it can actually enrich: SBIR topic description (via prior-award
-`Topic Code`), PSC description, NAICS description, contract Award Title, and any
-solicitation/J&A notice text already in the recovered corpus.
-→ verify: a coverage table (source × % enrichable, median added chars); an explicit
-  go/stop decision. If no source clears meaningful coverage on the sparse cells, STOP.
+## T1 — Source coverage + leakage-safety inventory (the gate)
+Per enrichment source, measure **two** things, not one:
+- **Coverage:** what fraction of the 45 T6-scored contracts (and the census) it enriches,
+  reported **on the sparse cells specifically** (DLA/logistics, thin-desc) — not on
+  average. A source that only enriches already-rich cells does not count.
+- **Leakage-safety:** classify each source **contract-intrinsic** (title, PSC/NAICS, the
+  contract's *own* referenced solicitation/topic number) vs **firm-linked** (prior-award
+  topic reached through the firm→contract link = the answer). Firm-linked sources are
+  **disqualified from the assembler** no matter how rich — plant the answer in the
+  candidate and precision inflates for a fake reason (`_scrub_identity` will NOT catch it,
+  it is content not identity-token leakage).
+Sources evaluated: SBIR topic description, PSC description, NAICS description, contract
+Award Title, recovered solicitation/J&A notice text.
+→ verify: a table (source × sparse-cell coverage % × median added chars × intrinsic/
+  firm-linked). **GO** only if ≥1 contract-intrinsic source meaningfully covers the sparse
+  cells; else **STOP** and redirect to T3 (non-text features) / verified negatives.
 
 ## T2 — `enriched_text` assembler
-Deterministic function: contract → enriched text field from the high-coverage sources,
-with provenance flags (which sources contributed). Identity-scrubbed (reuse
-`_scrub_identity`). Unit-tested on fixtures.
-→ verify: fixture tests pass; provenance flags correct; scrub applied.
+Deterministic function: contract → enriched text field from **only the contract-intrinsic,
+leakage-safe** sources T1 cleared, with provenance flags (which sources contributed).
+Firm-linked sources are excluded by construction. Identity-scrubbed (reuse
+`_scrub_identity`) on top. Unit-tested on fixtures — including a test that asserts no
+firm-linked text can enter the assembler.
+→ verify: fixture tests pass; provenance flags correct; scrub applied; leakage-guard test
+  proves firm-linked sources are rejected.
 
 ## T3 — Description-independent features
 Add firm prior-award lineage, agency/topic continuity, timing gap, NAICS ancestry as

--- a/specs/phase3-candidate-enrichment/tasks.md
+++ b/specs/phase3-candidate-enrichment/tasks.md
@@ -1,0 +1,40 @@
+# Phase III Candidate-Text Enrichment — Tasks
+
+> Sequenced so the cheap coverage gate (T1) runs before any assembler is built —
+> if the enrichment sources are as empty as the FPDS descriptions, stop and say so.
+
+## T1 — Source-coverage inventory (the gate)
+Measure, per enrichment source, what fraction of the 45 T6-scored contracts (and the
+wider Phase III census) it can actually enrich: SBIR topic description (via prior-award
+`Topic Code`), PSC description, NAICS description, contract Award Title, and any
+solicitation/J&A notice text already in the recovered corpus.
+→ verify: a coverage table (source × % enrichable, median added chars); an explicit
+  go/stop decision. If no source clears meaningful coverage on the sparse cells, STOP.
+
+## T2 — `enriched_text` assembler
+Deterministic function: contract → enriched text field from the high-coverage sources,
+with provenance flags (which sources contributed). Identity-scrubbed (reuse
+`_scrub_identity`). Unit-tested on fixtures.
+→ verify: fixture tests pass; provenance flags correct; scrub applied.
+
+## T3 — Description-independent features
+Add firm prior-award lineage, agency/topic continuity, timing gap, NAICS ancestry as
+fusion inputs. Extend the feature vector; keep `fusion_coefficients.json` frozen unless
+T4 justifies a re-fit (held-out fold).
+→ verify: features computed for all scored cases; no NaNs; leakage scrub re-checked.
+
+## T4 — Re-score on the frozen #481 set
+Run `score_t6.py` with enriched text + new features. Report p@1/@3/MRR per domain and
+per agency with bootstrap CIs, as before/after lift vs the 0.467 baseline; include the
+hard-decoy variant.
+→ verify: before/after table committed; per-domain lift stated; no rich-text regression.
+
+## T5 — Decision memo
+Does the lift justify revisiting the deadline-primary verdict? State the numbers, which
+cells moved, and whether any feature re-introduced leakage.
+→ verify: memo committed; a clear recommendation, not a hedge.
+
+## Deferred (documented, not this PR)
+- Verified negatives for a routing/threshold gate.
+- Embeddings vs word-matching bake-off on the independent set.
+- Forward / open-solicitation validation.

--- a/tests/unit/phase3_benchmark/test_measure_firm_ranking.py
+++ b/tests/unit/phase3_benchmark/test_measure_firm_ranking.py
@@ -1,0 +1,31 @@
+"""Tests for the firm-ranking lineage-feature helpers."""
+
+import numpy as np
+
+from scripts.phase3_benchmark.measure_firm_ranking import (
+    _fusion_text,
+    firm_bucket,
+    normalize_name,
+    notice_bucket,
+)
+
+_K = {"cw": 2.21, "cc": -0.71, "mw": 0.028, "mc": 0.204, "sw": 0.039, "sc": 0.131}
+
+
+def test_normalize_and_buckets():
+    assert normalize_name("Acme Photonics, Inc.") == "ACME PHOTONICS"
+    assert firm_bucket("Department of Defense", "Navy") == "NAVY"
+    assert firm_bucket("Department of Health and Human Services", "") == "HHS"
+    assert notice_bucket("DEPT OF DEFENSE", "DEPT OF THE ARMY") == "ARMY"
+    assert notice_bucket("DEPT OF HEALTH", "") == "HHS"
+
+
+def test_fusion_text_ranks_topical_firm_first():
+    opp = "seeking a quantum radar system for electromagnetic sensing of aircraft"
+    firms = [
+        "quantum radar electromagnetic sensing platform for detecting aircraft",  # true
+        "bioresorbable bone adhesive for cranial flap fixation",
+        "logistics optimization software for supply chains",
+    ]
+    order = np.argsort(-_fusion_text(opp, firms, _K))
+    assert int(order[0]) == 0


### PR DESCRIPTION
## What this is

A **spec-first** follow-on to the Phase III ground-truth validation (#481). That PR measured *why* the fusion ranker underperforms; this one proposes the fix.

## Why

#481 established the ranker's ceiling is **empty candidate text, not the algorithm**: it matches words, and when a Phase III contract's whole FPDS description is "SBIR PHASE III AWARD." there's nothing to match. Measured: sensing (rich text) **0.60** vs logistics/DLA (near-empty) **0.21**, thin-desc **0.29**. T7's two highest-leverage fixes are both **data, not model**.

## What the spec proposes

1. **Enrich candidate text** — assemble real words per contract from SBIR topic descriptions (via the prior award's Topic Code), PSC/NAICS descriptions, award title, and recovered notice text — feeding the existing fusion text path in place of the bare FPDS description.
2. **Add description-independent features** — firm prior-award lineage, agency/topic continuity, timing gap, NAICS ancestry — signal that survives empty text.
3. **Re-score on the frozen #481 ground-truth set** (`score_t6.py`) for a **per-domain before/after lift** vs the 0.467 baseline, with CIs and the hard-decoy variant.

## The honest gate (T1)

The enrichment sources might be **as empty as what they replace** (Phase III sole-source awards often have no solicitation at all). So T1 is a cheap **source-coverage inventory** — measure per-source enrichable %, then a go/stop decision *before* building anything. Mirrors the step-0 check that saved effort in #481.

## Out of scope

Verified negatives / gating, forward-solicitation validation, and an embeddings bake-off — all documented as separate efforts.

## Success criterion

Sparse-description cells (logistics, thin-text) lift toward the rich-text band (~0.6) **without regressing rich-text cells**, reported per-domain with CIs. If they don't move, the spec says so.

> Depends on #481 (reuses its frozen ground-truth set + `score_t6.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)