### PR TITLE
Fix red main, shard the unit suite, drop dangling CI filters

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -85,12 +85,14 @@ test-results*.json
 # OpenSpec
 openspec/
 
-# Specs (only frozen Phase III census inputs are needed in container)
+# Specs (only frozen runtime provenance inputs are needed in container)
 specs/*
 !specs/phase-iii-census/
 specs/phase-iii-census/*
 !specs/phase-iii-census/design.md
 !specs/phase-iii-census/amendments.md
+!specs/phase3-notice-corpus-fusion/
+!specs/phase3-notice-corpus-fusion/**
 
 # Archive (not needed in container)
 archive/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,7 @@ jobs:
       pull-requests: read
     outputs:
       performance: ${{ steps.detect.outputs.performance }}
-      transition: ${{ steps.detect.outputs.transition }}
       docker: ${{ steps.detect.outputs.docker }}
-      workflows: ${{ steps.detect.outputs.workflows }}
       docs-only: ${{ steps.detect.outputs.docs-only }}
     steps:
       - uses: actions/checkout@v7
@@ -72,25 +70,11 @@ jobs:
               - 'scripts/performance/benchmark_enrichment.py'
               - 'scripts/performance/detect_performance_regression.py'
               - 'config/base.yaml'
-            transition:
-              - 'packages/sbir-analytics/sbir_analytics/assets/phase_transition/**'
-              - 'packages/sbir-analytics/sbir_analytics/assets/jobs/phase_transition_job.py'
-              - 'packages/sbir-ml/sbir_ml/transition/**'
-              - 'tests/e2e/transition/**'
-              - 'tests/integration/test_transition_*.py'
-              - 'docs/transition/**'
-              - 'packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/**'
-              - 'packages/sbir-ml/sbir_ml/transition/detection/scoring.py'
-              - 'scripts/phase_iii_precision_backtest.py'
-              - 'tests/integration/test_phase_iii_retrospective_asset.py'
             docker:
               - 'Dockerfile*'
               - 'docker-compose*.yml'
               - '.dockerignore'
               - 'docker/**'
-            workflows:
-              - '.github/workflows/**'
-              - '.github/actions/**'
 
   code-quality:
     name: Code Quality (Lint + Type Check)
@@ -233,20 +217,39 @@ jobs:
 
     strategy:
       fail-fast: false
+      # Unit tests are sharded by count rather than split on the slow marker.
+      # The old split was 5,254 tests in unit-fast against 2 in unit-slow, so
+      # it provisioned a whole runner for two tests while one leg carried the
+      # entire suite. Shards cover exactly the same tests, just balanced.
+      # Coverage runs on shard 0 only: it costs ~33% wall clock (measured 64s
+      # vs 48s on 4 cores) and one shard is enough to produce the report.
       matrix:
         suite:
-          - name: unit-fast
+          - name: unit-shard-0
             path: tests/unit/
-            args: '-m "not slow and not integration"'
+            args: "--num-shards=4 --shard-id=0"
             needs_neo4j: false
-          - name: unit-slow
+            coverage: true
+          - name: unit-shard-1
             path: tests/unit/
-            args: '-m "slow and not integration"'
+            args: "--num-shards=4 --shard-id=1"
             needs_neo4j: false
+            coverage: false
+          - name: unit-shard-2
+            path: tests/unit/
+            args: "--num-shards=4 --shard-id=2"
+            needs_neo4j: false
+            coverage: false
+          - name: unit-shard-3
+            path: tests/unit/
+            args: "--num-shards=4 --shard-id=3"
+            needs_neo4j: false
+            coverage: false
           - name: integration
             path: tests/integration/
             args: '-m "integration and not slow"'
             needs_neo4j: true
+            coverage: true
 
     steps:
       - uses: actions/checkout@v7
@@ -281,9 +284,16 @@ jobs:
           NEO4J_PASSWORD: ${{ env.NEO4J_PASSWORD }}
           REQUIRE_NEO4J: ${{ matrix.suite.needs_neo4j && '1' || '' }}
         run: |
-          uv run pytest ${{ matrix.suite.path }} ${{ matrix.suite.args }} \
-            --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-report=xml --cov-report=term \
-            --junitxml=test-results-${{ matrix.suite.name }}.xml -v
+          # -v already comes from addopts in pyproject.toml; repeating it here
+          # emitted a second verbose line per test through the xdist workers.
+          COV=""
+          if [ "${{ matrix.suite.coverage }}" = "true" ]; then
+            COV="--cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-report=xml --cov-report=term"
+          else
+            COV="--no-cov"
+          fi
+          uv run pytest ${{ matrix.suite.path }} ${{ matrix.suite.args }} $COV \
+            --junitxml=test-results-${{ matrix.suite.name }}.xml
 
       - name: Stop Neo4j service
         if: always() && matrix.suite.needs_neo4j
@@ -335,7 +345,7 @@ jobs:
           TOTAL_FAILED=0
           TOTAL_SKIPPED=0
 
-          for suite in unit-fast unit-slow integration; do
+          for suite in unit-shard-0 unit-shard-1 unit-shard-2 unit-shard-3 integration; do
             XML_FILE="test-results/test-results-${suite}/test-results-${suite}.xml"
             if [ -f "$XML_FILE" ]; then
               # Parse JUnit XML for test counts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,35 +221,30 @@ jobs:
       # The old split was 5,254 tests in unit-fast against 2 in unit-slow, so
       # it provisioned a whole runner for two tests while one leg carried the
       # entire suite. Shards cover exactly the same tests, just balanced.
-      # Coverage runs on shard 0 only: it costs ~33% wall clock (measured 64s
-      # vs 48s on 4 cores) and one shard is enough to produce the report.
+      # Every shard writes a coverage report. Codecov merges the five reports,
+      # preserving whole-suite coverage while retaining parallel test execution.
       matrix:
         suite:
           - name: unit-shard-0
             path: tests/unit/
             args: "--num-shards=4 --shard-id=0"
             needs_neo4j: false
-            coverage: true
           - name: unit-shard-1
             path: tests/unit/
             args: "--num-shards=4 --shard-id=1"
             needs_neo4j: false
-            coverage: false
           - name: unit-shard-2
             path: tests/unit/
             args: "--num-shards=4 --shard-id=2"
             needs_neo4j: false
-            coverage: false
           - name: unit-shard-3
             path: tests/unit/
             args: "--num-shards=4 --shard-id=3"
             needs_neo4j: false
-            coverage: false
           - name: integration
             path: tests/integration/
             args: '-m "integration and not slow"'
             needs_neo4j: true
-            coverage: true
 
     steps:
       - uses: actions/checkout@v7
@@ -286,13 +281,13 @@ jobs:
         run: |
           # -v already comes from addopts in pyproject.toml; repeating it here
           # emitted a second verbose line per test through the xdist workers.
-          COV=""
-          if [ "${{ matrix.suite.coverage }}" = "true" ]; then
-            COV="--cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-report=xml --cov-report=term"
-          else
-            COV="--no-cov"
-          fi
-          uv run pytest ${{ matrix.suite.path }} ${{ matrix.suite.args }} $COV \
+          uv run pytest ${{ matrix.suite.path }} ${{ matrix.suite.args }} \
+            --cov=sbir_etl \
+            --cov=packages/sbir-analytics/sbir_analytics \
+            --cov=packages/sbir-ml/sbir_ml \
+            --cov=packages/sbir-graph/sbir_graph \
+            --cov-report=xml \
+            --cov-report=term \
             --junitxml=test-results-${{ matrix.suite.name }}.xml
 
       - name: Stop Neo4j service
@@ -302,7 +297,7 @@ jobs:
           container-name: test-neo4j
 
       - name: Upload coverage
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && hashFiles('coverage.xml') != '' }}
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.xml
@@ -336,10 +331,7 @@ jobs:
 
       - name: Aggregate test results
         run: |
-          cat > /tmp/test_summary.md << 'EOF'
-          ## 🧪 Test Results Summary
-
-          EOF
+          : > /tmp/test_failures.md
 
           TOTAL_PASSED=0
           TOTAL_FAILED=0
@@ -362,23 +354,32 @@ jobs:
               TOTAL_SKIPPED=$((TOTAL_SKIPPED + SKIPPED))
 
               if [ "$FAILED" -gt 0 ]; then
-                echo "### ❌ ${suite} Failures" >> /tmp/test_summary.md
-                echo "" >> /tmp/test_summary.md
+                echo "### ❌ ${suite} Failures" >> /tmp/test_failures.md
+                echo "" >> /tmp/test_failures.md
                 # Extract failure messages from JUnit XML
                 grep -oP '<failure[^>]*message="\K[^"]+' "$XML_FILE" | head -5 | while read msg; do
-                  echo "- $msg" >> /tmp/test_summary.md
+                  echo "- $msg" >> /tmp/test_failures.md
                 done
-                echo "" >> /tmp/test_summary.md
+                echo "" >> /tmp/test_failures.md
               fi
             fi
           done
 
-          # Add summary at top
-          sed -i "3i **Total:** $TOTAL_PASSED ✅ passed, $TOTAL_FAILED ❌ failed, $TOTAL_SKIPPED ⏭️ skipped\n" /tmp/test_summary.md
-
           if [ "$TOTAL_FAILED" -eq 0 ]; then
-            sed -i "3i ### ✅ All Tests Passed!\n" /tmp/test_summary.md
+            STATUS="### ✅ All Tests Passed!"
+          else
+            STATUS="### ❌ Test Failures Detected"
           fi
+
+          {
+            echo "## 🧪 Test Results Summary"
+            echo ""
+            echo "$STATUS"
+            echo ""
+            echo "**Total:** $TOTAL_PASSED ✅ passed, $TOTAL_FAILED ❌ failed, $TOTAL_SKIPPED ⏭️ skipped"
+            echo ""
+            cat /tmp/test_failures.md
+          } > /tmp/test_summary.md
 
       - name: Comment PR
         uses: actions/github-script@v9

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY scripts/ /app/scripts/
 COPY config/ /app/config/
 COPY specs/phase-iii-census/ /app/specs/phase-iii-census/
+COPY specs/phase3-notice-corpus-fusion/ /app/specs/phase3-notice-corpus-fusion/
 COPY workspace.server.yaml /app/workspace.server.yaml
 COPY data/reference/ /app/data/reference/
 COPY pyproject.toml /app/

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -35,6 +35,7 @@ COPY packages/sbir-graph/sbir_graph/ /app/sbir_graph/
 COPY packages/sbir-ml/sbir_ml/ /app/sbir_ml/
 COPY config/ /app/config/
 COPY specs/phase-iii-census/ /app/specs/phase-iii-census/
+COPY specs/phase3-notice-corpus-fusion/ /app/specs/phase3-notice-corpus-fusion/
 COPY data/reference/ /app/data/reference/
 COPY scripts/ /app/scripts/
 COPY pyproject.toml /app/

--- a/codecov.yml
+++ b/codecov.yml
@@ -16,14 +16,14 @@ coverage:
       default:
         informational: true
 
-# The CI test job uploads three coverage reports per commit (unit-fast,
-# unit-slow, integration flags in .github/workflows/ci.yml). Wait for all
-# three before computing status or commenting, so partial uploads don't
+# The CI test job uploads five coverage reports per commit (four unit shards
+# and one integration suite in .github/workflows/ci.yml). Wait for all five
+# before computing status or commenting, so partial uploads don't
 # produce false coverage-drop failures.
 codecov:
   notify:
-    after_n_builds: 3
+    after_n_builds: 5
 
 comment:
-  after_n_builds: 3
+  after_n_builds: 5
   require_changes: true

--- a/tests/integration/test_sam_gov_integration.py
+++ b/tests/integration/test_sam_gov_integration.py
@@ -79,12 +79,11 @@ class TestSAMGovExtractorIntegration:
         # Create extractor with mock config
         with patch("sbir_etl.extractors.sam_gov.get_config") as mock_config:
             mock_config.return_value.extraction.sam_gov.parquet_path = str(sample_sam_gov_parquet)
-            mock_config.return_value.extraction.sam_gov.use_s3_first = False
 
             extractor = SAMGovExtractor()
 
             # Load parquet
-            df = extractor.load_parquet(parquet_path=sample_sam_gov_parquet, use_s3_first=False)
+            df = extractor.load_parquet(parquet_path=sample_sam_gov_parquet)
 
             # Verify data loaded
             assert len(df) == 5
@@ -112,10 +111,9 @@ class TestSAMGovExtractorIntegration:
         """Test handling of multiple NAICS codes in naics_code_string."""
         with patch("sbir_etl.extractors.sam_gov.get_config") as mock_config:
             mock_config.return_value.extraction.sam_gov.parquet_path = str(sample_sam_gov_parquet)
-            mock_config.return_value.extraction.sam_gov.use_s3_first = False
 
             extractor = SAMGovExtractor()
-            df = extractor.load_parquet(parquet_path=sample_sam_gov_parquet, use_s3_first=False)
+            df = extractor.load_parquet(parquet_path=sample_sam_gov_parquet)
 
             # Check entity with multiple NAICS codes
             entity = extractor.get_entity_by_uei(df, "DEF987654321")
@@ -143,7 +141,6 @@ class TestSAMGovAssetIntegration:
 
         with patch("sbir_analytics.assets.sam_gov_ingestion.get_config") as mock_config:
             mock_config.return_value.extraction.sam_gov.parquet_path = str(sample_sam_gov_parquet)
-            mock_config.return_value.extraction.sam_gov.use_s3_first = False
             mock_config.return_value.s3 = {}
 
             # Mock SAMGovExtractor to return our test data
@@ -182,7 +179,6 @@ class TestSAMGovAssetIntegration:
         # Mock config with non-existent file
         with patch("sbir_analytics.assets.sam_gov_ingestion.get_config") as mock_config:
             mock_config.return_value.extraction.sam_gov.parquet_path = "/nonexistent/file.parquet"
-            mock_config.return_value.extraction.sam_gov.use_s3_first = False
             mock_config.return_value.s3 = {}
 
             # Mock Path.exists to return False


### PR DESCRIPTION
## Description

This PR repairs the integration tests broken by #494 and makes the CI suite genuinely parallel without dropping tests or coverage.

### 1. Repair the integration suite

Phase 3 of #494 removed `use_s3_first` from `SAMGovExtractor.load_parquet`; two integration-test call sites still passed it. The stale arguments are removed.

### 2. Balance the unit suite

The former `unit-fast`/`unit-slow` split assigned 5,254 tests to one runner and two tests to another. Four count-balanced `pytest-shard` jobs now cover the same unit-test set. The integration suite remains a separate Neo4j-backed job.

Each of the four unit shards and the integration job generates and uploads coverage. Codecov waits for all five reports before computing project status, so the merged report still represents the complete suite. Uploads are skipped when a job did not produce `coverage.xml`.

### 3. Make the PR test summary reliable

The previous summary inserted status lines at a nonexistent line 3 and produced a header-only comment. The workflow now composes the status, totals, and optional failures explicitly.

### 4. Restore the container provenance contract

The container test failure was traced to a missing frozen asset:

```
/app/specs/phase3-notice-corpus-fusion/corpus.manifest.json
```

Both production Dockerfiles now copy the fusion provenance directory, and `.dockerignore` admits only that frozen spec alongside the census spec.

### 5. Remove dangling change-detection outputs

The unused `transition` and `workflows` outputs and filters are removed.

## Verification

- Full local suite from the original change: `5,432 passed, 39 skipped`
- Four unit shards reproduced locally and balanced within 4%
- Edited workflow and Codecov YAML parse successfully
- Docker image builds with the fusion provenance spec included
- Previously failing provenance hash test passes inside the rebuilt Linux image
- Synthetic JUnit report renders a populated summary with correct totals

## Checklist

- [x] Integration regression fixed
- [x] Unit suite sharded without changing test membership
- [x] Whole-suite coverage preserved across five reports
- [x] Empty Codecov uploads prevented
- [x] PR test summary repaired
- [x] Container provenance test reproduced and fixed
