### PR TITLE
Fix procurement award identity and plan remaining P1 work

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/assets.py
@@ -239,8 +239,8 @@ def _to_date(value: Any):
     return ts.date()
 
 
-def _candidate_id(signal_class: SignalClass, prior_award_id: str, target_id: str) -> str:
-    h = hashlib.sha1(f"{signal_class.value}|{prior_award_id}|{target_id}".encode())
+def _candidate_id(signal_class: SignalClass, prior_identity: str, target_id: str) -> str:
+    h = hashlib.sha1(f"{signal_class.value}|{prior_identity}|{target_id}".encode())
     return f"{signal_class.value}-{h.hexdigest()[:16]}"
 
 
@@ -375,6 +375,7 @@ def _evidence_bundle(
         "candidate_id": candidate.candidate_id,
         "signal_class": candidate.signal_class.value,
         "award_id": candidate.prior_award_id,
+        "award_key": candidate.prior_award_key,
         "contract_id": candidate.target_id,
         "target_type": candidate.target_type,
         "score": candidate.candidate_score,
@@ -428,10 +429,15 @@ def _iso_or_none(value: Any) -> str | None:
 
 
 def _str_or_none(value: Any) -> str | None:
-    if value is None or (isinstance(value, float) and pd.isna(value)):
+    if value is None:
         return None
+    try:
+        if bool(pd.isna(value)):
+            return None
+    except (TypeError, ValueError):
+        pass
     s = str(value).strip()
-    return s or None
+    return None if not s or s.upper() in {"NAN", "NAT", "NONE", "NULL", "<NA>", r"\N"} else s
 
 
 def _float_or_none(value: Any) -> float | None:
@@ -450,6 +456,7 @@ def _candidate_dataframe(candidates: list[PhaseIIICandidate]) -> pd.DataFrame:
                 "candidate_id",
                 "signal_class",
                 "prior_award_id",
+                "prior_award_key",
                 "target_type",
                 "target_id",
                 "candidate_score",
@@ -494,15 +501,18 @@ def score_candidate_pairs(
             text_similarity=text_similarities[position],
             id_xref_weight=weights["id_xref"],
         )
-        prior_id = str(row.get("prior_award_id") or "")
-        target_id = str(row.get("target_id") or "")
+        prior_id = _str_or_none(row.get("prior_award_id"))
+        prior_key = _str_or_none(row.get("prior_award_key"))
+        target_id = _str_or_none(row.get("target_id"))
         if not prior_id or not target_id:
             continue
-        cid = _candidate_id(signal_class, prior_id, target_id)
+        prior_identity = f"key:{prior_key}" if prior_key else f"id:{prior_id}"
+        cid = _candidate_id(signal_class, prior_identity, target_id)
         candidate = PhaseIIICandidate(
             candidate_id=cid,
             signal_class=signal_class,
             prior_award_id=prior_id,
+            prior_award_key=prior_key,
             target_type=target_type,  # type: ignore[arg-type]
             target_id=target_id,
             candidate_score=composite,
@@ -578,7 +588,7 @@ _PRIOR_DETAIL_FIELDS: dict[str, tuple[str, ...]] = {
 
 
 def enrich_prior_awards(priors: pd.DataFrame, detail: pd.DataFrame) -> pd.DataFrame:
-    """Join the descriptive award fields the Phase II contract lacks, by ``award_id``.
+    """Join descriptive fields by award grain, with a guarded public-id fallback.
 
     Left join — priors without a detail row keep their (null) values, and the
     frame's row grain is unchanged. Existing non-null values always win.
@@ -587,25 +597,84 @@ def enrich_prior_awards(priors: pd.DataFrame, detail: pd.DataFrame) -> pd.DataFr
     if priors.empty or detail.empty or "award_id" not in priors or "award_id" not in detail:
         return priors
 
-    projected = pd.DataFrame({"award_id": detail["award_id"].astype(str)})
+    def _normalized(frame: pd.DataFrame, column: str) -> pd.Series:
+        values = (
+            frame.get(column, pd.Series(pd.NA, index=frame.index, dtype="string"))
+            .astype("string")
+            .str.strip()
+            .str.upper()
+        )
+        return values.mask(values.isin(["", "NAN", "NAT", "NONE", "<NA>", r"\N"]))
+
+    prior_ids = _normalized(priors, "award_id")
+    detail_ids = _normalized(detail, "award_id")
+    prior_keys = _normalized(priors, "award_key")
+    detail_keys = _normalized(detail, "award_key")
+    shared_keys = set(prior_keys.dropna()) & set(detail_keys.dropna())
+    safe_public_ids = set(prior_ids.value_counts().loc[lambda count: count == 1].index) & set(
+        detail_ids.value_counts().loc[lambda count: count == 1].index
+    )
+    prior_safe = prior_ids.isin(safe_public_ids)
+    detail_safe = detail_ids.isin(safe_public_ids)
+    rollout_keys = pd.DataFrame(
+        {
+            "prior": pd.Series(
+                prior_keys.loc[prior_safe].array,
+                index=prior_ids.loc[prior_safe].array,
+            ),
+            "detail": pd.Series(
+                detail_keys.loc[detail_safe].array,
+                index=detail_ids.loc[detail_safe].array,
+            ),
+        }
+    )
+    conflicts = (
+        rollout_keys["prior"].notna()
+        & rollout_keys["detail"].notna()
+        & rollout_keys["prior"].ne(rollout_keys["detail"])
+    )
+    conflicting_public_ids = set(rollout_keys.index[conflicts])
+    if conflicting_public_ids:
+        logger.warning(
+            "Skipping descriptive enrichment for {} conflicting award keys",
+            len(conflicting_public_ids),
+        )
+        safe_public_ids -= conflicting_public_ids
+
+    def _identity(keys: pd.Series, public_ids: pd.Series) -> pd.Series:
+        identities = pd.Series(pd.NA, index=public_ids.index, dtype="string")
+        keyed = keys.isin(shared_keys)
+        identities.loc[keyed] = "key:" + keys.loc[keyed]
+        public = ~keyed & public_ids.isin(safe_public_ids)
+        identities.loc[public] = "id:" + public_ids.loc[public]
+        return identities
+
+    projected = pd.DataFrame({"_award_identity": _identity(detail_keys, detail_ids)})
     for canonical, sources in _PRIOR_DETAIL_FIELDS.items():
         for source in sources:
             if source in detail.columns:
                 projected[canonical] = detail[source]
                 break
-    projected = projected.drop_duplicates(subset=["award_id"], keep="first")
+    projected = projected.loc[projected["_award_identity"].notna()]
+    ambiguous = projected["_award_identity"].duplicated(keep=False)
+    if ambiguous.any():
+        logger.warning(
+            "Skipping descriptive enrichment for {} ambiguous award identities",
+            projected.loc[ambiguous, "_award_identity"].nunique(),
+        )
+        projected = projected.loc[~ambiguous]
     if len(projected.columns) == 1:
         return priors
 
     out = priors.copy()
-    merged = out.assign(_award_key=out["award_id"].astype(str)).merge(
-        projected.rename(columns={"award_id": "_award_key"}),
-        on="_award_key",
+    merged = out.assign(_award_identity=_identity(prior_keys, prior_ids)).merge(
+        projected,
+        on="_award_identity",
         how="left",
         suffixes=("", "_detail"),
     )
     for canonical in projected.columns:
-        if canonical == "award_id":
+        if canonical == "_award_identity":
             continue
         detail_column = f"{canonical}_detail" if f"{canonical}_detail" in merged else canonical
         if canonical in out.columns and detail_column != canonical:
@@ -613,7 +682,7 @@ def enrich_prior_awards(priors: pd.DataFrame, detail: pd.DataFrame) -> pd.DataFr
         elif detail_column != canonical:
             merged[canonical] = merged[detail_column]
     drop = [column for column in merged.columns if column.endswith("_detail")]
-    return merged.drop(columns=[*drop, "_award_key"])
+    return merged.drop(columns=[*drop, "_award_identity"])
 
 
 def _default_prior_detail_loader(_context: Any) -> pd.DataFrame:

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/pairing.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/pairing.py
@@ -22,6 +22,7 @@ _CODED_STATUS_COLUMNS: tuple[str, ...] = ("research", "sbir_phase")
 
 PAIR_S1_COLUMNS: list[str] = [
     "prior_award_id",
+    "prior_award_key",
     "prior_recipient_uei",
     "prior_agency",
     "prior_sub_agency",
@@ -48,8 +49,8 @@ PAIR_S1_COLUMNS: list[str] = [
 ]
 
 # Transaction-grain schema shared by the weighted retrospective path and the
-# label-free census.  ``pair_filter_s1`` projects back to ``PAIR_S1_COLUMNS`` so
-# its existing public contract remains unchanged.
+# label-free census. ``pair_filter_s1`` projects back to the declared
+# ``PAIR_S1_COLUMNS`` contract after its internal grain checks.
 PAIR_COLUMNS: list[str] = [
     *PAIR_S1_COLUMNS[:-1],
     "target_research",
@@ -95,6 +96,14 @@ def _normalize(value: object) -> str:
         return ""
     s = str(value).strip().upper()
     return "" if s in _MISSING_TOKENS or s == r"\N" else s
+
+
+def _prior_identity(df: pd.DataFrame) -> pd.Series:
+    """Internal grain key without promoting a legacy public id to ``award_key``."""
+
+    public_ids = df.get("prior_award_id", pd.Series(None, index=df.index)).map(_normalize)
+    award_keys = df.get("prior_award_key", pd.Series(None, index=df.index)).map(_normalize)
+    return ("key:" + award_keys).where(award_keys.ne(""), "id:" + public_ids)
 
 
 def _is_phase_iii_already_coded(row: pd.Series) -> bool:
@@ -148,9 +157,15 @@ def _prepare_priors(prior_awards: pd.DataFrame) -> pd.DataFrame:
             return df[name]
         return pd.Series([default] * len(df), index=df.index)
 
+    award_ids = _col("award_id")
+    award_keys = _col("award_key")
+    award_keys = award_keys.where(award_keys.map(_normalize).ne(""), None)
     out = pd.DataFrame(
         {
-            "prior_award_id": _col("award_id"),
+            "prior_award_id": award_ids,
+            # Preserve absence on legacy inputs. Internal pairing can use the
+            # public id, but downstream reports must not mistake it for a true key.
+            "prior_award_key": award_keys,
             "prior_recipient_uei": _col("recipient_uei"),
             "prior_agency": _col("agency"),
             "prior_sub_agency": _col("sub_agency"),
@@ -407,9 +422,8 @@ def pair_filter_s1(
     # The transaction-grain universe intentionally retains duplicate source
     # rows so census validation can fail on them. Legacy S1, however, emitted
     # exactly one selected row per prior × award after its grain collapse.
-    eligible = eligible.drop_duplicates(
-        ["prior_award_id", "target_contract_key"],
-        keep="last",
+    eligible = eligible.assign(_prior_identity=_prior_identity(eligible)).drop_duplicates(
+        ["_prior_identity", "target_contract_key"], keep="last"
     )
 
     target_order = {
@@ -421,7 +435,7 @@ def pair_filter_s1(
         return pd.DataFrame(columns=PAIR_S1_COLUMNS)
 
     eligible = eligible.assign(
-        _prior_order=pd.factorize(eligible["prior_award_id"], sort=False)[0],
+        _prior_order=pd.factorize(eligible["_prior_identity"], sort=False)[0],
         _target_order=eligible["target_contract_key"].map(_normalize).map(target_order),
     ).sort_values(["_prior_order", "_target_order"], kind="mergesort")
     return eligible.loc[:, PAIR_S1_COLUMNS].reset_index(drop=True)
@@ -555,7 +569,10 @@ def pair_filter_s2(prior_awards: pd.DataFrame, opportunities: pd.DataFrame) -> p
         )
         fallback = fallback.loc[lineage & (naics | missing_codes)].copy()
     merged = pd.concat([exact, fallback], ignore_index=True, sort=False)
-    return _with_pair_metadata(merged.drop_duplicates(["prior_award_id", "target_id"]))
+    merged = merged.assign(_prior_identity=_prior_identity(merged)).drop_duplicates(
+        ["_prior_identity", "target_id"]
+    )
+    return _with_pair_metadata(merged.drop(columns="_prior_identity"))
 
 
 def pair_filter_s3(prior_awards: pd.DataFrame, opportunities: pd.DataFrame) -> pd.DataFrame:
@@ -587,9 +604,11 @@ def pair_filter_s3(prior_awards: pd.DataFrame, opportunities: pd.DataFrame) -> p
         missing["_agency"] = missing["prior_agency"].map(_normalize)
         by_agency = targets.assign(_agency=targets["target_agency"].map(_normalize))
         parts.append(missing.loc[missing["_agency"] != ""].merge(by_agency, on="_agency"))
-    merged = pd.concat(parts, ignore_index=True, sort=False).drop_duplicates(
-        ["prior_award_id", "target_id"]
+    merged = pd.concat(parts, ignore_index=True, sort=False)
+    merged = merged.assign(_prior_identity=_prior_identity(merged)).drop_duplicates(
+        ["_prior_identity", "target_id"]
     )
+    merged = merged.drop(columns="_prior_identity")
     paired = _with_pair_metadata(merged)
     return paired.loc[paired["topical_similarity"] >= 0.10].reset_index(drop=True)
 

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/criteria.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/criteria.py
@@ -252,7 +252,11 @@ def validate_pair_frame(pairs: pd.DataFrame) -> None:
 
     transaction_key = _normalized_key(pairs["target_transaction_id"])
     contract_key = _normalized_key(pairs["target_contract_key"])
-    prior_key = _normalized_key(pairs["prior_award_id"])
+    prior_award_key = _normalized_key(
+        pairs.get("prior_award_key", pd.Series(pd.NA, index=pairs.index))
+    )
+    prior_public_id = _normalized_key(pairs["prior_award_id"])
+    prior_key = ("KEY:" + prior_award_key).where(prior_award_key.notna(), "ID:" + prior_public_id)
     prior_uei = _normalized_key(pairs["prior_recipient_uei"])
     target_uei = _normalized_key(pairs["target_recipient_uei"])
 

--- a/sbir_etl/models/phase_iii_candidate.py
+++ b/sbir_etl/models/phase_iii_candidate.py
@@ -30,6 +30,13 @@ class PhaseIIICandidate(BaseModel):
     prior_award_id: str = Field(
         ..., description="Upstream Phase I/II award id the candidate is scored against."
     )
+    prior_award_key: str | None = Field(
+        None,
+        description=(
+            "Award-grain identity used for joins and deduplication. Legacy rows may omit it "
+            "only when prior_award_id is unambiguous."
+        ),
+    )
     target_type: TargetType = Field(
         ..., description="Corpus the target came from: FPDS contract or SAM.gov opportunity."
     )

--- a/sbir_etl/reporting/procurement_transition/core.py
+++ b/sbir_etl/reporting/procurement_transition/core.py
@@ -32,6 +32,8 @@ from sbir_etl.utils.procurement_text import (
 
 logger = logging.getLogger(__name__)
 
+_AWARD_KEY_VERSION = "sbir-source-v2"
+
 _ANNOTATION_FIELDS = (
     ("interest_alignment", "Mission-interest alignment"),
     ("technology_ecosystem", "Technology ecosystem"),
@@ -55,53 +57,100 @@ def _coalesce(df: pd.DataFrame, *names: str) -> pd.Series:
     return result
 
 
-# Fields that together identify one award. The public SBIR.gov snapshot reuses
-# Agency Tracking Numbers across tens of thousands of distinct award rows, so a
-# bare tracking number is a *firm/topic* key, not an award key: collapsing on it
-# makes unchanged rows look changed and silently merges distinct awards.
-_AWARD_GRAIN_FIELDS = (
-    "Company",
-    "Agency",
-    "Branch",
-    "Phase",
-    "Program",
-    "Proposal Award Date",
-    "Contract End Date",
-    "Award Title",
-    "Award Amount",
+# Stable source fields used to identify one award. Mutable report content such
+# as title, abstract, amount, and recorded end date deliberately stays out of
+# this key; changes to those fields belong in ``row_hash``.
+_AWARD_KEY_FIELDS = (
+    ("Agency Tracking Number", "agency_tracking_number"),
+    ("Contract", "contract_number"),
+    ("Agency", "agency"),
+    ("Branch", "branch", "sub_agency"),
+    ("Phase", "phase"),
+    ("Program", "program"),
+    ("Proposal Award Date", "award_date"),
+    ("Solicitation Number", "solicitation_number"),
 )
 
 
-def _natural_award_id(row: pd.Series) -> str | None:
-    for name in ("Agency Tracking Number", "Contract", "award_id"):
-        # ``_display`` rejects the nan/NaT/None/<NA> spellings ``str()`` would keep.
+def _row_value(row: pd.Series, *names: str) -> str | None:
+    for name in names:
         if (value := _display(row.get(name))) is not None:
             return value
     return None
+
+
+def _identity_component(value: Any) -> str:
+    return re.sub(r"\s+", " ", _display(value) or "").strip().upper()
+
+
+def _award_key_field_value(row: pd.Series, names: tuple[str, ...]) -> str | None:
+    value = _row_value(row, *names)
+    if names[0] != "Proposal Award Date" or value is None:
+        return value
+    text = value.strip()
+    match = re.match(r"^(\d{4})[-/](\d{1,2})[-/](\d{1,2})(?:\D|$)", text)
+    parts: tuple[str, str, str] | None
+    if match is None:
+        match = re.match(r"^(\d{1,2})/(\d{1,2})/(\d{4})(?:\D|$)", text)
+        parts = (match.group(3), match.group(1), match.group(2)) if match else None
+    else:
+        parts = (match.group(1), match.group(2), match.group(3))
+    if parts is None:
+        return value
+    try:
+        year, month, day = (int(part) for part in parts)
+        return date(year, month, day).isoformat()
+    except ValueError:
+        return value
+
+
+def _natural_award_id(row: pd.Series) -> str | None:
+    # Preserve the report's existing public lineage identifier for readable
+    # output and legacy candidate files. It is never used as award grain: the
+    # separate ``award_key`` owns joins, deduplication, and candidate identity.
+    return _row_value(
+        row,
+        "Agency Tracking Number",
+        "agency_tracking_number",
+        "Contract",
+        "contract_number",
+        "award_id",
+    )
 
 
 def _stable_award_id(row: pd.Series) -> str:
     natural = _natural_award_id(row)
     if natural is not None:
         return natural
-    material = "|".join(_display(row.get(name)) or "" for name in _AWARD_GRAIN_FIELDS)
-    return "sbir-" + hashlib.sha256(material.encode()).hexdigest()[:20]
+    return "sbir-" + _award_grain_key(row)[:20]
 
 
 def _award_grain_key(row: pd.Series) -> str:
     """Identity of one *award*, not one firm/topic.
 
-    ``award_id`` stays the natural identifier so it keeps joining to the
-    candidate frame, but it is not award-grain on its own — hence this separate
-    key for snapshot comparison.
+    ``award_id`` stays the natural identifier for readable lineage. It is not
+    award-grain on its own, so joins, deduplication, and snapshot comparison use
+    this separate stable source compound.
     """
 
-    material = "|".join(
-        [
-            _natural_award_id(row) or "",
-            *(_display(row.get(name)) or "" for name in _AWARD_GRAIN_FIELDS),
-        ]
+    if existing := _row_value(row, "award_key"):
+        if _row_value(row, "award_key_version") != _AWARD_KEY_VERSION:
+            raise ValueError(
+                "pre-migration award_key cannot be reused; regenerate identity from raw awards"
+            )
+        return existing
+
+    recipient = (
+        _row_value(row, "UEI", "uei", "recipient_uei")
+        or _row_value(row, "Duns", "duns", "recipient_duns")
+        or _row_value(row, "Company", "company", "recipient_name")
     )
+    components = (
+        "sbir",
+        recipient,
+        *(_award_key_field_value(row, names) for names in _AWARD_KEY_FIELDS),
+    )
+    material = "|".join(_identity_component(value) for value in components)
     return hashlib.sha256(material.encode()).hexdigest()[:24]
 
 
@@ -113,6 +162,9 @@ def normalize_awards(raw: pd.DataFrame) -> pd.DataFrame:
             columns=[
                 "award_id",
                 "award_key",
+                "award_key_version",
+                "agency_tracking_number",
+                "contract_number",
                 "company",
                 "title",
                 "agency",
@@ -125,16 +177,24 @@ def normalize_awards(raw: pd.DataFrame) -> pd.DataFrame:
                 "amount",
                 "abstract",
                 "row_hash",
+                "source_edition_count",
+                "source_edition_variants",
+                "public_id_award_count",
                 "naics_code",
                 "psc_code",
                 "office",
                 "cet",
                 "source_url",
+                "solicitation_number",
+                "topic_code",
             ]
         )
     out = pd.DataFrame(index=raw.index)
     out["award_id"] = raw.apply(_stable_award_id, axis=1)
     out["award_key"] = raw.apply(_award_grain_key, axis=1)
+    out["award_key_version"] = _AWARD_KEY_VERSION
+    out["agency_tracking_number"] = _pick(raw, "Agency Tracking Number", "agency_tracking_number")
+    out["contract_number"] = _pick(raw, "Contract", "contract_number")
     out["company"] = _pick(raw, "Company", "company", "recipient_name")
     out["title"] = _pick(raw, "Award Title", "title")
     out["agency"] = _pick(raw, "Agency", "agency")
@@ -159,8 +219,39 @@ def normalize_awards(raw: pd.DataFrame) -> pd.DataFrame:
     out["office"] = _pick(raw, "Office", "office", "awarding_office_name")
     out["cet"] = _pick(raw, "CET", "cet")
     out["source_url"] = _pick(raw, "source_url", "SBIR URL")
-    material = out.fillna("").astype(str).agg("|".join, axis=1)
+    out["solicitation_number"] = _pick(raw, "Solicitation Number", "solicitation_number")
+    out["topic_code"] = _pick(raw, "Topic Code", "topic_code")
+    material = out.astype("string").fillna("").agg("|".join, axis=1)
     out["row_hash"] = material.map(lambda value: hashlib.sha256(value.encode()).hexdigest())
+
+    # SBIR.gov sometimes publishes several editions of the same stable award
+    # (typically revised amount/end-date records). Treat them as revisions, not
+    # distinct awards, and retain the most current-looking public edition.
+    edition_counts = out.groupby("award_key")["award_key"].transform("size")
+    edition_variants = out.groupby("award_key")["row_hash"].transform("nunique")
+    out["source_edition_count"] = edition_counts
+    out["source_edition_variants"] = edition_variants
+    duplicate_editions = edition_counts.gt(1)
+    if duplicate_editions.any():
+        logger.warning(
+            "Collapsing %d SBIR source rows across %d stable award keys",
+            int(duplicate_editions.sum()),
+            int(out.loc[duplicate_editions, "award_key"].nunique()),
+        )
+        out = (
+            out.assign(
+                _end_sort=pd.to_datetime(out["recorded_end_date"], errors="coerce"),
+                _amount_sort=pd.to_numeric(out["amount"], errors="coerce"),
+            )
+            .sort_values(
+                ["award_key", "_end_sort", "_amount_sort", "row_hash"],
+                kind="stable",
+                na_position="first",
+            )
+            .drop_duplicates("award_key", keep="last")
+            .drop(columns=["_end_sort", "_amount_sort"])
+        )
+    out["public_id_award_count"] = out.groupby("award_id")["award_key"].transform("nunique")
     return out.reset_index(drop=True)
 
 
@@ -177,14 +268,31 @@ def build_award_cohorts(
     report_month: str,
     approaching_days: int = 180,
 ) -> pd.DataFrame:
-    current = normalize_awards(current) if "row_hash" not in current.columns else current.copy()
-    prior = (
-        normalize_awards(previous)
-        if previous is not None and "row_hash" not in previous.columns
-        else (previous.copy() if previous is not None else pd.DataFrame())
-    )
+    def _prepare(frame: pd.DataFrame | None, *, label: str) -> pd.DataFrame:
+        if frame is None or frame.empty:
+            return pd.DataFrame() if frame is None else frame.copy()
+        if "row_hash" not in frame.columns:
+            return normalize_awards(frame)
+        versions = frame.get("award_key_version", pd.Series(pd.NA, index=frame.index))
+        if not versions.eq(_AWARD_KEY_VERSION).all():
+            raise ValueError(
+                f"{label} uses a pre-migration award key; regenerate it from raw awards"
+            )
+        return frame.copy()
+
+    current = _prepare(current, label="current award snapshot")
+    prior = _prepare(previous, label="previous award snapshot")
     start, end = _month_bounds(report_month)
     horizon = (pd.Timestamp(end) + pd.Timedelta(days=approaching_days)).date()
+
+    def _between(value: Any, lower: date, upper: date, *, include_lower: bool = True) -> bool:
+        if value is None or bool(pd.isna(value)):
+            return False
+        parsed = value if isinstance(value, date) else pd.to_datetime(value, errors="coerce")
+        if pd.isna(parsed):
+            return False
+        comparable = parsed.date() if isinstance(parsed, datetime) else parsed
+        return lower <= comparable <= upper if include_lower else lower < comparable <= upper
 
     # Diff on the compound award-grain key, never on the bare tracking number:
     # the public snapshot reuses tracking numbers across tens of thousands of
@@ -206,13 +314,13 @@ def build_award_cohorts(
         for key, row_hash in zip(current_keys, current["row_hash"], strict=True)
     ]
     current["awarded_in_period"] = current["award_date"].map(
-        lambda value: bool(value and start <= value <= end)
+        lambda value: _between(value, start, end)
     )
     current["recent_recorded_end"] = current["recorded_end_date"].map(
-        lambda value: bool(value and start <= value <= end)
+        lambda value: _between(value, start, end)
     )
     current["approaching_recorded_end"] = current["recorded_end_date"].map(
-        lambda value: bool(value and end < value <= horizon)
+        lambda value: _between(value, end, horizon, include_lower=False)
     )
     flags = [
         "newly_observed",
@@ -397,19 +505,27 @@ def _cited_award_identifier(row: pd.Series) -> str | None:
     6 normalized characters are ignored (false-hit prone).
     """
 
-    award_id = _display(_first_value(row.get("award_id"), row.get("prior_award_id")))
-    if award_id is None:
-        return None
-    needle = re.sub(r"[^A-Z0-9]+", "", award_id.upper())
-    if len(needle) < 6:
-        return None
     notice_text = _display(
         _first_value(row.get("opportunity_description"), row.get("target_description"))
     )
     if notice_text is None:
         return None
     haystack = re.sub(r"[^A-Z0-9]+", "", notice_text.upper())
-    return award_id if needle in haystack else None
+    for value in (
+        row.get("award_contract_number"),
+        row.get("prior_contract_number"),
+        row.get("award_agency_tracking_number"),
+        row.get("prior_agency_tracking_number"),
+        row.get("award_id"),
+        row.get("prior_award_id"),
+    ):
+        award_id = _display(value)
+        if award_id is None:
+            continue
+        needle = re.sub(r"[^A-Z0-9]+", "", award_id.upper())
+        if len(needle) >= 6 and needle in haystack:
+            return award_id
+    return None
 
 
 def _notice_names_awardee(row: pd.Series) -> bool:
@@ -659,6 +775,49 @@ def _awardee_key(award: pd.Series) -> str:
     return f"award:{award.get('award_id')}"
 
 
+def _award_identity(row: pd.Series, *, candidate: bool = False) -> str:
+    names = (
+        ("_report_award_key", "prior_award_key", "award_key", "prior_award_id")
+        if candidate
+        else ("award_key", "award_id")
+    )
+    value = _first_value(*(row.get(name) for name in names))
+    return _display(value) or ""
+
+
+def _ambiguous_public_award_ids(awards: pd.DataFrame) -> set[str]:
+    if "award_id" not in awards:
+        return set()
+    public_ids = awards["award_id"].map(_display)
+    source_counts = pd.to_numeric(
+        awards.get("public_id_award_count", pd.Series(1, index=awards.index)),
+        errors="coerce",
+    ).fillna(1)
+    ambiguous = public_ids.duplicated(keep=False) | source_counts.gt(1)
+    return {value for value in public_ids.loc[ambiguous] if value is not None}
+
+
+def _award_for_entry(group: dict[str, Any], entry: pd.Series) -> pd.Series:
+    """Resolve the award actually associated with a candidate path."""
+
+    identity = _award_identity(entry, candidate=True)
+    matches = [award for award in group["awards"] if _award_identity(award) == identity]
+    if len(matches) == 1:
+        return matches[0]
+
+    # Legacy direct callers may provide only a public id. The report join has
+    # already rejected ambiguity, so a unique match remains safe here.
+    prior_id = _display(entry.get("prior_award_id"))
+    legacy_matches = [
+        award
+        for award in group["awards"]
+        if prior_id is not None and _display(award.get("award_id")) == prior_id
+    ]
+    if len(legacy_matches) == 1:
+        return legacy_matches[0]
+    raise ValueError("candidate path does not resolve to one award-grain record")
+
+
 def _procurement_key(row: pd.Series) -> str | None:
     return _display(_first_value(row.get("target_id"), row.get("opportunity_title")))
 
@@ -762,11 +921,26 @@ def group_candidates_by_awardee(rows: pd.DataFrame, awards: pd.DataFrame) -> lis
 
     signals = rows.get("signal_class", pd.Series(index=rows.index, dtype="object"))
     confidence = rows.get("confidence_bucket", pd.Series(index=rows.index, dtype="object"))
-    award_ids = (
-        rows.get("prior_award_id", pd.Series(index=rows.index, dtype="object")).astype(str)
-        if not rows.empty
-        else pd.Series(dtype="object")
+    candidate_award_keys = _coalesce(rows, "_report_award_key", "prior_award_key", "award_key").map(
+        _display
     )
+    candidate_public_ids = rows.get(
+        "prior_award_id", pd.Series(None, index=rows.index, dtype="object")
+    ).map(_display)
+    ambiguous_public_ids = _ambiguous_public_award_ids(awards)
+    available_award_keys = {
+        _award_identity(award) for _, award in awards.iterrows() if _award_identity(award)
+    }
+    available_public_ids = {
+        value for value in awards.get("award_id", pd.Series(dtype="object")).map(_display) if value
+    }
+    resolved = candidate_award_keys.isin(available_award_keys) | (
+        candidate_award_keys.isna()
+        & candidate_public_ids.isin(available_public_ids)
+        & ~candidate_public_ids.isin(ambiguous_public_ids)
+    )
+    if not resolved.all():
+        raise ValueError("candidate rows do not resolve to unique award-grain records")
 
     def _entries(mask: pd.Series, seen: set[str]) -> list[pd.Series]:
         subset = rows.loc[mask]
@@ -801,8 +975,14 @@ def group_candidates_by_awardee(rows: pd.DataFrame, awards: pd.DataFrame) -> lis
         # already puts the most time-sensitive award of the firm first).
         primary = awardee_awards[0]
         ids = [str(award.get("award_id")) for award in awardee_awards]
+        keys = [_award_identity(award) for award in awardee_awards]
         same = (
-            award_ids.isin(ids)
+            candidate_award_keys.isin(keys)
+            | (
+                candidate_award_keys.isna()
+                & candidate_public_ids.isin(ids)
+                & ~candidate_public_ids.isin(ambiguous_public_ids)
+            )
             if not rows.empty
             else pd.Series(False, index=rows.index, dtype=bool)
         )
@@ -818,6 +998,7 @@ def group_candidates_by_awardee(rows: pd.DataFrame, awards: pd.DataFrame) -> lis
             {
                 "award_id": str(primary.get("award_id")),
                 "award_ids": ids,
+                "award_keys": keys,
                 "award": primary,
                 "awards": awardee_awards,
                 "directed": directed,
@@ -970,13 +1151,62 @@ class MonthlyReportBuilder:
                     "naics_code": "award_naics_code",
                     "psc_code": "award_psc_code",
                     "source_url": "award_source_url",
+                    "agency_tracking_number": "award_agency_tracking_number",
+                    "contract_number": "award_contract_number",
                 }
             )
-            master = master.merge(
-                award_fields,
-                left_on="prior_award_id",
-                right_on="award_id",
-                how="left",
+            prior_keys = master.get(
+                "prior_award_key", pd.Series([None] * len(master), index=master.index)
+            ).map(_display)
+            keyed = prior_keys.notna()
+            master = master.assign(_candidate_order=range(len(master)))
+            joined: list[pd.DataFrame] = []
+            if keyed.any():
+                if "award_key" not in award_fields:
+                    raise ValueError("award-keyed candidates require award_key on every award")
+                joined.append(
+                    master.loc[keyed].merge(
+                        award_fields,
+                        left_on="prior_award_key",
+                        right_on="award_key",
+                        how="left",
+                        validate="many_to_one",
+                    )
+                )
+            if (~keyed).any():
+                # Backward compatibility for hand-authored candidate rows. A
+                # reused public id is ambiguous and must fail rather than fan out.
+                legacy = master.loc[~keyed]
+                candidate_ids = set(legacy["prior_award_id"].map(_display).dropna())
+                ambiguous_ids = sorted(_ambiguous_public_award_ids(award_fields) & candidate_ids)
+                if ambiguous_ids:
+                    preview = ", ".join(ambiguous_ids[:5])
+                    raise ValueError(
+                        "legacy prior_award_id is ambiguous; regenerate candidates with "
+                        f"prior_award_key (examples: {preview})"
+                    )
+                joined.append(
+                    legacy.merge(
+                        award_fields,
+                        left_on="prior_award_id",
+                        right_on="award_id",
+                        how="left",
+                        validate="many_to_one",
+                    )
+                )
+            master = (
+                pd.concat(joined, ignore_index=True, sort=False)
+                .sort_values("_candidate_order", kind="stable")
+                .drop(columns="_candidate_order")
+                .reset_index(drop=True)
+            )
+            missing_awards = master["award_id"].map(_display).isna()
+            if missing_awards.any():
+                missing = _coalesce(master.loc[missing_awards], "prior_award_key", "prior_award_id")
+                preview = ", ".join(str(value) for value in missing.head(5))
+                raise ValueError(f"candidate rows reference missing awards: {preview}")
+            master["_report_award_key"] = _coalesce(
+                master, "award_key", "prior_award_key", "award_id", "prior_award_id"
             )
         if "target_id" in master and "notice_id" in opportunities:
             opportunity_fields = opportunities.rename(
@@ -1190,15 +1420,16 @@ class MonthlyReportBuilder:
         ]
         emitted = False
         for group in groups:
-            award = group["award"]
             for entry in group["directed"]:
-                lines += self._path_detail(award, entry, "direct-award")
+                lines += self._path_detail(_award_for_entry(group, entry), entry, "direct-award")
                 emitted = True
             for entry in group["competitive"]:
-                lines += self._path_detail(award, entry, "competitive")
+                lines += self._path_detail(_award_for_entry(group, entry), entry, "competitive")
                 emitted = True
             for entry in group["watchlist"]:
-                lines += self._path_detail(award, entry, "needs more evidence")
+                lines += self._path_detail(
+                    _award_for_entry(group, entry), entry, "needs more evidence"
+                )
                 emitted = True
         if not emitted:
             lines += ["No paths to detail this month.", ""]
@@ -1254,18 +1485,24 @@ class MonthlyReportBuilder:
             "|---|---|---|---|---|",
         ]
         for group in groups:
-            award = group["award"]
-            company = _markdown_text(award.get("company"), default="Company unavailable", limit=120)
-            built = self._plain_award_summary(award)
+            primary = group["award"]
+            company = _markdown_text(
+                primary.get("company"), default="Company unavailable", limit=120
+            )
             paths = [(entry, "direct-award") for entry in group["directed"]]
             paths += [(entry, "competitive") for entry in group["competitive"]]
             paths += [(entry, "needs more evidence") for entry in group["watchlist"]]
             if not paths:
-                end_date = _display(award.get("recorded_end_date"))
+                built = self._plain_award_summary(primary)
+                end_date = _display(primary.get("recorded_end_date"))
                 note = f"ends {end_date}" if end_date else "no recorded end date"
                 lines.append(f"| {company} | {built} | — no matched procurement | — | {note} |")
                 continue
+            prior_award_identity: str | None = None
             for index, (entry, path_label) in enumerate(paths):
+                award = _award_for_entry(group, entry)
+                award_identity = _award_identity(award)
+                built = self._plain_award_summary(award)
                 procurement = _markdown_text(
                     _first_value(entry.get("opportunity_title"), entry.get("target_id")),
                     default="Untitled opportunity",
@@ -1283,11 +1520,12 @@ class MonthlyReportBuilder:
                 )
                 why = self._why_it_connects(entry)
                 awardee_cell = company if index == 0 else ""
-                built_cell = built if index == 0 else ""
+                built_cell = built if award_identity != prior_award_identity else ""
                 lines.append(
                     f"| {awardee_cell} | {built_cell} | {procurement} ({path_label}) | "
                     f"{why} | {deadline} |"
                 )
+                prior_award_identity = award_identity
         lines.append("")
         return lines
 
@@ -1453,13 +1691,19 @@ class MonthlyReportBuilder:
         # center's packet, where it would be listed as "no matched procurement",
         # while still emitting every awardee at a center that has any match.
         linked_by_center = {
-            center: set(rows.get("prior_award_id", pd.Series(dtype="object")).dropna().astype(str))
+            center: {
+                value
+                for value in _coalesce(
+                    rows, "_report_award_key", "prior_award_key", "prior_award_id"
+                ).map(_display)
+                if value is not None
+            }
             for center, rows in groups.items()
         }
         linked_anywhere = set().union(*linked_by_center.values()) if linked_by_center else set()
-        cohort_award_ids = award_cohorts.get(
-            "award_id", pd.Series(dtype="object", index=award_cohorts.index)
-        ).astype(str)
+        cohort_award_ids = _coalesce(award_cohorts, "award_key", "award_id").map(
+            lambda value: _display(value) or ""
+        )
 
         if groups:
             for center, rows in groups.items():

--- a/scripts/phase_iii_precision_backtest.py
+++ b/scripts/phase_iii_precision_backtest.py
@@ -67,6 +67,7 @@ def _build_pair_row(prior: pd.Series, contract: pd.Series) -> pd.Series:
 
     data = {
         "prior_award_id": prior.get("prior_award_id"),
+        "prior_award_key": prior.get("prior_award_key"),
         "prior_recipient_uei": prior.get("prior_recipient_uei"),
         "prior_agency": prior.get("prior_agency"),
         "prior_sub_agency": prior.get("prior_sub_agency"),

--- a/specs/procurement-transition-p1-remediation/plan.md
+++ b/specs/procurement-transition-p1-remediation/plan.md
@@ -1,0 +1,86 @@
+# Procurement transition P1 remediation plan
+
+## Objective
+
+Make the monthly procurement packet safe to use as a human review queue. A displayed path must
+identify one SBIR/STTR award, preserve the public evidence behind that identity, and never turn
+missing state or an unvalidated ranking model into a plausible-looking acquisition recommendation.
+
+The work is split into small pull requests because the source-matching repair will greatly expand
+the candidate universe. Cold-start safeguards must land before that expansion.
+
+## Phase 1 — award identity and path attribution (this PR)
+
+- Separate stable award identity (`award_key`) from public identifiers and mutable row content.
+- Build that identity from the full stable source compound; neither tracking nor contract number
+  is unique by itself. Canonicalize multiple published editions of the same stable award.
+- Carry `prior_award_key` through pairing, candidate IDs, evidence, and report joins.
+- Use the same key for descriptive enrichment; skip ambiguous legacy enrichment instead of
+  assigning one award's technical fields to another.
+- Version the identity contract and fail closed on pre-migration normalized snapshots; raw award
+  snapshots must be re-normalized during rollout.
+- Preserve legacy candidate files only when their public award ID identifies exactly one award;
+  fail closed on ambiguity.
+- Render each awardee-to-procurement path from the award that produced that candidate, not the
+  awardee group's first award.
+
+Acceptance gates:
+
+1. Awards sharing an Agency Tracking Number or contract number remain distinct through pairing
+   and reporting when their stable source lineage differs.
+2. Editing title, abstract, amount, or recorded end date changes `row_hash`, not `award_key`.
+3. Multiple source editions of the same stable award become one canonical award with an auditable
+   edition count.
+4. Candidate IDs differ for distinct award keys even when their public identifiers are equal.
+5. A legacy ambiguous `prior_award_id` raises a clear error instead of creating a many-to-many join.
+6. Every rendered **Built on** statement comes from the candidate's associated award.
+7. A pre-migration normalized snapshot cannot silently make the full history appear newly observed.
+
+## Phase 2 — cold-start and historical execution safety
+
+This phase must precede source normalization.
+
+- Add an explicit bootstrap mode; a missing prior snapshot must not mark the full SBIR history as
+  newly observed.
+- Fail closed when a scheduled incremental run unexpectedly loses its baseline.
+- Put bounded row/pair budgets and coverage metrics ahead of company enrichment and code joins.
+- Define backfill semantics around versioned input snapshots and an explicit `as_of` date rather
+  than today's active/deadline state.
+
+Acceptance gate: a cache miss produces either a bounded bootstrap cohort or an actionable failure,
+never an all-history monthly packet.
+
+## Phase 3 — source normalization and enrichment provenance
+
+- Introduce canonical organization identifiers/aliases for SBIR.gov and SAM.gov agency, branch,
+  sub-tier, and office values; retain raw source values beside them.
+- Replace the top-100 company workaround with measured coverage and a bounded fallback strategy.
+- Stop assigning the first sorted company-wide NAICS code to every award. Treat company-level
+  codes as separately sourced screening evidence, never as award-record facts.
+- Require independent technical evidence for common-code follow-on matches and report coverage by
+  source/gate.
+
+Acceptance gate: realistic `Department of Defense` / `DEPT OF DEFENSE` records with matching
+technical text survive hydration and pairing without fabricating award-level NAICS evidence.
+
+## Phase 4 — ranking decision and auditability
+
+- Restore deadline-primary packet order until an opportunity-to-firm model has fitted weights and
+  forward, notice-grained validation.
+- Treat the current fusion model as advisory research output, not a silent packet orderer.
+- Populate every served feature, make missing values neutral, and persist score, model/version,
+  ranking orientation, and fallback state in the master ledger and manifest.
+- Reconcile the packet implementation with the PR 481/484 findings and the 85% hand-audit gate.
+
+Acceptance gate: the same packet has a reproducible order, a visible fallback, and an audit record
+that identifies the model and evidence used; unvalidated scores cannot reorder or drop leads.
+
+## Release order
+
+1. Phase 1: identity and attribution.
+2. Phase 2: bootstrap and execution bounds.
+3. Phase 3: normalization and provenance-aware matching.
+4. Phase 4: ranking orientation and production validation.
+
+Each phase should ship with a focused regression fixture derived from the failure that motivated it
+and should not weaken the representative-distribution precision gate.

--- a/tests/unit/phase_iii_candidates/test_candidate_outputs.py
+++ b/tests/unit/phase_iii_candidates/test_candidate_outputs.py
@@ -68,6 +68,58 @@ def test_evidence_records_only_observed_match_keys_and_every_subscore():
     assert record["score"] == pytest.approx(sum(record["subscores"].values()))
 
 
+def test_candidate_identity_uses_award_grain_key():
+    pairs = pd.concat(
+        [
+            _pairs().assign(prior_award_key="award-key-1"),
+            _pairs().assign(prior_award_key="award-key-2"),
+        ],
+        ignore_index=True,
+    )
+
+    candidates, evidence = score_candidate_pairs(
+        pairs,
+        signal_class=SignalClass.FOLLOWON,
+        weights=WEIGHTS_FOLLOWON,
+        high_threshold=HIGH_THRESHOLD_FOLLOWON,
+    )
+
+    assert candidates["candidate_id"].nunique() == 2
+    assert set(candidates["prior_award_key"]) == {"award-key-1", "award-key-2"}
+    assert {record["award_key"] for record in evidence} == {"award-key-1", "award-key-2"}
+
+
+def test_legacy_scoring_does_not_promote_public_id_to_award_key():
+    candidates, evidence = score_candidate_pairs(
+        _pairs(),
+        signal_class=SignalClass.FOLLOWON,
+        weights=WEIGHTS_FOLLOWON,
+        high_threshold=HIGH_THRESHOLD_FOLLOWON,
+    )
+
+    assert pd.isna(candidates.loc[0, "prior_award_key"])
+    assert evidence[0]["award_key"] is None
+
+
+def test_candidate_identity_namespaces_keys_from_legacy_public_ids():
+    pairs = pd.concat(
+        [
+            _pairs().assign(prior_award_id="PUBLIC-1", prior_award_key="A-1"),
+            _pairs(),
+        ],
+        ignore_index=True,
+    )
+
+    candidates, _ = score_candidate_pairs(
+        pairs,
+        signal_class=SignalClass.FOLLOWON,
+        weights=WEIGHTS_FOLLOWON,
+        high_threshold=HIGH_THRESHOLD_FOLLOWON,
+    )
+
+    assert candidates["candidate_id"].nunique() == 2
+
+
 def test_each_signal_class_owns_its_own_artifacts(isolated_outputs):
     directed, directed_evidence = score_candidate_pairs(
         _pairs(),
@@ -131,3 +183,56 @@ def test_enrich_prior_awards_adds_the_fields_the_phase_ii_contract_lacks():
     assert enriched.loc[0, "naics_code"] == "541715"
     assert enriched.loc[0, "cet"] == "Autonomy"
     assert len(enriched) == len(priors)
+
+
+def test_enrich_prior_awards_uses_award_key_when_public_ids_are_reused():
+    priors = pd.DataFrame(
+        [
+            {"award_id": "A-1", "award_key": "key-1"},
+            {"award_id": "A-1", "award_key": "key-2"},
+        ]
+    )
+    detail = pd.DataFrame(
+        [
+            {"award_id": "A-1", "award_key": "key-1", "award_title": "Radar hardware"},
+            {"award_id": "A-1", "award_key": "key-2", "award_title": "Navigation software"},
+        ]
+    )
+
+    enriched = enrich_prior_awards(priors, detail)
+
+    assert enriched["title"].tolist() == ["Radar hardware", "Navigation software"]
+
+
+def test_enrich_prior_awards_skips_ambiguous_legacy_details():
+    priors = pd.DataFrame([{"award_id": "A-1"}])
+    detail = pd.DataFrame(
+        [
+            {"award_id": "A-1", "award_title": "Radar hardware"},
+            {"award_id": "A-1", "award_title": "Navigation software"},
+        ]
+    )
+
+    enriched = enrich_prior_awards(priors, detail)
+
+    assert pd.isna(enriched.loc[0, "title"])
+
+
+def test_enrich_prior_awards_uses_unique_public_id_during_key_rollout():
+    priors = pd.DataFrame([{"award_id": "A-1", "award_key": "key-1"}])
+    legacy_detail = pd.DataFrame([{"award_id": "A-1", "award_title": "Autonomous navigation"}])
+
+    enriched = enrich_prior_awards(priors, legacy_detail)
+
+    assert enriched.loc[0, "title"] == "Autonomous navigation"
+
+
+def test_enrich_prior_awards_rejects_explicit_key_conflicts():
+    priors = pd.DataFrame([{"award_id": "A-1", "award_key": "key-1"}])
+    conflicting_detail = pd.DataFrame(
+        [{"award_id": "A-1", "award_key": "key-2", "award_title": "Wrong technology"}]
+    )
+
+    enriched = enrich_prior_awards(priors, conflicting_detail)
+
+    assert pd.isna(enriched.loc[0, "title"])

--- a/tests/unit/phase_iii_candidates/test_opportunity_pairing.py
+++ b/tests/unit/phase_iii_candidates/test_opportunity_pairing.py
@@ -201,3 +201,53 @@ def test_followon_keeps_rich_prior_without_uei():
 def test_blank_notice_id_is_not_paired():
     opportunities = pd.DataFrame([_opportunity(notice_id="   ", awardee_uei="UEI000000001")])
     assert pair_filter_s2(_priors(), opportunities).empty
+
+
+def test_followon_pairing_preserves_awards_that_share_a_public_id():
+    priors = pd.concat(
+        [
+            _priors().assign(award_key="award-key-1"),
+            _priors().assign(award_key="award-key-2", title="Navigation integration"),
+        ],
+        ignore_index=True,
+    )
+    opportunities = pd.DataFrame(
+        [
+            _opportunity(
+                notice_type_code="o",
+                naics_code="541715",
+                psc_code="AJ11",
+                description="Autonomous aircraft navigation prototype transition",
+            )
+        ]
+    )
+
+    pairs = pair_filter_s3(priors, opportunities)
+
+    assert set(pairs["prior_award_key"]) == {"award-key-1", "award-key-2"}
+    assert len(pairs) == 2
+
+
+def test_followon_pairing_keeps_separate_legacy_public_ids():
+    priors = pd.concat(
+        [
+            _priors(),
+            _priors().assign(award_id="A-2", title="Navigation integration"),
+        ],
+        ignore_index=True,
+    )
+    opportunities = pd.DataFrame(
+        [
+            _opportunity(
+                notice_type_code="o",
+                naics_code="541715",
+                psc_code="AJ11",
+                description="Autonomous aircraft navigation prototype transition",
+            )
+        ]
+    )
+
+    pairs = pair_filter_s3(priors, opportunities)
+
+    assert set(pairs["prior_award_id"]) == {"A-1", "A-2"}
+    assert pairs["prior_award_key"].isna().all()

--- a/tests/unit/phase_iii_census/test_criteria.py
+++ b/tests/unit/phase_iii_census/test_criteria.py
@@ -340,6 +340,28 @@ def test_pair_validation_rejects_duplicate_prior_transaction_composite() -> None
         validate_pair_frame(pairs)
 
 
+def test_pair_validation_uses_award_grain_key_for_reused_public_ids() -> None:
+    pairs = pd.DataFrame(
+        [
+            _pair(prior_award_id="SHARED", prior_award_key="award-key-1"),
+            _pair(prior_award_id="SHARED", prior_award_key="award-key-2"),
+        ]
+    )
+
+    validate_pair_frame(pairs)
+
+
+def test_pair_validation_namespaces_key_from_legacy_public_id() -> None:
+    pairs = pd.DataFrame(
+        [
+            _pair(prior_award_id="PUBLIC-1", prior_award_key="SHARED"),
+            _pair(prior_award_id="SHARED", prior_award_key=pd.NA),
+        ]
+    )
+
+    validate_pair_frame(pairs)
+
+
 @pytest.mark.parametrize(
     "overrides",
     [

--- a/tests/unit/reporting/test_procurement_transition_outputs.py
+++ b/tests/unit/reporting/test_procurement_transition_outputs.py
@@ -3,11 +3,13 @@
 import json
 
 import pandas as pd
+import pytest
 
 from sbir_etl.reporting.procurement_transition import (
     MonthlyReportBuilder,
     build_award_cohorts,
     group_candidates_by_awardee,
+    normalize_awards,
 )
 
 
@@ -46,13 +48,113 @@ def test_duplicate_tracking_numbers_are_not_collapsed_across_snapshots():
     assert cohorts["award_key"].nunique() == 2
 
 
+def test_reused_contract_numbers_are_scoped_by_full_award_lineage():
+    snapshot = pd.DataFrame(
+        [
+            _award(**{"Agency Tracking Number": "A-1", "Contract": "SHARED-CONTRACT"}),
+            _award(
+                Company="Sensor Co",
+                UEI="UEI000000002",
+                **{
+                    "Agency Tracking Number": "A-2",
+                    "Contract": "SHARED-CONTRACT",
+                    "Award Title": "Radar payload",
+                },
+            ),
+        ]
+    )
+
+    normalized = normalize_awards(snapshot)
+
+    assert normalized["award_key"].nunique() == 2
+    assert set(normalized["award_id"]) == {"A-1", "A-2"}
+
+
+def test_award_key_canonicalizes_supported_date_representations():
+    keys = [
+        normalize_awards(pd.DataFrame([_award(**{"Proposal Award Date": value})])).loc[
+            0, "award_key"
+        ]
+        for value in ("2026-06-12", "06/12/2026", pd.Timestamp("2026-06-12"))
+    ]
+
+    assert len(set(keys)) == 1
+
+
+def test_pre_migration_normalized_snapshot_fails_closed():
+    old_snapshot = normalize_awards(pd.DataFrame([_award()])).drop(columns="award_key_version")
+
+    with pytest.raises(ValueError, match="pre-migration award key"):
+        build_award_cohorts(old_snapshot, pd.DataFrame(), report_month="2026-06")
+
+
 def test_a_real_edit_is_still_reported_as_changed():
     previous = pd.DataFrame([_award()])
     current = pd.DataFrame([_award(**{"Award Amount": "$2,000,000"})])
 
     cohorts = build_award_cohorts(current, previous, report_month="2026-06")
 
-    assert bool(cohorts.iloc[0]["newly_observed"]) is True
+    assert bool(cohorts.iloc[0]["newly_observed"]) is False
+    assert bool(cohorts.iloc[0]["changed_since_prior_report"]) is True
+
+
+def test_mutable_award_edits_do_not_change_award_identity():
+    previous = pd.DataFrame([_award()])
+    current = pd.DataFrame(
+        [
+            _award(
+                **{
+                    "Award Title": "Updated autonomous navigation",
+                    "Abstract": "Updated technical description.",
+                    "Award Amount": "$2,000,000",
+                    "Contract End Date": "2026-10-31",
+                }
+            )
+        ]
+    )
+
+    prior = build_award_cohorts(previous, pd.DataFrame(), report_month="2026-06")
+    cohorts = build_award_cohorts(current, previous, report_month="2026-06")
+
+    assert cohorts.loc[0, "award_key"] == prior.loc[0, "award_key"]
+    assert cohorts.loc[0, "row_hash"] != prior.loc[0, "row_hash"]
+    assert bool(cohorts.loc[0, "newly_observed"]) is False
+    assert bool(cohorts.loc[0, "changed_since_prior_report"]) is True
+
+
+def test_multiple_source_editions_collapse_to_one_stable_award():
+    raw = pd.DataFrame(
+        [
+            _award(**{"Award Amount": "$1,000,000", "Contract End Date": "2026-08-15"}),
+            _award(**{"Award Amount": "$2,000,000", "Contract End Date": "2027-08-15"}),
+        ]
+    )
+
+    normalized = normalize_awards(raw)
+
+    assert len(normalized) == 1
+    assert normalized.loc[0, "amount"] == 2_000_000
+    assert normalized.loc[0, "source_edition_count"] == 2
+    assert normalized.loc[0, "source_edition_variants"] == 2
+
+
+def test_sparse_award_rows_still_receive_a_row_hash():
+    raw = pd.DataFrame(
+        [
+            {
+                "Agency Tracking Number": "A-1",
+                "Company": "Drone Co",
+                "Agency": "DEFENSE",
+                "Phase": "Phase II",
+            }
+        ]
+    )
+    normalized = normalize_awards(raw)
+    cohorts = build_award_cohorts(raw, pd.DataFrame(), report_month="2026-06")
+
+    assert len(normalized.loc[0, "row_hash"]) == 64
+    assert bool(cohorts.loc[0, "recent_recorded_end"]) is False
+    assert bool(cohorts.loc[0, "approaching_recorded_end"]) is False
 
 
 def test_missing_identifiers_do_not_become_the_literal_na_token():
@@ -174,6 +276,45 @@ def test_awardee_with_several_awards_is_one_section():
     assert len(groups[0]["directed"]) == 1
 
 
+def test_direct_grouping_resolves_unique_legacy_id_against_keyed_award():
+    awards = normalize_awards(pd.DataFrame([_award()]))
+    rows = pd.DataFrame(
+        [
+            {
+                "prior_award_id": "A-1",
+                "signal_class": "directed",
+                "confidence_bucket": "HIGH",
+                "target_id": "O-1",
+                "opportunity_title": "Navigation procurement",
+            }
+        ]
+    )
+
+    groups = group_candidates_by_awardee(rows, awards)
+
+    assert len(groups) == 1
+    assert len(groups[0]["directed"]) == 1
+
+
+def test_direct_grouping_rejects_ambiguous_legacy_id():
+    awards = normalize_awards(
+        pd.DataFrame([_award(), _award(**{"Award Title": "Second effort", "Phase": "Phase I"})])
+    )
+    rows = pd.DataFrame(
+        [
+            {
+                "prior_award_id": "A-1",
+                "signal_class": "directed",
+                "confidence_bucket": "HIGH",
+                "target_id": "O-1",
+            }
+        ]
+    )
+
+    with pytest.raises(ValueError, match="unique award-grain"):
+        group_candidates_by_awardee(rows, awards)
+
+
 def test_unmatched_awardees_at_a_matched_center_are_still_listed(tmp_path):
     awards = pd.DataFrame(
         [
@@ -207,3 +348,119 @@ def test_a_matched_award_is_not_repeated_as_unmatched_elsewhere(tmp_path):
     assert "navy.md" in packets
     unmatched = [name for name, text in packets.items() if "| — no matched procurement" in text]
     assert unmatched == []
+
+
+def test_ambiguous_legacy_award_id_fails_closed(tmp_path):
+    awards = pd.DataFrame(
+        [
+            _award(),
+            _award(**{"Award Title": "Second effort", "Phase": "Phase I"}),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="legacy prior_award_id is ambiguous"):
+        _write(tmp_path, awards, _candidates(), _opportunities())
+
+
+def test_legacy_ambiguity_is_preserved_after_monthly_cohort_filter(tmp_path):
+    first = _award(**{"Proposal Award Date": "2020-01-01", "Contract End Date": "2021-01-01"})
+    second = {
+        **first,
+        "Award Title": "Second effort",
+        "Phase": "Phase I",
+    }
+    cohorts = build_award_cohorts(
+        pd.DataFrame([first, second]),
+        pd.DataFrame([first]),
+        report_month="2026-06",
+    )
+
+    assert len(cohorts) == 1
+    assert cohorts.loc[0, "public_id_award_count"] == 2
+    with pytest.raises(ValueError, match="legacy prior_award_id is ambiguous"):
+        MonthlyReportBuilder(report_month="2026-06", output_root=tmp_path).write(
+            award_cohorts=cohorts,
+            candidates=_candidates(),
+            opportunities=_opportunities(),
+        )
+
+
+def test_report_supports_safe_mixed_key_rollout(tmp_path):
+    awards = pd.DataFrame(
+        [
+            _award(),
+            _award(
+                **{
+                    "Agency Tracking Number": "A-2",
+                    "Award Title": "Radar payload",
+                    "Proposal Award Date": "2026-06-20",
+                }
+            ),
+        ]
+    )
+    cohorts = build_award_cohorts(awards, pd.DataFrame(), report_month="2026-06")
+    award_2_key = cohorts.loc[cohorts["award_id"] == "A-2", "award_key"].item()
+    candidates = pd.DataFrame(
+        [
+            _candidates().iloc[0].to_dict(),
+            {
+                **_candidates().iloc[0].to_dict(),
+                "candidate_id": "C-2",
+                "prior_award_id": "A-2",
+                "prior_award_key": award_2_key,
+                "target_id": "O-2",
+            },
+        ]
+    )
+    opportunities = pd.concat(
+        [
+            _opportunities(),
+            _opportunities().assign(notice_id="O-2", title="Radar procurement"),
+        ],
+        ignore_index=True,
+    )
+
+    output = MonthlyReportBuilder(report_month="2026-06", output_root=tmp_path).write(
+        award_cohorts=cohorts,
+        candidates=candidates,
+        opportunities=opportunities,
+    )
+    master = pd.read_csv(output / "master_candidates.csv").set_index("candidate_id")
+
+    assert master.loc["C-1", "award_title"] == "Autonomous navigation"
+    assert master.loc["C-2", "award_title"] == "Radar payload"
+
+
+def test_path_renders_the_award_that_produced_the_candidate(tmp_path):
+    awards = pd.DataFrame(
+        [
+            _award(
+                **{
+                    "Agency Tracking Number": "A-1",
+                    "Abstract": "Award A built radar calibration hardware.",
+                    "Contract End Date": "2026-07-01",
+                }
+            ),
+            _award(
+                **{
+                    "Award Title": "Navigation integration",
+                    "Abstract": "Award B built autonomous navigation software.",
+                    "Contract End Date": "2026-12-01",
+                    "Proposal Award Date": "2026-06-20",
+                }
+            ),
+        ]
+    )
+    cohorts = build_award_cohorts(awards, pd.DataFrame(), report_month="2026-06")
+    award_b_key = cohorts.loc[cohorts["title"] == "Navigation integration", "award_key"].item()
+    candidates = _candidates().assign(prior_award_key=award_b_key)
+
+    output = MonthlyReportBuilder(report_month="2026-06", output_root=tmp_path).write(
+        award_cohorts=cohorts,
+        candidates=candidates,
+        opportunities=_opportunities(),
+    )
+    packet = (output / "centers" / "navair.md").read_text()
+
+    assert "**Built on:** Award B built autonomous navigation software." in packet
+    assert "**Built on:** Award A built radar calibration hardware." not in packet


### PR DESCRIPTION
## What changed

- Adds the four-phase remediation plan covering award identity, cold-start safety, source
  normalization/provenance, and ranking orientation/auditability.
- Introduces a versioned, award-grain key built from the full stable SBIR source lineage. Public
  tracking and contract identifiers remain available for evidence, but no longer control joins,
  deduplication, or candidate identity.
- Carries `prior_award_key` through S1/S2/S3 pairing, candidate/evidence artifacts, census
  validation, enrichment, and the monthly report ledger.
- Canonicalizes multiple SBIR.gov editions of one stable award and records edition counts.
- Makes legacy rollout fail closed when a public ID is ambiguous or conflicts with an explicit
  key; safe mixed keyed/keyless ledgers remain supported.
- Resolves each rendered transition path to its actual award, so **Built on** cannot silently use
  another award held by the same firm.

## Why

The report treated Agency Tracking Number as award grain even though it is reused. Contract number
is also reused. That collapsed candidate pairs and let awardee-first rendering attach the wrong
funded technology to a solicitation. The same conflation also affected descriptive enrichment and
the Phase III census. The root fix is to separate readable public lineage identifiers from the key
used for data identity.

## Impact and rollout

- The current 219,500-row local SBIR snapshot normalizes to 219,445 unique award keys. The 54
  repeated keys are published revisions of the same stable lineage and are retained as canonical
  records with edition counts (maximum three editions).
- Pre-migration normalized snapshots fail with an actionable error. Regenerate them from raw award
  snapshots when rolling this out.
- This draft intentionally implements only Phase 1. Phase 2 must add cache-miss/bootstrap bounds
  before Phase 3 expands matching coverage; Phase 4 restores deadline-primary ordering until the
  opportunity-to-firm model is production-validated.

## Verification

- `pytest -q -m fast tests/unit`: 4,222 passed, 7 skipped.
- Focused reporting/pairing/census/model/backtest/retrospective suite: 246 passed.
- Final changed-area regression suite: 98 passed.
- MyPy: 5 changed source modules passed.
- Ruff lint/format and `git diff --check`: passed.
- Full local SBIR snapshot: 219,445 normalized awards, 219,445 unique non-null keys.

## Known baseline issue

`tests/unit/phase_iii_census/test_import_isolation.py::test_census_import_and_freeze_verification_work_in_shallow_container_layout`
fails on unchanged `main`: its shallow fixture copies `sbir_analytics` but not the already-required
`sbir_etl.utils.award_identity` module. This PR does not broaden scope to repair that pre-existing
container-fixture issue.
