### PR TITLE
Phase III undercount extension — new capture lists + separate vehicle layer (B3)

### DIFF
--- a/specs/phase3-undercount-extension/requirements.md
+++ b/specs/phase3-undercount-extension/requirements.md
@@ -1,0 +1,91 @@
+# Phase III Undercount Extension — Requirements
+
+> **Status:** Draft spec. Builds on existing undercount work (M0a + 3-source
+> capture-recapture) and the coverage-expansion sources (#485). Answers the north-star
+> question **B3**: *"How much undercount exists in Phase III coding?"* — the transition
+> **classifier/measurement** use case (recall), not ranking.
+
+**Research question anchor:** B3 (Phase III undercount, transition rate), B2 (did-it-transition), A2/A3 (rate / multiplier)
+**Answers for:** SBA / agency program managers, GAO — how complete is Phase III coding
+**Complexity tier:** Inferential (Tier 3)
+
+---
+
+## Done when
+
+> The Phase III coding undercount is re-estimated with the **new capture lists** the
+> coverage work produced, reported as **two clearly separated layers**:
+> **(1) contract-coding undercount** — comparable to the existing ~19–28% capture-recapture,
+> now with §638 self-labeled notices added as an independent capture list; and
+> **(2) a separate non-contract vehicle layer** — subaward and grant transitions that FPDS
+> contract coding cannot see at all, reported as a *bounded, provisional* count (relevance-
+> filtered), NOT folded into the contract number. Both are broken out **by agency** and
+> **by vehicle**, with capture-recapture independence assumptions stated and the ≥85%
+> classifier-precision benchmark reported against the pooled ground truth.
+
+---
+
+## Why
+
+`docs/research-questions.md` **B3** asks how much undercount exists in Phase III coding — a
+**recall** question, the north-star use case (see #481 T7 superseding note). Existing work:
+- **M0a** (`m0a_undercount_summary.json`): DoD FY16–25, **14.7% uncoded** — a narrow lower
+  bound (only contracts whose *description* says "SBIR PHASE III").
+- **3-source capture-recapture** (`nano_capture_recapture.py`, commit 52b005a1): dark ~1,543
+  [915–2,745], coding misses **~19–28%** (contract universe).
+
+The coverage-expansion work (#485) produced **new independent detection sources** that the
+existing estimate never used — and two of them lie *outside* the FPDS contract universe. Adding
+them (a) tightens the contract-coding estimate and (b) exposes a non-contract layer the current
+undercount does not count at all.
+
+## The layers (keep them separate — do not conflate)
+
+1. **Contract-coding undercount** — the existing question: of Phase III *contracts*, what share
+   is uncoded? Capture lists: M0a coded/dark pools + **§638 self-labeled notices (new)**. Метric:
+   dark estimate + miss-rate %, by agency. Comparable to the 19–28% baseline.
+2. **Non-contract vehicle layer (new, separate denominator)** — transitions via **subaward**
+   (firm as sub to a prime) and **grant** (civilian assistance), which FPDS contract coding
+   cannot represent. These are not "miscoded contracts"; they are a different population.
+   Reported as a **bounded, provisional** count with the relevance caveat, explicitly *not*
+   added to the contract-coding %.
+
+## Scope
+
+### In scope
+1. **SHALL** reuse M0a's coded/grey/dark pools and generalize `nano_capture_recapture` from the
+   nanotech cohort to the full DoD (and, where data allows, civilian) Phase III frame.
+2. **SHALL** add the **§638 self-labeled** notices (from #485 `extract_phase3_selflabeled`) as an
+   independent capture list; re-run capture-recapture; report the tightened contract-coding
+   undercount by agency vs the 19–28% baseline.
+3. **SHALL** quantify the **non-contract vehicle layer** — subaward and grant transitions
+   (#485), relevance-filtered (SBIR-derivation gate), reported as a separate bounded count by
+   vehicle and agency, with the provisional caveat.
+4. **SHALL** report **classifier precision/recall** of the coded Phase III set against the
+   **pooled ground truth** (293 hand-collected + 66 self-labeled + MDA-35 + component harvest),
+   at the ≥85% precision operating point — the B2 companion metric.
+5. **SHALL** state capture-recapture independence assumptions and where they are weak.
+
+### Out of scope
+- The firm-ranking / PCR-packet product (separate; #484).
+- Production ingestion / scheduling.
+- A full civilian-contract undercount (data-limited); civilian appears in the grant vehicle layer.
+- Claiming subaward/grant counts are verified transitions — they are bounded, provisional, caveated.
+
+## Risks
+| Risk | Mitigation |
+|---|---|
+| Capture lists not independent (self-labeled ⊂ description-coded) | test overlap; use lists whose detection mechanism differs from FPDS coding; report dependence |
+| Subaward/grant "transitions" include non-transitions | SBIR-derivation relevance gate (tech + timing); report as bounded/provisional, separate layer |
+| Conflating vehicle layer with contract undercount inflates the headline | two separate denominators, never summed into one % |
+| Small ground-truth N → wide recall CI | pool all sources; report CI; don't over-claim |
+
+## Verification plan
+1. Capture-recapture generalized + re-run with §638 list → verify: contract-coding undercount by
+   agency, with the new list's marginal effect vs the 19–28% baseline; independence stated.
+2. Non-contract layer → verify: bounded subaward + grant transition counts by vehicle/agency,
+   relevance-filtered, reported separately with caveats.
+3. Classifier recall → verify: precision/recall of coded set vs pooled ground truth at ≥85%
+   precision; recall (undercount) stated.
+4. Memo → verify: one-page B3 answer — contract-coding undercount (updated) + the separate
+   vehicle layer, with what's solid vs provisional.

--- a/specs/phase3-undercount-extension/tasks.md
+++ b/specs/phase3-undercount-extension/tasks.md
@@ -1,0 +1,50 @@
+# Phase III Undercount Extension — Tasks
+
+> Builds on M0a + the 3-source capture-recapture. **Reuse, don't re-inline:** import the
+> canonical `normalize_name` (`sbir_etl.utils.text_normalization`), the firm resolver
+> (`resolve_firm_awards`, #481), the SAM self-label extractor (#485), and #467's fusion —
+> pending the consolidation PR that lands the shared pieces on `main`. Log any place a
+> helper had to be inlined because its home isn't merged yet, as consolidation debt.
+
+## T0 — Reuse audit (before writing code)
+Confirm which shared modules are importable on this branch (off `main`): core
+`normalize_name` and #467 fusion are on `main`; the resolver / self-label extractor / coverage
+data are on unmerged branches. List what must be imported vs temporarily vendored, and file it
+against the consolidation PR so it's paid down, not duplicated silently.
+→ verify: a short reuse table (module → home → importable now Y/N → plan).
+
+## T1 — Generalize capture-recapture to the full Phase III frame
+Lift `scripts/data/nano_capture_recapture.py` from the nanotech cohort to the DoD Phase III
+frame, using M0a's coded/grey/dark pools as the base capture lists. Keep the estimator + CI.
+→ verify: reproduces the ~1,543 [915–2,745] dark / 19–28% miss baseline on the existing lists.
+
+## T2 — Add §638 self-labeled as a new contract-universe capture list
+Materialize the §638 self-labeled notices (#485 `extract_phase3_selflabeled`, full sweep),
+resolve to firms/awards, add as an independent capture list. Re-run capture-recapture. Report
+the **tightened contract-coding undercount by agency** vs the 19–28% baseline. **Test list
+independence** (self-labeled ⊄ description-coded — different detection mechanism).
+→ verify: updated dark estimate + CI; per-agency miss-rate; independence checked and stated.
+
+## T3 — Non-contract vehicle layer (separate denominator)
+Quantify **subaward** and **grant** transitions (#485), relevance-filtered (SBIR-derivation
+gate: tech-area + Phase-II proximity), as a **bounded, provisional** count by vehicle and
+agency. **Do NOT fold into the contract-coding %** — a distinct population, reported separately.
+→ verify: subaward + grant transition counts by vehicle/agency, with the provisional caveat and
+  the relevance-filter definition; explicit that it is not summed into the contract undercount.
+
+## T4 — Classifier precision/recall against the pooled ground truth
+Pool the ground truth (293 hand-collected #481 + 66 self-labeled #485 + MDA-35 + component
+harvest), dedupe to firm+award identity, and measure the coded Phase III set's **precision and
+recall** at the **≥85% precision** operating point. Recall = the undercount, measured directly.
+→ verify: precision/recall + CI; recall stated as the direct undercount; ≥85% precision gate.
+
+## T5 — B3 memo
+One page: contract-coding undercount (updated, by agency) + the separate non-contract vehicle
+layer, with what's solid vs provisional, capture-recapture independence caveats, and the
+classifier recall number. A clear answer to "how much undercount exists in Phase III coding."
+→ verify: memo committed; contract layer and vehicle layer never conflated.
+
+## Deferred (documented, not this PR)
+- Full civilian-contract undercount (data-limited).
+- Production ingestion / scheduling of the capture lists.
+- The consolidation PR itself (shared ER toolkit) — a prerequisite tracked separately.


### PR DESCRIPTION
## What this is

A **spec-first** PR for the north-star question **B3**: *"How much undercount exists in Phase III coding?"* — the transition **classifier/measurement** use case (recall), not ranking. It builds on existing undercount work and folds in the coverage sources this thread produced.

## Foundation it builds on

- **M0a** (`m0a_undercount_summary.json`): DoD FY16–25 **14.7% uncoded** — a narrow lower bound (description-only).
- **3-source capture-recapture** (`nano_capture_recapture.py`, commit `52b005a1`): dark ~**1,543 [915–2,745]**, coding misses **~19–28%**.

## What it adds — two clearly separated layers

1. **Contract-coding undercount** — add the **§638 self-labeled notices** (#485) as a new *independent* capture list → tighten the 19–28%, by agency.
2. **Non-contract vehicle layer (separate denominator)** — **subaward** + **grant** transitions (#485) that FPDS contract coding *cannot see at all*, relevance-filtered, reported as a **bounded, provisional** count by vehicle/agency — **never summed** into the contract %.

Plus **classifier precision/recall** of the coded set vs the pooled ground truth (293 + 66 self-labeled + MDA-35 + component harvest) at the **≥85%** benchmark — recall = the direct undercount.

## Why now / dependencies

The reframe (see #481 T7 superseding note) established that B2/B3/A2/A3 need a **classifier on recall**, and that #485's coverage work is exactly the recall lever. This PR depends on #485 (self-labeled extractor + coverage data) and #481 (resolver + ground truth); T0 tracks **reuse-don't-reinline** so the shared helpers get imported, not copied (see the consolidation discussion).

## Out of scope

Firm-ranking / PCR packet (#484), production ingestion, full civilian-contract undercount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)