### PR TITLE
Stage 2: consolidate transition vendor identity keys

### DIFF
--- a/docs/steering/company-identity.md
+++ b/docs/steering/company-identity.md
@@ -31,6 +31,12 @@ linkage. It folds case and accents, normalizes punctuation, and removes recogniz
 designators only at the end of a name. Removing designator-like words from the middle of
 a name creates false collisions (for example, `PC Photonics` with `Photonics, Inc.`).
 
+`vendor-key-v1` is the durable transition-vendor key. It preserves legal designators but
+canonicalizes common long and short forms (`Corporation`/`Corp`, `Company`/`Co`, and
+`Limited`/`Ltd`) because vendor records use those distinctions as matching evidence while
+still needing spelling variants to share an index entry. Persisted canonical and alias
+names remain display text; they are never replaced by the lowercase matching key.
+
 The initial consumer-named profiles remain available as compatibility policies so
 migration cannot silently change research outputs:
 
@@ -40,8 +46,8 @@ migration cannot silently change research outputs:
 | `recipient-v1` | legacy USAspending recipient normalization |
 | `entity-resolution-v1` | Phase 0 cross-source resolver |
 | `groundtruth-v1` | legacy Phase III success-story normalization |
-| `vendor-crosswalk-v1` | transition vendor crosswalk persistence |
-| `vendor-resolver-v1` | transition vendor resolver |
+| `vendor-crosswalk-v1` | transition crosswalk display cleanup only; never a match key |
+| `vendor-resolver-v1` | legacy transition resolver key; equivalent to `vendor-key-v1` |
 | `form-d-join-v1` | agency/private-capital join keys |
 | `ucc-v1` | UCC debtor matching |
 | `sec-edgar-v1` | SEC company lookup and mention filtering |
@@ -70,6 +76,21 @@ ground-truth profile, it adds the `Coherent Photonics` legal-name variants and r
 the false `PC Photonics` / `Photonics, Inc.` collision. Relative to the ranking profile,
 it removes its broad `CORP\w*` behavior, which created false collisions among unrelated
 names beginning with `Corp...`.
+
+### Second consolidation audit
+
+The transition vendor crosswalk and resolver now use `vendor-key-v1` for all name indices,
+exact comparisons, and fuzzy-match inputs. Crosswalk persistence continues to retain
+cleaned human-readable canonical and alias names, so an identity key cannot overwrite
+source-facing display text.
+
+The legacy crosswalk and shared vendor keys were compared over the same 34,464 distinct
+awardee names and pinned `award_data.csv` SHA-256 used in the first audit. The shared key
+reduces 34,459 legacy crosswalk partitions to 34,424 vendor-key partitions. All 35 newly
+joined groups were reviewed. They consist exclusively of case, punctuation, ampersand,
+or canonical legal-designator variants; no ambiguous firms were joined. Examples include
+`Planetary Systems Corp.` / `PLANETARY SYSTEMS CORPORATION`, `Alme & Associates` /
+`Alme and Associates`, and `I. C. Gomes...` / `I.C. Gomes...`.
 
 Person-name matching, grant-number matching, and storage-only display cleanup are separate
 domains and do not use company-name profiles merely because their old helper was also

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
@@ -302,6 +302,11 @@ class VendorCrosswalk:
     ) -> tuple[CrosswalkRecord, float] | None:
         """
         Find best matching canonical record by name. Returns (record, score) or None.
+
+        A name that identifies more than one canonical record is ambiguous and returns
+        None. The shared vendor key deliberately joins spelling variants, so distinct
+        identifier-backed records can share a key; resolving that by index position
+        would select a record by insertion order.
         """
         if not name:
             return None
@@ -311,17 +316,17 @@ class VendorCrosswalk:
         # exact match
         cids = self._name_index.get(norm)
         if cids:
-            return self.records[cids[0]], 1.0
+            return (self.records[cids[0]], 1.0) if len(cids) == 1 else None
         # fuzzy choose best across canonical names
         best_score = 0.0
