### PR TITLE
Document live Mac mini deployment contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions
+
+Read [CLAUDE.md](CLAUDE.md) for the repository's project conventions, testing
+requirements, code standards, and scope rules. Those instructions apply to all
+coding agents; tool-specific agent definitions may differ by runtime.
+
+## Live deployment
+
+Before any deployment, server operation, or live Dagster materialization, read
+[the Mac mini runbook](docs/deployment/mac-mini-server.md#live-instance-on-this-mac-mini).
+
+- The only live checkout is `/Users/conradhollomon/projects/sbir-analytics-server`.
+  Never operate the live stack from the development checkout.
+- Preserve `.env.server`, `/Volumes/SSDmini/sbir-analytics`, and the Docker
+  `dagster_home` volume.
+- Ingress must remain Tailscale Serve over tailnet-only HTTPS. Never enable
+  Funnel or expose server ports to the LAN or public internet.
+- Treat materialization as a live-data mutation. Confirm the SSD is mounted,
+  the deployment checkout is clean, and the stack is healthy before running it.
+- Keep schedules disabled until their jobs have completed successfully by hand
+  with the inputs available on this host.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,15 @@ Graph-based ETL: SBIR awards → Neo4j. Dagster orchestration, DuckDB processing
 
 Architectural patterns and technical docs live in `docs/steering/`. Feature specs live in `specs/`.
 
+## Live deployment
+
+Before any deployment, server operation, or live Dagster materialization, read
+[the Mac mini runbook](docs/deployment/mac-mini-server.md#live-instance-on-this-mac-mini).
+The only live checkout is `/Users/conradhollomon/projects/sbir-analytics-server`;
+never operate the live stack from the development checkout. Preserve
+`.env.server`, `/Volumes/SSDmini/sbir-analytics`, and the Docker `dagster_home`
+volume. Ingress must remain Tailscale Serve only; never enable Funnel.
+
 ## Agents
 
 Custom agents in `.claude/agents/`:

--- a/docs/deployment/mac-mini-server.md
+++ b/docs/deployment/mac-mini-server.md
@@ -4,6 +4,48 @@ A private, always-on deployment of SBIR Analytics on a single Apple-silicon
 Mac mini. The stack is ARM64-native and reachable **only** over your Tailscale
 tailnet — there is no public DNS, no port forwarding, and no LAN exposure.
 
+## Live instance on this Mac mini
+
+This machine hosts the live SBIR Analytics deployment.
+
+- **Deployment checkout:** `/Users/conradhollomon/projects/sbir-analytics-server`
+- **Development checkout:** `/Users/conradhollomon/projects/sbir-analytics` —
+  never operate the live stack from here.
+- **Installed baseline as of 2026-08-02:** tag `0.1`, commit `054bd862`. Always
+  verify the deployment checkout with `git status --short` and
+  `git describe --tags --always --dirty`; do not infer the live version from
+  another checkout or from the image tag.
+- **Persistent application data:** `/Volumes/SSDmini/sbir-analytics`
+- **Local secrets:** `.env.server` in the deployment checkout. It is ignored,
+  mode `0600`, and must never be printed, committed, or replaced.
+- **Dagster metadata:** the Docker `dagster_home` named volume. Preserve it
+  alongside SSD data; never use `docker compose down -v`.
+- **Ingress:** Tailscale Serve over tailnet-only HTTPS. Tailscale Funnel,
+  public port exposure, and LAN exposure are prohibited.
+
+Run every `make server-*` command and shell-driven live materialization from
+the clean deployment checkout. Use the documented Make targets; do not run
+`git clean`, destructive resets, or hand-written Compose teardown commands
+there. Treat materialization as a live-data mutation: confirm the SSD is
+mounted and the stack is healthy first. Keep schedules disabled until their
+jobs have completed successfully by hand with the inputs available on this
+host.
+
+### Materialized state as of 2026-08-02
+
+- The current SBIR.gov source is
+  `/Volumes/SSDmini/sbir-analytics/data/raw/sbir/award_data.csv`, data vintage
+  `2026-08-01`, containing 219,503 award records.
+- The API serves the full-source snapshot
+  `tech_census_drone_manufacturing/2026-Q3` (2,241 in-scope awards).
+- Neo4j contains a bounded validation seed from the first 25,000 source
+  records, materialized by Dagster run
+  `70e7d2f8-2a90-453f-a2a9-ae9bd4abc9c2`. This produced 24,794 validated rows
+  and 22,566 unique `FinancialTransaction` nodes. It is not a full-universe
+  graph and must not be represented as one.
+- Broad schedules remain disabled. `sbir_weekly_refresh_job` still requires
+  SAM.gov and USAspending bulk inputs that are not installed on this host.
+
 ## What runs here
 
 The `server` Compose profile (`docker-compose.server.yml`) runs exactly five


### PR DESCRIPTION
## Summary

- add a root `AGENTS.md` entrypoint so Codex and other agents discover the live-deployment rules
- point both agent entrypoints to the canonical Mac mini runbook
- document the live checkout, release baseline, persistent storage, secrets, Dagster metadata, and Tailscale-only ingress
- record the initial materialized state and explicitly distinguish the bounded Neo4j seed from a full-universe graph

## Why

The live stack operates from a clean checkout separate from the active development checkout, but that identity was not present in tracked agent guidance. An agent could otherwise run deployment commands from the dirty development tree, replace local secrets, remove persistent volumes, enable public ingress, or overstate the completeness of the seeded graph.

## Operational state recorded

- deployed baseline: tag `0.1`, commit `054bd862`
- persistent data: `/Volumes/SSDmini/sbir-analytics`
- full-source `2026-Q3` drone-manufacturing snapshot
- bounded 25,000-record Neo4j validation seed, with broad schedules still disabled

## Validation

- `git diff --check`
- live Dagster materialization run `70e7d2f8-2a90-453f-a2a9-ae9bd4abc9c2` succeeded
- API snapshot and graph freshness endpoints verified
- all five server containers healthy after the initial Neo4j backup