### PR TITLE
Add a path-filtered verify-setup-script job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,12 +234,13 @@ jobs:
         if: failure()
         run: docker logs test-neo4j --tail 100 || true
 
-  docker-changes:
-    name: Detect Docker Changes
+  detect-changes:
+    name: Detect File Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
+      setup: ${{ steps.filter.outputs.setup }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -254,11 +255,19 @@ jobs:
             docker:
               - 'Dockerfile*'
               - '.dockerignore'
+            # uv.lock and pyproject.toml stay out of the docker filter (#507:
+            # the Dockerfile never reads them) but belong here, because
+            # setup_dev.sh runs `uv sync` and a lockfile change can genuinely
+            # break it.
+            setup:
+              - 'scripts/setup_dev.sh'
+              - 'uv.lock'
+              - 'pyproject.toml'
 
   docker:
     name: Docker Build and Smoke Test
-    needs: [docker-changes]
-    if: needs.docker-changes.outputs.docker == 'true'
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -285,4 +294,22 @@ jobs:
 
       - name: Smoke test the entrypoint
         run: docker run --rm sbir-analytics:ci-${{ github.sha }} dagster --version
+
+  verify-setup-script:
+    name: Verify Developer Setup Script
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.setup == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Run setup script
+        run: bash scripts/setup_dev.sh
+
+      # Reproduce the original ci.yml assertions: venv activates, pydantic imports.
+      - name: Assert venv activates and pydantic imports
+        run: |
+          source .venv/bin/activate
+          python -c "import pydantic"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      # setup_dev.sh invokes `python3.11` by name (line 20), not `python3`, so
+      # it depends on that exact interpreter being on PATH. ubuntu-latest
+      # happens to ship it today, but the image contents drift and the script
+      # would start failing for a reason unrelated to the change under test.
+      # Pin it explicitly.
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
       - name: Run setup script
         run: bash scripts/setup_dev.sh
 

--- a/specs/actions-migration-followups/setup-script-verification.md
+++ b/specs/actions-migration-followups/setup-script-verification.md
@@ -1,6 +1,7 @@
 # Verify the developer setup path
 
-Tracking stub. Nothing here is implemented yet.
+**Resolved.** Option 1 implemented in `ci.yml` — see the `detect-changes` /
+`verify-setup-script` jobs.
 
 `scripts/setup_dev.sh` was checked by `ci.yml` · `verify-setup-script` until
 GitHub Actions was rescoped to tests only. Nothing verifies it now, so the
@@ -10,20 +11,13 @@ exercises daily, because everyone already has a working environment.
 The old job ran the script on a clean runner, then confirmed the venv activated
 and `pydantic` imported.
 
-## Scope
+## Decision
 
-- [ ] Decide where this belongs. It is genuinely a *test* — "does a clean
-      checkout produce a working environment" — but it needs a clean machine,
-      which is the one thing local runs never have.
-- [ ] Options, roughly in order of preference:
-  - A path-filtered CI job gated on `scripts/setup_dev.sh`, `pyproject.toml`,
-    `uv.lock` — same shape as the `docker` job, near-zero cost, fires exactly
-    when the setup path can break
-  - A documented manual check in the contributing guide
-  - Nothing, and accept the rot
-- [ ] If CI: reuse the `docker-changes` filter pattern rather than adding a
-      second detect job
-- [ ] Keep the original assertions — venv activates, `pydantic` imports
+Option 1 chosen: a path-filtered CI job gated on `scripts/setup_dev.sh`,
+`pyproject.toml`, and `uv.lock`, sharing the existing `detect-changes` filter
+job (renamed from `docker-changes`). Near-zero cost on PRs that don't touch
+those paths; fires exactly when the setup path can break. Original assertions
+kept: venv activates, `pydantic` imports.
 
 ## Related
 

--- a/specs/actions-migration-followups/setup-script-verification.md
+++ b/specs/actions-migration-followups/setup-script-verification.md
@@ -1,0 +1,33 @@
+# Verify the developer setup path
+
+Tracking stub. Nothing here is implemented yet.
+
+`scripts/setup_dev.sh` was checked by `ci.yml` · `verify-setup-script` until
+GitHub Actions was rescoped to tests only. Nothing verifies it now, so the
+onboarding path can rot silently — and it rots in the one place nobody
+exercises daily, because everyone already has a working environment.
+
+The old job ran the script on a clean runner, then confirmed the venv activated
+and `pydantic` imported.
+
+## Scope
+
+- [ ] Decide where this belongs. It is genuinely a *test* — "does a clean
+      checkout produce a working environment" — but it needs a clean machine,
+      which is the one thing local runs never have.
+- [ ] Options, roughly in order of preference:
+  - A path-filtered CI job gated on `scripts/setup_dev.sh`, `pyproject.toml`,
+    `uv.lock` — same shape as the `docker` job, near-zero cost, fires exactly
+    when the setup path can break
+  - A documented manual check in the contributing guide
+  - Nothing, and accept the rot
+- [ ] If CI: reuse the `docker-changes` filter pattern rather than adding a
+      second detect job
+- [ ] Keep the original assertions — venv activates, `pydantic` imports
+
+## Related
+
+`weekly.yml` also had `verify-local-workflow` (`make setup-local`,
+`make sample-data`) and `verify-ml-workflow` (`make install-ml`,
+`make setup-ml`, executing `notebooks/getting_started.ipynb`). Same category,
+same question. Decide them together or explicitly drop them.


### PR DESCRIPTION
## Description

Opened as a doc-only tracking stub; a `ci.yml` change was pushed to the branch afterwards (`57ba270`) implementing option 1 from the stub's own list. Title, body and checkboxes are corrected to describe what actually merges — per Copilot's review, the metadata was stale, not the code.

**What merges:** a path-filtered `verify-setup-script` job, plus the stub doc recording what's still undecided.

`scripts/setup_dev.sh` was checked by `ci.yml` · `verify-setup-script` until #501 rescoped Actions to tests only. Nothing verified it after that, so the onboarding path could rot silently — and it rots where nobody notices, because everyone already has a working environment.

The job runs the script on a clean runner and reproduces the original assertions: the venv activates and `pydantic` imports. It's gated on `scripts/setup_dev.sh`, `uv.lock`, `pyproject.toml`, so a typical PR doesn't pay for it.

The implementation reuses the existing filter job — renaming `docker-changes` → `detect-changes` and adding a `setup` output — rather than adding a second detect job, which is what the stub asked for.

### Review feedback addressed

**Pin Python 3.11.** `setup_dev.sh:20` invokes `python3.11` *by name*, not `python3`, in four places, so the job depends on that exact interpreter being on PATH. `ubuntu-latest` ships it today, but image contents drift — and when it stops, the failure reads as "your setup script broke" rather than "the runner image changed", pointing the next person at the wrong thing. Added `actions/setup-python@v7` pinned to 3.11.

### Sequencing note

`57ba270` renames `docker-changes` → `detect-changes`. #507 also edits that job's filter, so whichever lands second needs a rebase. Not a defect — just don't merge both blind.

### Still open, in the doc

`verify-local-workflow` (`make setup-local`, `make sample-data`) and `verify-ml-workflow` (`make install-ml`, `make setup-ml`, notebook execution) were dropped by the same rescope and remain undecided. Notebook execution in particular now has nothing catching it rotting.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update

## Testing

- `actionlint` clean
- Verified Copilot's claim directly rather than taking it on trust: `grep -nE "python3\.11" scripts/setup_dev.sh` shows four call sites, the first at line 20

The job itself runs on a clean runner, which is the one condition a local run can't reproduce — that's the whole reason it belongs in CI.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes