### PR TITLE
Centralize company identity policies

### DIFF
--- a/docs/steering/company-identity.md
+++ b/docs/steering/company-identity.md
@@ -1,0 +1,54 @@
+# Company identity contract
+
+Company identity is an evidence-producing decision, not generic string cleanup. Live
+callers use `sbir_etl.identity` for company-name normalization and similarity. The shared
+API has two guarantees:
+
+1. every normalization policy is explicitly named and versioned; and
+2. every similarity score uses a `0..1` scale, even when a compatibility adapter exposes
+   RapidFuzz's historical `0..100` convention.
+
+## Decision order
+
+Identity resolution remains identifier-first:
+
+1. exact validated UEI;
+2. exact validated CAGE or DUNS when the source and study permit it;
+3. exact name under the declared profile;
+4. fuzzy name candidate generation under declared thresholds; and
+5. human or study-specific adjudication where required.
+
+Name similarity alone must not establish a negative claim such as “this firm never
+received an SBIR award.” Absence claims require a study-specific coverage contract over
+the identifiers, aliases, source universe, and data cut being searched. The Phase III
+census study manifest therefore keeps `negative_evidence_allowed: false` until that
+contract exists.
+
+## Compatibility profiles
+
+The initial profiles preserve existing behavior so migration cannot silently change
+research outputs:
+
+| Profile | Current consumer |
+|---|---|
+| `matching-v1` | local company-master matching |
+| `recipient-v1` | USAspending recipient matching |
+| `entity-resolution-v1` | Phase 0 cross-source resolver |
+| `groundtruth-v1` | Phase III success-story award resolution |
+| `vendor-crosswalk-v1` | transition vendor crosswalk persistence |
+| `vendor-resolver-v1` | transition vendor resolver |
+| `form-d-join-v1` | agency/private-capital join keys |
+| `ucc-v1` | UCC debtor matching |
+| `sec-edgar-v1` | SEC company lookup and mention filtering |
+| `sec-edgar-trailing-v1` | single-suffix SEC mention/noise filtering |
+| `notice-key-v1` | Phase III notice attribution |
+| `phase3-ranking-v1` | Phase III firm-ranking benchmark |
+
+These profiles intentionally do not imply equivalent recall. Consolidating two profiles
+requires a versioned change, a before/after output comparison on the relevant corpus,
+and review of every changed auto-link and dropped candidate. Compatibility shims may keep
+old import paths temporarily, but the implementation belongs in `sbir_etl.identity`.
+
+Person-name matching, grant-number matching, and storage-only display cleanup are separate
+domains and do not use company-name profiles merely because their old helper was also
+called `normalize_name`.

--- a/docs/steering/company-identity.md
+++ b/docs/steering/company-identity.md
@@ -26,15 +26,20 @@ contract exists.
 
 ## Compatibility profiles
 
-The initial profiles preserve existing behavior so migration cannot silently change
-research outputs:
+`organization-key-v1` is the durable suffixless comparison key for ordinary company
+linkage. It folds case and accents, normalizes punctuation, and removes recognized legal
+designators only at the end of a name. Removing designator-like words from the middle of
+a name creates false collisions (for example, `PC Photonics` with `Photonics, Inc.`).
+
+The initial consumer-named profiles remain available as compatibility policies so
+migration cannot silently change research outputs:
 
 | Profile | Current consumer |
 |---|---|
 | `matching-v1` | local company-master matching |
-| `recipient-v1` | USAspending recipient matching |
+| `recipient-v1` | legacy USAspending recipient normalization |
 | `entity-resolution-v1` | Phase 0 cross-source resolver |
-| `groundtruth-v1` | Phase III success-story award resolution |
+| `groundtruth-v1` | legacy Phase III success-story normalization |
 | `vendor-crosswalk-v1` | transition vendor crosswalk persistence |
 | `vendor-resolver-v1` | transition vendor resolver |
 | `form-d-join-v1` | agency/private-capital join keys |
@@ -42,12 +47,29 @@ research outputs:
 | `sec-edgar-v1` | SEC company lookup and mention filtering |
 | `sec-edgar-trailing-v1` | single-suffix SEC mention/noise filtering |
 | `notice-key-v1` | Phase III notice attribution |
-| `phase3-ranking-v1` | Phase III firm-ranking benchmark |
+| `phase3-ranking-v1` | legacy Phase III firm-ranking normalization |
 
 These profiles intentionally do not imply equivalent recall. Consolidating two profiles
 requires a versioned change, a before/after output comparison on the relevant corpus,
 and review of every changed auto-link and dropped candidate. Compatibility shims may keep
 old import paths temporarily, but the implementation belongs in `sbir_etl.identity`.
+
+### First consolidation audit
+
+USAspending and the Phase III ground-truth and ranking callers now use
+`organization-key-v1`. Phase 0 remains on `entity-resolution-v1` because its normalized
+name participates in stable canonical IDs and needs an explicit ID migration.
+
+The new profile was compared with the three replaced policies over all 34,464 distinct
+company names in `award_data.csv` (SHA-256
+`efdf7ca5a398703002ebb33345275b0f68e50af3c5db361d48a2456266a23628`). It keeps the
+same number of exact-name partitions as `recipient-v1` while changing two partitions:
+it removes the false `Engineering Inc` / `Engineering Partnership, Ltd` collision and
+joins the punctuated/unpunctuated `Pelletized Straw L.L.C.` variants. Relative to the
+ground-truth profile, it adds the `Coherent Photonics` legal-name variants and removes
+the false `PC Photonics` / `Photonics, Inc.` collision. Relative to the ranking profile,
+it removes its broad `CORP\w*` behavior, which created false collisions among unrelated
+names beginning with `Corp...`.
 
 Person-name matching, grant-number matching, and storage-only display cleanup are separate
 domains and do not use company-name profiles merely because their old helper was also

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -69,6 +69,9 @@ docs/
 
 ## Code Organization Principles
 
+Company-name normalization and similarity belong in `sbir_etl/identity`; callers select
+an explicit versioned profile. See [company-identity.md](company-identity.md).
+
 ### Separation of Concerns
 
 - **Single responsibility**: Each module has one clear purpose
@@ -120,5 +123,6 @@ from sbir_etl.models.sbir_award import SbirAward
 - **[product.md](product.md)** - Project overview and business context
 - **[tech.md](tech.md)** - Technology stack and development tools
 - **[pipeline-orchestration.md](pipeline-orchestration.md)** - Dagster asset organization patterns
+- **[company-identity.md](company-identity.md)** - Versioned company identity policies
 - **[configuration.md](../configuration.md)** - Configuration management examples
 - **[quick-reference.md](quick-reference.md)** - Common commands and development setup

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
@@ -20,6 +20,7 @@ from typing import Any
 import pandas as pd
 
 from sbir_etl.enrichers.sec_edgar.form_d_scoring import EXCLUDED_INDUSTRY_GROUPS
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 
 DEFAULT_FORM_D_MATCHES_PATH = Path("data/form_d_details.jsonl")
@@ -27,11 +28,9 @@ DEFAULT_FORM_D_CONTROL_UNIVERSE_PATH = Path("data/form_d_control_universe.jsonl"
 
 
 def normalize_name(value: object) -> str:
-    """Return the normalized join key used by the existing Form D analyses."""
+    """Compatibility shim for the versioned Form D join-key policy."""
 
-    if value is None or (isinstance(value, float) and pd.isna(value)):
-        return ""
-    return " ".join(str(value).strip().upper().split())
+    return normalize_company_name(value, profile=CompanyNameProfile.FORM_D_JOIN_V1)
 
 
 def read_jsonl(path: Path) -> list[dict[str, Any]]:

--- a/packages/sbir-analytics/sbir_analytics/tools/phase0/resolve_entities.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/phase0/resolve_entities.py
@@ -21,29 +21,24 @@ output quality for everything downstream.
 from __future__ import annotations
 
 import hashlib
-import re
 from typing import Any
 
 import pandas as pd
 from loguru import logger
 
+from sbir_etl.identity import (
+    CompanyNameProfile,
+    normalize_company_name,
+    rapidfuzz_token_set_100,
+)
+
 from ..base import BaseTool, DataSourceRef, ToolMetadata, ToolResult
 
 
 def _normalize_name(name: str | None) -> str:
-    """Normalize company name for matching."""
-    if not name:
-        return ""
-    s = str(name).upper().strip()
-    # Remove common suffixes
-    for suffix in [" INC", " LLC", " LP", " LLP", " CORP", " CO", " LTD", " PLC"]:
-        if s.endswith(suffix):
-            s = s[: -len(suffix)]
-    s = s.rstrip(",. ")
-    # Collapse whitespace and remove punctuation
-    s = re.sub(r"[^A-Z0-9\s]", "", s)
-    s = re.sub(r"\s+", " ", s).strip()
-    return s
+    """Compatibility shim for the versioned Phase 0 identity policy."""
+
+    return normalize_company_name(name, profile=CompanyNameProfile.ENTITY_RESOLUTION_V1)
 
 
 def _generate_canonical_id(name: str, uei: str | None = None) -> str:
@@ -246,7 +241,10 @@ class ResolveEntitiesTool(BaseTool):
         flagged_for_review = 0
         if unmatched_sbir and entities:
             try:
-                from rapidfuzz import fuzz
+                from rapidfuzz import process
+
+                if process is None:  # pragma: no cover - import contract guard
+                    raise ImportError
 
                 canonical_names = [(e["canonical_name"], i) for i, e in enumerate(entities)]
                 name_list = [n for n, _ in canonical_names]
@@ -260,7 +258,7 @@ class ResolveEntitiesTool(BaseTool):
                     best_score = 0.0
                     best_idx = -1
                     for i, ref_name in enumerate(name_list):
-                        score = fuzz.token_set_ratio(norm, _normalize_name(ref_name))
+                        score = rapidfuzz_token_set_100(norm, _normalize_name(ref_name))
                         if score > best_score:
                             best_score = score
                             best_idx = i

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
@@ -29,11 +29,17 @@ import re
 from collections.abc import Iterable
 from dataclasses import asdict, dataclass, field
 from datetime import date, datetime
-from difflib import SequenceMatcher
 from pathlib import Path
 from uuid import uuid4
 
 from loguru import logger
+
+from sbir_etl.identity import (
+    CompanyNameMetric,
+    CompanyNameProfile,
+    company_name_similarity,
+    normalize_company_name,
+)
 
 
 # Optional dependencies
@@ -46,14 +52,6 @@ try:
     import duckdb
 except Exception:
     duckdb = None  # type: ignore
-
-try:
-    from rapidfuzz import fuzz
-
-    _RAPIDFUZZ_AVAILABLE = True
-except Exception:
-    fuzz = None  # type: ignore
-    _RAPIDFUZZ_AVAILABLE = False
 
 # ---------------------------------------------------------------------------
 # Utilities
@@ -74,23 +72,11 @@ def _normalize_identifier(val: str | None) -> str | None:
 def _normalize_name(name: str | None) -> str | None:
     if name is None:
         return None
-    s = " ".join(str(name).strip().split())
-    s = s.replace(",", " ").replace(".", " ").replace("/", " ").replace("&", " AND ")
-    return s.strip()
+    return normalize_company_name(name, profile=CompanyNameProfile.VENDOR_CROSSWALK_V1)
 
 
 def _fuzzy_score(a: str, b: str) -> float:
-    if not a or not b:
-        return 0.0
-    if _RAPIDFUZZ_AVAILABLE:
-        try:
-            return float(fuzz.token_sort_ratio(a, b) / 100.0)
-        except Exception:
-            pass
-    try:
-        return float(SequenceMatcher(None, a, b).ratio())
-    except Exception:
-        return 0.0
+    return company_name_similarity(a, b, metric=CompanyNameMetric.TOKEN_SORT)
 
 
 def _iso_date(val: str | date | datetime | None) -> str | None:

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from loguru import logger
 
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 from sbir_ml.transition.features.vendor_crosswalk import _fuzzy_score as _crosswalk_fuzzy_score
 
 
@@ -132,26 +133,7 @@ class VendorResolver:
         """Normalize company names for indexing and exact comparisons."""
         if name is None:
             return ""  # type: ignore[unreachable]
-        # Basic normalization: uppercase, trim, collapse whitespace, strip punctuation-ish chars
-        n = " ".join(name.strip().split())
-        n = n.replace(",", " ").replace(".", " ").replace("/", " ").replace("&", " AND ")
-        n = n.lower()
-        # Normalize common business suffix variants so "corp" vs "corporation" etc. compare closely.
-        replacements = {
-            "incorporated": "inc",
-            "inc": "inc",
-            "corporation": "corp",
-            "corp": "corp",
-            "company": "co",
-            "co": "co",
-            "limited": "ltd",
-            "ltd": "ltd",
-            "llc": "llc",
-            "llp": "llp",
-        }
-        tokens = n.split()
-        normalized_tokens = [replacements.get(tok, tok) for tok in tokens]
-        return " ".join(normalized_tokens)
+        return normalize_company_name(name, profile=CompanyNameProfile.VENDOR_RESOLVER_V1)
 
     def _load_records(self, records: Iterable[VendorRecord]) -> None:
         """Populate indices from the provided VendorRecord iterable."""

--- a/sbir_etl/enrichers/company_fuzzy_matcher.py
+++ b/sbir_etl/enrichers/company_fuzzy_matcher.py
@@ -43,6 +43,7 @@ import pandas as pd
 
 from ..exceptions import ValidationError
 from ..utils.text_normalization import normalize_name
+from sbir_etl.identity import rapidfuzz_jaro_winkler_100, rapidfuzz_token_set_100
 
 
 def _set_award_match(
@@ -69,8 +70,7 @@ def _set_award_match(
 
 
 try:
-    from rapidfuzz import fuzz, process
-    from rapidfuzz.distance import JaroWinkler
+    from rapidfuzz import process
 except Exception as e:  # pragma: no cover - defensive runtime behavior
     raise ImportError(
         "rapidfuzz is required for the company enricher. Install via `pip install rapidfuzz`."
@@ -229,7 +229,7 @@ def enrich_awards_with_companies(
     high_threshold: int = 90,
     low_threshold: int = 75,
     top_k: int = 3,
-    scorer=fuzz.token_set_ratio,
+    scorer=rapidfuzz_token_set_100,
     return_candidates: bool = False,
     enhanced_config: dict[str, Any] | None = None,
 ) -> pd.DataFrame:
@@ -510,7 +510,12 @@ def enrich_awards_with_companies(
             def jw_scorer(
                 s1: str, s2: str, prefix_weight: float = prefix_weight_val, **kwargs: Any
             ) -> float:
-                return JaroWinkler.similarity(s1, s2, prefix_weight=prefix_weight) * 100.0
+                return rapidfuzz_jaro_winkler_100(
+                    s1,
+                    s2,
+                    prefix_weight=prefix_weight,
+                    **kwargs,
+                )
 
             active_scorer = jw_scorer
 

--- a/sbir_etl/enrichers/matching.py
+++ b/sbir_etl/enrichers/matching.py
@@ -13,104 +13,17 @@ from __future__ import annotations
 
 from typing import Any
 
+from sbir_etl.identity import (
+    ENHANCED_ABBREVIATIONS,
+    SUFFIX_TOKENS as SUFFIX_TOKENS,
+    rapidfuzz_jaro_winkler_100,
+)
+
 
 try:
     import jellyfish
 except ImportError:  # pragma: no cover
     jellyfish = None  # type: ignore
-
-try:
-    from rapidfuzz.distance import JaroWinkler
-except ImportError:  # pragma: no cover
-    JaroWinkler = None  # type: ignore
-
-
-# Business-entity suffix tokens removed during name normalization.
-SUFFIX_TOKENS: frozenset[str] = frozenset(
-    {
-        "inc",
-        "incorporated",
-        "llc",
-        "l.l.c",
-        "l l c",
-        "ltd",
-        "limited",
-        "corp",
-        "corporation",
-        "co",
-        "lp",
-        "llp",
-        "company",
-        "the",
-    }
-)
-
-# Enhanced abbreviation dictionary for company name normalization
-ENHANCED_ABBREVIATIONS = {
-    # Technology terms
-    "technologies": "tech",
-    "technology": "tech",
-    "systems": "sys",
-    "system": "sys",
-    "solutions": "sol",
-    "solution": "sol",
-    "software": "sw",
-    "engineering": "eng",
-    "engineer": "eng",
-    "development": "dev",
-    "developer": "dev",
-    "advanced": "adv",
-    "international": "intl",
-    # Aerospace & Defense
-    "aerospace": "aero",
-    "aeronautical": "aero",
-    "defense": "def",
-    "defence": "def",
-    "military": "mil",
-    # Research & Science
-    "research": "res",
-    "laboratory": "lab",
-    "laboratories": "lab",
-    "scientific": "sci",
-    "science": "sci",
-    # Industry-specific
-    "biotechnology": "biotech",
-    "pharmaceutical": "pharma",
-    "pharmaceuticals": "pharma",
-    "manufacturing": "mfg",
-    "manufacture": "mfg",
-    "medical": "med",
-    "communications": "comm",
-    "communication": "comm",
-    "telecommunications": "telecom",
-    # Business terms
-    "associates": "assoc",
-    "associate": "assoc",
-    "consulting": "consult",
-    "consultants": "consult",
-    "services": "svc",
-    "service": "svc",
-    "enterprises": "ent",
-    "enterprise": "ent",
-    "industries": "ind",
-    "industry": "ind",
-    "management": "mgmt",
-    # Directional
-    "north": "n",
-    "south": "s",
-    "east": "e",
-    "west": "w",
-    "northeast": "ne",
-    "northwest": "nw",
-    "southeast": "se",
-    "southwest": "sw",
-    # Common words
-    "america": "amer",
-    "american": "amer",
-    "united": "utd",
-    "group": "grp",
-    "national": "natl",
-}
 
 
 def get_phonetic_code(name: str, algorithm: str = "metaphone") -> str | None:
@@ -203,13 +116,15 @@ def jaro_winkler_similarity(name1: str, name2: str, prefix_weight: float = 0.1) 
         >>> jaro_winkler_similarity("Boeing Systems", "Boeing Solutions")
         > 85.0  # High due to matching "Boeing" prefix
     """
-    if not JaroWinkler or not name1 or not name2:
+    if not name1 or not name2:
         return 0.0
 
     try:
-        # JaroWinkler.similarity returns 0.0-1.0, scale to 0-100
-        score = JaroWinkler.similarity(str(name1), str(name2), prefix_weight=prefix_weight)
-        return score * 100.0
+        return rapidfuzz_jaro_winkler_100(
+            name1,
+            name2,
+            prefix_weight=prefix_weight,
+        )
     except Exception:  # pragma: no cover
         return 0.0
 

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -13,7 +13,13 @@ from typing import Any
 
 import pandas as pd
 from loguru import logger
-from rapidfuzz import fuzz
+
+from sbir_etl.identity import (
+    CompanyNameMetric,
+    CompanyNameProfile,
+    company_name_similarity,
+    normalize_company_name,
+)
 
 from ...models.sec_edgar import (
     CompanyEdgarProfile,
@@ -163,11 +169,6 @@ _FORM_TYPE_LABELS: dict[str, str] = {
     "SC 13G": "ownership_passive",
     "SC 13G/A": "ownership_passive",
 }
-
-_CORP_SUFFIX = re.compile(
-    r",?\s*(Inc\.?|Corp\.?|LLC|Ltd\.?|Co\.?|L\.?P\.?|/DE|/NV|/MD|CORP|INC)$",
-    re.IGNORECASE,
-)
 
 # Keyword regexes for surrounding-text context classification, ordered by priority.
 _MENTION_CONTEXT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
@@ -353,7 +354,10 @@ async def _extract_mention_context(
 
     match = re.search(re.escape(company_name), text, re.IGNORECASE)
     if not match:
-        clean_name = _CORP_SUFFIX.sub("", company_name).strip()
+        clean_name = normalize_company_name(
+            company_name,
+            profile=CompanyNameProfile.SEC_EDGAR_TRAILING_V1,
+        )
         if len(clean_name) >= 5:
             match = re.search(re.escape(clean_name), text, re.IGNORECASE)
     if not match:
@@ -397,8 +401,14 @@ def _is_noise(filer_name: str, target_name: str, sics: list[str]) -> bool:
         if any(sic in r for r in _NOISE_SIC_RANGES):
             return True
 
-    target_clean = _CORP_SUFFIX.sub("", target_name).strip().upper()
-    filer_clean = _CORP_SUFFIX.sub("", filer_name).strip().upper()
+    target_clean = normalize_company_name(
+        target_name,
+        profile=CompanyNameProfile.SEC_EDGAR_TRAILING_V1,
+    )
+    filer_clean = normalize_company_name(
+        filer_name,
+        profile=CompanyNameProfile.SEC_EDGAR_TRAILING_V1,
+    )
     return (
         target_clean in filer_clean
         and filer_clean != target_clean
@@ -429,7 +439,15 @@ async def _search_filing_mentions_filtered(
         filer_name = mention.get("filer_name", "")
         if not filer_name:
             continue
-        if fuzz.token_set_ratio(company_name.upper(), filer_name.upper()) >= name_match_threshold:
+        if (
+            company_name_similarity(
+                company_name.upper(),
+                filer_name.upper(),
+                metric=CompanyNameMetric.TOKEN_SET,
+            )
+            * 100.0
+            >= name_match_threshold
+        ):
             continue  # self-filing
         if _is_noise(filer_name, company_name, mention.get("sics", [])):
             continue
@@ -524,7 +542,14 @@ async def _search_form_d_filings(
         entity_name = result.get("entity_name", "")
         if not entity_name:
             continue
-        score = fuzz.token_set_ratio(company_name.upper(), entity_name.upper())
+        score = (
+            company_name_similarity(
+                company_name.upper(),
+                entity_name.upper(),
+                metric=CompanyNameMetric.TOKEN_SET,
+            )
+            * 100.0
+        )
         if score < match_threshold:
             continue
         filing_date_str = result.get("file_date")
@@ -592,14 +617,9 @@ _GENERIC_WORDS = frozenset(
 
 
 def _clean_company_name(name: str) -> str:
-    """Iteratively strip corporate suffixes (handles 'QUALCOMM INC/DE')."""
-    upper = name.strip().upper()
-    for _ in range(3):
-        cleaned = _CORP_SUFFIX.sub("", upper).strip()
-        if cleaned == upper:
-            break
-        upper = cleaned
-    return upper
+    """Compatibility shim for the versioned SEC EDGAR company-name policy."""
+
+    return normalize_company_name(name, profile=CompanyNameProfile.SEC_EDGAR_V1)
 
 
 def _distinctive_words(cleaned_name: str) -> set[str]:
@@ -639,9 +659,20 @@ async def _resolve_cik(
             continue
         entity_clean = _clean_company_name(entity_name)
 
-        score = max(
-            fuzz.token_set_ratio(query_clean, entity_clean),
-            fuzz.ratio(query_clean, entity_clean),
+        score = (
+            max(
+                company_name_similarity(
+                    query_clean,
+                    entity_clean,
+                    metric=CompanyNameMetric.TOKEN_SET,
+                ),
+                company_name_similarity(
+                    query_clean,
+                    entity_clean,
+                    metric=CompanyNameMetric.RATIO,
+                ),
+            )
+            * 100.0
         )
         if score < threshold:
             continue

--- a/sbir_etl/enrichers/usaspending/enricher.py
+++ b/sbir_etl/enrichers/usaspending/enricher.py
@@ -22,8 +22,11 @@ import json
 
 import pandas as pd
 
-from ...utils.text_normalization import normalize_recipient_name
-from sbir_etl.identity import rapidfuzz_token_set_100
+from sbir_etl.identity import (
+    CompanyNameProfile,
+    normalize_company_name,
+    rapidfuzz_token_set_100,
+)
 
 
 try:
@@ -31,6 +34,10 @@ try:
 except ImportError:
     # Fallback to simple string matching if rapidfuzz not available
     process = None  # type: ignore[assignment, no-redef]
+
+
+def _normalize_recipient_name(name: str) -> str:
+    return normalize_company_name(name, profile=CompanyNameProfile.ORGANIZATION_KEY_V1)
 
 
 def enrich_sbir_with_usaspending(
@@ -91,9 +98,11 @@ def enrich_sbir_with_usaspending(
                 break
 
     # Add normalized names
-    sbir["_norm_name"] = sbir[sbir_company_col].fillna("").astype(str).map(normalize_recipient_name)
+    sbir["_norm_name"] = (
+        sbir[sbir_company_col].fillna("").astype(str).map(_normalize_recipient_name)
+    )
     recipients["_norm_name"] = (
-        recipients[recipient_name_col].fillna("").astype(str).map(normalize_recipient_name)
+        recipients[recipient_name_col].fillna("").astype(str).map(_normalize_recipient_name)
     )
 
     # Build indexes for exact matching

--- a/sbir_etl/enrichers/usaspending/enricher.py
+++ b/sbir_etl/enrichers/usaspending/enricher.py
@@ -23,16 +23,13 @@ import json
 import pandas as pd
 
 from ...utils.text_normalization import normalize_recipient_name
+from sbir_etl.identity import rapidfuzz_token_set_100
 
 
 try:
-    from rapidfuzz import fuzz, process
-
-    _rapidfuzz_available = True
+    from rapidfuzz import process
 except ImportError:
     # Fallback to simple string matching if rapidfuzz not available
-    _rapidfuzz_available = False
-    fuzz = None  # type: ignore[assignment, no-redef]
     process = None  # type: ignore[assignment, no-redef]
 
 
@@ -156,14 +153,14 @@ def enrich_sbir_with_usaspending(
     # Only process rows that don't have exact matches
     unmatched_mask = sbir["_usaspending_recipient_idx"].isna()
     for idx, row in sbir[unmatched_mask].iterrows():
-        if fuzz and process:
+        if process:
             norm_name = row.get("_norm_name", "")
             if norm_name:
                 # Get candidate recipients (simple approach: all for now, could add blocking)
                 choices = recipients["_norm_name"].to_dict()
 
                 results = process.extract(
-                    norm_name, choices, scorer=fuzz.token_set_ratio, limit=top_k
+                    norm_name, choices, scorer=rapidfuzz_token_set_100, limit=top_k
                 )
 
                 candidates = []

--- a/sbir_etl/identity/__init__.py
+++ b/sbir_etl/identity/__init__.py
@@ -1,0 +1,28 @@
+"""Shared company-identity normalization and similarity contracts."""
+
+from .company_names import (
+    ENHANCED_ABBREVIATIONS,
+    SUFFIX_TOKENS,
+    CompanyNameMetric,
+    CompanyNameProfile,
+    company_name_similarity,
+    normalize_company_name,
+    rapidfuzz_jaro_winkler_100,
+    rapidfuzz_ratio_100,
+    rapidfuzz_token_set_100,
+    rapidfuzz_token_sort_100,
+)
+
+
+__all__ = [
+    "ENHANCED_ABBREVIATIONS",
+    "SUFFIX_TOKENS",
+    "CompanyNameMetric",
+    "CompanyNameProfile",
+    "company_name_similarity",
+    "normalize_company_name",
+    "rapidfuzz_jaro_winkler_100",
+    "rapidfuzz_ratio_100",
+    "rapidfuzz_token_set_100",
+    "rapidfuzz_token_sort_100",
+]

--- a/sbir_etl/identity/company_names.py
+++ b/sbir_etl/identity/company_names.py
@@ -26,6 +26,7 @@ except ImportError:  # pragma: no cover - supported dependency-light fallback
 class CompanyNameProfile(StrEnum):
     """Named, versioned normalization behavior used by live consumers."""
 
+    ORGANIZATION_KEY_V1 = "organization-key-v1"
     MATCHING_V1 = "matching-v1"
     RECIPIENT_V1 = "recipient-v1"
     ENTITY_RESOLUTION_V1 = "entity-resolution-v1"
@@ -143,6 +144,37 @@ _SEC_SUFFIX = re.compile(
     r",?\s*(Inc\.?|Corp\.?|LLC|Ltd\.?|Co\.?|L\.?P\.?|/DE|/NV|/MD|CORP|INC)$",
     re.IGNORECASE,
 )
+_DOTTED_DESIGNATORS = (
+    (re.compile(r"\bp\s*\.\s*l\s*\.\s*l\s*\.\s*c\s*\.?", re.IGNORECASE), "pllc"),
+    (re.compile(r"\bl\s*\.\s*l\s*\.\s*c\s*\.?", re.IGNORECASE), "llc"),
+    (re.compile(r"\bl\s*\.\s*l\s*\.\s*p\s*\.?", re.IGNORECASE), "llp"),
+    (re.compile(r"\bl\s*\.\s*p\s*\.?", re.IGNORECASE), "lp"),
+    (re.compile(r"\bp\s*\.\s*c\s*\.?", re.IGNORECASE), "pc"),
+)
+_TRAILING_DESIGNATOR_PHRASES = (
+    ("professional", "limited", "liability", "company"),
+    ("limited", "liability", "company"),
+    ("limited", "liability", "partnership"),
+)
+_TRAILING_DESIGNATORS = frozenset(
+    {
+        "co",
+        "company",
+        "corp",
+        "corporation",
+        "inc",
+        "incorporated",
+        "incorporation",
+        "llc",
+        "llp",
+        "lp",
+        "ltd",
+        "limited",
+        "pc",
+        "plc",
+        "pllc",
+    }
+)
 
 
 def _matching_v1(
@@ -171,6 +203,32 @@ def _matching_v1(
     return " ".join(text.split())
 
 
+def _organization_key_v1(value: Any) -> str:
+    """Build a comparison key by removing only trailing legal designators."""
+    text = unicodedata.normalize("NFKD", str(value).strip().lower())
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    for pattern, replacement in _DOTTED_DESIGNATORS:
+        text = pattern.sub(replacement, text)
+    tokens = re.sub(r"[^a-z0-9\s]", " ", text).split()
+    while len(tokens) > 1:
+        phrase = next(
+            (
+                candidate
+                for candidate in _TRAILING_DESIGNATOR_PHRASES
+                if len(tokens) > len(candidate) and tuple(tokens[-len(candidate) :]) == candidate
+            ),
+            None,
+        )
+        if phrase is not None:
+            del tokens[-len(phrase) :]
+            continue
+        if tokens[-1] in _TRAILING_DESIGNATORS:
+            tokens.pop()
+            continue
+        break
+    return " ".join(tokens).upper()
+
+
 def normalize_company_name(
     value: Any,
     *,
@@ -181,6 +239,8 @@ def normalize_company_name(
 
     if _blank(value):
         return ""
+    if profile is CompanyNameProfile.ORGANIZATION_KEY_V1:
+        return _organization_key_v1(value)
     if profile is CompanyNameProfile.MATCHING_V1:
         return _matching_v1(value, remove_suffixes=False, abbreviations=abbreviations)
     if profile is CompanyNameProfile.RECIPIENT_V1:

--- a/sbir_etl/identity/company_names.py
+++ b/sbir_etl/identity/company_names.py
@@ -1,0 +1,342 @@
+"""Versioned company-name policies with a single 0..1 similarity contract.
+
+The profiles preserve current analytical behavior while making differences
+explicit and reviewable. They are compatibility policies, not a claim that all
+name-matching use cases should have identical recall. New consumers must select
+a profile rather than silently inventing another normalization rule.
+"""
+
+import re
+import unicodedata
+from difflib import SequenceMatcher
+from enum import StrEnum
+from typing import Any
+
+from sbir_etl.utils.coercion import _blank
+
+
+try:
+    from rapidfuzz import fuzz
+    from rapidfuzz.distance import JaroWinkler
+except ImportError:  # pragma: no cover - supported dependency-light fallback
+    fuzz = None  # type: ignore[assignment]
+    JaroWinkler = None  # type: ignore[assignment, misc]
+
+
+class CompanyNameProfile(StrEnum):
+    """Named, versioned normalization behavior used by live consumers."""
+
+    MATCHING_V1 = "matching-v1"
+    RECIPIENT_V1 = "recipient-v1"
+    ENTITY_RESOLUTION_V1 = "entity-resolution-v1"
+    GROUNDTRUTH_V1 = "groundtruth-v1"
+    VENDOR_CROSSWALK_V1 = "vendor-crosswalk-v1"
+    VENDOR_RESOLVER_V1 = "vendor-resolver-v1"
+    FORM_D_JOIN_V1 = "form-d-join-v1"
+    UCC_V1 = "ucc-v1"
+    SEC_EDGAR_V1 = "sec-edgar-v1"
+    SEC_EDGAR_TRAILING_V1 = "sec-edgar-trailing-v1"
+    NOTICE_KEY_V1 = "notice-key-v1"
+    PHASE3_RANKING_V1 = "phase3-ranking-v1"
+
+
+class CompanyNameMetric(StrEnum):
+    """Supported similarity algorithms; every result is scaled to 0..1."""
+
+    RATIO = "ratio"
+    TOKEN_SET = "token-set"
+    TOKEN_SORT = "token-sort"
+    JARO_WINKLER = "jaro-winkler"
+
+
+SUFFIX_TOKENS: frozenset[str] = frozenset(
+    {
+        "inc",
+        "incorporated",
+        "llc",
+        "l.l.c",
+        "l l c",
+        "ltd",
+        "limited",
+        "corp",
+        "corporation",
+        "co",
+        "lp",
+        "llp",
+        "company",
+        "the",
+    }
+)
+
+ENHANCED_ABBREVIATIONS = {
+    "technologies": "tech",
+    "technology": "tech",
+    "systems": "sys",
+    "system": "sys",
+    "solutions": "sol",
+    "solution": "sol",
+    "software": "sw",
+    "engineering": "eng",
+    "engineer": "eng",
+    "development": "dev",
+    "developer": "dev",
+    "advanced": "adv",
+    "international": "intl",
+    "aerospace": "aero",
+    "aeronautical": "aero",
+    "defense": "def",
+    "defence": "def",
+    "military": "mil",
+    "research": "res",
+    "laboratory": "lab",
+    "laboratories": "lab",
+    "scientific": "sci",
+    "science": "sci",
+    "biotechnology": "biotech",
+    "pharmaceutical": "pharma",
+    "pharmaceuticals": "pharma",
+    "manufacturing": "mfg",
+    "manufacture": "mfg",
+    "medical": "med",
+    "communications": "comm",
+    "communication": "comm",
+    "telecommunications": "telecom",
+    "associates": "assoc",
+    "associate": "assoc",
+    "consulting": "consult",
+    "consultants": "consult",
+    "services": "svc",
+    "service": "svc",
+    "enterprises": "ent",
+    "enterprise": "ent",
+    "industries": "ind",
+    "industry": "ind",
+    "management": "mgmt",
+    "north": "n",
+    "south": "s",
+    "east": "e",
+    "west": "w",
+    "northeast": "ne",
+    "northwest": "nw",
+    "southeast": "se",
+    "southwest": "sw",
+    "america": "amer",
+    "american": "amer",
+    "united": "utd",
+    "group": "grp",
+    "national": "natl",
+}
+
+_GROUNDTRUTH_SUFFIX = re.compile(
+    r"\b(INC|INCORPORATED|LLC|L\.?L\.?C|CORP|CORPORATION|CO|COMPANY|LTD|LP|LLP|PC|PLLC)\b\.?",
+    re.IGNORECASE,
+)
+_PHASE3_RANKING_SUFFIX = re.compile(
+    r"\b(INC|LLC|CORP\w*|CO|COMPANY|LTD|LP|LLP|PC|PLLC|INCORPORATED)\b\.?",
+    re.IGNORECASE,
+)
+_NOTICE_SUFFIX = re.compile(
+    r"\b(INC|INCORPORATED|LLC|CORP|CORPORATION|CO|COMPANY|LTD|LP)\b\.?",
+    re.IGNORECASE,
+)
+_SEC_SUFFIX = re.compile(
+    r",?\s*(Inc\.?|Corp\.?|LLC|Ltd\.?|Co\.?|L\.?P\.?|/DE|/NV|/MD|CORP|INC)$",
+    re.IGNORECASE,
+)
+
+
+def _matching_v1(
+    value: Any,
+    *,
+    remove_suffixes: bool,
+    abbreviations: dict[str, str] | None,
+) -> str:
+    text = str(value).strip().lower()
+    text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    text = re.sub(r"[^\w\s]", " ", text)
+    if remove_suffixes:
+        text = re.sub(
+            r"\b(incorporated|incorporation|inc|corp|corporation|llc|llp|lp|ltd|limited"
+            r"|plc|liability|partnership|co|company)\b",
+            "",
+            text,
+        )
+    else:
+        text = re.sub(r"\b(incorporated|incorporation)\b", "inc", text)
+        text = re.sub(r"\b(company|co)\b", "company", text)
+        text = re.sub(r"\b(limited|ltd)\b", "ltd", text)
+    if abbreviations:
+        text = " ".join(abbreviations.get(token, token) for token in text.split())
+    return " ".join(text.split())
+
+
+def normalize_company_name(
+    value: Any,
+    *,
+    profile: CompanyNameProfile,
+    abbreviations: dict[str, str] | None = None,
+) -> str:
+    """Normalize ``value`` using an explicit, versioned company-name profile."""
+
+    if _blank(value):
+        return ""
+    if profile is CompanyNameProfile.MATCHING_V1:
+        return _matching_v1(value, remove_suffixes=False, abbreviations=abbreviations)
+    if profile is CompanyNameProfile.RECIPIENT_V1:
+        return _matching_v1(value, remove_suffixes=True, abbreviations=abbreviations)
+
+    text = str(value)
+    if profile is CompanyNameProfile.ENTITY_RESOLUTION_V1:
+        text = text.upper().strip()
+        for suffix in (" INC", " LLC", " LP", " LLP", " CORP", " CO", " LTD", " PLC"):
+            if text.endswith(suffix):
+                text = text[: -len(suffix)]
+        text = text.rstrip(",. ")
+        text = re.sub(r"[^A-Z0-9\s]", "", text)
+        return " ".join(text.split())
+    if profile is CompanyNameProfile.GROUNDTRUTH_V1:
+        text = _GROUNDTRUTH_SUFFIX.sub(" ", text.upper())
+        return " ".join(re.sub(r"[^A-Z0-9 ]", " ", text).split())
+    if profile is CompanyNameProfile.VENDOR_CROSSWALK_V1:
+        text = " ".join(text.strip().split())
+        return (
+            text.replace(",", " ").replace(".", " ").replace("/", " ").replace("&", " AND ").strip()
+        )
+    if profile is CompanyNameProfile.VENDOR_RESOLVER_V1:
+        text = " ".join(text.strip().split())
+        text = text.replace(",", " ").replace(".", " ").replace("/", " ").replace("&", " AND ")
+        aliases = {
+            "incorporated": "inc",
+            "inc": "inc",
+            "corporation": "corp",
+            "corp": "corp",
+            "company": "co",
+            "co": "co",
+            "limited": "ltd",
+            "ltd": "ltd",
+            "llc": "llc",
+            "llp": "llp",
+        }
+        return " ".join(aliases.get(token, token) for token in text.lower().split())
+    if profile is CompanyNameProfile.FORM_D_JOIN_V1:
+        return " ".join(text.strip().upper().split())
+    if profile is CompanyNameProfile.UCC_V1:
+        text = re.sub(r"[^a-z0-9 ]+", " ", text.lower())
+        replacements = abbreviations or ENHANCED_ABBREVIATIONS
+        text = " ".join(replacements.get(token, token) for token in text.split())
+        return " ".join(token for token in text.split() if token not in SUFFIX_TOKENS)
+    if profile in {
+        CompanyNameProfile.SEC_EDGAR_V1,
+        CompanyNameProfile.SEC_EDGAR_TRAILING_V1,
+    }:
+        text = text.strip().upper()
+        iterations = 3 if profile is CompanyNameProfile.SEC_EDGAR_V1 else 1
+        for _ in range(iterations):
+            cleaned = _SEC_SUFFIX.sub("", text).strip()
+            if cleaned == text:
+                break
+            text = cleaned
+        return text
+    if profile is CompanyNameProfile.NOTICE_KEY_V1:
+        text = _NOTICE_SUFFIX.sub("", text)
+        return re.sub(r"[^A-Z0-9]", "", text.upper())
+    if profile is CompanyNameProfile.PHASE3_RANKING_V1:
+        text = _PHASE3_RANKING_SUFFIX.sub(" ", text.upper())
+        return " ".join(re.sub(r"[^A-Z0-9 ]", " ", text).split())
+    raise ValueError(f"unsupported company-name profile: {profile}")
+
+
+def _fallback_token_set(left: str, right: str) -> float:
+    left_tokens = set(left.split())
+    right_tokens = set(right.split())
+    intersection = " ".join(sorted(left_tokens & right_tokens))
+    left_joined = " ".join(sorted(left_tokens))
+    right_joined = " ".join(sorted(right_tokens))
+    return max(
+        SequenceMatcher(None, intersection, left_joined).ratio(),
+        SequenceMatcher(None, intersection, right_joined).ratio(),
+        SequenceMatcher(None, left_joined, right_joined).ratio(),
+    )
+
+
+def _raw_name(value: Any) -> str:
+    return "" if _blank(value) else str(value)
+
+
+def company_name_similarity(
+    left: Any,
+    right: Any,
+    *,
+    metric: CompanyNameMetric,
+    profile: CompanyNameProfile | None = None,
+    prefix_weight: float = 0.1,
+) -> float:
+    """Return company-name similarity on a stable 0..1 scale."""
+
+    left_text = normalize_company_name(left, profile=profile) if profile else _raw_name(left)
+    right_text = normalize_company_name(right, profile=profile) if profile else _raw_name(right)
+    if not left_text or not right_text:
+        return 0.0
+    if fuzz is not None:
+        scorers = {
+            CompanyNameMetric.RATIO: fuzz.ratio,
+            CompanyNameMetric.TOKEN_SET: fuzz.token_set_ratio,
+            CompanyNameMetric.TOKEN_SORT: fuzz.token_sort_ratio,
+        }
+        if metric in scorers:
+            return float(scorers[metric](left_text, right_text)) / 100.0
+    if metric is CompanyNameMetric.JARO_WINKLER and JaroWinkler is not None:
+        return float(JaroWinkler.similarity(left_text, right_text, prefix_weight=prefix_weight))
+    if metric is CompanyNameMetric.TOKEN_SET:
+        return _fallback_token_set(left_text, right_text)
+    if metric is CompanyNameMetric.TOKEN_SORT:
+        left_text = " ".join(sorted(left_text.split()))
+        right_text = " ".join(sorted(right_text.split()))
+    return float(SequenceMatcher(None, left_text, right_text).ratio())
+
+
+def _rapidfuzz_100(left: Any, right: Any, metric: CompanyNameMetric, **kwargs: Any) -> float:
+    score = company_name_similarity(left, right, metric=metric) * 100.0
+    score_cutoff = kwargs.get("score_cutoff")
+    return 0.0 if score_cutoff is not None and score < float(score_cutoff) else score
+
+
+def rapidfuzz_token_set_100(left: Any, right: Any, **kwargs: Any) -> float:
+    """RapidFuzz-compatible token-set scorer backed by the shared contract."""
+
+    return _rapidfuzz_100(left, right, CompanyNameMetric.TOKEN_SET, **kwargs)
+
+
+def rapidfuzz_token_sort_100(left: Any, right: Any, **kwargs: Any) -> float:
+    """RapidFuzz-compatible token-sort scorer backed by the shared contract."""
+
+    return _rapidfuzz_100(left, right, CompanyNameMetric.TOKEN_SORT, **kwargs)
+
+
+def rapidfuzz_ratio_100(left: Any, right: Any, **kwargs: Any) -> float:
+    """RapidFuzz-compatible ratio scorer backed by the shared contract."""
+
+    return _rapidfuzz_100(left, right, CompanyNameMetric.RATIO, **kwargs)
+
+
+def rapidfuzz_jaro_winkler_100(
+    left: Any,
+    right: Any,
+    *,
+    prefix_weight: float = 0.1,
+    **kwargs: Any,
+) -> float:
+    """RapidFuzz-compatible Jaro-Winkler scorer backed by the shared contract."""
+
+    score = (
+        company_name_similarity(
+            left,
+            right,
+            metric=CompanyNameMetric.JARO_WINKLER,
+            prefix_weight=prefix_weight,
+        )
+        * 100.0
+    )
+    score_cutoff = kwargs.get("score_cutoff")
+    return 0.0 if score_cutoff is not None and score < float(score_cutoff) else score

--- a/sbir_etl/ucc/matcher.py
+++ b/sbir_etl/ucc/matcher.py
@@ -27,11 +27,11 @@ import re
 import sys
 from pathlib import Path
 
-from sbir_etl.enrichers.matching import (  # noqa: E402
-    ENHANCED_ABBREVIATIONS,
-    SUFFIX_TOKENS,
-    apply_enhanced_abbreviations,
-    jaro_winkler_similarity,
+from sbir_etl.identity import (  # noqa: E402
+    CompanyNameMetric,
+    CompanyNameProfile,
+    company_name_similarity,
+    normalize_company_name,
 )
 
 from sbir_etl.ucc._common import data_path
@@ -87,13 +87,9 @@ _ENTITY_INDICATORS = {
 
 
 def normalize_name(name: str) -> str:
-    """Lowercase, strip punctuation, expand abbreviations, drop suffix tokens."""
-    if not name:
-        return ""
-    n = re.sub(r"[^a-z0-9 ]+", " ", name.lower())
-    n = apply_enhanced_abbreviations(n, ENHANCED_ABBREVIATIONS)
-    tokens = [t for t in n.split() if t not in SUFFIX_TOKENS]
-    return " ".join(tokens).strip()
+    """Compatibility shim for the versioned UCC company-name policy."""
+
+    return normalize_company_name(name, profile=CompanyNameProfile.UCC_V1)
 
 
 def classify_match(name_a: str, name_b: str) -> tuple[str, float]:
@@ -108,7 +104,7 @@ def classify_match(name_a: str, name_b: str) -> tuple[str, float]:
         return ("drop", 0.0)
     if a == b:
         return ("high", 1.0)
-    score = jaro_winkler_similarity(a, b) / 100.0
+    score = company_name_similarity(a, b, metric=CompanyNameMetric.JARO_WINKLER)
     if score >= TIER_MEDIUM_THRESHOLD:
         return ("medium", score)
     if score >= TIER_LOW_THRESHOLD:

--- a/sbir_etl/utils/text_normalization.py
+++ b/sbir_etl/utils/text_normalization.py
@@ -12,8 +12,8 @@ Key Features:
 
 from __future__ import annotations
 
-import re
-import unicodedata
+from sbir_etl.identity import CompanyNameProfile
+from sbir_etl.identity import normalize_company_name as _normalize_company_name
 
 
 def normalize_name(
@@ -49,53 +49,20 @@ def normalize_name(
         >>> normalize_name("Advanced Technologies", apply_abbreviations=True)
         'adv tech'
     """
-    if not name:
-        return ""
-
-    s = str(name).strip().lower()
-
-    # Apply Unicode NFKD normalization and strip combining characters (accents).
-    # This turns "Café" → "cafe", "naïve" → "naive", "ñ" → "n", etc.
-    s = unicodedata.normalize("NFKD", s)
-    s = "".join(ch for ch in s if not unicodedata.combining(ch))
-
-    # Replace punctuation with spaces
-    s = re.sub(r"[^\w\s]", " ", s)
-
-    if remove_suffixes:
-        # Remove all common business suffixes (usaspending_enricher behavior)
-        s = re.sub(
-            r"\b(incorporated|incorporation|inc|corp|corporation|llc|llp|lp|ltd|limited"
-            r"|plc|liability|partnership|co|company)\b",
-            "",
-            s,
-        )
-    else:
-        # Normalize suffixes to standard forms (company_fuzzy_matcher behavior)
-        s = re.sub(r"\b(incorporated|incorporation)\b", "inc", s)
-        s = re.sub(r"\b(company|co)\b", "company", s)
-        s = re.sub(r"\b(limited|ltd)\b", "ltd", s)
-
-    # Apply abbreviations if requested
+    selected_abbreviations = abbreviations
     if apply_abbreviations:
-        if abbreviations is None:
-            # Import here to avoid circular dependency
-            try:
-                from sbir_etl.enrichers.matching import ENHANCED_ABBREVIATIONS
+        if selected_abbreviations is None:
+            from sbir_etl.identity import ENHANCED_ABBREVIATIONS
 
-                abbreviations = ENHANCED_ABBREVIATIONS
-            except ImportError:  # pragma: no cover
-                abbreviations = {}
-
-        if abbreviations:
-            tokens = s.split()
-            normalized_tokens = [abbreviations.get(token, token) for token in tokens]
-            s = " ".join(normalized_tokens)
-
-    # Collapse whitespace
-    s = re.sub(r"\s+", " ", s).strip()
-
-    return s
+            selected_abbreviations = ENHANCED_ABBREVIATIONS
+    else:
+        selected_abbreviations = None
+    profile = CompanyNameProfile.RECIPIENT_V1 if remove_suffixes else CompanyNameProfile.MATCHING_V1
+    return _normalize_company_name(
+        name,
+        profile=profile,
+        abbreviations=selected_abbreviations,
+    )
 
 
 # Backward-compatible aliases for existing code

--- a/scripts/ci/check_identity_boundaries.py
+++ b/scripts/ci/check_identity_boundaries.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Prevent unreviewed company-name scoring outside ``sbir_etl.identity``."""
+
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+REVIEWED_DIRECT_SCORER_FILES = frozenset(
+    {
+        "sbir_etl/identity/company_names.py",
+        # PatentAssignmentTransformer scores grant-number strings, not company identity.
+        "sbir_etl/transformers/patent_transformer.py",
+        # Form D confidence compares principal-investigator and related-person names.
+        "sbir_etl/enrichers/sec_edgar/form_d_scoring.py",
+        # Contract tests compare shared adapters with the upstream scorer implementation.
+        "tests/unit/identity/test_company_names.py",
+    }
+)
+
+
+@dataclass(frozen=True)
+class IdentityBoundaryViolation:
+    path: str
+    line_number: int
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line_number}: {self.message}"
+
+
+def _uses_direct_rapidfuzz_scorer(node: ast.AST) -> bool:
+    if isinstance(node, ast.ImportFrom):
+        if node.module == "rapidfuzz" and any(alias.name == "fuzz" for alias in node.names):
+            return True
+        return bool(node.module and node.module.startswith("rapidfuzz.distance"))
+    return isinstance(node, ast.Import) and any(
+        alias.name in {"rapidfuzz.fuzz", "rapidfuzz.distance"} for alias in node.names
+    )
+
+
+def scan_file(
+    path: Path, *, repository_root: Path = REPOSITORY_ROOT
+) -> list[IdentityBoundaryViolation]:
+    """Find direct scorer imports in one unreviewed Python file."""
+
+    relative = path.resolve().relative_to(repository_root.resolve()).as_posix()
+    if relative in REVIEWED_DIRECT_SCORER_FILES or relative.startswith(
+        ("scripts/archive/", "tests/unit/scripts/archive/")
+    ):
+        return []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return [
+        IdentityBoundaryViolation(
+            path=relative,
+            line_number=node.lineno,
+            message=(
+                "direct RapidFuzz scorer bypasses sbir_etl.identity; use the shared "
+                "similarity contract or document a reviewed non-company exception"
+            ),
+        )
+        for node in ast.walk(tree)
+        if _uses_direct_rapidfuzz_scorer(node)
+    ]
+
+
+def tracked_python_files(*, repository_root: Path = REPOSITORY_ROOT) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=repository_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [repository_root / relative for relative in result.stdout.splitlines()]
+
+
+def scan_repository(*, repository_root: Path = REPOSITORY_ROOT) -> list[IdentityBoundaryViolation]:
+    violations: list[IdentityBoundaryViolation] = []
+    for path in tracked_python_files(repository_root=repository_root):
+        violations.extend(scan_file(path, repository_root=repository_root))
+    return sorted(violations, key=lambda violation: (violation.path, violation.line_number))
+
+
+def main() -> int:
+    violations = scan_repository()
+    if violations:
+        print("Company identity boundary violations were found:")
+        print("\n".join(violation.format() for violation in violations))
+        return 1
+    print("Company identity boundary checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_identity_boundaries.py
+++ b/scripts/ci/check_identity_boundaries.py
@@ -36,8 +36,14 @@ def _uses_direct_rapidfuzz_scorer(node: ast.AST) -> bool:
         if node.module == "rapidfuzz" and any(alias.name == "fuzz" for alias in node.names):
             return True
         return bool(node.module and node.module.startswith("rapidfuzz.distance"))
+    # ``import rapidfuzz`` reaches fuzz and distance through attribute access, so
+    # it bypasses the guard unless the bare package import is flagged too.
+    # ``rapidfuzz.process`` stays allowed for the same reason ``from rapidfuzz
+    # import process`` does: it drives the search while the scorer is supplied
+    # from ``sbir_etl.identity``.
     return isinstance(node, ast.Import) and any(
-        alias.name in {"rapidfuzz.fuzz", "rapidfuzz.distance"} for alias in node.names
+        alias.name == "rapidfuzz" or alias.name.startswith(("rapidfuzz.fuzz", "rapidfuzz.distance"))
+        for alias in node.names
     )
 
 

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -15,6 +15,7 @@ AUTOMATION_PREFIXES = (".github/", "scripts/", "sbir_etl/", "packages/", "tests/
 SCANNED_FILES = {"Makefile", ".pre-commit-config.yaml"}
 EXCLUDED_HISTORICAL_DOCUMENTS = {"docs/decisions/ADR-002-etl-library-extraction.md"}
 EXCLUDED_SCAN_FILES = {
+    "scripts/ci/check_identity_boundaries.py",
     "tests/unit/scripts/test_repository_hygiene.py",
 }
 REMOVED_SRC_PATTERNS = (

--- a/scripts/phase3_benchmark/measure_firm_ranking.py
+++ b/scripts/phase3_benchmark/measure_firm_ranking.py
@@ -29,12 +29,11 @@ import pandas as pd
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.metrics.pairwise import cosine_similarity
 
-_SUFFIX = re.compile(r"\b(INC|LLC|CORP\w*|CO|COMPANY|LTD|LP|LLP|PC|PLLC|INCORPORATED)\b\.?", re.I)
-_NON_ALNUM = re.compile(r"[^A-Z0-9 ]")
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 
 def normalize_name(s: object) -> str:
-    return " ".join(_NON_ALNUM.sub(" ", _SUFFIX.sub(" ", str(s or "").upper())).split())
+    return normalize_company_name(s, profile=CompanyNameProfile.PHASE3_RANKING_V1)
 
 
 def firm_bucket(agency: str, branch: str) -> str:

--- a/scripts/phase3_benchmark/measure_firm_ranking.py
+++ b/scripts/phase3_benchmark/measure_firm_ranking.py
@@ -33,7 +33,7 @@ from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 
 def normalize_name(s: object) -> str:
-    return normalize_company_name(s, profile=CompanyNameProfile.PHASE3_RANKING_V1)
+    return normalize_company_name(s, profile=CompanyNameProfile.ORGANIZATION_KEY_V1)
 
 
 def firm_bucket(agency: str, branch: str) -> str:

--- a/scripts/phase3_benchmark/notice_matching.py
+++ b/scripts/phase3_benchmark/notice_matching.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 _NKEY_RE = re.compile(r"[^A-Z0-9]")
-_SUFFIX_RE = re.compile(r"\b(INC|INCORPORATED|LLC|CORP|CORPORATION|CO|COMPANY|LTD|LP)\b\.?", re.I)
 
 # Minimum lengths guard against short, ambiguous keys matching by chance.
 MIN_NAME_KEY = 8
@@ -37,7 +37,7 @@ def normalize_key(value: object) -> str:
 def normalize_firm_name(name: object) -> str:
     """Normalize a firm name for matching: drop legal suffixes, then keyify."""
 
-    return normalize_key(_SUFFIX_RE.sub("", str(name or "")))
+    return normalize_company_name(name, profile=CompanyNameProfile.NOTICE_KEY_V1)
 
 
 @dataclass(frozen=True)

--- a/scripts/phase3_groundtruth/resolve_firm_awards.py
+++ b/scripts/phase3_groundtruth/resolve_firm_awards.py
@@ -16,30 +16,26 @@ human can spot-check the fuzzy ones.
 from __future__ import annotations
 
 import argparse
-import re
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
 
 import pandas as pd
-from rapidfuzz import fuzz, process
+from rapidfuzz import process
 
-
-_SUFFIX_RE = re.compile(
-    r"\b(INC|INCORPORATED|LLC|L\.?L\.?C|CORP|CORPORATION|CO|COMPANY|LTD|LP|LLP|PC|PLLC)\b\.?",
-    re.IGNORECASE,
+from sbir_etl.identity import (
+    CompanyNameProfile,
+    normalize_company_name,
+    rapidfuzz_token_set_100,
 )
-_NON_ALNUM = re.compile(r"[^A-Z0-9 ]")
 
 FUZZY_THRESHOLD = 88.0
 
 
 def normalize_name(name: object) -> str:
-    """Uppercase, drop legal suffixes and punctuation, collapse whitespace."""
+    """Compatibility shim for the frozen ground-truth identity policy."""
 
-    text = _SUFFIX_RE.sub(" ", str(name or "").upper())
-    text = _NON_ALNUM.sub(" ", text)
-    return " ".join(text.split())
+    return normalize_company_name(name, profile=CompanyNameProfile.GROUNDTRUTH_V1)
 
 
 @dataclass
@@ -97,7 +93,7 @@ def resolve_firm(
 
     # Fuzzy: score the query against the distinct known name keys.
     choices = awards["name_key"].dropna().unique().tolist()
-    best = process.extractOne(key, choices, scorer=fuzz.token_set_ratio)
+    best = process.extractOne(key, choices, scorer=rapidfuzz_token_set_100)
     if best is not None and best[1] >= threshold:
         matched_key = best[0]
         rows = awards.loc[awards["name_key"] == matched_key]

--- a/scripts/phase3_groundtruth/resolve_firm_awards.py
+++ b/scripts/phase3_groundtruth/resolve_firm_awards.py
@@ -33,9 +33,9 @@ FUZZY_THRESHOLD = 88.0
 
 
 def normalize_name(name: object) -> str:
-    """Compatibility shim for the frozen ground-truth identity policy."""
+    """Normalize firms with the shared suffixless organization policy."""
 
-    return normalize_company_name(name, profile=CompanyNameProfile.GROUNDTRUTH_V1)
+    return normalize_company_name(name, profile=CompanyNameProfile.ORGANIZATION_KEY_V1)
 
 
 @dataclass

--- a/tests/unit/identity/test_company_names.py
+++ b/tests/unit/identity/test_company_names.py
@@ -1,0 +1,111 @@
+import math
+
+import pytest
+import pandas as pd
+from rapidfuzz import fuzz, process
+
+from sbir_etl.enrichers import matching as legacy_matching
+from sbir_etl.identity import (
+    ENHANCED_ABBREVIATIONS,
+    SUFFIX_TOKENS,
+    CompanyNameMetric,
+    CompanyNameProfile,
+    company_name_similarity,
+    normalize_company_name,
+    rapidfuzz_jaro_winkler_100,
+    rapidfuzz_ratio_100,
+    rapidfuzz_token_set_100,
+    rapidfuzz_token_sort_100,
+)
+
+
+@pytest.mark.parametrize(
+    ("profile", "raw", "expected"),
+    [
+        (
+            CompanyNameProfile.MATCHING_V1,
+            "Café Technologies, Incorporated",
+            "cafe technologies inc",
+        ),
+        (CompanyNameProfile.RECIPIENT_V1, "Café Technologies, Inc.", "cafe technologies"),
+        (CompanyNameProfile.ENTITY_RESOLUTION_V1, "O'Brien & Associates Inc", "OBRIEN ASSOCIATES"),
+        (CompanyNameProfile.GROUNDTRUTH_V1, "Acme Photonics, L.L.C.", "ACME PHOTONICS"),
+        (CompanyNameProfile.VENDOR_CROSSWALK_V1, "Acme, Inc.", "Acme  Inc"),
+        (CompanyNameProfile.VENDOR_RESOLVER_V1, "Acme & Corporation", "acme and corp"),
+        (CompanyNameProfile.FORM_D_JOIN_V1, "  Acme   Corp ", "ACME CORP"),
+        (CompanyNameProfile.UCC_V1, "Advanced Materials Corporation", "adv materials"),
+        (CompanyNameProfile.SEC_EDGAR_V1, "QUALCOMM INC/DE", "QUALCOMM"),
+        (CompanyNameProfile.SEC_EDGAR_TRAILING_V1, "QUALCOMM INC/DE", "QUALCOMM INC"),
+        (CompanyNameProfile.NOTICE_KEY_V1, "Acme Photonics, Inc.", "ACMEPHOTONICS"),
+        (CompanyNameProfile.PHASE3_RANKING_V1, "Acme CorpTech LLC", "ACME"),
+    ],
+)
+def test_versioned_profiles_preserve_declared_outputs(
+    profile: CompanyNameProfile,
+    raw: str,
+    expected: str,
+) -> None:
+    assert normalize_company_name(raw, profile=profile) == expected
+
+
+def test_matching_profile_accepts_explicit_abbreviation_dictionary() -> None:
+    normalized = normalize_company_name(
+        "Advanced Technologies, Inc.",
+        profile=CompanyNameProfile.MATCHING_V1,
+        abbreviations=ENHANCED_ABBREVIATIONS,
+    )
+
+    assert normalized == "adv tech inc"
+
+
+@pytest.mark.parametrize("blank", [None, "", "   ", float("nan")])
+def test_all_profiles_return_empty_for_blank_values(blank: object) -> None:
+    for profile in CompanyNameProfile:
+        assert normalize_company_name(blank, profile=profile) == ""
+
+
+def test_similarity_treats_pandas_missing_value_as_blank() -> None:
+    assert company_name_similarity(pd.NA, "Acme", metric=CompanyNameMetric.TOKEN_SET) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("metric", "direct"),
+    [
+        (CompanyNameMetric.RATIO, fuzz.ratio),
+        (CompanyNameMetric.TOKEN_SET, fuzz.token_set_ratio),
+        (CompanyNameMetric.TOKEN_SORT, fuzz.token_sort_ratio),
+    ],
+)
+def test_similarity_contract_uses_zero_to_one_scale(metric, direct) -> None:
+    left = "acme advanced systems"
+    right = "advanced acme system"
+
+    score = company_name_similarity(left, right, metric=metric)
+
+    assert 0.0 <= score <= 1.0
+    assert math.isclose(score, direct(left, right) / 100.0)
+
+
+def test_rapidfuzz_adapters_preserve_historical_score_scale_and_process_api() -> None:
+    left = "acme advanced systems"
+    right = "advanced acme system"
+
+    assert rapidfuzz_ratio_100(left, right) == pytest.approx(fuzz.ratio(left, right))
+    assert rapidfuzz_token_set_100(left, right) == pytest.approx(fuzz.token_set_ratio(left, right))
+    assert rapidfuzz_token_sort_100(left, right) == pytest.approx(
+        fuzz.token_sort_ratio(left, right)
+    )
+    assert 0.0 <= rapidfuzz_jaro_winkler_100(left, right) <= 100.0
+    assert (
+        process.extractOne(
+            left,
+            {1: right},
+            scorer=rapidfuzz_token_set_100,
+        )[2]
+        == 1
+    )
+
+
+def test_legacy_matching_constants_are_shared_identity_objects() -> None:
+    assert legacy_matching.ENHANCED_ABBREVIATIONS is ENHANCED_ABBREVIATIONS
+    assert legacy_matching.SUFFIX_TOKENS is SUFFIX_TOKENS

--- a/tests/unit/identity/test_company_names.py
+++ b/tests/unit/identity/test_company_names.py
@@ -23,6 +23,11 @@ from sbir_etl.identity import (
     ("profile", "raw", "expected"),
     [
         (
+            CompanyNameProfile.ORGANIZATION_KEY_V1,
+            "Café Technologies, L.L.C.",
+            "CAFE TECHNOLOGIES",
+        ),
+        (
             CompanyNameProfile.MATCHING_V1,
             "Café Technologies, Incorporated",
             "cafe technologies inc",
@@ -56,6 +61,25 @@ def test_matching_profile_accepts_explicit_abbreviation_dictionary() -> None:
     )
 
     assert normalized == "adv tech inc"
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Coherent Photonics, Limited Liability Company", "COHERENT PHOTONICS"),
+        ("Pelletized Straw, L.L.C.", "PELLETIZED STRAW"),
+        ("Acme Corp Inc LLC", "ACME"),
+        ("Acme LLC Limited Liability Company", "ACME"),
+        ("PC Photonics", "PC PHOTONICS"),
+        ("AEROPLAS CORP. INTERNATIONAL", "AEROPLAS CORP INTERNATIONAL"),
+        ("Corptech, Inc.", "CORPTECH"),
+    ],
+)
+def test_organization_key_removes_only_trailing_legal_designators(
+    raw: str,
+    expected: str,
+) -> None:
+    assert normalize_company_name(raw, profile=CompanyNameProfile.ORGANIZATION_KEY_V1) == expected
 
 
 @pytest.mark.parametrize("blank", [None, "", "   ", float("nan")])

--- a/tests/unit/scripts/test_identity_boundaries.py
+++ b/tests/unit/scripts/test_identity_boundaries.py
@@ -24,11 +24,40 @@ def test_unreviewed_direct_rapidfuzz_scorer_is_rejected(tmp_path: Path) -> None:
 
 
 def test_plain_process_import_is_allowed(tmp_path: Path) -> None:
+    # ``process`` drives the search; callers supply a scorer from
+    # ``sbir_etl.identity``, so importing it is not itself a bypass.
     path = _write(
         tmp_path,
         "sbir_etl/example.py",
         "from rapidfuzz import process\n",
     )
+
+    assert boundaries.scan_file(path, repository_root=tmp_path) == []
+
+
+def test_bare_package_import_is_rejected(tmp_path: Path) -> None:
+    # ``import rapidfuzz`` reaches fuzz and distance by attribute access, so it
+    # would otherwise bypass the guard without ever naming a scorer submodule.
+    path = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "import rapidfuzz\nscore = rapidfuzz.fuzz.token_set_ratio('a', 'b')\n",
+    )
+
+    violations = boundaries.scan_file(path, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].path == "sbir_etl/example.py"
+
+
+def test_scorer_submodule_import_is_rejected(tmp_path: Path) -> None:
+    path = _write(tmp_path, "sbir_etl/example.py", "import rapidfuzz.fuzz\n")
+
+    assert len(boundaries.scan_file(path, repository_root=tmp_path)) == 1
+
+
+def test_process_submodule_import_is_allowed(tmp_path: Path) -> None:
+    path = _write(tmp_path, "sbir_etl/example.py", "import rapidfuzz.process\n")
 
     assert boundaries.scan_file(path, repository_root=tmp_path) == []
 

--- a/tests/unit/scripts/test_identity_boundaries.py
+++ b/tests/unit/scripts/test_identity_boundaries.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from scripts.ci import check_identity_boundaries as boundaries
+
+
+def _write(root: Path, relative: str, text: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_unreviewed_direct_rapidfuzz_scorer_is_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "from rapidfuzz import fuzz\nscore = fuzz.token_set_ratio('a', 'b')\n",
+    )
+
+    violations = boundaries.scan_file(path, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].path == "sbir_etl/example.py"
+
+
+def test_plain_process_import_is_allowed(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "from rapidfuzz import process\n",
+    )
+
+    assert boundaries.scan_file(path, repository_root=tmp_path) == []
+
+
+def test_current_repository_obeys_identity_boundaries() -> None:
+    assert boundaries.scan_repository() == []

--- a/tests/unit/scripts/test_repository_hygiene.py
+++ b/tests/unit/scripts/test_repository_hygiene.py
@@ -70,6 +70,18 @@ def test_archive_guard_ignores_archive_scripts_and_flags_live_references(tmp_pat
     assert violations[0].path == "sbir_etl/example.py"
 
 
+def test_archive_guard_ignores_identity_guard_self_reference(tmp_path: Path):
+    identity_guard = _write(
+        tmp_path,
+        "scripts/ci/check_identity_boundaries.py",
+        'EXCLUDED = ("scripts/archive/", "tests/unit/scripts/archive/")\n',
+    )
+
+    violations = hygiene.scan_archive_references([identity_guard], root=tmp_path)
+
+    assert violations == []
+
+
 def test_removed_src_guard_scans_automation_paths(tmp_path: Path):
     workflow = _write(
         tmp_path,


### PR DESCRIPTION
## Summary
- add one `sbir_etl.identity` contract for versioned company-name normalization profiles and 0..1 similarity scores
- migrate company-master, USAspending, transition vendor, Phase 0, UCC, SEC EDGAR, Form D, and Phase III research callers through compatibility shims
- consolidate USAspending and both Phase III paths on the durable `organization-key-v1` policy while retaining consumer-named legacy profiles
- prohibit unreviewed direct RapidFuzz scorers outside the shared identity contract, with reviewed exceptions for grant-number and person-name matching

## Evidence semantics
Name similarity remains candidate evidence, not proof of identity. It cannot support a negative claim such as never received an SBIR award without a separate study-specific coverage contract over identifiers, aliases, source universe, and data cut.

## Consolidation audit
Compared all 34,464 distinct company names in `award_data.csv` (SHA-256 `efdf7ca5a398703002ebb33345275b0f68e50af3c5db361d48a2456266a23628`).

The new policy:
- preserves 34,292 exact-name groups, the same count as `recipient-v1`
- removes the false `Engineering Inc` / `Engineering Partnership, Ltd` collision
- joins punctuated/unpunctuated `Pelletized Straw L.L.C.` variants
- adds the `Coherent Photonics` legal-name variants
- removes the false `PC Photonics` / `Photonics, Inc.` collision
- eliminates the ranking profile's broad `CORP\w*` behavior, which collided unrelated `Corp...` firms

Phase 0 remains on `entity-resolution-v1` because its normalized key participates in stable canonical IDs and needs an explicit ID migration.

## Verification
- 5,203 unit tests passed; 7 skipped
- 52 consolidation-focused identity/caller/guard tests passed
- MyPy passed: sbir_etl 208 files, sbir-ml + sbir-analytics 165 files
- Ruff lint and format checks passed for changed/CI surfaces
- company identity boundary and repository hygiene guards passed

## Relationship to PR #493
This PR is independent of #493 and can be reviewed separately. PR #493 establishes package and evidence boundaries; this PR addresses the output-sensitive identity primitive.