-        best_cid = None
+        best_cids: list[str] = []
         for canon_name, cid_list in self._name_index.items():
             score = _fuzzy_score(norm, canon_name)
             if score > best_score:
                 best_score = score
-                best_cid = cid_list[0]
-        if best_score >= fuzzy_threshold and best_cid:
-            return self.records[best_cid], best_score
+                best_cids = cid_list
+        if best_score >= fuzzy_threshold and len(best_cids) == 1:
+            return self.records[best_cids[0]], best_score
         return None
 
     def find_by_any(
@@ -374,8 +379,9 @@ class VendorCrosswalk:
             return False
         rec = self.records[canonical_id]
         alias_name_norm = _clean_display_name(alias_name) or alias_name
-        # avoid duplicates
-        if any(a.name == alias_name_norm for a in rec.aliases):
+        alias_key = _normalize_name(alias_name)
+        # avoid duplicates on the matching key, not on display text
+        if any(_normalize_name(a.name) == alias_key for a in rec.aliases):
             return True
         ad = AliasRecord(
             name=alias_name_norm,
@@ -385,9 +391,10 @@ class VendorCrosswalk:
         )
         rec.aliases.append(ad)
         # update name index
-        alias_key = _normalize_name(alias_name_norm)
         if alias_key:
-            self._name_index.setdefault(alias_key, []).append(canonical_id)
+            indexed = self._name_index.setdefault(alias_key, [])
+            if canonical_id not in indexed:
+                indexed.append(canonical_id)
         logger.info("Added alias '%s' to %s", alias_name, canonical_id)
         return True
 

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
@@ -70,6 +70,14 @@ def _normalize_identifier(val: str | None) -> str | None:
 
 
 def _normalize_name(name: str | None) -> str | None:
+    """Build the shared transition-vendor key used for matching and indexing."""
+    if name is None:
+        return None
+    return normalize_company_name(name, profile=CompanyNameProfile.VENDOR_KEY_V1)
+
+
+def _clean_display_name(name: str | None) -> str | None:
+    """Clean persisted display text without turning it into an identity key."""
     if name is None:
         return None
     return normalize_company_name(name, profile=CompanyNameProfile.VENDOR_CROSSWALK_V1)
@@ -130,12 +138,12 @@ class CrosswalkRecord:
         return d
 
     def normalize(self) -> None:
-        self.canonical_name = _normalize_name(self.canonical_name) or self.canonical_name
+        self.canonical_name = _clean_display_name(self.canonical_name) or self.canonical_name
         self.uei = _normalize_identifier(self.uei)
         self.cage = _normalize_identifier(self.cage)
         self.duns = _normalize_identifier(self.duns)
         for a in self.aliases:
-            a.name = _normalize_name(a.name) or a.name
+            a.name = _clean_display_name(a.name) or a.name
 
 
 # ---------------------------------------------------------------------------
@@ -240,7 +248,7 @@ class VendorCrosswalk:
         # If canonical name differs, keep existing canonical_name but add alias
         if _normalize_name(base.canonical_name) != _normalize_name(rec.canonical_name):
             # add rec canonical name as alias if not present
-            alias_name = _normalize_name(rec.canonical_name) or rec.canonical_name
+            alias_name = _clean_display_name(rec.canonical_name) or rec.canonical_name
             if alias_name and alias_name not in existing_alias_names:
                 base.aliases.append(AliasRecord(name=alias_name, note="merged-canonical"))
         logger.info("Merged record %s into %s", rec.canonical_id, canonical_id)
@@ -365,7 +373,7 @@ class VendorCrosswalk:
         if canonical_id not in self.records:
             return False
         rec = self.records[canonical_id]
-        alias_name_norm = _normalize_name(alias_name) or alias_name
+        alias_name_norm = _clean_display_name(alias_name) or alias_name
         # avoid duplicates
         if any(a.name == alias_name_norm for a in rec.aliases):
             return True
@@ -377,7 +385,9 @@ class VendorCrosswalk:
         )
         rec.aliases.append(ad)
         # update name index
-        self._name_index.setdefault(alias_name_norm, []).append(canonical_id)
+        alias_key = _normalize_name(alias_name_norm)
+        if alias_key:
+            self._name_index.setdefault(alias_key, []).append(canonical_id)
         logger.info("Added alias '%s' to %s", alias_name, canonical_id)
         return True
 

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_resolver.py
@@ -133,7 +133,7 @@ class VendorResolver:
         """Normalize company names for indexing and exact comparisons."""
         if name is None:
             return ""  # type: ignore[unreachable]
-        return normalize_company_name(name, profile=CompanyNameProfile.VENDOR_RESOLVER_V1)
+        return normalize_company_name(name, profile=CompanyNameProfile.VENDOR_KEY_V1)
 
     def _load_records(self, records: Iterable[VendorRecord]) -> None:
         """Populate indices from the provided VendorRecord iterable."""

--- a/sbir_etl/identity/company_names.py
+++ b/sbir_etl/identity/company_names.py
@@ -32,6 +32,7 @@ class CompanyNameProfile(StrEnum):
     ENTITY_RESOLUTION_V1 = "entity-resolution-v1"
     GROUNDTRUTH_V1 = "groundtruth-v1"
     VENDOR_CROSSWALK_V1 = "vendor-crosswalk-v1"
+    VENDOR_KEY_V1 = "vendor-key-v1"
     VENDOR_RESOLVER_V1 = "vendor-resolver-v1"
     FORM_D_JOIN_V1 = "form-d-join-v1"
     UCC_V1 = "ucc-v1"
@@ -263,7 +264,10 @@ def normalize_company_name(
         return (
             text.replace(",", " ").replace(".", " ").replace("/", " ").replace("&", " AND ").strip()
         )
-    if profile is CompanyNameProfile.VENDOR_RESOLVER_V1:
+    if profile in {
+        CompanyNameProfile.VENDOR_KEY_V1,
+        CompanyNameProfile.VENDOR_RESOLVER_V1,
+    }:
         text = " ".join(text.strip().split())
         text = text.replace(",", " ").replace(".", " ").replace("/", " ").replace("&", " AND ")
         aliases = {

--- a/tests/unit/identity/test_company_names.py
+++ b/tests/unit/identity/test_company_names.py
@@ -36,6 +36,7 @@ from sbir_etl.identity import (
         (CompanyNameProfile.ENTITY_RESOLUTION_V1, "O'Brien & Associates Inc", "OBRIEN ASSOCIATES"),
         (CompanyNameProfile.GROUNDTRUTH_V1, "Acme Photonics, L.L.C.", "ACME PHOTONICS"),
         (CompanyNameProfile.VENDOR_CROSSWALK_V1, "Acme, Inc.", "Acme  Inc"),
+        (CompanyNameProfile.VENDOR_KEY_V1, "Acme & Corporation", "acme and corp"),
         (CompanyNameProfile.VENDOR_RESOLVER_V1, "Acme & Corporation", "acme and corp"),
         (CompanyNameProfile.FORM_D_JOIN_V1, "  Acme   Corp ", "ACME CORP"),
         (CompanyNameProfile.UCC_V1, "Advanced Materials Corporation", "adv materials"),
@@ -86,6 +87,19 @@ def test_organization_key_removes_only_trailing_legal_designators(
 def test_all_profiles_return_empty_for_blank_values(blank: object) -> None:
     for profile in CompanyNameProfile:
         assert normalize_company_name(blank, profile=profile) == ""
+
+
+def test_vendor_key_preserves_resolver_compatibility() -> None:
+    names = ["Acme Corporation", "Acme, Corp.", "Acme & Company", "Acme/LLC"]
+
+    for name in names:
+        assert normalize_company_name(
+            name,
+            profile=CompanyNameProfile.VENDOR_KEY_V1,
+        ) == normalize_company_name(
+            name,
+            profile=CompanyNameProfile.VENDOR_RESOLVER_V1,
+        )
 
 
 def test_similarity_treats_pandas_missing_value_as_blank() -> None:

--- a/tests/unit/transition/features/test_vendor_crosswalk.py
+++ b/tests/unit/transition/features/test_vendor_crosswalk.py
@@ -64,10 +64,10 @@ class TestUtilityFunctions:
     @pytest.mark.parametrize(
         "input_val,expected",
         [
-            ("  Acme   Corporation  ", "Acme Corporation"),
-            ("Acme\n\tCorporation", "Acme Corporation"),
-            ("Acme, Inc.", "Acme  Inc"),
-            ("Acme/Corp", "Acme Corp"),
+            ("  Acme   Corporation  ", "acme corp"),
+            ("Acme\n\tCorporation", "acme corp"),
+            ("Acme, Inc.", "acme inc"),
+            ("Acme/Corp", "acme corp"),
             (None, None),
         ],
         ids=["whitespace", "newline_tab", "comma_dot", "slash", "none"],
@@ -272,8 +272,8 @@ class TestAddOrMerge:
 
         cw.add_or_merge(record)
 
-        assert "Acme Corporation" in cw._name_index
-        assert "co-123" in cw._name_index["Acme Corporation"]
+        assert "acme corp" in cw._name_index
+        assert "co-123" in cw._name_index["acme corp"]
 
     def test_merge_by_uei_match(self):
         """Test merging records with matching UEI."""
@@ -469,6 +469,19 @@ class TestLookupMethods:
         assert result[0].canonical_id == "co-123"
         assert result[1] == 1.0  # Perfect score
 
+    def test_find_by_name_uses_shared_vendor_key(self):
+        """Legal-designator and punctuation variants are exact matches."""
+        cw = VendorCrosswalk()
+        record = CrosswalkRecord(canonical_id="co-123", canonical_name="Acme Corporation")
+        cw.add_or_merge(record)
+
+        result = cw.find_by_name("ACME, CORP.")
+
+        assert result is not None
+        assert result[0].canonical_id == "co-123"
+        assert result[1] == 1.0
+        assert result[0].canonical_name == "Acme Corporation"
+
     def test_find_by_name_fuzzy_match(self):
         """Test finding by name with fuzzy matching."""
         cw = VendorCrosswalk()
@@ -636,8 +649,8 @@ class TestAliasHandling:
         cw.add_alias("co-123", "Acme Inc")
 
         # Should be findable by alias name
-        assert "Acme Inc" in cw._name_index
-        assert "co-123" in cw._name_index["Acme Inc"]
+        assert "acme inc" in cw._name_index
+        assert "co-123" in cw._name_index["acme inc"]
 
 
 class TestAcquisitionHandling:
@@ -895,8 +908,9 @@ class TestEdgeCases:
         cw.add_or_merge(record1)
         cw.add_or_merge(record2)
 
-        # Both normalize to "Acme  Corp"
+        # Both share the matching key while retaining separate identifier-backed records.
         assert len(cw.records) == 2
+        assert cw._name_index["acme corp"] == ["co-1", "co-2"]
 
     def test_jsonl_with_empty_lines(self):
         """Test loading JSONL handles empty lines."""

--- a/tests/unit/transition/features/test_vendor_crosswalk.py
+++ b/tests/unit/transition/features/test_vendor_crosswalk.py
@@ -482,6 +482,25 @@ class TestLookupMethods:
         assert result[1] == 1.0
         assert result[0].canonical_name == "Acme Corporation"
 
+    def test_find_by_name_returns_none_when_key_matches_two_records(self):
+        """An ambiguous vendor key is not resolved by index position."""
+        cw = VendorCrosswalk()
+        cw.add_or_merge(
+            CrosswalkRecord(
+                canonical_id="co-1", canonical_name="Acme Corporation", uei="AAAAAAAAAAAA"
+            )
+        )
+        cw.add_or_merge(
+            CrosswalkRecord(canonical_id="co-2", canonical_name="Acme, Corp.", uei="BBBBBBBBBBBB")
+        )
+
+        assert cw._name_index["acme corp"] == ["co-1", "co-2"]
+        assert cw.find_by_name("Acme Corporation") is None
+        assert cw.find_by_name("ACME CORP") is None
+        assert cw.find_by_any(name="Acme Corporation", fuzzy_threshold=0.7) is None
+        # Identifier lookups are unaffected by name ambiguity.
+        assert cw.find_by_uei("AAAAAAAAAAAA").canonical_id == "co-1"
+
     def test_find_by_name_fuzzy_match(self):
         """Test finding by name with fuzzy matching."""
         cw = VendorCrosswalk()
@@ -651,6 +670,42 @@ class TestAliasHandling:
         # Should be findable by alias name
         assert "acme inc" in cw._name_index
         assert "co-123" in cw._name_index["acme inc"]
+
+    def test_add_alias_deduplicates_display_variants_of_one_key(self):
+        """Variants sharing a vendor key add one alias and one index entry."""
+        cw = VendorCrosswalk()
+        cw.add_or_merge(CrosswalkRecord(canonical_id="co-123", canonical_name="Acme Corporation"))
+
+        assert cw.add_alias("co-123", "Acme Inc") is True
+        assert cw.add_alias("co-123", "ACME, INC.") is True
+        assert cw.add_alias("co-123", "Acme Incorporated") is True
+
+        assert [a.name for a in cw.records["co-123"].aliases] == ["Acme Inc"]
+        assert cw._name_index["acme inc"] == ["co-123"]
+        assert cw.find_by_name("Acme Inc")[0].canonical_id == "co-123"
+
+
+class TestVendorKeyIndexing:
+    """The display profile must never change which records share a matching key."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "Acme Corporation",
+            "Acme, Corp.",
+            "Alme & Associates",
+            "I. C. Gomes Consulting, L.L.C.",
+            "PC Photonics/Inc",
+            "Planetary Systems Corp.",
+        ],
+    )
+    def test_display_cleanup_does_not_change_the_matching_key(self, name):
+        from sbir_ml.transition.features.vendor_crosswalk import (
+            _clean_display_name,
+            _normalize_name,
+        )
+
+        assert _normalize_name(_clean_display_name(name)) == _normalize_name(name)
 
 
 class TestAcquisitionHandling:


### PR DESCRIPTION
## Summary

- add durable `vendor-key-v1` policy for transition vendor matching
- route both the vendor crosswalk and resolver through the same name key
- keep persisted canonical and alias names as human-readable display text
- retain the consumer-named Stage 1 profiles as compatibility policies
- document the Stage 2 corpus audit and matching semantics

## Why this is Stage 2

Stage 1 centralized the previously forked implementations behind `sbir_etl.identity` without silently changing most outputs. This PR consolidates the next demonstrably safe pair: the transition crosswalk and resolver had separate keys for the same vendor-resolution domain.

The crosswalk previously indexed display-cleaned names, while the resolver canonicalized case, punctuation, ampersands, and common long/short legal designators. Both now use `vendor-key-v1` for name indices, exact comparisons, and fuzzy-match inputs. Display cleanup remains separate so matching keys cannot overwrite persisted source-facing names.

## Real-data audit

Compared the legacy crosswalk key with `vendor-key-v1` over 34,464 distinct company names from:

```
award_data.csv
SHA-256 efdf7ca5a398703002ebb33345275b0f68e50af3c5db361d48a2456266a23628
```

Results:

- legacy crosswalk partitions: 34,459
- shared vendor-key partitions: 34,424
- newly joined groups: 35
- differences from the legacy resolver key: 0

All 35 joined groups were inspected. They are case, punctuation, ampersand, or legal-designator synonyms, including `Planetary Systems Corp.` / `PLANETARY SYSTEMS CORPORATION` and `Alme & Associates` / `Alme and Associates`. No ambiguous firms were joined.

## Verification

- `5,290 passed, 7 skipped` — full unit suite
- `179 passed` — focused identity, vendor-crosswalk, and vendor-resolver tests
- MyPy: no issues in 249 source files
- Ruff lint and format checks pass
- company identity boundary check passes
- corpus SHA and partition counts reproduced after implementation

## Scope boundary

This PR does not alter Phase 0 canonical IDs, UCC-specific abbreviation policy, SEC filing-name policy, Form D exact joins, or Phase III notice attribution. Those require their own output audits before consolidation.