### PR TITLE
Stop paying for Docker builds that cannot break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,18 @@ jobs:
       # That is not hypothetical: on 2026-08-02 a step left with an empty
       # `env:` (parses as null, which Actions rejects) took weekly.yml out of
       # service for hours. yaml.safe_load accepts that; actionlint does not.
+      # Compose validation needs no image and takes about a second, so it
+      # lives here rather than behind the docker job's build. That also means
+      # it now runs on every PR instead of only when a Docker path changed.
+
+      # Compose validation needs no image and takes about a second, so it
+      # lives here rather than behind the docker job's build. That also means
+      # it now runs on every PR instead of only when a Docker path changed.
+      - name: Validate compose files
+        run: |
+          docker compose -f docker-compose.yml config -q
+          docker compose -f docker-compose.server.yml --env-file .env.server.example config -q
+
       - name: Validate this workflow with actionlint
         env:
           ACTIONLINT_VERSION: "1.7.12"
@@ -201,12 +213,14 @@ jobs:
         id: filter
         with:
           filters: |
+            # Only what can actually break the image build. The Dockerfile
+            # pip-installs pinned versions and never reads uv.lock, so a
+            # lockfile bump cannot affect it — including uv.lock here meant
+            # every dependabot PR paid a ~2m30s build for nothing. Compose
+            # files are gone too: they are validated in `quality` for free.
             docker:
               - 'Dockerfile*'
-              - 'docker-compose*.yml'
               - '.dockerignore'
-              - 'uv.lock'
-              - 'pyproject.toml'
 
   docker:
     name: Docker Build and Smoke Test
@@ -239,7 +253,3 @@ jobs:
       - name: Smoke test the entrypoint
         run: docker run --rm sbir-analytics:ci-${{ github.sha }} dagster --version
 
-      - name: Validate compose files
-        run: |
-          docker compose -f docker-compose.yml config -q
-          docker compose -f docker-compose.server.yml --env-file .env.server.example config -q


### PR DESCRIPTION
## Description

Two problems with the docker job as merged in #502, both found by reading what the build actually does rather than trusting the filter I wrote.

**1. `uv.lock` cannot affect this image.** The Dockerfile `pip install`s pinned versions and never reads the lockfile — `grep uv.lock Dockerfile` is empty. It was in the path filter anyway, so **every Dependabot lockfile bump paid a ~2m30s build for an image the change cannot reach.** #502 itself triggered a build for exactly this reason. The filter is now just `Dockerfile*` and `.dockerignore` — the inputs that can genuinely break the build.

**2. Compose validation was hiding behind a 2m30s build.** It needs no image and takes ~1s, but sat inside the docker job. So a compose-only edit paid the full build, and a PR that didn't touch Docker paths never validated compose at all. Moved to `quality`, where it costs ~1s and now runs on **every** PR.

Net: the expensive job fires only on real Dockerfile changes, and compose coverage goes **up** while total time goes down.

### Where the 2m16s actually goes

Reading the Dockerfile, the dominant layer is `playwright install --with-deps chromium` — ~150MB of Chromium plus apt system deps, needed because `uspto_download_job` requires real browser automation since data.uspto.gov stopped serving plain HTTP clients. That layer only invalidates when the base image or the pinned pip list changes, so it caches well *if the cache is warm*.

### Two things I deliberately did not do

- **`type=gha` cache evicts after 7 days idle.** Because this job now fires rarely by design, the cache will usually be cold when it does fire, so most runs pay the full build anyway. A `type=registry` cache never expires and would largely fix this — but it needs `packages: write` and a GHCR login, which reintroduces registry interaction that #501 deliberately removed. That's a trade worth making deliberately, not silently.
- **`sbir-analytics-python-base:latest` is frozen.** Nothing rebuilds it now that `build-images.yml` is gone, so it will drift from the dependency set and the ETL build will install progressively more on top over time. Not a problem today; will be.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- `actionlint` clean
- Parsed the workflow and confirmed step placement: `quality` ends with `Validate compose files` → `Validate this workflow with actionlint`; `docker` is now Buildx → Build → Smoke test only
- Both compose validations run locally against the current tree
- This PR touches no Docker path, so the `docker` job should **skip** — which is itself the fix demonstrating itself

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLD9yHKbZ9Ds8m6fikn8b7)_