### PR TITLE
Fix open Dependabot and CodeQL security alerts

### DIFF
--- a/scripts/ci/scan_secrets.py
+++ b/scripts/ci/scan_secrets.py
@@ -19,6 +19,12 @@ import tempfile
 from pathlib import Path
 
 
+# CodeQL's py/clear-text-logging-sensitive-data flags the status messages below
+# because SECRET_PATTERNS entries ("NEO4J_PASSWORD", "AWS_SECRET_ACCESS_KEY", ...)
+# reach a print(). Those are pattern *names* declared in this file, not values, so
+# the matching sites carry an inline suppression. Matched content is never printed
+# — see _match_locations.
+
 # Patterns to scan for (common secret patterns)
 SECRET_PATTERNS = [
     "NEO4J_PASSWORD",
@@ -65,6 +71,34 @@ def run_command(cmd: list[str], check: bool = True) -> subprocess.CompletedProce
     """Run a shell command and return the result."""
     result = subprocess.run(cmd, capture_output=True, text=True, check=check)
     return result
+
+
+def _match_locations(grep_lines: list[str]) -> list[str]:
+    """Reduce ``grep -RInZ`` output to ``path:lineno`` locations.
+
+    grep emits ``path\\0lineno:content``, so echoing it verbatim would publish a
+    matched secret's value into the CI log. The location is the actionable part;
+    the value is not.
+
+    The ``-Z`` flag is what makes this unambiguous. Without it grep emits
+    ``path:lineno:content`` and the split is guesswork in both directions: a
+    colon may appear in the path (POSIX permits it) *and* in the matched
+    content (``AWS_SECRET_ACCESS_KEY=a:b:c``). Splitting from the left loses
+    the line number for a colon-bearing path; splitting from the right leaks
+    part of the secret, which is the failure this function exists to prevent.
+    A NUL terminator after the filename removes the ambiguity entirely.
+    """
+    locations = []
+    for line in grep_lines:
+        path, sep, remainder = line.partition("\0")
+        if not sep:
+            # No NUL: not grep -Z output. Emit nothing beyond the raw field so
+            # a format change cannot silently start leaking content.
+            locations.append(line.partition(":")[0])
+            continue
+        lineno = remainder.partition(":")[0]
+        locations.append(f"{path}:{lineno}" if lineno else path)
+    return locations
 
 
 def scan_with_detect_secrets(baseline_path: Path | None = None) -> tuple[int, str]:
@@ -221,11 +255,11 @@ def scan_patterns() -> tuple[int, str]:
         try:
             if is_regex:
                 # Use -P for Perl regex
-                cmd = ["grep", "-RInP", pattern] + exclude_args + ["."]
+                cmd = ["grep", "-RInPZ", pattern] + exclude_args + ["."]
                 result = run_command(cmd, check=False)
             else:
                 # Regular string match
-                cmd = ["grep", "-RIn", pattern] + exclude_args + ["."]
+                cmd = ["grep", "-RInZ", pattern] + exclude_args + ["."]
                 result = run_command(cmd, check=False)
 
             if result.returncode == 0 and result.stdout:
@@ -241,8 +275,8 @@ def scan_patterns() -> tuple[int, str]:
                     found_secrets = True
                     patterns_found.append(pattern)
                     print(f"Pattern '{pattern}' found in:")
-                    for line in lines[:5]:  # Show first 5 matches
-                        print(f"  {line}")
+                    for location in _match_locations(lines)[:5]:  # Show first 5 matches
+                        print(f"  {location}")
 
         except FileNotFoundError:
             return (1, "grep not found")
@@ -290,6 +324,7 @@ def main() -> int:
             exit_code = precommit_exit
             if precommit_exit == 1:
                 # Hard failure - new secrets found
+                # codeql[py/clear-text-logging-sensitive-data]: status text only
                 print(f"ERROR: {precommit_msg}", file=sys.stderr)
                 # Also print stdout/stderr for debugging
                 return exit_code
@@ -300,6 +335,7 @@ def main() -> int:
         if detect_exit != 0:
             exit_code = detect_exit
             if detect_exit == 1:
+                # codeql[py/clear-text-logging-sensitive-data]: status text only
                 print(f"ERROR: {detect_msg}", file=sys.stderr)
                 # Run detect-secrets with verbose output to show what was found
                 print("\nRunning detect-secrets scan to show detected secrets:", file=sys.stderr)
@@ -332,11 +368,13 @@ def main() -> int:
 
     # Print summary
     for msg in messages:
+        # codeql[py/clear-text-logging-sensitive-data]: pattern names, not values
         print(msg)
 
     if exit_code == 0:
         print("✓ Secret scan completed successfully")
     else:
+        # codeql[py/clear-text-logging-sensitive-data]: exit code only
         print(f"✗ Secret scan failed with exit code {exit_code}", file=sys.stderr)
 
     return exit_code

--- a/tests/unit/test_scan_secrets.py
+++ b/tests/unit/test_scan_secrets.py
@@ -1,0 +1,53 @@
+"""Tests for the CI secret scanner's log redaction."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "ci"))
+
+from scan_secrets import _match_locations  # noqa: E402
+
+
+pytestmark = pytest.mark.fast
+
+
+class TestMatchLocations:
+    """`grep -RInZ` output must be reduced to locations before it reaches a log.
+
+    Input is NUL-delimited: ``path\\0lineno:content``.
+    """
+
+    def test_strips_matched_content(self):
+        """The matched line's content — the secret itself — is never returned."""
+        locations = _match_locations(["./deploy/prod.env\x0012:NEO4J_PASSWORD=hunter2"])
+        assert locations == ["./deploy/prod.env:12"]
+
+    def test_strips_content_containing_colons(self):
+        """Content with embedded colons does not bleed past the line number.
+
+        A right-split would return "./a.env:7:AWS_SECRET_ACCESS_KEY=a:b" here,
+        publishing most of the secret — the exact leak this guards against.
+        """
+        locations = _match_locations(["./a.env\x007:AWS_SECRET_ACCESS_KEY=a:b:c"])
+        assert locations == ["./a.env:7"]
+
+    def test_path_containing_colons_keeps_its_line_number(self):
+        """POSIX allows ':' in a path; the NUL delimiter keeps parsing exact."""
+        locations = _match_locations(["./wei:rd/x.env\x001:NEO4J_PASSWORD=a:b:c"])
+        assert locations == ["./wei:rd/x.env:1"]
+
+    def test_preserves_all_matches(self):
+        locations = _match_locations(["./a\x001:x", "./b\x002:y"])
+        assert locations == ["./a:1", "./b:2"]
+
+    def test_input_without_nul_never_leaks_content(self):
+        """If grep ever stops emitting -Z, degrade closed rather than leaking."""
+        assert _match_locations(["./a.env:7:NEO4J_PASSWORD=hunter2"]) == ["./a.env"]
+
+    def test_handles_line_without_location_prefix(self):
+        """Malformed input degrades safely rather than raising."""
+        assert _match_locations(["./nolineno"]) == ["./nolineno"]
+        assert _match_locations([""]) == [""]

--- a/uv.lock
+++ b/uv.lock
@@ -1389,14 +1389,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -2100,11 +2100,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Clears the 3 open Dependabot alerts and the CodeQL alerts on `main`.

**Rebased onto `main` after #501.** The original branch predated it and carried a `permissions:` addition to `build-images.yml` — a file #501 deleted. Merging as-is would have resurrected the workflow. That hunk is dropped, and CodeQL alert **#9 is moot** now that the file is gone.

**Dependabot (`uv.lock`)** — both packages are transitive; neither is declared directly.

| Alert | Package | Change |
|---|---|---|
| #44, #31 (High) — Mako path traversal in `TemplateLookup` | `mako` (via `alembic`) | 1.3.10 → 1.3.12 |
| #26 (Low) — Pygments ReDoS in GUID regex | `pygments` (via `pytest`/`rich`/`ipython`) | 2.19.2 → 2.20.0 |

A 6-line lockfile diff; nothing else moves. Real-world exposure is nil — the Mako advisories require attacker-controlled template URIs, and this repo never calls Mako directly.

**CodeQL #2–#6 (High), `scan_secrets.py`** — one genuine leak and four false positives.

- *Genuine:* `grep -RIn` emits `path:lineno:content`, so printing its output echoed a matched secret's **value** into the CI log — the exact disclosure the scanner exists to prevent. `_match_locations` reduces each match to `path:lineno`.
- *False positives:* the rest fire because `SECRET_PATTERNS` holds pattern **names** (`"NEO4J_PASSWORD"`, `"AWS_SECRET_ACCESS_KEY"`) that reach a `print()`. Those are constants declared in the file, not values. Suppressed inline with a stated rationale.

## Review feedback addressed

Copilot flagged that splitting on the first colon mis-parses paths containing `:` (POSIX permits it) and suggested a right-split.

**The suggestion was rejected — it would have been a security regression.** Colons appear on *both* sides of the line number. On `./a.env:7:AWS_SECRET_ACCESS_KEY=a:b:c`, `rsplit(":", 1)` returns `./a.env:7:AWS_SECRET_ACCESS_KEY=a:b`, publishing most of the secret. That is the leak the function exists to stop, and an existing test covers the case.

**The underlying observation was still correct,** so I fixed the ambiguity at its source instead: both `grep` calls now pass `-Z`, making the output `path\0lineno:content`. A NUL terminator after the filename is unambiguous regardless of colons on either side of it. A colon-bearing path now yields `./wei:rd/x.env:1` — full path, correct line number, no content. Input without a NUL degrades closed (path only), so a future format change cannot silently start leaking.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- `tests/unit/test_scan_secrets.py` — **6 passed.** Covers both directions of the colon ambiguity: content-with-colons, path-with-colons, and the no-NUL fallback that must never leak.
- End-to-end against a real `grep -RInZ` over a file at a colon-bearing path: raw `./wei:rd/x.env\x001:NEO4J_PASSWORD=a:b:c` → logged `./wei:rd/x.env:1`.
- `ruff check`, `ruff format --check` clean on touched files; `actionlint` clean.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes