### PR TITLE
Fix February mirror contract extraction

### DIFF
--- a/sbir_etl/extractors/contract_extractor.py
+++ b/sbir_etl/extractors/contract_extractor.py
@@ -133,6 +133,20 @@ FILENAME != "-" {
 }
 
 {
+    source_line++
+    record = $0
+    sub(/\r+$/, "", record)
+    if (copy_terminated) {
+        if (record != "") {
+            fail("line " source_line " contains non-empty data after COPY terminator")
+        }
+        next
+    }
+    if (record == "\\.") {
+        copy_terminated = 1
+        next
+    }
+
     scanned++
     if (scanned % 100000 == 0) {
         print progress_marker, scanned, contracts
@@ -213,6 +227,26 @@ class ArchiveSchemaError(RuntimeError):
 
 class SourceDataError(RuntimeError):
     """A serialized source row violates a fail-closed extraction invariant."""
+
+
+class _DigestingReader:
+    """Hash every serialized member byte consumed by the gzip reader."""
+
+    def __init__(self, source: object) -> None:
+        self.source = source
+        self.digest = hashlib.sha256()
+        self.bytes_read = 0
+
+    def read(self, size: int = -1) -> bytes:
+        data = self.source.read(size)  # type: ignore[attr-defined]
+        self.digest.update(data)
+        self.bytes_read += len(data)
+        return data
+
+    def seek(self, offset: int) -> object:
+        if offset != self.bytes_read:
+            raise OSError("Digesting ZIP member reader cannot seek across hashed bytes")
+        return self.source.seek(offset)  # type: ignore[attr-defined]
 
 
 @dataclass(frozen=True)
@@ -409,7 +443,7 @@ class ContractExtractor:
         }
         self._parent_ids_seen: set[str] = set()
         self._idv_parent_ids_seen: set[str] = set()
-        self.source_provenance: dict[str, str | int] = {}
+        self.source_provenance: dict[str, object] = {}
 
     def _load_vendor_filters(self, filter_file: Path | None) -> dict[str, set[str]]:
         """Load vendor filter sets from JSON file."""
@@ -666,7 +700,20 @@ class ContractExtractor:
             "business_categories",
         }
         indexes = {name: index for index, name in enumerate(columns) if name in projected_names}
+        copy_terminated = False
         for line_num, line in enumerate(lines, 1):
+            serialized = line.rstrip("\r\n")
+            if copy_terminated:
+                if serialized:
+                    raise SourceDataError(
+                        f"{source_name} line {line_num} contains non-empty data "
+                        "after COPY terminator"
+                    )
+                continue
+            if serialized == r"\.":
+                copy_terminated = True
+                continue
+
             self.stats["records_scanned"] += 1
 
             # Progress logging
@@ -676,7 +723,7 @@ class ContractExtractor:
                     f"found {self.stats['records_extracted']} contracts"
                 )
 
-            values = line.rstrip("\r\n").split("\t")
+            values = serialized.split("\t")
             if len(values) != len(columns):
                 raise SourceDataError(
                     f"{source_name} row {line_num} has {len(values)} fields; "
@@ -738,7 +785,7 @@ class ContractExtractor:
             )
 
     @staticmethod
-    def _provenance(source: TransactionSource) -> dict[str, str | int]:
+    def _provenance(source: TransactionSource) -> dict[str, object]:
         toc_sha256 = source.toc_sha256
         if (
             not isinstance(toc_sha256, str)
@@ -786,34 +833,44 @@ class ContractExtractor:
             ) from error
 
         with RemoteZip(zip_url) as remote_zip:
-            names = [info.filename for info in remote_zip.infolist()]
-            toc_members = [name for name in names if PurePosixPath(name).name == "toc.dat"]
-            if len(toc_members) != 1:
-                raise ArchiveSchemaError(
-                    f"Remote archive must contain exactly one toc.dat; found {len(toc_members)}"
-                )
-            toc_member = toc_members[0]
-            with tempfile.TemporaryDirectory(prefix="usaspending-toc-") as temp_name:
-                archive_dir = Path(temp_name) / "archive"
-                archive_dir.mkdir()
-                with (
-                    remote_zip.open(toc_member) as source_file,
-                    open(archive_dir / "toc.dat", "wb") as target_file,
-                ):
-                    shutil.copyfileobj(source_file, target_file)
-                toc_text = cls._run_pg_restore(archive_dir, "--list")
-                schema_sql = cls._run_pg_restore(archive_dir, "--schema-only", "--file=-")
-                entry, _ = _select_table_entry(toc_text, schema_sql)
-                copy_sql = cls._restore_copy_statement(archive_dir / "toc.dat", entry)
-                source = replace(
-                    _resolve_source(toc_text, schema_sql, copy_sql),
-                    toc_sha256=_file_sha256(archive_dir / "toc.dat"),
-                )
+            return cls._resolve_remote_source_from_archive(remote_zip)
 
-            member = str(PurePosixPath(toc_member).parent / source.member_name)
-            if member not in names:
-                raise ArchiveSchemaError(f"TOC selected {source.relation}, but {member} is absent")
-            return replace(source, member_name=member)
+    @classmethod
+    def _resolve_remote_source_from_archive(cls, remote_zip: object) -> TransactionSource:
+        """Resolve TOC/schema metadata from the exact archive instance later streamed."""
+
+        infos = remote_zip.infolist()  # type: ignore[attr-defined]
+        toc_infos = [info for info in infos if PurePosixPath(info.filename).name == "toc.dat"]
+        if len(toc_infos) != 1:
+            raise ArchiveSchemaError(
+                f"Remote archive must contain exactly one toc.dat; found {len(toc_infos)}"
+            )
+        toc_info = toc_infos[0]
+        with tempfile.TemporaryDirectory(prefix="usaspending-toc-") as temp_name:
+            archive_dir = Path(temp_name) / "archive"
+            archive_dir.mkdir()
+            with (
+                remote_zip.open(toc_info) as source_file,  # type: ignore[attr-defined]
+                open(archive_dir / "toc.dat", "wb") as target_file,
+            ):
+                shutil.copyfileobj(source_file, target_file)
+            toc_text = cls._run_pg_restore(archive_dir, "--list")
+            schema_sql = cls._run_pg_restore(archive_dir, "--schema-only", "--file=-")
+            entry, _ = _select_table_entry(toc_text, schema_sql)
+            copy_sql = cls._restore_copy_statement(archive_dir / "toc.dat", entry)
+            source = replace(
+                _resolve_source(toc_text, schema_sql, copy_sql),
+                toc_sha256=_file_sha256(archive_dir / "toc.dat"),
+            )
+
+        member = str(PurePosixPath(toc_info.filename).parent / source.member_name)
+        member_infos = [info for info in infos if info.filename == member]
+        if len(member_infos) != 1:
+            raise ArchiveSchemaError(
+                f"TOC selected {source.relation}, but expected exactly one {member}; "
+                f"found {len(member_infos)}"
+            )
+        return replace(source, member_name=member)
 
     def stream_dat_gz_file(
         self,
@@ -1082,39 +1139,79 @@ class ContractExtractor:
             ) from e
 
         logger.info(f"Streaming member {member_name} from {zip_url} (HTTP range)")
-        with (
-            RemoteZip(zip_url) as remote_zip,
-            remote_zip.open(member_name) as member,
+        with RemoteZip(zip_url) as remote_zip:
+            yield from self._stream_remote_archive_member(
+                remote_zip,
+                member_name,
+                columns,
+                fpds_only=fpds_only,
+            )
+
+    def _stream_remote_archive_member(
+        self,
+        remote_zip: object,
+        member_name: str,
+        columns: Sequence[str],
+        *,
+        fpds_only: bool,
+    ) -> Iterator[FederalContract]:
+        """Stream one unique ZipInfo through outer ZIP CRC, inner gzip, then parsing."""
+
+        member_infos = [
+            info
+            for info in remote_zip.infolist()  # type: ignore[attr-defined]
+            if info.filename == member_name
+        ]
+        if len(member_infos) != 1:
+            raise ArchiveSchemaError(
+                f"Remote archive must contain exactly one selected member {member_name}; "
+                f"found {len(member_infos)}"
+            )
+        member_info = member_infos[0]
+        with remote_zip.open(member_info) as member:  # type: ignore[attr-defined]
+            digesting_member = _DigestingReader(member)
             # `member` yields the gzip-compressed .dat.gz bytes; decompress streaming.
-            gzip.GzipFile(fileobj=member) as gz,
-        ):
-            awk_path = self._awk_prefilter_path()
-            if awk_path is None:
-                with io.TextIOWrapper(gz, encoding="utf-8", errors="replace") as text:
+            with gzip.GzipFile(fileobj=digesting_member) as gz:
+                awk_path = self._awk_prefilter_path()
+                if awk_path is None:
+                    with io.TextIOWrapper(gz, encoding="utf-8", errors="replace") as text:
+                        yield from self._parse_lines(
+                            text,
+                            member_name,
+                            columns,
+                            fpds_only=fpds_only,
+                        )
+                else:
+                    logger.info(
+                        f"Prefiltering {member_name} with {awk_path}; "
+                        "Python will revalidate every emitted vendor candidate"
+                    )
+                    candidates = self._awk_prefilter_lines(
+                        gz,
+                        member_name,
+                        columns,
+                        fpds_only=fpds_only,
+                        awk_path=awk_path,
+                    )
                     yield from self._parse_lines(
-                        text,
+                        candidates,
                         member_name,
                         columns,
                         fpds_only=fpds_only,
                     )
