### PR TITLE
docs: tier the repo by epistemic status, and make the tiers operative

### DIFF
--- a/.claude/agents/quality-sweep.md
+++ b/.claude/agents/quality-sweep.md
@@ -17,11 +17,32 @@ You are a code quality engineer for the SBIR Analytics project. Your job is to s
 6. **Run ruff format**: `uv run ruff format sbir_etl/` to standardize formatting
 7. **Run tests**: `uv run pytest tests/unit/ -x -q -m "not slow"` to verify nothing broke
 
+## Sweep Intensity by Tier
+
+Read `docs/steering/epistemic-tiers.md`. Cleanup effort is not uniform — spending
+it evenly is how maintenance cost grows without bound as research questions
+accumulate. Sweep hardest where things depend on the code:
+
+| Tier | Where | Effort |
+|---|---|---|
+| `primitives` | `sbir_etl/identity/`, `sbir_etl/config/`, `sbir_etl/models/` | Full: ruff, mypy, formatting, type annotations, docstrings |
+| `pipelines` | `sbir_etl/` (rest), `packages/` | Full ruff + mypy; annotate what you touch |
+| `evidence` | Phase III census assets and their specs | Ruff + mypy, but **change no behavior** — output hashes are pinned. If a lint fix would alter output, report it instead of applying it. |
+| `exploratory` | most of `scripts/`, all of `scripts/archive/` | Leave it alone unless asked |
+
+Do not "improve" `scripts/` on your own initiative. Untouched exploratory code is
+the tiering working as designed, not a backlog.
+
 ## Rules
 
 - Code standards are in CLAUDE.md — follow them
 - MyPy: Gradual typing (relaxed), Pydantic plugin enabled
 - Fix issues in batches by file, not one at a time
 - Don't add type annotations to code you didn't change (unless that's the goal)
+- Never let a cleanup change a pinned output. In `evidence` code, formatting and
+  annotations are safe; reordering operations, changing float handling, or altering
+  iteration order are not.
+- If a sweep would consolidate duplicate logic into a shared helper, that is a
+  primitive change — report it, don't do it inline
 - Run tests after each batch of fixes
-- Report what was fixed at the end
+- Report what was fixed at the end, grouped by tier

--- a/.claude/agents/scope-guard.md
+++ b/.claude/agents/scope-guard.md
@@ -53,23 +53,55 @@ For each item, answer these questions:
 - Does this produce an analytical output that replicates or exceeds a NASEM claim?
 - Is this building awards infrastructure (duplicative) or outcomes infrastructure (novel)?
 
+### 5. Tier
+Read `docs/steering/epistemic-tiers.md` first. Every change targets one tier:
+`primitives`, `pipelines`, `evidence`, or `exploratory`.
+
+- What tier does this claim? If the spec doesn't say, it is `exploratory` — hold
+  it to that and say so.
+- Does the work match the tier's contract, in both directions?
+  - **Under-built**: claims `evidence` without all four items (frozen spec, SHA
+    enforcement, blocking asset checks, declared estimand). This is the
+    dangerous direction — a citable claim resting on uncontracted work.
+  - **Over-built**: `exploratory` work carrying tests, abstractions, and
+    config it will never need. This is most of the waste you'll find.
+- Is this a **silent promotion**? Exploratory code acquiring importers,
+  becoming a dependency, or having its numbers quoted — without the promotion
+  being done as explicit work with the new contract satisfied. Flag it as
+  `PROMOTION` regardless of how good the code is.
+- If it claims `primitives`: does an implementation of this concept already
+  exist? A second unnamed implementation of an existing primitive is a defect,
+  not a feature. A new *named, versioned* behavior on an existing primitive's
+  interface is fine.
+
+Tier and milestone are orthogonal. A change can serve M2 and still be
+mis-tiered, and mis-tiering is the more expensive error — it is what makes
+cleanup cost grow without bound as questions accumulate.
+
 ## How to Run a Review
 
 1. Read the spec or code being reviewed
-2. Read `docs/research-plan-alignment.md` for milestone context
-3. Check existing code — does something already handle this?
-4. Produce your assessment using the output format below
+2. Read `docs/steering/epistemic-tiers.md` for the tier contracts
+3. Read `docs/research-plan-alignment.md` for milestone context
+4. Check existing code — does something already handle this?
+5. Produce your assessment using the output format below
 
 ## Output Format
 
 ```
 ## Scope Guard Assessment: [spec-name or description]
 
-### Verdict: [PROCEED / TRIM / DEFER / REJECT]
+### Verdict: [PROCEED / TRIM / DEFER / RETIER / REJECT]
 
 ### Milestone Alignment
 - Primary: [M1/M2/M3/M4/M5 or NONE]
 - Justification: [one sentence]
+
+### Tier
+- Claimed: [primitives/pipelines/evidence/exploratory, or UNSTATED]
+- Correct: [tier]
+- Contract: [MET / UNDER-BUILT / OVER-BUILT] [what's missing or excessive]
+- Silent promotion: [NO / YES — what is being promoted without the contract]
 
 ### Necessity Check
 - [PASS/CONCERN] [explanation]
@@ -90,8 +122,11 @@ For each item, answer these questions:
 
 ## Verdicts
 
-- **PROCEED** — Aligned, necessary, appropriately scoped. Go build it.
+- **PROCEED** — Aligned, necessary, appropriately scoped, correctly tiered. Go build it.
 - **TRIM** — Right direction but over-scoped. Cut the identified tasks/features, then proceed.
+- **RETIER** — The work is wanted, but the tier is wrong. Either meet the claimed
+  tier's contract or restate the work at the tier it actually occupies. Use this
+  when the code is fine and only its epistemic status is misrepresented.
 - **DEFER** — Not wrong, but not now. Other milestones should come first.
 - **REJECT** — Doesn't serve the research plan. Don't build it.
 
@@ -104,3 +139,13 @@ For each item, answer these questions:
 - **Defensive coding against impossible states** — Validation at internal boundaries
 - **"Nice to have" features in specs** — Tasks that don't have a gate condition dependency
 - **Duplicating awards-layer work** — Building entity storage/tracking that SAM.gov already does
+- **Citable claim on uncontracted work** — A number headed for a memo, a briefing,
+  or `research-questions.md` as "answerable", produced by something missing any of
+  the four `evidence` contract items
+- **Second implementation of a primitive** — A new normalizer, matcher, config
+  reader, or schema validator alongside one that exists. Check `sbir_etl/identity/`
+  and `sbir_etl/config/loader.py` before accepting one.
+- **Production hardening in `exploratory`** — Retry logic, abstraction layers, and
+  config surfaces on code that answers one question once
+- **A script becoming infrastructure** — Anything under `scripts/` acquiring
+  importers from `sbir_etl/` or `packages/`

--- a/.claude/agents/spec-implementer.md
+++ b/.claude/agents/spec-implementer.md
@@ -10,12 +10,32 @@ You are an autonomous feature implementer for the SBIR Analytics project. You pi
 ## Your Workflow
 
 1. **Read the spec**: Load the requirements.md, design.md, and tasks.md from the specified spec directory in `specs/`
-2. **Identify incomplete tasks**: Find all `- [ ]` tasks that haven't been completed yet
-3. **Read existing code**: Before writing anything, read the relevant source files to understand current patterns
-4. **Implement sequentially**: Work through tasks in order, respecting dependencies
-5. **Test each change**: Run `uv run pytest tests/unit/ -x -q --no-header -m "not slow"` after each significant change
-6. **Lint check**: Run `uv run ruff check` on changed files
-7. **Mark tasks complete**: Update tasks.md to check off completed items
+2. **Establish the tier**: Read `docs/steering/epistemic-tiers.md`. Find the spec's
+   declared target tier in requirements.md. If it doesn't declare one, treat the work
+   as `exploratory` and say so in your report — do not infer a higher tier from how
+   important the work looks.
+3. **Identify incomplete tasks**: Find all `- [ ]` tasks that haven't been completed yet
+4. **Read existing code**: Before writing anything, read the relevant source files to understand current patterns
+5. **Implement sequentially**: Work through tasks in order, respecting dependencies
+6. **Build to the tier, not above it**: Match the contract for the declared tier and stop
+   there. `exploratory` work does not get tests, abstraction layers, or config surfaces
+   it has no use for. `evidence` work is not complete until all four contract items
+   exist — a passing test suite is not a substitute for a declared estimand.
+7. **Test each change**: Run `uv run pytest tests/unit/ -x -q --no-header -m "not slow"` after each significant change
+8. **Lint check**: Run `uv run ruff check` on changed files
+9. **Mark tasks complete**: Update tasks.md to check off completed items
+
+## Tier Rules
+
+- **Reuse primitives; never fork them.** Company-name normalization and similarity
+  go through `sbir_etl.identity`. Configuration goes through
+  `sbir_etl/config/loader.py`. If you need behavior these don't have, add a named
+  versioned profile to the primitive — do not write a local variant.
+- **Never promote silently.** If a task requires importing `scripts/` code from
+  `sbir_etl/` or `packages/`, or quoting an exploratory number as a finding, stop.
+  Promotion is separate work with the destination tier's contract satisfied.
+- **Report the tier you built at**, and flag any place the spec's tasks implied a
+  higher tier than the spec declared.
 
 ## Project Conventions
 

--- a/.claude/agents/test-fixer.md
+++ b/.claude/agents/test-fixer.md
@@ -34,9 +34,31 @@ You are a test diagnostician and fixer for the SBIR Analytics project. Your job 
 - Neo4j fixture teardown issues (use `cleanup_test_data` fixture)
 - Async test issues (use `@pytest.mark.asyncio` or `asyncio_mode = "auto"`)
 
+## Coverage Expectations by Tier
+
+Read `docs/steering/epistemic-tiers.md`. Coverage targets differ by tier, and
+chasing uniform coverage is wasted effort:
+
+- **`primitives`** (`sbir_etl/identity/`, `config/`, `models/`) — comprehensive.
+  Every named behavior version needs a test pinning it. This is where gaps are
+  worth hunting.
+- **`pipelines`** — cover the contracts and the failure modes, not every branch.
+- **`evidence`** (Phase III census) — asset checks are the real gate and they must
+  **block**, not warn. A check downgraded to a warning is a broken test even if
+  the suite is green. Treat pinned hashes and manifest assertions as the
+  specification: if code and hash disagree, the hash is right until a human says
+  otherwise.
+- **`exploratory`** (`scripts/`) — no coverage obligation. Don't add tests here to
+  raise a number.
+
 ## Rules
 
 - Never disable or skip a test unless it's truly irrelevant
 - Don't weaken assertions just to make tests pass
 - If source code changed, tests should reflect the new behavior
 - Add comments explaining non-obvious test logic
+- **Never fix a failing test by weakening a tier contract.** Turning a blocking
+  asset check into a warning, loosening a pinned hash, or relaxing an identity
+  profile assertion is a contract change, not a test fix — stop and report it.
+- `tests/unit/scripts/test_identity_boundaries.py` guards the identity primitive.
+  If it fails, something forked the primitive — fix the caller, not the guard.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,11 @@ jobs:
           uv run python scripts/ci/check_architecture_boundaries.py
           uv run python scripts/ci/check_removed_src_references.py
           uv run python scripts/ci/validate_study_manifests.py
+          # Guards the company-identity primitive: a direct RapidFuzz scorer
+          # outside sbir_etl.identity is a second, unnamed implementation of
+          # the similarity contract. Previously exercised only by its own unit
+          # test, which caught accidents but not drift.
+          uv run python scripts/ci/check_identity_boundaries.py
 
       # This file is now the only workflow in the repository, so an invalid
       # ci.yml means CI silently stops running with nothing left to notice.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,24 @@
 # Agent Instructions
 
-Read [CLAUDE.md](CLAUDE.md) for the repository's project conventions, testing
-requirements, code standards, and scope rules. Those instructions apply to all
-coding agents; tool-specific agent definitions may differ by runtime.
+This file routes; it does not carry rules of its own. Everything below lives
+canonically somewhere else, so there is nothing here to drift out of sync.
 
-## Epistemic tiers
+**Read [CLAUDE.md](CLAUDE.md) first.** It is the canonical source for project
+conventions, epistemic tiers, testing requirements, code standards, scope rules,
+and the live-deployment constraints. Those instructions apply to all coding
+agents regardless of runtime; only the tool-specific agent definitions in
+`.claude/agents/` vary.
 
-Before implementing anything, establish which tier the work targets —
-`primitives`, `pipelines`, `evidence`, or `exploratory`. The contracts are in
-[docs/steering/epistemic-tiers.md](docs/steering/epistemic-tiers.md) and summarized
-in CLAUDE.md.
+Then, depending on the work:
 
-Build to the declared tier and no higher. Unstated tier means `exploratory`.
-Promotion between tiers is explicit work that satisfies the destination contract —
-never a side effect of code becoming useful or gaining callers.
+| Doing | Read |
+|---|---|
+| Anything at all | [CLAUDE.md](CLAUDE.md) |
+| Deployment, server operations, or live Dagster materialization | [the Mac mini runbook](docs/deployment/mac-mini-server.md#live-instance-on-this-mac-mini) — **before** acting, not after — plus the live-deployment section of CLAUDE.md |
+| Implementing a spec | [docs/steering/epistemic-tiers.md](docs/steering/epistemic-tiers.md) for the tier contract, then the spec directory in `specs/` |
+| Judging whether work is in scope | [docs/research-questions.md](docs/research-questions.md) |
+| Architecture context | [docs/architecture/detailed-overview.md](docs/architecture/detailed-overview.md), patterns in `docs/steering/` |
 
-## Live deployment
-
-Before any deployment, server operation, or live Dagster materialization, read
-[the Mac mini runbook](docs/deployment/mac-mini-server.md#live-instance-on-this-mac-mini).
-On the live host, also read `docs/deployment/mac-mini-status.local.md` when it
-exists. That ignored file is the source of truth for current materialization
-state; never copy its host-specific contents into tracked documentation.
-
-- The only live checkout is `/Users/conradhollomon/projects/sbir-analytics-server`.
-  Never operate the live stack from the development checkout.
-- Preserve `.env.server`, `/Volumes/SSDmini/sbir-analytics`, and the Docker
-  `dagster_home` volume.
-- Ingress must remain Tailscale Serve over tailnet-only HTTPS. Never enable
-  Funnel or expose server ports to the LAN or public internet.
-- Treat materialization as a live-data mutation. Confirm the SSD is mounted,
-  the deployment checkout is clean, and the stack is healthy before running it.
-- Keep schedules disabled until their jobs have completed successfully by hand
-  with the inputs available on this host.
+If guidance appears to conflict, CLAUDE.md wins for conventions and the runbook
+wins for anything touching the live host. If you find a rule stated here rather
+than referenced, that is a bug in this file — move it to CLAUDE.md.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,17 @@ Read [CLAUDE.md](CLAUDE.md) for the repository's project conventions, testing
 requirements, code standards, and scope rules. Those instructions apply to all
 coding agents; tool-specific agent definitions may differ by runtime.
 
+## Epistemic tiers
+
+Before implementing anything, establish which tier the work targets —
+`primitives`, `pipelines`, `evidence`, or `exploratory`. The contracts are in
+[docs/steering/epistemic-tiers.md](docs/steering/epistemic-tiers.md) and summarized
+in CLAUDE.md.
+
+Build to the declared tier and no higher. Unstated tier means `exploratory`.
+Promotion between tiers is explicit work that satisfies the destination contract —
+never a side effect of code becoming useful or gaining callers.
+
 ## Live deployment
 
 Before any deployment, server operation, or live Dagster materialization, read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,34 @@ Graph-based ETL: SBIR awards → Neo4j. Dagster orchestration, DuckDB processing
 
 Architectural patterns and technical docs live in `docs/steering/`. Feature specs live in `specs/`.
 
+## Epistemic tiers
+
+Every artifact sits in one tier, which fixes what it costs to maintain and how
+much weight it can carry. Full contracts:
+[docs/steering/epistemic-tiers.md](docs/steering/epistemic-tiers.md).
+
+| Tier | Contract | Where today |
+|------|----------|-------------|
+| `primitives` | One implementation per concept, versioned behavior, comprehensive tests | `sbir_etl/identity/`, `sbir_etl/config/`, `sbir_etl/models/` |
+| `pipelines` | Deterministic, reproducible from a declared data cut, no inference | `sbir_etl/`, `packages/` |
+| `evidence` | Frozen spec + SHA enforcement + blocking asset checks + declared estimand — all four | Phase III census |
+| `exploratory` | Labeled non-citable. Nothing else required. | most of `scripts/` |
+
+Three rules:
+
+- **Declare the tier.** Specs state their target tier in `requirements.md`; new
+  assets and modules state theirs. Unstated means `exploratory`.
+- **Build to the tier, not above it.** Exploratory code getting tests and
+  abstractions is the most common form of waste here. Untended `scripts/` is the
+  design working, not a backlog.
+- **Promotion is explicit work.** Nothing moves up by being useful, by gaining
+  importers, or by having its numbers quoted. A number cannot be cited, or a
+  research question marked answerable, on exploratory-tier work.
+
+Reuse primitives rather than forking them: company-name normalization and
+similarity go through `sbir_etl.identity` (add a named profile if you need new
+behavior); config goes through `sbir_etl/config/loader.py`.
+
 ## Live deployment
 
 Before any deployment, server operation, or live Dagster materialization, read
@@ -33,6 +61,11 @@ Custom agents in `.claude/agents/`:
 
 For **spec work**: scope-guard → spec-implementer → test-fixer → quality-sweep.
 For **bug fixes**: skip to test-fixer or quality-sweep directly.
+
+Each agent reads the tier from the spec and holds to it: `scope-guard` checks the
+declared tier against the contract and can return `RETIER`, `spec-implementer`
+builds to the tier and refuses silent promotion, `test-fixer` and `quality-sweep`
+scale coverage and cleanup effort by tier rather than uniformly.
 
 ## Skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,13 @@ materialization state belongs there, not in tracked documentation.
 The only live checkout is `/Users/conradhollomon/projects/sbir-analytics-server`;
 never operate the live stack from the development checkout. Preserve
 `.env.server`, `/Volumes/SSDmini/sbir-analytics`, and the Docker `dagster_home`
-volume. Ingress must remain Tailscale Serve only; never enable Funnel.
+volume. Ingress must remain Tailscale Serve over tailnet-only HTTPS; never enable
+Funnel and never expose server ports to the LAN or public internet.
+
+Treat materialization as a live-data mutation: confirm the SSD is mounted, the
+deployment checkout is clean, and the stack is healthy before running one. Keep
+schedules disabled until their jobs have completed successfully by hand with the
+inputs available on this host.
 
 ## Agents
 

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -680,6 +680,11 @@ Everything above section 9 describes the current state. This section describes
 where the architecture is headed and why. It is a direction of travel, not an
 account of the repository as it stands.
 
+The tier contracts are maintained canonically in
+[steering/epistemic-tiers.md](../steering/epistemic-tiers.md), which is what the
+agents in `.claude/agents/` read. This section gives the architectural rationale;
+that document gives the operative rules. Where they disagree, it wins.
+
 ### 10.1 The problem this solves
 
 The organizing axis of the current layout is technical role — extract, enrich,

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -2,7 +2,8 @@
 
 ## Executive Summary
 
-**sbir-analytics** is an experimental ETL (Extract, Transform, Load) research pipeline for linking Small Business Innovation Research (SBIR) program data to commercialization signals in a Neo4j graph database. It orchestrates multi-source data ingestion, transformations, and exploratory analysis workflows through Dagster asset definitions. As described in the README, this is a personal side project rather than production software; the architecture below describes the current documented approach, including an optional cloud setup.
+**sbir-analytics** is an experimental ETL (Extract, Transform, Load) research pipeline for linking Small Business Innovation Research (SBIR) program data to commercialization signals in a Neo4j graph database. It orchestrates multi-source data ingestion, transformations, and exploratory analysis workflows through Dagster asset definitions. As described in the README, this is a personal side project rather than production software; the architecture below describes the current documented approach. Historical AWS deployment material remains in the repository but is
+not part of the live architecture.
 
 **Key Characteristics:**
 

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -8,12 +8,18 @@
 
 - **Data Sources**: SBIR.gov awards, USAspending contracts, USPTO patents, transition detection
 - **Processing**: DuckDB (extraction), Pandas/Python (transformation), Neo4j (graph storage)
-- **Orchestration**: GitHub Actions and optional AWS Step Functions for documented repeatable runs
-- **Compute**: GitHub Actions runners, with optional AWS Lambda functions for cloud experiments
-- **Storage**: Local filesystem for development, with optional AWS S3 data lake paths
-- **Database**: Neo4j via Docker for local development, with optional EC2-hosted Neo4j notes
-- **Deployment**: Docker for local development, plus an experimental GitHub Actions + AWS + Neo4j EC2 deployment path
-- **Tech Stack**: Python 3.11/3.12, Neo4j 5.x, AWS Lambda, S3, DuckDB, Pandas, Pydantic, scikit-learn
+- **Orchestration**: Dagster assets, jobs, schedules, and sensors; GitHub Actions for CI
+- **Compute**: The operator's own hardware — a Mac mini running the Docker Compose stack; GitHub Actions runners for CI
+- **Storage**: Local filesystem and an attached SSD volume
+- **Database**: Neo4j 5.x in Docker, both locally and on the live host
+- **Deployment**: Docker Compose. See [the Mac mini runbook](../deployment/mac-mini-server.md) for the live stack
+- **Tech Stack**: Python 3.11/3.12, Neo4j 5.x, DuckDB, Pandas, Pydantic, scikit-learn, FastAPI
+
+The AWS material that earlier revisions of this document described as the
+deployment path (Step Functions orchestration, an S3 data lake, EC2-hosted
+Neo4j) is not the live architecture. Lambda handlers survive under the
+top-level `lambda/` directory; the CDK `infrastructure/` tree that older
+revisions referenced is not in the repository.
 
 ---
 
@@ -44,8 +50,8 @@ sbir-analytics/
 │   │       ├── assets/jobs/       # Dagster job definitions
 │   │       ├── assets/sensors/    # Dagster sensors
 │   │       ├── clients/           # Orchestration-layer clients
-│   │       ├── lambda/            # Lambda entry points/helpers
-│   │       ├── tools/             # Analysis tool modules
+│   │       ├── api/               # FastAPI private analytics service (read-only Neo4j)
+│   │       ├── tools/             # Analysis tool modules (mission_a/b/c, phase0, tech_census)
 │   │       └── definitions.py     # Dagster repository root
 │   │
 │   ├── sbir-graph/                # Neo4j graph loading and graph query utilities
@@ -64,7 +70,8 @@ sbir-analytics/
 ├── examples/                      # Standalone demonstration scripts
 ├── notebooks/                     # Exploratory Jupyter notebooks
 ├── scripts/                       # One-off analysis, data, validation, CI, Docker, and operational scripts
-├── infrastructure/                # AWS CDK deployment resources
+├── studies/                       # Written analytical studies
+├── lambda/                        # Lambda handlers and dependency layers (not the live path)
 ├── tests/                         # Unit, integration, functional, e2e, slow, and validation tests
 ├── .github/workflows/             # CI/CD and scheduled workflow definitions
 ├── workspace.yaml                 # Dagster workspace entry point (loads sbir_analytics.definitions)
@@ -87,6 +94,30 @@ and validators are under `sbir_etl/extractors/` and `sbir_etl/validators/`.
 | `Dockerfile` | Multi-stage Docker build |
 | `docker-compose.yml` | Local dev/test services (Dagster, Neo4j) |
 | `Makefile` | Development commands (docker-build, docker-up-dev, etc.) |
+
+### 1.3 Layering and Dependency Direction
+
+The `sbir_etl/` library is the foundation layer; the three `packages/` are
+application layers built on top of it. The dependency graph is acyclic and
+measurably one-directional:
+
+| Edge | Count |
+|------|-------|
+| `packages/*` → `sbir_etl` | 141 import statements |
+| `sbir_etl` → `packages/*` | 0 |
+| `scripts/*` → `sbir_etl` | 75 files |
+
+Counts are from the working tree and will drift; re-measure rather than
+trusting them. The property that matters is the zero: `sbir_etl` imports
+nothing from `packages/`, including under `TYPE_CHECKING` and in deferred
+function-local imports. The layering is real, not aspirational.
+
+The repository tree understates this. `sbir_etl/` sits at the root as a bare
+directory while the three layers that depend on it sit one level down under
+`packages/`, so a reader meeting the tree first reads all four as peers.
+Relocating `sbir_etl/` to `packages/sbir-etl/` would make the layout say what
+the import graph already enforces. That move is mechanical — a path change and
+a `[tool.uv.sources]` entry, no logic — and is not yet scheduled.
 
 ---
 
@@ -640,6 +671,112 @@ Located in `docs/decisions/`:
 - **CET Classification**: ≥60% high-confidence (score ≥70)
 - **Transition Detection**: Evidence completeness ≥80%
 - **Neo4j Loading**: ≥99% successful node/relationship creation
+
+---
+
+## 10. Target Architecture: Tiering by Epistemic Status
+
+Everything above section 9 describes the current state. This section describes
+where the architecture is headed and why. It is a direction of travel, not an
+account of the repository as it stands.
+
+### 10.1 The problem this solves
+
+The organizing axis of the current layout is technical role — extract, enrich,
+transform, load. That axis is stable and the layering along it is clean (§1.3).
+It is not, however, the axis on which the work actually varies.
+
+What varies is **how much epistemic weight an artifact can carry**. The
+Phase III census is specified in a frozen design note, pins its input file by
+SHA-256, records a materialization manifest with column-list and output
+hashes, and declares its estimand. A cohort-builder written in an afternoon to
+answer one question does none of that. Both currently present as ordinary
+repository contents, discovered the same way, with the same apparent authority.
+
+A reader cannot tell them apart from the tree. That — not the import graph —
+is the failure mode this repository will actually hand someone.
+
+### 10.2 The four tiers
+
+| Tier | Contents | Contract |
+|------|----------|----------|
+| **`primitives/`** | Identity resolution, config loading, schemas | One implementation each. Heavily tested. Depends on nothing; everything depends on it. |
+| **`pipelines/`** | Extraction and materialization | Deterministic and reproducible, pinned to a declared data cut. No inference. |
+| **`evidence/`** | Artifacts citable outside the repository | Frozen spec, SHA enforcement, blocking asset checks, declared estimand. Nothing enters without all four. |
+| **`exploratory/`** | Everything else | Explicitly labeled non-citable. Scripts live here without apology. |
+
+The tiers are an admission-control mechanism, not a filing system. The point of
+the `evidence/` boundary is that it is expensive to cross and visibly so; the
+point of `exploratory/` is that useful throwaway work gets a home where its
+status is legible instead of being laundered by proximity to rigorous work.
+
+The Phase III census already meets the `evidence/` bar
+(`specs/phase-iii-census/`, `packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/`).
+It is the reference implementation for what that tier requires.
+
+### 10.3 Shared primitives: status
+
+Company-name normalization and similarity scoring were, at one point,
+independently implemented across roughly nine live locations. That
+consolidation has largely landed and the current state is better than the
+folk history suggests:
+
+- `sbir_etl/identity/` exposes a single similarity contract
+  (`company_name_similarity`, 0..1) over versioned, named policies
+  (`CompanyNameProfile`).
+- Every live caller previously listed as a separate implementation now routes
+  through it — the SEC EDGAR enricher, the USAspending enricher, the UCC
+  matcher, `company_fuzzy_matcher`, `text_normalization`, the Form D asset
+  inputs, `tools/phase0/resolve_entities`, the vendor crosswalk and resolver,
+  and the phase3 groundtruth scripts.
+- `scripts/ci/check_identity_boundaries.py` walks the AST for direct
+  `rapidfuzz` scorer imports outside an explicit reviewed-file allowlist.
+
+Two gaps remain, and they are narrower than "consolidate the primitive":
+
+1. **The profiles preserve divergent recall by design.** They are
+   compatibility policies — the module's own docstring is explicit that this
+   is not a claim that all name-matching should behave identically. So the
+   question "which normalization decides a firm never received an SBIR award,
+   for the census control frame?" now has an answer: a named, versioned
+   profile. That answer is not written down anywhere a reader of the census
+   would find it. It belongs in the census spec, next to the estimand.
+2. **The boundary checker is not wired into CI.** It is exercised by
+   `tests/unit/scripts/test_identity_boundaries.py` and nothing else — it
+   appears in no workflow, Makefile target, or pre-commit hook. A guard that
+   runs only when someone runs its unit test is a guard against accidents,
+   not against drift.
+
+Configuration has the same shape of problem, unaddressed: 15 separate
+`yaml.safe_load` call sites across `sbir_etl/` and `packages/`, alongside the
+merge-and-validate path in `sbir_etl/config/loader.py` that is supposed to be
+the way configuration gets read.
+
+### 10.4 `scripts/` is an unbounded annex
+
+`scripts/` is 42,867 lines of Python across 15 subtrees — larger than any
+single package under `packages/` (`sbir-analytics` is 32,101), though smaller
+than `sbir_etl` itself (59,902). 75 of its files import `sbir_etl`, and a
+43-file `archive/` subtree is still tracked on `main`.
+
+The concern is not size, it is that `scripts/phase3_groundtruth/` and
+`scripts/validation/` are doing real analytical duty from a directory with no
+tests, no interface contract, and no review expectation. Work that answers a
+research question durably has been accumulating in the one place structured
+for work that does not.
+
+Under §10.2 this resolves without a mass migration: most of `scripts/` is
+already `exploratory/` and only needs to be labeled as such. The subtrees
+carrying analytical weight get promoted to `pipelines/` or `evidence/` and
+acquire the corresponding contract.
+
+### 10.5 What this is not
+
+This is not a package reshuffle, and the sequencing matters. The
+`sbir_etl/` → `packages/sbir-etl/` relocation (§1.3) is cosmetic and cheap.
+The tiering is neither, and it delivers value before any directory moves: the
+first useful step is writing down which existing artifacts meet the
+`evidence/` bar and which do not.
 
 ---
 

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -473,9 +473,11 @@ Each detected transition carries a likelihood score (0.0–1.0), confidence band
 
 ---
 
-## 6. Technology Stack & Integration Points
+## 6. Historical AWS Architecture (Archived Reference)
 
-### 6.1 Core Technologies
+### 6.1 Historical Technologies
+
+This section preserves the earlier AWS deployment notes as historical context. It does not describe the live deployment; the current stack is Docker Compose on the Mac mini, as summarized above and documented in the deployment runbook.
 
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
@@ -495,7 +497,7 @@ Each detected transition carries a likelihood score (0.0–1.0), confidence band
 | **Testing** | Pytest + Pytest-Cov | Unit/integration/E2E tests |
 | **Local Development** | Docker + Docker Compose | Local dev/test environment |
 
-### 6.2 Data Flow Connections (Optional Cloud Architecture)
+### 6.2 Historical AWS Data Flow
 
 ```
 ┌─────────────────────────────────────────┐
@@ -559,10 +561,10 @@ Each detected transition carries a likelihood score (0.0–1.0), confidence band
 │   (Queryable Knowledge Graph)           │
 └─────────────────────────────────────────┘
 
-Local Development Alternative:
-- S3 → Local filesystem fallback (data/ directory)
-- Neo4j EC2 → Docker Neo4j (docker-compose.yml)
-- GitHub Actions → Local Dagster (dagster dev)
+Current deployment instead:
+- Docker Compose → local filesystem and attached SSD
+- Neo4j 5.x → Docker Neo4j on the live host
+- Dagster assets/jobs/schedules → the host stack; GitHub Actions → CI
 ```
 
 ### 6.3 Neo4j Integration

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -1,0 +1,163 @@
+# Epistemic Tiers
+
+Every artifact in this repository sits in one of four tiers. The tier declares
+how much weight the artifact can carry, and each tier's contract states what it
+costs to sit there.
+
+This is the axis the work actually varies on. Technical role — extract, enrich,
+transform, load — describes what code does; it says nothing about whether a
+number it produces can be quoted to a program officer. Two artifacts with
+identical technical roles can differ completely in how much they can be trusted,
+and the repository has to make that difference visible.
+
+See [architecture/detailed-overview.md §10](../architecture/detailed-overview.md)
+for how this relates to the current directory layout.
+
+## Why this exists
+
+The cost that grows fastest as research questions accumulate is not lines of
+code. It is the maintenance obligation attached to those lines. A repository
+with one undifferentiated standard has to hold everything to the standard of its
+most rigorous artifact, so every throwaway cohort-builder either gets tests it
+does not need or quietly erodes the standard.
+
+Tiering caps that cost by making it **legitimate to not maintain most of the
+code**. `exploratory/` work is allowed to be untested, unrefactored, and stale,
+because it is labeled non-citable and nothing downstream depends on it. In
+exchange, `evidence/` is small, expensive, and genuinely trustworthy.
+
+The tiers are admission control, not a filing system. If a tier's contract is
+not enforced, the tier is decoration.
+
+## The four tiers
+
+### 1. `primitives`
+
+Identity resolution, configuration loading, schemas.
+
+| | |
+|---|---|
+| **Depends on** | Nothing in the repository |
+| **Depended on by** | Everything |
+| **Contract** | One implementation per concept. Comprehensive tests. Versioned behavior — a change in output is a new named version, never an edit in place. |
+| **Reviewed as** | Load-bearing. Assume every downstream number moves when this changes. |
+
+The one-implementation rule is about *contract*, not uniformity. A primitive may
+legitimately expose several named, versioned behaviors —
+`sbir_etl/identity/` exposes one `company_name_similarity` interface over many
+`CompanyNameProfile` policies, because different matching tasks genuinely want
+different recall. What is forbidden is a second, unnamed implementation
+somewhere else in the tree. Divergent behavior is fine when it is declared;
+invisible divergence is the defect.
+
+### 2. `pipelines`
+
+Extraction and materialization.
+
+| | |
+|---|---|
+| **Contract** | Deterministic. Reproducible from a declared data cut. Re-running on the same inputs produces the same outputs. |
+| **Must not** | Perform inference, estimation, or scoring that a reader could mistake for a finding |
+| **Reviewed as** | Infrastructure. Correctness means faithfulness to the source, not plausibility of the result. |
+
+Pipelines move and reshape data. The moment a stage starts *deciding* something
+contestable, it is doing evidence-tier or exploratory-tier work and needs the
+matching contract.
+
+### 3. `evidence`
+
+Artifacts that can be cited outside this repository.
+
+All four of these are required. There is no partial admission:
+
+1. **Frozen spec** — a design note fixed at a content hash, describing the
+   method before the run.
+2. **SHA enforcement** — inputs pinned by hash; a manifest recording input
+   hashes, sizes, row counts, and output hash.
+3. **Blocking asset checks** — quality gates that fail the materialization
+   rather than warn.
+4. **Declared estimand** — a written statement of what quantity is being
+   estimated, and what would make the estimate wrong.
+
+Reference implementation: the Phase III census
+(`specs/phase-iii-census/`, `packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/`).
+Anything proposed for this tier should be compared against it directly.
+
+Entering this tier is meant to be expensive and visibly so. The correct default
+answer to "should this be evidence-tier?" is no.
+
+### 4. `exploratory`
+
+Everything else.
+
+| | |
+|---|---|
+| **Contract** | Labeled non-citable. That is the whole contract. |
+| **Permitted** | No tests, no interface stability, no cleanup, going stale |
+| **Forbidden** | Being depended on by any other tier; producing numbers that leave the repository without relabeling |
+
+Most of `scripts/` belongs here and there is no shame in it. Exploratory work
+answering a question once is the normal mode of research. The failure is not
+writing it — it is leaving it indistinguishable from work that earned a stronger
+claim.
+
+## Classifying an artifact
+
+Work the questions in order and stop at the first yes:
+
+1. Does anything else in the repository import it? → at least `primitives` or `pipelines`
+2. Will a number from it be quoted outside the repository? → `evidence`, and it needs all four contract items
+3. Does it move data without deciding anything contestable? → `pipelines`
+4. Otherwise → `exploratory`
+
+Two rules make this stick:
+
+- **Tier is declared, not inferred.** Every spec states its target tier in
+  `requirements.md`. Every new asset or module states its tier. Unstated means
+  `exploratory`.
+- **Promotion is explicit work.** Moving up a tier is its own change, with the
+  new contract satisfied in that change. Nothing gets promoted by being useful,
+  by being imported, or by accumulating callers.
+
+## Relationship to the research questions
+
+[research-questions.md](../research-questions.md) is the inventory of what the
+repository exists to answer, and its **Status** lines already speak in
+epistemic terms — what is answerable today, what is a lower-bound proxy, what
+is contested. The tiers are the supply side of that same distinction:
+
+| research-questions.md says | Backing tier |
+|---|---|
+| Answerable today, citable | `evidence` |
+| Answerable but lower-bound proxy | `evidence`, with the bound in the declared estimand |
+| Partial or contested | `pipelines` + `exploratory` |
+| Design target, not built | none yet |
+
+A question cannot be marked answerable on the strength of exploratory-tier
+work. If the inventory claims an answer, something in `evidence` has to stand
+behind it.
+
+## Current status
+
+The tiers are a target, not a description of the tree as it stands. There are no
+`primitives/`, `pipelines/`, `evidence/`, or `exploratory/` directories today.
+
+What already holds:
+
+- `sbir_etl/` is a clean foundation layer — 141 imports inbound from
+  `packages/`, zero outbound.
+- `sbir_etl/identity/` meets the `primitives` contract, with a boundary checker
+  at `scripts/ci/check_identity_boundaries.py`.
+- The Phase III census meets the `evidence` contract.
+
+What does not:
+
+- The identity boundary checker runs in no workflow or hook — only in
+  `tests/unit/scripts/test_identity_boundaries.py`.
+- Configuration has 15 `yaml.safe_load` sites outside
+  `sbir_etl/config/loader.py`.
+- `scripts/` carries analytical weight from `phase3_groundtruth/` and
+  `validation/` with no contract at all.
+
+The first useful step is labeling, not moving directories. Directory
+reorganization is the last step, and optional.

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -2,6 +2,12 @@
 
 For the full directory tree and pipeline architecture, see [architecture/detailed-overview.md](../architecture/detailed-overview.md). This document covers the developer-facing conventions: directory layout, naming rules, and code organization principles.
 
+The conventions below organize code by **technical role** — extractors,
+enrichers, transformers, loaders. That axis is orthogonal to
+[epistemic tiers](epistemic-tiers.md), which govern what an artifact can be
+trusted to support and what it costs to maintain. A module's directory tells you
+what it does; its tier tells you how much weight it carries. Both apply.
+
 ## Directory Conventions
 
 ### Configuration Files


### PR DESCRIPTION
## Description

Establishes tiering by epistemic status as the repository's organizing pattern, and wires it into the places that actually govern day-to-day work. Documentation and agent definitions only — no code moves, no directories created.

The motivating problem is maintenance cost. As research questions accumulate, a repository with one undifferentiated standard has to hold everything to the standard of its most rigorous artifact. The tiers cap that by making it *legitimate to not maintain most of the code*: `exploratory` work is allowed to be untested and stale because it is labeled non-citable, and in exchange `evidence` stays small and genuinely trustworthy.

### 1. Architecture overview — drift fixes and the tier rationale

Corrected an AWS deployment path (Step Functions, S3 data lake, EC2 Neo4j) that is not the live architecture, an `infrastructure/` CDK tree that is not in the repository, and a Lambda path that doesn't exist. Added the FastAPI `api/` package and `studies/` to the tree.

New §1.3 records the measured dependency direction: 141 imports from `packages/` into `sbir_etl`, zero the other way, including under `TYPE_CHECKING` and in deferred imports. The layering is acyclic. The section also notes the tree understates it — `sbir_etl/` sits at the root as an apparent peer of its own dependents — and that relocating it to `packages/sbir-etl/` would make layout match imports.

New §10 gives the architectural rationale for the four tiers and records the Phase III census as the `evidence` reference implementation.

### 2. `docs/steering/epistemic-tiers.md` — the canonical contract

New steering doc, and the single source the agents read: per-tier contracts, a four-question classification procedure, the declare-and-promote rules, and a mapping from `research-questions.md` answerability labels to the tier that has to stand behind each one. A question cannot be marked answerable on exploratory-tier work.

| Tier | Contract |
|---|---|
| `primitives` | One implementation per concept, versioned behavior, comprehensive tests |
| `pipelines` | Deterministic, reproducible from a declared data cut, no inference |
| `evidence` | Frozen spec + SHA enforcement + blocking asset checks + declared estimand — all four, no partial admission |
| `exploratory` | Labeled non-citable. Nothing else required. |

The doc records current status honestly: no tier directories exist yet; `sbir_etl/identity/` and the Phase III census already meet their contracts; the identity boundary checker runs in no workflow; config has 15 loader-bypassing `yaml.safe_load` sites.

### 3. Agents — enforcement at the points where tier is decidable

- **`scope-guard`** gains a tier check and a `RETIER` verdict, catching both directions of mis-tiering — a citable claim resting on uncontracted work, and exploratory code carrying hardening it will never need — plus silent promotion, which no other stage sees.
- **`spec-implementer`** establishes the tier before writing code, builds to it and not above it, and refuses to promote by importing `scripts/` code or quoting an exploratory number.
- **`quality-sweep`** and **`test-fixer`** scale effort by tier instead of uniformly. Untended exploratory code is explicitly the design working rather than a backlog. Neither may resolve a failure by weakening a contract — downgrading a blocking asset check or loosening a pinned hash is a contract change, not a cleanup.

### 4. `CLAUDE.md` / `AGENTS.md` — single-sourced

CLAUDE.md carries the tier summary and rules. AGENTS.md is now a pure routing file with no rules of its own — it had duplicated the live-deployment rule set from CLAUDE.md since before this branch. Nothing was dropped: the two bullets AGENTS.md uniquely carried moved into CLAUDE.md (both were already in the runbook), and two qualifiers that were *stronger* in AGENTS.md are now the CLAUDE.md wording — ingress as Tailscale Serve over tailnet-only HTTPS, and LAN/public port exposure prohibited alongside Funnel.

### Findings worth flagging

The premises this started from were partly stale; the corrections are in the docs:

- **The identity consolidation already landed.** `sbir_etl/identity/` exposes one `company_name_similarity` contract over versioned `CompanyNameProfile` policies, and all nine previously-forked call sites route through it. The profiles preserve divergent recall deliberately — the module docstring is explicit that uniform behavior is not the goal. The remaining gap is narrow: `scripts/ci/check_identity_boundaries.py` is wired into no workflow, Makefile target, or pre-commit hook, and the profile governing the census control frame isn't documented next to the estimand.
- **There is no back-edge.** `sbir_etl` → `packages/` is zero, not one.
- Config is the one primitive genuinely still forked: 15 `yaml.safe_load` sites. Deliberately **not** in this PR — see below.

## Type of Change

- [x] Documentation update

## Testing

Documentation and agent definitions only; no code paths touched, so no tests were added.

- `markdownlint-cli2` on every changed and added file: the new steering doc is clean; the remaining findings are pre-existing and none are in added text (counts verified identical on `main` by stashing).
- Every referenced path checked to exist — the 13 module, spec, script, and test paths quoted across the docs.
- Every figure re-measured against the working tree rather than carried over from the analysis that prompted this PR. Three were wrong on first write and corrected before commit: the `scripts/` subtree count, the back-edge count, and the "larger than any package" claim (`scripts/` at 42,867 lines is larger than `sbir-analytics` at 32,101 but smaller than `sbir_etl` at 59,902).
- Consolidation checked for loss by diffing the old AGENTS.md rule set against CLAUDE.md — all nine rule keys confirmed present.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Follow-ups, deliberately not in this PR

1. **Config primitive consolidation** — 15 `yaml.safe_load` sites routed through `sbir_etl/config/loader.py`. Behavioral risk (validation, defaults, and env overrides would begin applying where they don't today), so it wants its own PR and its own test pass.
2. **Wire `check_identity_boundaries.py` into CI** — a guard that runs only in its own unit test is a guard against accidents, not drift. Roughly a one-line workflow addition.
3. **Document the census control-frame profile** in `specs/phase-iii-census/`, next to the estimand.
4. **Tier labels in spec `requirements.md` files** — the labeling step §10.5 calls the first useful move.
5. **`sbir_etl/` → `packages/sbir-etl/`** — cosmetic, cheap, and explicitly last.