### PR TITLE
Build the mini's Python base from source instead of pulling a frozen image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -581,15 +581,33 @@ server-check: ## Validate server prerequisites (Docker, storage, ports, Tailscal
 	$(call run,SERVER_ENV_FILE=$(SERVER_ENV_FILE) ./scripts/server/check-prerequisites.sh)
 
 .PHONY: server-base-image
-server-base-image: server-check ## Pull the native Python base, or build it locally
-	@$(call info,Preparing the native Python base image)
-	@set -euo pipefail; \
-	 if docker pull $(SERVER_PYTHON_BASE_IMAGE); then \
-	   $(call success,Native Python base image is available); \
-	 else \
-	   $(call warn,Published base is unavailable for this architecture; building locally); \
-	   docker build -f Dockerfile.python-base -t $(SERVER_PYTHON_BASE_IMAGE) .; \
-	 fi
+server-base-image: server-check ## Build the native Python base image from source
+	@$(call info,Building the native Python base image)
+	# Built locally rather than pulled. This used to try `docker pull` first and
+	# only build when the pull failed, which meant "missing manifest for this
+	# architecture" was the sole trigger. Since build-images.yml was retired
+	# nothing republishes ghcr.io/.../sbir-analytics-python-base:latest, so the
+	# pull always succeeded and pinned this host to a base image that will never
+	# be refreshed again. Building from Dockerfile.python-base keeps the base in
+	# step with the repository; Docker's layer cache makes repeat builds cheap,
+	# so only a real change to the base's inputs costs the full build.
+	$(call run,docker build -f Dockerfile.python-base -t $(SERVER_PYTHON_BASE_IMAGE) .)
+	@$(call success,Native Python base image is ready)
+
+.PHONY: server-rebuild
+server-rebuild: server-env-check ## Rebuild base + app images from source and restart the stack
+	@$(call warn,This recreates containers: any in-flight Dagster run will be killed)
+	@$(call info,Rebuilding the native Python base image (pulling its upstream base))
+	# --pull refreshes the upstream image Dockerfile.python-base builds FROM, so
+	# a scheduled rebuild picks up base-OS and interpreter security updates
+	# rather than rebuilding on top of an increasingly old cached layer.
+	$(call run,docker build --pull -f Dockerfile.python-base -t $(SERVER_PYTHON_BASE_IMAGE) .)
+	@$(call info,Rebuilding the application images)
+	$(call run,$(SERVER_COMPOSE) --profile server build --pull)
+	@$(call info,Restarting the stack on the new images)
+	$(call run,$(SERVER_COMPOSE) --profile server up -d --wait --wait-timeout 300)
+	$(call run,$(SERVER_COMPOSE) --profile server ps)
+	@$(call success,Server stack rebuilt. Run 'docker image prune' to reclaim superseded layers)
 
 .PHONY: server-up
 server-up: server-base-image ## Preflight and start the always-on server stack (profile=server)

--- a/docs/deployment/mac-mini-server.md
+++ b/docs/deployment/mac-mini-server.md
@@ -136,10 +136,27 @@ make server-status
 
 Generate the API token with `openssl rand -hex 32`.
 
-`make server-up` first pulls the published native Python base image. If GHCR
-does not yet have a manifest for the Mac's architecture, it builds
-`Dockerfile.python-base` locally and then continues. The first fallback build
-can take several minutes; later builds use the local image cache.
+`make server-up` builds the native Python base image from
+`Dockerfile.python-base` before starting the stack. The first build takes
+several minutes; later builds reuse Docker's layer cache and are quick unless
+the base's inputs actually changed.
+
+It no longer pulls the published image first. Nothing republishes
+`ghcr.io/hollomancer/sbir-analytics-python-base:latest` since the image-build
+workflow was retired, so preferring the pull pinned this host to a base that
+will never be refreshed again.
+
+To force a full refresh — including the upstream image the base builds `FROM`,
+which is how OS and interpreter security updates arrive — use:
+
+```bash
+make server-rebuild     # rebuilds base + app images, then restarts the stack
+docker image prune      # reclaim the superseded layers
+```
+
+`server-rebuild` recreates containers, so **any in-flight Dagster run is
+killed**. Check `make server-status` for active runs before using it, and
+prefer a quiet window.
 
 ## Tailscale grant (least privilege)
 


### PR DESCRIPTION
## Description

Steps 1 and 2 of the "build on the mini" discussion. The mini already builds both images — `make server-up` → `server-base-image` → compose `--build`. The problem was never capability, it was *when* the base gets rebuilt.

### The active defect

`server-base-image` tried `docker pull` first and only built locally when the pull **failed**:

```make
if docker pull $(SERVER_PYTHON_BASE_IMAGE); then ... else docker build -f Dockerfile.python-base ... fi
```

So the only trigger for a local build was "GHCR has no manifest for this architecture". That was correct while `build-images.yml` republished the image weekly. It was retired in #501, nothing republishes `ghcr.io/hollomancer/sbir-analytics-python-base:latest` now, and the pull therefore **always succeeds** — pinning the mini to a base image that will never be refreshed again and drifts further from the repo every week.

I'd previously described this fallback as graceful degradation. It is, but only when the manifest is *missing* — not when it's *stale*, which is now the permanent state.

**Fix:** build from `Dockerfile.python-base`. Docker's layer cache keeps repeat builds cheap, so only a real change to the base's inputs costs the full build.

### `make server-rebuild`

A deliberate full refresh. Rebuilds the base with `--pull` so the upstream image it builds `FROM` is refreshed too — that's how OS and interpreter security updates arrive, and without it a scheduled rebuild just keeps stacking layers on an ageing cached parent. Then rebuilds the app images and restarts the stack.

It **recreates containers and kills in-flight Dagster runs**, so it warns before doing anything and the runbook says to check `make server-status` first.

### Why this is a manual target

Scheduling belongs on the host, not in Dagster. `grep docker.sock docker-compose.server.yml` is empty — no server container can build images. Putting builds in Dagster means mounting `/var/run/docker.sock` into the dagster container, which is root-equivalent host access and undercuts the least-privilege posture the rest of the deployment is built around (loopback-only binds, Tailscale-only ingress, Funnel prohibited).

When you do schedule it: **launchd, not cron** — macOS won't fire a cron job missed while the machine was asleep, whereas launchd's `StartCalendarInterval` runs on wake.

### Not addressed, deliberately

The locally built image still carries the GHCR tag, which shadows the remote and makes provenance ambiguous. Retagging touches `Dockerfile`'s `BASE_IMAGE` default and `docker-compose.server.yml`, so it wants to be a deliberate change rather than folded in here.

This also does **not** replace the CI docker job — GitHub can't reach the mini (Tailscale-only, no self-hosted runner), so a mini build is post-merge and arm64-only. The two are complementary.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Testing

Repo-side only; I have not run anything against the live host, per the runbook.

- `make -n server-base-image` and `make -n server-rebuild` expand to the intended commands with correct `SERVER_COMPOSE` interpolation
- `markdownlint-cli2` clean on the runbook

The runbook's bring-up section documented the old pull-first behaviour and is updated to match, including the `server-rebuild` + `docker image prune` procedure and the in-flight-run warning.

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DLD9yHKbZ9Ds8m6fikn8b7)_