-            else:
-                logger.info(
-                    f"Prefiltering {member_name} with {awk_path}; "
-                    "Python will revalidate every emitted vendor candidate"
+
+            # Successful parsing must consume the selected ZipExtFile to EOF.
+            # That final read makes stdlib zipfile compare its full CRC32 rather
+            # than treating close() as proof of integrity.
+            while digesting_member.read(1024 * 1024):
+                pass
+            member_size = int(member_info.file_size)
+            if digesting_member.bytes_read != member_size or member.tell() != member_size:
+                raise SourceDataError(
+                    f"Selected ZIP member {member_name} did not reach its verified EOF"
                 )
-                candidates = self._awk_prefilter_lines(
-                    gz,
-                    member_name,
-                    columns,
-                    fpds_only=fpds_only,
-                    awk_path=awk_path,
-                )
-                yield from self._parse_lines(
-                    candidates,
-                    member_name,
-                    columns,
-                    fpds_only=fpds_only,
-                )
+            self.source_provenance["member_sha256"] = digesting_member.digest.hexdigest()
+
         logger.info(
             f"Completed streaming {member_name}: "
             f"{self.stats['records_extracted']} contracts extracted"
@@ -1162,6 +1259,9 @@ class ContractExtractor:
         zip_url: str,
         member_name: str | None,
         output_file: Path,
+        *,
+        parallel_range: bool = False,
+        replica_urls: Sequence[str] = (),
     ) -> int:
         """Extract SBIR-relevant contracts by streaming one member from a remote zip.
 
@@ -1176,22 +1276,75 @@ class ContractExtractor:
         Returns:
             Number of contracts extracted.
         """
-        source = self._resolve_remote_source(zip_url)
-        self.source_provenance = self._provenance(source)
-        if member_name is not None and member_name != source.member_name:
-            raise ArchiveSchemaError(
-                f"Requested member {member_name!r} does not match TOC-selected "
-                f"member {source.member_name!r}"
+        if replica_urls and not parallel_range:
+            raise ValueError("Explicit remote ZIP replicas require parallel_range=True")
+        if not parallel_range:
+            source = self._resolve_remote_source(zip_url)
+            self.source_provenance = self._provenance(source)
+            if member_name is not None and member_name != source.member_name:
+                raise ArchiveSchemaError(
+                    f"Requested member {member_name!r} does not match TOC-selected "
+                    f"member {source.member_name!r}"
+                )
+            return self._collect_and_write(
+                self.stream_remote_zip_member(
+                    zip_url,
+                    source.member_name,
+                    source.columns,
+                    fpds_only=source.fpds_only,
+                ),
+                Path(output_file),
             )
-        return self._collect_and_write(
-            self.stream_remote_zip_member(
-                zip_url,
+
+        from sbir_etl.extractors.parallel_range_reader import ValidatedParallelRemoteZip
+
+        with ValidatedParallelRemoteZip(zip_url, replica_urls) as remote_zip:
+            source = self._resolve_remote_source_from_archive(remote_zip)
+            self.source_provenance = self._provenance(source)
+            if member_name is not None and member_name != source.member_name:
+                raise ArchiveSchemaError(
+                    f"Requested member {member_name!r} does not match TOC-selected "
+                    f"member {source.member_name!r}"
+                )
+            member_infos = [
+                info for info in remote_zip.infolist() if info.filename == source.member_name
+            ]
+            if len(member_infos) != 1:  # pragma: no cover - resolver invariant
+                raise ArchiveSchemaError(
+                    f"Expected one selected member {source.member_name}; found {len(member_infos)}"
+                )
+            member_info = member_infos[0]
+            self.source_provenance.update(
+                {
+                    "archive_url": remote_zip.range_file.canonical_url,
+                    "archive_replica_urls": list(remote_zip.range_file.replica_urls),
+                    "archive_etag": remote_zip.identity.etag,
+                    "archive_total_bytes": remote_zip.identity.total_bytes,
+                    "member_crc32": f"{member_info.CRC:08x}",
+                    "member_compressed_bytes": member_info.compress_size,
+                    "member_uncompressed_bytes": member_info.file_size,
+                    "range_chunk_bytes": remote_zip.range_file.chunk_size,
+                    "range_workers": remote_zip.range_file.workers,
+                }
+            )
+            remote_zip.enable_parallel_prefetch()
+            contracts = self._stream_remote_archive_member(
+                remote_zip,
                 source.member_name,
                 source.columns,
                 fpds_only=source.fpds_only,
-            ),
-            Path(output_file),
-        )
+            )
+
+            def verified_contracts() -> Iterator[FederalContract]:
+                yield from contracts
+                # Run before iterator exhaustion so _collect_and_write cannot
+                # atomically publish output while a scheduled range is invalid.
+                remote_zip.range_file.validate_pending()
+
+            return self._collect_and_write(
+                verified_contracts(),
+                Path(output_file),
+            )
 
     def _collect_and_write(
         self,

--- a/sbir_etl/extractors/parallel_range_reader.py
+++ b/sbir_etl/extractors/parallel_range_reader.py
@@ -1,0 +1,587 @@
+"""Bounded, identity-checked parallel HTTP ranges for remote ZIP archives."""
+
+import io
+import re
+import threading
+import zipfile
+from collections.abc import Callable, Mapping, Sequence
+from concurrent.futures import CancelledError, Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+
+DEFAULT_CHUNK_SIZE = 32 * 1024 * 1024
+DEFAULT_WORKERS = 4
+DEFAULT_ATTEMPTS = 3
+_TRANSIENT_HTTP_STATUSES = frozenset({408, 425, 429, 500, 502, 503, 504})
+_CONTENT_RANGE_RE = re.compile(r"bytes\s+(\d+)-(\d+)/(\d+)", re.IGNORECASE)
+
+
+class ParallelRangeError(OSError):
+    """A remote archive cannot be read without weakening an integrity invariant."""
+
+
+class ParallelRangeTransportError(ParallelRangeError):
+    """A transient request failure that may be retried for the exact same range."""
+
+
+class ParallelRangeValidationError(ParallelRangeError):
+    """A response does not prove that it contains the requested archive bytes."""
+
+
+@dataclass(frozen=True)
+class RemoteArchiveIdentity:
+    """Strong identity shared by the canonical URL and every explicit replica."""
+
+    etag: str
+    total_bytes: int
+
+
+class ValidatedParallelRangeFile(io.IOBase):
+    """Seekable HTTP range file with one bounded foreground/prefetch window.
+
+    The canonical URL is always probed. Explicit replicas are eligible for data
+    requests only after a one-byte response proves the same strong ETag and total
+    byte length. Metadata reads use a one-chunk window; callers explicitly enable
+    parallel lookahead only when beginning the selected large member.
+    """
+
+    def __init__(
+        self,
+        canonical_url: str,
+        replica_urls: Sequence[str] = (),
+        *,
+        _chunk_size: int = DEFAULT_CHUNK_SIZE,
+        _workers: int = DEFAULT_WORKERS,
+        _attempts: int = DEFAULT_ATTEMPTS,
+        _retry_backoff_seconds: float = 0.25,
+        _requester: Callable[[str, Mapping[str, str]], Any] | None = None,
+    ) -> None:
+        super().__init__()
+        if _chunk_size <= 0:
+            raise ValueError("chunk size must be greater than zero")
+        if not 1 <= _workers <= 4:
+            raise ValueError("parallel range workers must be between one and four")
+        if _attempts <= 0:
+            raise ValueError("range request attempts must be greater than zero")
+
+        self._canonical_url = self._validated_url(canonical_url)
+        replicas = tuple(self._validated_url(url) for url in replica_urls)
+        self._replica_urls = tuple(
+            url for index, url in enumerate(replicas) if url not in replicas[:index]
+        )
+        self._chunk_size = _chunk_size
+        self._workers = _workers
+        self._attempts = _attempts
+        self._retry_backoff_seconds = _retry_backoff_seconds
+        self._requester = requester = _requester or self._request_http
+        self._sessions: list[Any] = []
+        self._sessions_lock = threading.Lock()
+        self._thread_state = threading.local()
+        self._executor: ThreadPoolExecutor | None = None
+        self._pending: dict[int, Future[bytes]] = {}
+        self._cache: dict[int, bytes] = {}
+        self._fatal_error: ParallelRangeError | None = None
+        self._fatal_error_lock = threading.Lock()
+        self._cancel_event = threading.Event()
+        self._active_responses: dict[int, Any] = {}
+        self._active_responses_lock = threading.Lock()
+        self._position = 0
+        self._prefetch_enabled = False
+        self._peak_payload_slots = 0
+
+        try:
+            canonical_byte, identity = self._fetch_once(
+                self._canonical_url,
+                0,
+                0,
+                expected_identity=None,
+                requester=requester,
+            )
+            for replica_url in self._replica_urls:
+                replica_byte, _ = self._fetch_once(
+                    replica_url,
+                    0,
+                    0,
+                    expected_identity=identity,
+                    requester=requester,
+                )
+                if replica_byte != canonical_byte:
+                    raise ParallelRangeValidationError(
+                        "Replica probe byte differs from the canonical archive"
+                    )
+        except BaseException:
+            self._close_sessions()
+            raise
+
+        self.identity = identity
+        # Explicit replicas are the requested data plane; the direct canonical
+        # endpoint remains the identity anchor.
+        self._data_urls = self._replica_urls or (self._canonical_url,)
+        self._chunk_count = (identity.total_bytes + _chunk_size - 1) // _chunk_size
+        self._executor = ThreadPoolExecutor(
+            max_workers=_workers,
+            thread_name_prefix="validated-range",
+        )
+
+    @staticmethod
+    def _validated_url(url: str) -> str:
+        parsed = urlsplit(url)
+        if (
+            parsed.scheme != "https"
+            or not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.fragment
+        ):
+            raise ValueError("parallel range URLs must be credential-free https URLs")
+        return url
+
+    @property
+    def canonical_url(self) -> str:
+        return self._canonical_url
+
+    @property
+    def replica_urls(self) -> tuple[str, ...]:
+        return self._replica_urls
+
+    @property
+    def chunk_size(self) -> int:
+        return self._chunk_size
+
+    @property
+    def workers(self) -> int:
+        return self._workers
+
+    @property
+    def peak_payload_slots(self) -> int:
+        """Largest active/completed/cache payload window observed (for audits/tests)."""
+
+        return self._peak_payload_slots
+
+    def enable_parallel_prefetch(self) -> None:
+        """Enable bounded lookahead after archive metadata selects the large member."""
+
+        self._checkClosed()
+        self._prefetch_enabled = True
+
+    def _session_for_thread(self) -> Any:
+        session = getattr(self._thread_state, "session", None)
+        if session is None:
+            import requests
+
+            session = requests.Session()
+            self._thread_state.session = session
+            with self._sessions_lock:
+                self._sessions.append(session)
+        return session
+
+    def _request_http(self, url: str, headers: Mapping[str, str]) -> Any:
+        """Issue one non-redirecting raw response; validation reads the bounded body."""
+
+        if self._cancel_event.is_set():
+            raise ParallelRangeTransportError("Parallel range reader is closing")
+        session = self._session_for_thread()
+        if self._cancel_event.is_set():
+            session.close()
+            raise ParallelRangeTransportError("Parallel range reader is closing")
+        try:
+            return session.get(
+                url,
+                headers=dict(headers),
+                stream=True,
+                allow_redirects=False,
+                timeout=(30, 180),
+            )
+        except Exception as error:
+            raise ParallelRangeTransportError(f"HTTP range request failed: {error}") from error
+
+    @staticmethod
+    def _normalized_headers(response: Any) -> dict[str, str]:
+        try:
+            return {str(key).lower(): str(value).strip() for key, value in response.headers.items()}
+        except Exception as error:
+            raise ParallelRangeValidationError("Range response has unreadable headers") from error
+
+    def _fetch_once(
+        self,
+        url: str,
+        start: int,
+        end: int,
+        *,
+        expected_identity: RemoteArchiveIdentity | None,
+        requester: Callable[[str, Mapping[str, str]], Any],
+    ) -> tuple[bytes, RemoteArchiveIdentity]:
+        headers = {
+            "Accept-Encoding": "identity",
+            "Range": f"bytes={start}-{end}",
+            "User-Agent": "sbir-analytics-validated-range/1",
+        }
+        if expected_identity is not None:
+            headers["If-Match"] = expected_identity.etag
+
+        try:
+            response = requester(url, headers)
+        except ParallelRangeError:
+            raise
+        except Exception as error:
+            raise ParallelRangeTransportError(f"HTTP range request failed: {error}") from error
+
+        with self._active_responses_lock:
+            cancelled = self._cancel_event.is_set()
+            if not cancelled:
+                self._active_responses[id(response)] = response
+        if cancelled:
+            try:
+                response.close()
+            except Exception:
+                pass
+            raise ParallelRangeTransportError("Parallel range reader closed during request")
+
+        try:
+            status = int(response.status_code)
+            if status in _TRANSIENT_HTTP_STATUSES:
+                raise ParallelRangeTransportError(
+                    f"Range endpoint returned transient HTTP {status}"
+                )
+            if status == 412:
+                raise ParallelRangeValidationError("Range endpoint rejected the archive If-Match")
+            if status != 206:
+                raise ParallelRangeValidationError(
+                    f"Range endpoint returned HTTP {status}; exact 206 required"
+                )
+
+            response_headers = self._normalized_headers(response)
+            content_encoding = response_headers.get("content-encoding", "identity").lower()
+            if content_encoding != "identity":
+                raise ParallelRangeValidationError(
+                    f"Range endpoint used forbidden Content-Encoding {content_encoding!r}"
+                )
+
+            content_range = response_headers.get("content-range", "")
+            match = _CONTENT_RANGE_RE.fullmatch(content_range)
+            if match is None:
+                raise ParallelRangeValidationError("Range response has invalid Content-Range")
+            actual_start, actual_end, total_bytes = (int(value) for value in match.groups())
+            if (actual_start, actual_end) != (start, end):
+                raise ParallelRangeValidationError(
+                    "Range response Content-Range does not match the exact requested bytes"
+                )
+            if total_bytes <= end:
+                raise ParallelRangeValidationError("Range response has an invalid total byte size")
+
+            etag = response_headers.get("etag", "")
+            if len(etag) < 2 or not etag.startswith('"') or not etag.endswith('"'):
+                raise ParallelRangeValidationError("Range response has no strong quoted ETag")
+            if etag[:2].lower() == "w/":
+                raise ParallelRangeValidationError("Weak ETags cannot identify a remote archive")
+
+            identity = RemoteArchiveIdentity(etag=etag, total_bytes=total_bytes)
+            if expected_identity is not None and identity != expected_identity:
+                raise ParallelRangeValidationError(
+                    "Range response archive identity differs from the canonical source"
+                )
+
+            expected_bytes = end - start + 1
+            content_length = response_headers.get("content-length", "")
+            if not content_length.isdigit() or int(content_length) != expected_bytes:
+                raise ParallelRangeValidationError(
+                    "Range response Content-Length does not match the requested bytes"
+                )
+
+            raw = response.raw
+            if hasattr(raw, "decode_content"):
+                raw.decode_content = False
+            try:
+                body = raw.read(expected_bytes + 1, decode_content=False)
+            except TypeError:
+                # Minimal response doubles may implement only ``read(size)``.
+                body = raw.read(expected_bytes + 1)
+            except Exception as error:
+                raise ParallelRangeTransportError(
+                    f"Range response body terminated while reading: {error}"
+                ) from error
+            if not isinstance(body, bytes):
+                body = bytes(body)
+            if len(body) < expected_bytes:
+                raise ParallelRangeTransportError(
+                    f"Range response was truncated: expected {expected_bytes}, got {len(body)}"
+                )
+            if len(body) != expected_bytes:
+                raise ParallelRangeValidationError(
+                    "Range response exceeded its declared byte range"
+                )
+            return body, identity
+        finally:
+            try:
+                response.close()
+            except Exception:
+                pass
+            finally:
+                with self._active_responses_lock:
+                    self._active_responses.pop(id(response), None)
+
+    def _fetch_chunk(self, chunk_index: int) -> bytes:
+        start = chunk_index * self._chunk_size
+        end = min(self.identity.total_bytes, start + self._chunk_size) - 1
+        transport_errors: list[str] = []
+        for attempt in range(self._attempts):
+            if self._cancel_event.is_set():
+                raise ParallelRangeTransportError("Parallel range reader is closing")
+            url = self._data_urls[(chunk_index + attempt) % len(self._data_urls)]
+            try:
+                body, _ = self._fetch_once(
+                    url,
+                    start,
+                    end,
+                    expected_identity=self.identity,
+                    requester=self._requester,
+                )
+                return body
+            except ParallelRangeValidationError:
+                # Identity/header violations poison this run; mixing in another
+                # endpoint after one cannot prove the same object is not allowed.
+                raise
+            except ParallelRangeTransportError as error:
+                transport_errors.append(f"{url}: {error}")
+                if attempt + 1 < self._attempts and self._retry_backoff_seconds:
+                    if self._cancel_event.wait(self._retry_backoff_seconds * (2**attempt)):
+                        raise ParallelRangeTransportError(
+                            "Parallel range reader closed during retry backoff"
+                        ) from error
+        detail = "; ".join(transport_errors)
+        raise ParallelRangeTransportError(
+            f"Exact range {start}-{end} failed after {self._attempts} attempts: {detail}"
+        )
+
+    def _payload_slots(self) -> int:
+        # A Future is one payload slot whether its worker is active or its result
+        # is complete. Moving the same bytes object into cache never adds a slot.
+        return len(self._pending) + len(self._cache)
+
+    def _remember_future_error(self, future: Future[bytes]) -> None:
+        """Make every scheduled range failure terminal, including stale lookahead."""
+
+        try:
+            error = future.exception()
+        except CancelledError:
+            return
+        if not isinstance(error, ParallelRangeError):
+            return
+        self._remember_error(error)
+
+    def _remember_error(self, error: ParallelRangeError) -> None:
+        with self._fatal_error_lock:
+            if self._fatal_error is None:
+                self._fatal_error = error
+
+    def _raise_fatal_error(self) -> None:
+        with self._fatal_error_lock:
+            error = self._fatal_error
+        if error is not None:
+            raise error
+
+    def _observe_slots(self) -> None:
+        self._peak_payload_slots = max(self._peak_payload_slots, self._payload_slots())
+        if self._payload_slots() > self._workers:  # pragma: no cover - invariant guard
+            raise ParallelRangeError("Parallel range payload window exceeded its worker bound")
+
+    def _desired_chunks(self, current_index: int) -> tuple[int, ...]:
+        width = self._workers if self._prefetch_enabled else 1
+        return tuple(range(current_index, min(self._chunk_count, current_index + width)))
+
+    def _drop_stale(self, desired: set[int]) -> None:
+        for chunk_index in tuple(self._cache):
+            if chunk_index not in desired:
+                self._cache.pop(chunk_index)
+        for chunk_index, future in tuple(self._pending.items()):
+            if chunk_index in desired:
+                continue
+            if future.cancel():
+                self._pending.pop(chunk_index)
+                continue
+            # A running stale request still owns a payload slot. Wait for it and
+            # discard it before scheduling the new seek target, preserving the
+            # one-window memory bound and preventing stale lookahead starvation.
+            self._pending.pop(chunk_index)
+            try:
+                future.result()
+            except ParallelRangeError as error:
+                self._remember_error(error)
+        self._observe_slots()
+        self._raise_fatal_error()
+
+    def _schedule_window(self, current_index: int) -> None:
+        self._raise_fatal_error()
+        desired = self._desired_chunks(current_index)
+        desired_set = set(desired)
+        self._drop_stale(desired_set)
+        executor = self._executor
+        if executor is None:  # pragma: no cover - closed-object guard
+            raise ValueError("I/O operation on closed parallel range file")
+        for chunk_index in desired:
+            if chunk_index in self._cache or chunk_index in self._pending:
+                continue
+            if self._payload_slots() >= self._workers:  # pragma: no cover - invariant guard
+                raise ParallelRangeError("No bounded payload slot available for requested chunk")
+            future = executor.submit(self._fetch_chunk, chunk_index)
+            self._pending[chunk_index] = future
+            future.add_done_callback(self._remember_future_error)
+            self._observe_slots()
+
+    def _chunk(self, chunk_index: int) -> bytes:
+        self._schedule_window(chunk_index)
+        if chunk_index in self._cache:
+            return self._cache[chunk_index]
+        future = self._pending.pop(chunk_index)
+        try:
+            payload = future.result()
+        except BaseException:
+            self._drop_stale(set())
+            raise
+        self._cache[chunk_index] = payload
+        self._observe_slots()
+        return payload
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def tell(self) -> int:
+        self._checkClosed()
+        self._raise_fatal_error()
+        return self._position
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        self._checkClosed()
+        self._raise_fatal_error()
+        if whence == io.SEEK_SET:
+            position = offset
+        elif whence == io.SEEK_CUR:
+            position = self._position + offset
+        elif whence == io.SEEK_END:
+            position = self.identity.total_bytes + offset
+        else:
+            raise ValueError(f"Unsupported seek mode: {whence}")
+        if position < 0:
+            raise ValueError("Negative seek position")
+        self._position = position
+        if position < self.identity.total_bytes:
+            self._drop_stale(set(self._desired_chunks(position // self._chunk_size)))
+        else:
+            self._drop_stale(set())
+        return position
+
+    def read(self, size: int = -1) -> bytes:
+        self._checkClosed()
+        self._raise_fatal_error()
+        if size == 0 or self._position >= self.identity.total_bytes:
+            return b""
+        if size is None or size < 0:
+            size = self.identity.total_bytes - self._position
+        end_position = min(self.identity.total_bytes, self._position + size)
+        cursor = self._position
+        pieces: list[bytes] = []
+        while cursor < end_position:
+            chunk_index = cursor // self._chunk_size
+            chunk = self._chunk(chunk_index)
+            chunk_offset = cursor - (chunk_index * self._chunk_size)
+            piece_size = min(end_position - cursor, len(chunk) - chunk_offset)
+            if piece_size <= 0:  # pragma: no cover - validated response invariant
+                raise ParallelRangeError("Validated range chunk cannot satisfy requested position")
+            pieces.append(chunk[chunk_offset : chunk_offset + piece_size])
+            cursor += piece_size
+        self._position = end_position
+        if self._position < self.identity.total_bytes:
+            self._schedule_window(self._position // self._chunk_size)
+        else:
+            self._drop_stale(set())
+        return b"".join(pieces)
+
+    def readinto(self, buffer: Any) -> int:
+        data = self.read(len(buffer))
+        buffer[: len(data)] = data
+        return len(data)
+
+    def validate_pending(self) -> None:
+        """Wait for every scheduled payload and surface any prefetch failure."""
+
+        self._checkClosed()
+        for future in tuple(self._pending.values()):
+            try:
+                future.result()
+            except ParallelRangeError as error:
+                self._remember_error(error)
+        self._raise_fatal_error()
+
+    def _close_sessions(self) -> None:
+        with self._sessions_lock:
+            sessions, self._sessions = self._sessions, []
+        for session in sessions:
+            try:
+                session.close()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        self._cancel_event.set()
+        with self._active_responses_lock:
+            active_responses = tuple(self._active_responses.values())
+        for response in active_responses:
+            try:
+                response.close()
+            except Exception:
+                pass
+        # Closing sessions before waiting on workers interrupts active sockets
+        # instead of allowing shutdown to inherit the full request read timeout.
+        self._close_sessions()
+        executor, self._executor = self._executor, None
+        if executor is not None:
+            for future in self._pending.values():
+                future.cancel()
+            executor.shutdown(wait=True, cancel_futures=True)
+        self._pending.clear()
+        self._cache.clear()
+        super().close()
+
+
+class ValidatedParallelRemoteZip(zipfile.ZipFile):
+    """A ``ZipFile`` backed by :class:`ValidatedParallelRangeFile`."""
+
+    def __init__(
+        self,
+        canonical_url: str,
+        replica_urls: Sequence[str] = (),
+        *,
+        _range_file_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        self.range_file = ValidatedParallelRangeFile(
+            canonical_url,
+            replica_urls,
+            **dict(_range_file_kwargs or {}),
+        )
+        try:
+            super().__init__(self.range_file, mode="r")
+        except BaseException:
+            self.range_file.close()
+            raise
+
+    @property
+    def identity(self) -> RemoteArchiveIdentity:
+        return self.range_file.identity
+
+    def enable_parallel_prefetch(self) -> None:
+        self.range_file.enable_parallel_prefetch()
+
+    def close(self) -> None:
+        try:
+            super().close()
+        finally:
+            range_file = getattr(self, "range_file", None)
+            if range_file is not None:
+                range_file.close()

--- a/scripts/archive/extract_federal_contracts.py
+++ b/scripts/archive/extract_federal_contracts.py
@@ -25,6 +25,7 @@ import json
 from collections.abc import Mapping
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from loguru import logger
 
@@ -44,6 +45,19 @@ SOURCE_PROVENANCE_KEYS = frozenset(
         "vendor_filter_sha256",
         "output_sha256",
         "provenance_version",
+    }
+)
+PARALLEL_SOURCE_PROVENANCE_KEYS = frozenset(
+    {
+        "archive_url",
+        "archive_replica_urls",
+        "archive_etag",
+        "archive_total_bytes",
+        "member_crc32",
+        "member_compressed_bytes",
+        "member_uncompressed_bytes",
+        "range_chunk_bytes",
+        "range_workers",
     }
 )
 
@@ -66,6 +80,23 @@ def _valid_sha256(value: object) -> bool:
     )
 
 
+def _valid_positive_int(value: object) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def _valid_https_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlsplit(value)
+    return bool(
+        parsed.scheme == "https"
+        and parsed.hostname
+        and parsed.username is None
+        and parsed.password is None
+        and not parsed.fragment
+    )
+
+
 def write_contract_provenance_checks(
     *,
     extractor: ContractExtractor,
@@ -73,7 +104,7 @@ def write_contract_provenance_checks(
     vendor_filter_file: Path,
     expected_vendor_filter_sha256: str,
     total_rows: int,
-    source: Mapping[str, str],
+    source: Mapping[str, object],
 ) -> Path:
     """Atomically bind an extracted parquet to its verified source inputs."""
 
@@ -117,6 +148,55 @@ def write_contract_provenance_checks(
     ):
         if not _valid_sha256(provenance.get(key)):
             raise RuntimeError(f"Verified contract provenance has an invalid {key}")
+    member_sha256 = provenance.get("member_sha256")
+    if member_sha256 is not None and not _valid_sha256(member_sha256):
+        raise RuntimeError("Verified contract provenance has an invalid member_sha256")
+
+    parallel_fields = PARALLEL_SOURCE_PROVENANCE_KEYS.intersection(provenance)
+    if parallel_fields:
+        required_parallel = PARALLEL_SOURCE_PROVENANCE_KEYS | {"member_sha256"}
+        if missing_parallel := sorted(required_parallel - set(provenance)):
+            raise RuntimeError(
+                f"Verified parallel-range provenance is missing fields: {missing_parallel}"
+            )
+        archive_etag = provenance["archive_etag"]
+        if (
+            not isinstance(archive_etag, str)
+            or not archive_etag.startswith('"')
+            or not archive_etag.endswith('"')
+            or archive_etag.lower().startswith("w/")
+        ):
+            raise RuntimeError("Verified parallel-range provenance has an invalid archive ETag")
+        positive_int_fields = (
+            "archive_total_bytes",
+            "member_uncompressed_bytes",
+            "range_chunk_bytes",
+        )
+        if any(not _valid_positive_int(provenance[field]) for field in positive_int_fields):
+            raise RuntimeError("Verified parallel-range provenance has an invalid byte size")
+        compressed_bytes = provenance["member_compressed_bytes"]
+        if (
+            not isinstance(compressed_bytes, int)
+            or isinstance(compressed_bytes, bool)
+            or compressed_bytes < 0
+        ):
+            raise RuntimeError("Verified parallel-range provenance has an invalid member size")
+        workers = provenance["range_workers"]
+        if not isinstance(workers, int) or isinstance(workers, bool) or not 1 <= workers <= 4:
+            raise RuntimeError("Verified parallel-range provenance has an invalid worker count")
+        member_crc32 = provenance["member_crc32"]
+        if (
+            not isinstance(member_crc32, str)
+            or len(member_crc32) != 8
+            or any(character not in "0123456789abcdef" for character in member_crc32.lower())
+        ):
+            raise RuntimeError("Verified parallel-range provenance has an invalid member CRC32")
+        archive_url = provenance["archive_url"]
+        replicas = provenance["archive_replica_urls"]
+        if not _valid_https_url(archive_url):
+            raise RuntimeError("Verified parallel-range provenance has an invalid archive URL")
+        if not isinstance(replicas, list) or any(not _valid_https_url(url) for url in replicas):
+            raise RuntimeError("Verified parallel-range provenance has invalid replica URLs")
 
     checks_path = output_file.with_suffix(".checks.json")
     checks = {
@@ -172,8 +252,31 @@ def main():
             "a mismatch fails closed."
         ),
     )
+    parser.add_argument(
+        "--parallel-range",
+        action="store_true",
+        help=(
+            "Read the selected remote ZIP member through four bounded, fully validated "
+            "parallel HTTP ranges. Archive metadata and payload share one strong ETag identity."
+        ),
+    )
+    parser.add_argument(
+        "--parallel-range-replica",
+        action="append",
+        default=[],
+        metavar="HTTPS_URL",
+        help=(
+            "Explicit byte-identical replica used by --parallel-range after its strong ETag "
+            "and total size match --remote-zip. Repeat for multiple replicas; URLs are never "
+            "derived heuristically."
+        ),
+    )
 
     args = parser.parse_args()
+    if args.parallel_range and not args.remote_zip:
+        parser.error("--parallel-range requires --remote-zip")
+    if args.parallel_range_replica and not args.parallel_range:
+        parser.error("--parallel-range-replica requires --parallel-range")
 
     # Load configuration for default paths
     config = get_config()
@@ -201,6 +304,8 @@ def main():
                 zip_url=args.remote_zip,
                 member_name=args.member,
                 output_file=output_file,
+                parallel_range=args.parallel_range,
+                replica_urls=args.parallel_range_replica,
             )
             checks_path = write_contract_provenance_checks(
                 extractor=extractor,
@@ -208,7 +313,11 @@ def main():
                 vendor_filter_file=vendor_filter_file,
                 expected_vendor_filter_sha256=vendor_filter_sha256,
                 total_rows=num_contracts,
-                source={"remote_zip": args.remote_zip},
+                source={
+                    "remote_zip": args.remote_zip,
+                    "parallel_range": args.parallel_range,
+                    "parallel_range_replicas": args.parallel_range_replica,
+                },
             )
             logger.success(f"Extraction complete! {num_contracts:,} contracts extracted")
             logger.success(f"Provenance checks saved to {checks_path}")

--- a/tests/unit/extractors/test_contract_extractor_schema.py
+++ b/tests/unit/extractors/test_contract_extractor_schema.py
@@ -215,6 +215,26 @@ def test_row_width_must_match_copy_list() -> None:
         list(extractor._parse_lines(["too\tshort"], "bad.dat.gz", COLUMNS, fpds_only=True))
 
 
+def test_named_parser_accepts_exact_copy_trailer_without_counting_it() -> None:
+    extractor = ContractExtractor()
+    lines = [_line(_row()), "\\.\n", "\n", "\n"]
+
+    contracts = list(extractor._parse_lines(lines, "fixture.dat.gz", COLUMNS, fpds_only=True))
+
+    assert len(contracts) == 1
+    assert extractor.stats["records_scanned"] == 1
+
+
+def test_named_parser_rejects_nonempty_data_after_copy_terminator() -> None:
+    extractor = ContractExtractor()
+    lines = [_line(_row()), "\\.\n", _line(_row(transaction_unique_id="TX-2"))]
+
+    with pytest.raises(SourceDataError, match="non-empty data after COPY terminator"):
+        list(extractor._parse_lines(lines, "fixture.dat.gz", COLUMNS, fpds_only=True))
+
+    assert extractor.stats["records_scanned"] == 1
+
+
 def test_matched_row_requires_both_stable_keys() -> None:
     extractor = ContractExtractor()
     with pytest.raises(SourceDataError, match="transaction_unique_id"):

--- a/tests/unit/extractors/test_contract_extractor_streaming.py
+++ b/tests/unit/extractors/test_contract_extractor_streaming.py
@@ -58,8 +58,9 @@ def _fake_remotezip_module(members: Mapping[str, bytes]) -> types.ModuleType:
         def infolist(self) -> list[_Info]:
             return [_Info(name) for name in members]
 
-        def open(self, member_name: str) -> io.BytesIO:
-            return io.BytesIO(members[member_name])
+        def open(self, member_name: str | _Info) -> io.BytesIO:
+            name = member_name if isinstance(member_name, str) else member_name.filename
+            return io.BytesIO(members[name])
 
     module.RemoteZip = _FakeRemoteZip  # type: ignore[attr-defined]
     return module
@@ -146,11 +147,12 @@ def test_stream_remote_zip_member_streams_verified_named_rows(
 ) -> None:
     member_name = "archive/9247.dat.gz"
     payload = _row_text([sample_contract_row_full], contract_copy_columns).encode()
+    compressed_payload = gzip.compress(payload)
     extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
 
     with patch.dict(
         sys.modules,
-        {"remotezip": _fake_remotezip_module({member_name: gzip.compress(payload)})},
+        {"remotezip": _fake_remotezip_module({member_name: compressed_payload})},
     ):
         contracts = list(
             extractor.stream_remote_zip_member(
@@ -163,6 +165,10 @@ def test_stream_remote_zip_member_streams_verified_named_rows(
 
     assert [contract.contract_id for contract in contracts] == ["SPE4A924D0001"]
     assert contracts[0].vendor_uei == "ABC123456789"  # pragma: allowlist secret
+    assert (
+        extractor.source_provenance["member_sha256"]
+        == hashlib.sha256(compressed_payload).hexdigest()
+    )
 
 
 def test_remote_awk_prefilter_preserves_full_scan_statistics(
@@ -290,6 +296,62 @@ def test_remote_awk_prefilter_fails_closed_on_malformed_row(
     assert extractor.stats["contracts_found"] == 1
 
 
+def test_remote_awk_prefilter_accepts_exact_copy_trailer_without_counting_it(
+    sample_vendor_filters,
+    sample_contract_row_full,
+    contract_copy_columns,
+) -> None:
+    member_name = "archive/9247.dat.gz"
+    row = _row_text([sample_contract_row_full], contract_copy_columns)
+    payload = f"{row}\n\\.\n\n\n".encode()
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+
+    with patch.dict(
+        sys.modules,
+        {"remotezip": _fake_remotezip_module({member_name: gzip.compress(payload)})},
+    ):
+        contracts = list(
+            extractor.stream_remote_zip_member(
+                "https://example.test/archive.zip",
+                member_name,
+                contract_copy_columns,
+                fpds_only=True,
+            )
+        )
+
+    assert len(contracts) == 1
+    assert extractor.stats["records_scanned"] == 1
+
+
+def test_remote_awk_prefilter_rejects_nonempty_data_after_copy_terminator(
+    sample_vendor_filters,
+    sample_contract_row_full,
+    contract_copy_columns,
+) -> None:
+    member_name = "archive/9247.dat.gz"
+    row = _row_text([sample_contract_row_full], contract_copy_columns)
+    payload = f"{row}\n\\.\n{row}\n".encode()
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+
+    with (
+        patch.dict(
+            sys.modules,
+            {"remotezip": _fake_remotezip_module({member_name: gzip.compress(payload)})},
+        ),
+        pytest.raises(SourceDataError, match="non-empty data after COPY terminator"),
+    ):
+        list(
+            extractor.stream_remote_zip_member(
+                "https://example.test/archive.zip",
+                member_name,
+                contract_copy_columns,
+                fpds_only=True,
+            )
+        )
+
+    assert extractor.stats["records_scanned"] == 1
+
+
 def test_remote_awk_prefilter_fails_closed_on_non_fpds_partition_row(
     sample_vendor_filters,
     sample_grant_row,
@@ -389,6 +451,8 @@ def test_extract_from_remote_zip_resolves_then_writes(
     sample_contract_row_full,
     contract_copy_columns,
 ) -> None:
+    from sbir_etl.utils.data import file_io
+
     source = _source(contract_copy_columns)
     payload = _row_text([sample_contract_row_full], contract_copy_columns).encode()
     output = tmp_path / "contracts.parquet"
@@ -399,7 +463,8 @@ def test_extract_from_remote_zip_resolves_then_writes(
         classmethod(lambda cls, url: source),
     )
     monkeypatch.setattr(
-        "sbir_etl.utils.data.file_io.save_dataframe_parquet",
+        file_io,
+        "save_dataframe_parquet",
         lambda frame, path, **kwargs: path.write_bytes(b"verified-parquet"),
     )
     extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
@@ -419,6 +484,81 @@ def test_extract_from_remote_zip_resolves_then_writes(
     assert extractor.source_provenance["physical_table"] == source.relation
     assert extractor.source_provenance["member"] == source.member_name
     assert extractor.source_provenance["toc_sha256"] == source.toc_sha256
+
+
+def test_parallel_prefetch_failure_cannot_replace_existing_output(
+    tmp_path,
+    monkeypatch,
+    sample_vendor_filters,
+    sample_contract_row_full,
+    contract_copy_columns,
+) -> None:
+    from sbir_etl.extractors import parallel_range_reader
+    from sbir_etl.extractors.parallel_range_reader import ParallelRangeValidationError
+
+    source = _source(contract_copy_columns)
+    output = tmp_path / "contracts.parquet"
+    output.write_bytes(b"existing-parquet")
+    extractor = ContractExtractor(vendor_filter_file=sample_vendor_filters)
+    contract = extractor._parse_contract_row(sample_contract_row_full)
+
+    class _RangeFile:
+        canonical_url = "https://canonical.example.test/archive.zip"
+        replica_urls = ("https://replica.example.test/archive.zip",)
+        chunk_size = 8
+        workers = 2
+
+        def validate_pending(self) -> None:
+            raise ParallelRangeValidationError("invalid unused lookahead")
+
+    class _Info:
+        filename = source.member_name
+        CRC = 0x12345678
+        compress_size = 20
+        file_size = 20
+
+    class _RemoteZip:
+        range_file = _RangeFile()
+        identity = types.SimpleNamespace(etag='"etag"', total_bytes=100)
+
+        def __init__(self, canonical_url, replica_urls) -> None:
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc) -> Literal[False]:
+            return False
+
+        def infolist(self):
+            return [_Info()]
+
+        def enable_parallel_prefetch(self) -> None:
+            pass
+
+    monkeypatch.setattr(parallel_range_reader, "ValidatedParallelRemoteZip", _RemoteZip)
+    monkeypatch.setattr(
+        ContractExtractor,
+        "_resolve_remote_source_from_archive",
+        classmethod(lambda cls, archive: source),
+    )
+    monkeypatch.setattr(
+        extractor,
+        "_stream_remote_archive_member",
+        lambda *args, **kwargs: iter([contract]),
+    )
+
+    with pytest.raises(ParallelRangeValidationError, match="unused lookahead"):
+        extractor.extract_from_remote_zip(
+            "https://canonical.example.test/archive.zip",
+            member_name=None,
+            output_file=output,
+            parallel_range=True,
+            replica_urls=["https://replica.example.test/archive.zip"],
+        )
+
+    assert output.read_bytes() == b"existing-parquet"
+    assert not output.with_suffix(".checks.json").exists()
 
 
 def test_remote_resolution_uses_toc_selected_member_not_file_size(
@@ -469,6 +609,41 @@ def test_remote_resolution_requires_exactly_one_toc() -> None:
     with patch.dict(sys.modules, {"remotezip": _fake_remotezip_module(members)}):
         with pytest.raises(ArchiveSchemaError, match="exactly one toc.dat"):
             ContractExtractor._resolve_remote_source("https://example.test/archive.zip")
+
+
+def test_remote_resolution_requires_exactly_one_toc_selected_member(
+    monkeypatch,
+    contract_copy_columns,
+) -> None:
+    class _Info:
+        def __init__(self, filename: str) -> None:
+            self.filename = filename
+
+    class _Archive:
+        def infolist(self):
+            return [
+                _Info("archive/toc.dat"),
+                _Info("archive/9247.dat.gz"),
+                _Info("archive/9247.dat.gz"),
+            ]
+
+        def open(self, info):
+            assert info.filename == "archive/toc.dat"
+            return io.BytesIO(_TOC_BYTES)
+
+    def fake_pg_restore(dump_dir: Path, *arguments: str) -> str:
+        if "--list" in arguments:
+            return _toc()
+        if "--schema-only" in arguments:
+            return _schema(contract_copy_columns)
+        if "--data-only" in arguments:
+            return _copy(contract_copy_columns)
+        raise AssertionError(f"Unexpected pg_restore arguments: {arguments!r}")
+
+    monkeypatch.setattr(ContractExtractor, "_run_pg_restore", staticmethod(fake_pg_restore))
+
+    with pytest.raises(ArchiveSchemaError, match="expected exactly one archive/9247.dat.gz"):
+        ContractExtractor._resolve_remote_source_from_archive(_Archive())
 
 
 def test_configured_remote_member_must_match_verified_metadata(

--- a/tests/unit/extractors/test_parallel_range_reader.py
+++ b/tests/unit/extractors/test_parallel_range_reader.py
@@ -1,0 +1,495 @@
+"""Offline integrity tests for bounded parallel HTTP range ZIP reads."""
+
+import gzip
+import io
+import struct
+import threading
+import time
+import zipfile
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from sbir_etl.extractors.parallel_range_reader import (
+    ParallelRangeTransportError,
+    ParallelRangeValidationError,
+    ValidatedParallelRangeFile,
+    ValidatedParallelRemoteZip,
+)
+
+
+pytestmark = pytest.mark.fast
+
+_CANONICAL = "https://canonical.example.test/archive.zip"
+_REPLICA_ONE = "https://replica-one.example.test/archive.zip"
+_REPLICA_TWO = "https://replica-two.example.test/archive.zip"
+_ETAG = '"strong-archive-etag"'
+
+
+class _Response:
+    def __init__(
+        self,
+        *,
+        status: int,
+        headers: Mapping[str, str],
+        body: bytes,
+    ) -> None:
+        self.status_code = status
+        self.headers = dict(headers)
+        self.raw = io.BytesIO(body)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _RangeServer:
+    """Small synchronous range server double safe for executor threads."""
+
+    def __init__(self, payload: bytes) -> None:
+        self.payload = payload
+        self.etags: dict[str, str] = {}
+        self.calls: list[tuple[str, dict[str, str]]] = []
+        self.completions: list[int] = []
+        self.delays: dict[int, float] = {}
+        self.active = 0
+        self.peak_active = 0
+        self.lock = threading.Lock()
+        self.override: Any = None
+
+    def __call__(self, url: str, headers: Mapping[str, str]) -> _Response:
+        request_headers = dict(headers)
+        start_text, end_text = request_headers["Range"].removeprefix("bytes=").split("-")
+        start, end = int(start_text), int(end_text)
+        with self.lock:
+            self.calls.append((url, request_headers))
+            self.active += 1
+            self.peak_active = max(self.peak_active, self.active)
+        try:
+            if delay := self.delays.get(start, 0):
+                time.sleep(delay)
+            if self.override is not None:
+                response = self.override(url, request_headers, start, end)
+                if response is not None:
+                    return response
+            body = self.payload[start : end + 1]
+            etag = self.etags.get(url, _ETAG)
+            return _Response(
+                status=206,
+                headers={
+                    "Content-Range": f"bytes {start}-{end}/{len(self.payload)}",
+                    "Content-Length": str(len(body)),
+                    "Content-Encoding": "identity",
+                    "ETag": etag,
+                },
+                body=body,
+            )
+        finally:
+            with self.lock:
+                self.active -= 1
+                # Identity probes are not part of the parallel completion audit.
+                if "If-Match" in request_headers and end > 0:
+                    self.completions.append(start)
+
+
+def _response(
+    server: _RangeServer,
+    *,
+    start: int,
+    end: int,
+    status: int = 206,
+    body: bytes | None = None,
+    content_range: str | None = None,
+    etag: str = _ETAG,
+) -> _Response:
+    data = server.payload[start : end + 1] if body is None else body
+    return _Response(
+        status=status,
+        headers={
+            "Content-Range": content_range or f"bytes {start}-{end}/{len(server.payload)}",
+            "Content-Length": str(end - start + 1),
+            "Content-Encoding": "identity",
+            "ETag": etag,
+        },
+        body=data,
+    )
+
+
+def test_parallel_reads_stay_ordered_and_use_at_most_four_payload_slots() -> None:
+    payload = bytes(range(32))
+    server = _RangeServer(payload)
+    server.delays = {0: 0.08, 8: 0.06, 16: 0.04, 24: 0.01}
+
+    with ValidatedParallelRangeFile(
+        _CANONICAL,
+        (_REPLICA_ONE, _REPLICA_TWO),
+        _chunk_size=8,
+        _workers=4,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    ) as source:
+        source.enable_parallel_prefetch()
+        assert source.read() == payload
+        assert source.peak_payload_slots == 4
+
+    assert server.completions[0] == 24
+    assert 2 <= server.peak_active <= 4
+    data_calls = [headers for _, headers in server.calls if headers["Range"] != "bytes=0-0"]
+    assert data_calls
+    assert all(headers["If-Match"] == _ETAG for headers in data_calls)
+    assert all(headers["Accept-Encoding"] == "identity" for headers in data_calls)
+
+
+def test_range_file_seek_and_read_match_bytesio_oracle() -> None:
+    payload = bytes(range(31))
+    server = _RangeServer(payload)
+    oracle = io.BytesIO(payload)
+
+    with ValidatedParallelRangeFile(
+        _CANONICAL,
+        _chunk_size=5,
+        _workers=3,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    ) as source:
+        operations = (
+            ("read", 3, None),
+            ("seek", 9, io.SEEK_SET),
+            ("read", 11, None),
+            ("seek", -6, io.SEEK_CUR),
+            ("read", 4, None),
+            ("seek", -7, io.SEEK_END),
+            ("read", -1, None),
+            ("seek", 0, io.SEEK_SET),
+            ("read", -1, None),
+        )
+        for operation, value, whence in operations:
+            if operation == "read":
+                assert source.read(value) == oracle.read(value)
+            else:
+                assert source.seek(value, whence) == oracle.seek(value, whence)
+            assert source.tell() == oracle.tell()
+
+
+def test_truncated_range_retries_on_another_validated_replica() -> None:
+    server = _RangeServer(b"abcdefgh")
+    attempts: list[str] = []
+
+    def truncate_once(url: str, headers: Mapping[str, str], start: int, end: int):
+        if headers["Range"] == "bytes=0-3":
+            attempts.append(url)
+            if len(attempts) == 1:
+                return _response(server, start=start, end=end, body=b"abc")
+        return None
+
+    server.override = truncate_once
+    with ValidatedParallelRangeFile(
+        _CANONICAL,
+        (_REPLICA_ONE, _REPLICA_TWO),
+        _chunk_size=4,
+        _workers=1,
+        _attempts=2,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    ) as source:
+        assert source.read(4) == b"abcd"
+
+    assert attempts == [_REPLICA_ONE, _REPLICA_TWO]
+
+
+@pytest.mark.parametrize(
+    ("replacement", "message"),
+    [
+        (
+            lambda server, start, end: _response(
+                server,
+                start=start,
+                end=end,
+                content_range=f"bytes {start + 1}-{end}/{len(server.payload)}",
+            ),
+            "Content-Range",
+        ),
+        (
+            lambda server, start, end: _response(
+                server,
+                start=start,
+                end=end,
+                etag='"different-etag"',
+            ),
+            "identity differs",
+        ),
+        (
+            lambda server, start, end: _response(
+                server,
+                start=start,
+                end=end,
+                status=302,
+            ),
+            "exact 206 required",
+        ),
+    ],
+)
+def test_integrity_or_redirect_failures_are_terminal_without_replica_retry(
+    replacement,
+    message: str,
+) -> None:
+    server = _RangeServer(b"abcdefgh")
+    data_calls = 0
+
+    def invalid_data(url: str, headers: Mapping[str, str], start: int, end: int):
+        nonlocal data_calls
+        if headers["Range"] != "bytes=0-0":
+            data_calls += 1
+            return replacement(server, start, end)
+        return None
+
+    server.override = invalid_data
+    with ValidatedParallelRangeFile(
+        _CANONICAL,
+        (_REPLICA_ONE, _REPLICA_TWO),
+        _chunk_size=4,
+        _workers=1,
+        _attempts=3,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    ) as source:
+        with pytest.raises(ParallelRangeValidationError, match=message):
+            source.read(4)
+
+    assert data_calls == 1
+
+
+def test_replica_probe_requires_the_canonical_strong_identity() -> None:
+    server = _RangeServer(b"abcdefgh")
+    server.etags[_REPLICA_TWO] = '"stale-replica"'
+
+    with pytest.raises(ParallelRangeValidationError, match="identity differs"):
+        ValidatedParallelRangeFile(
+            _CANONICAL,
+            (_REPLICA_ONE, _REPLICA_TWO),
+            _chunk_size=4,
+            _requester=server,
+        )
+
+
+def test_replica_probe_requires_the_same_first_byte_under_matching_identity() -> None:
+    server = _RangeServer(b"abcdefgh")
+
+    def wrong_probe_byte(url: str, headers: Mapping[str, str], start: int, end: int):
+        if url == _REPLICA_TWO and headers["Range"] == "bytes=0-0":
+            return _response(server, start=start, end=end, body=b"z")
+        return None
+
+    server.override = wrong_probe_byte
+    with pytest.raises(ParallelRangeValidationError, match="probe byte differs"):
+        ValidatedParallelRangeFile(
+            _CANONICAL,
+            (_REPLICA_ONE, _REPLICA_TWO),
+            _chunk_size=4,
+            _requester=server,
+        )
+
+
+def test_canonical_redirect_to_even_an_explicit_replica_fails_closed() -> None:
+    server = _RangeServer(b"abcdefgh")
+
+    def canonical_redirect(url: str, headers: Mapping[str, str], start: int, end: int):
+        if url != _CANONICAL:
+            return None
+        response = _response(server, start=start, end=end, status=302)
+        response.headers["Location"] = _REPLICA_TWO
+        return response
+
+    server.override = canonical_redirect
+    with pytest.raises(ParallelRangeValidationError, match="exact 206 required"):
+        ValidatedParallelRangeFile(
+            _CANONICAL,
+            (_REPLICA_ONE, _REPLICA_TWO),
+            _chunk_size=4,
+            _workers=2,
+            _retry_backoff_seconds=0,
+            _requester=server,
+        )
+
+    assert [url for url, _ in server.calls] == [_CANONICAL]
+
+
+def test_canonical_redirect_to_unlisted_url_fails_closed() -> None:
+    server = _RangeServer(b"abcdefgh")
+
+    def unlisted_redirect(url: str, headers: Mapping[str, str], start: int, end: int):
+        response = _response(server, start=start, end=end, status=302)
+        response.headers["Location"] = "https://unlisted.example.test/archive.zip"
+        return response
+
+    server.override = unlisted_redirect
+    with pytest.raises(ParallelRangeValidationError, match="exact 206 required"):
+        ValidatedParallelRangeFile(
+            _CANONICAL,
+            (_REPLICA_ONE, _REPLICA_TWO),
+            _requester=server,
+        )
+
+
+def test_exhausted_short_body_retry_fails_closed() -> None:
+    server = _RangeServer(b"abcdefgh")
+
+    def always_short(url: str, headers: Mapping[str, str], start: int, end: int):
+        if headers["Range"] != "bytes=0-0":
+            return _response(server, start=start, end=end, body=b"")
+        return None
+
+    server.override = always_short
+    with ValidatedParallelRangeFile(
+        _CANONICAL,
+        (_REPLICA_ONE,),
+        _chunk_size=4,
+        _workers=1,
+        _attempts=2,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    ) as source:
+        with pytest.raises(ParallelRangeTransportError, match="failed after 2 attempts"):
+            source.read(4)
+
+
+def test_unused_prefetch_failure_is_sticky_and_blocks_success() -> None:
+    server = _RangeServer(b"abcdefgh")
+
+    def bad_lookahead(url: str, headers: Mapping[str, str], start: int, end: int):
+        if start == 4:
+            return _response(server, start=start, end=end, etag='"bad-lookahead"')
+        return None
+
+    server.override = bad_lookahead
+    with ValidatedParallelRangeFile(
+        _CANONICAL,
+        (_REPLICA_ONE,),
+        _chunk_size=4,
+        _workers=2,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    ) as source:
+        source.enable_parallel_prefetch()
+        assert source.read(4) == b"abcd"
+        with pytest.raises(ParallelRangeValidationError, match="identity differs"):
+            source.validate_pending()
+
+
+def test_close_interrupts_a_blocked_active_response_before_waiting_for_workers() -> None:
+    server = _RangeServer(b"abcdefgh")
+    started = threading.Event()
+    released = threading.Event()
+
+    class _BlockingRaw:
+        decode_content = False
+
+        @staticmethod
+        def read(size: int, decode_content: bool = False) -> bytes:
+            started.set()
+            if not released.wait(5):
+                raise TimeoutError("test response was not interrupted")
+            raise OSError("response closed")
+
+    class _BlockingResponse(_Response):
+        def __init__(self, start: int, end: int) -> None:
+            super().__init__(
+                status=206,
+                headers={
+                    "Content-Range": f"bytes {start}-{end}/{len(server.payload)}",
+                    "Content-Length": str(end - start + 1),
+                    "Content-Encoding": "identity",
+                    "ETag": _ETAG,
+                },
+                body=b"",
+            )
+            self.raw = _BlockingRaw()
+
+        def close(self) -> None:
+            released.set()
+            super().close()
+
+    def block_data(url: str, headers: Mapping[str, str], start: int, end: int):
+        if headers["Range"] != "bytes=0-0":
+            return _BlockingResponse(start, end)
+        return None
+
+    server.override = block_data
+    source = ValidatedParallelRangeFile(
+        _CANONICAL,
+        (_REPLICA_ONE,),
+        _chunk_size=4,
+        _workers=1,
+        _attempts=1,
+        _retry_backoff_seconds=0,
+        _requester=server,
+    )
+    errors: list[BaseException] = []
+
+    def consume() -> None:
+        try:
+            source.read(4)
+        except BaseException as error:
+            errors.append(error)
+
+    consumer = threading.Thread(target=consume)
+    consumer.start()
+    assert started.wait(1)
+
+    before = time.monotonic()
+    source.close()
+    elapsed = time.monotonic() - before
+    consumer.join(1)
+
+    assert elapsed < 1
+    assert not consumer.is_alive()
+    assert errors and isinstance(errors[0], ParallelRangeTransportError)
+
+
+def _zip_payload(member: bytes) -> bytes:
+    target = io.BytesIO()
+    with zipfile.ZipFile(target, "w", compression=zipfile.ZIP_STORED) as archive:
+        archive.writestr("archive/member.dat.gz", member)
+    return target.getvalue()
+
+
+def test_zip_extfile_eof_validates_outer_crc() -> None:
+    archive_bytes = bytearray(_zip_payload(gzip.compress(b"complete inner gzip")))
+    central_directory = archive_bytes.index(b"PK\x01\x02")
+    original_crc = struct.unpack_from("<I", archive_bytes, central_directory + 16)[0]
+    struct.pack_into("<I", archive_bytes, central_directory + 16, original_crc ^ 0xFFFFFFFF)
+    server = _RangeServer(bytes(archive_bytes))
+
+    with ValidatedParallelRemoteZip(
+        _CANONICAL,
+        _range_file_kwargs={
+            "_chunk_size": 16,
+            "_workers": 4,
+            "_retry_backoff_seconds": 0,
+            "_requester": server,
+        },
+    ) as archive:
+        info = archive.getinfo("archive/member.dat.gz")
+        with archive.open(info) as member:
+            with pytest.raises(zipfile.BadZipFile, match="Bad CRC-32"):
+                while member.read(7):
+                    pass
+
+
+def test_inner_gzip_must_reach_a_valid_eof() -> None:
+    server = _RangeServer(_zip_payload(b"not a gzip stream"))
+
+    with ValidatedParallelRemoteZip(
+        _CANONICAL,
+        _range_file_kwargs={
+            "_chunk_size": 16,
+            "_workers": 4,
+            "_retry_backoff_seconds": 0,
+            "_requester": server,
+        },
+    ) as archive:
+        info = archive.getinfo("archive/member.dat.gz")
+        with archive.open(info) as member, gzip.GzipFile(fileobj=member) as inner:
+            with pytest.raises(gzip.BadGzipFile):
+                inner.read()

--- a/tests/unit/scripts/archive/test_extract_federal_contracts.py
+++ b/tests/unit/scripts/archive/test_extract_federal_contracts.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -101,3 +102,106 @@ def test_checks_require_archive_toc_fingerprint(tmp_path) -> None:
         )
 
     assert not output.with_suffix(".checks.json").exists()
+
+
+def test_sequential_remote_member_sha_does_not_require_parallel_fields(tmp_path) -> None:
+    output = tmp_path / "contracts_ingestion.parquet"
+    pd.DataFrame({"contract_id": ["contract-1"]}).to_parquet(output)
+    vendor_filter = tmp_path / "sbir_vendor_filters.json"
+    vendor_filter.write_text('{"uei": ["ABC123456789"]}', encoding="utf-8")
+    source_provenance = {**_source_provenance(), "member_sha256": "c" * 64}
+
+    checks_path = extract_federal_contracts.write_contract_provenance_checks(
+        extractor=SimpleNamespace(source_provenance=source_provenance, stats={}),
+        output_file=output,
+        vendor_filter_file=vendor_filter,
+        expected_vendor_filter_sha256=extract_federal_contracts._file_sha256(vendor_filter),
+        total_rows=1,
+        source={"remote_zip": "https://files.usaspending.gov/archive.zip"},
+    )
+
+    checks = json.loads(checks_path.read_text(encoding="utf-8"))
+    assert checks["source_provenance"]["member_sha256"] == "c" * 64
+
+
+def test_parallel_range_cli_forwards_only_explicit_replica_urls(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    vendor_filter = tmp_path / "sbir_vendor_filters.json"
+    vendor_filter.write_text('{"uei": ["ABC123456789"]}', encoding="utf-8")
+    output = tmp_path / "contracts.parquet"
+    observed: dict[str, object] = {}
+
+    class _Paths:
+        @staticmethod
+        def resolve_path(name: str) -> Path:
+            assert name == "transition_vendor_filters"
+            return vendor_filter
+
+    class _Extractor:
+        source_provenance = _source_provenance()
+        stats: dict[str, int] = {}
+
+        def extract_from_remote_zip(self, **kwargs) -> int:
+            observed.update(kwargs)
+            output.write_bytes(b"parquet")
+            return 1
+
+    monkeypatch.setattr(
+        extract_federal_contracts, "get_config", lambda: SimpleNamespace(paths=_Paths())
+    )
+    monkeypatch.setattr(
+        extract_federal_contracts, "ContractExtractor", lambda **kwargs: _Extractor()
+    )
+    monkeypatch.setattr(
+        extract_federal_contracts,
+        "write_contract_provenance_checks",
+        lambda **kwargs: output.with_suffix(".checks.json"),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "extract_federal_contracts.py",
+            "--remote-zip",
+            "https://canonical.example.test/archive.zip",
+            "--parallel-range",
+            "--parallel-range-replica",
+            "https://replica-one.example.test/archive.zip",
+            "--parallel-range-replica",
+            "https://replica-two.example.test/archive.zip",
+            "--output",
+            str(output),
+        ],
+    )
+
+    extract_federal_contracts.main()
+
+    assert observed == {
+        "zip_url": "https://canonical.example.test/archive.zip",
+        "member_name": None,
+        "output_file": output,
+        "parallel_range": True,
+        "replica_urls": [
+            "https://replica-one.example.test/archive.zip",
+            "https://replica-two.example.test/archive.zip",
+        ],
+    }
+
+
+def test_parallel_range_replica_cli_requires_explicit_parallel_mode(monkeypatch) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "extract_federal_contracts.py",
+            "--remote-zip",
+            "https://canonical.example.test/archive.zip",
+            "--parallel-range-replica",
+            "https://replica.example.test/archive.zip",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="2"):
+        extract_federal_contracts.main()


### PR DESCRIPTION
## What changed

- add a bounded, identity-checked parallel HTTP range reader for the selected USAspending ZIP member
- verify archive/member identity, CRC, full-member SHA-256, schema, output hash, and vendor-filter hash before publishing provenance
- handle PostgreSQL's exact terminal COPY marker (`\\.`) in both Python and awk parser paths
- continue to fail closed on malformed rows or any nonempty data after the COPY marker

## Why

The February USAspending mirror contains a 41.8 GB stored `.dat.gz` member. The first production pass processed all 105,947,242 data rows, then correctly stopped when the parser mistook PostgreSQL's one-field terminal COPY marker for a malformed 374-column row. This change recognizes only that exact terminal marker while retaining all row/schema integrity checks.

## Validation

- 76 focused unit and integration tests passed
- Ruff passed on all seven changed files
- mypy passed on both extractor modules
- `git diff --check` passed

## Production verification

The February extraction completed from clean commit `48493d59aa2ae61ba6d26da9ba1527dd317e330d`:

- scanned 105,947,242 source records and published 1,879,459 matched contract rows
- accepted the exact terminal COPY marker and rejected no data rows
- verified the 374-column TOC/COPY schema, full member CRC/SHA-256, archive ETag/length across both mirrors, vendor-filter hash, parquet footer/schema, and output SHA-256
- published the parquet and checks manifest atomically; the temporary parquet was removed

Output SHA-256: `c1518188ef674f3b301ef61be19f6db796a9389e4d03f1196280080f71803a98`.
