### PR TITLE
fix(config): one strict YAML mapping read, and three crash sites fixed

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/assets.py
@@ -21,6 +21,7 @@ from sbir_analytics.assets.phase_transition.sbir_gov_source import (
     sha256_file,
     verify_sbir_gov_materialization,
 )
+from sbir_etl.exceptions import ConfigurationError
 from sbir_etl.quality.study_manifest import load_study_manifest
 
 from .criteria import (
@@ -128,7 +129,7 @@ def verify_materialization_gate() -> dict[str, Any]:
 
     try:
         manifest = load_study_manifest(STUDY_MANIFEST_PATH)
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, ConfigurationError) as exc:
         raise CensusInputError(
             f"Phase III census study manifest is missing or invalid at {STUDY_MANIFEST_PATH}: {exc}"
         ) from exc

--- a/packages/sbir-ml/sbir_ml/ml/config/taxonomy_loader.py
+++ b/packages/sbir-ml/sbir_ml/ml/config/taxonomy_loader.py
@@ -7,10 +7,10 @@ Loads YAML configuration files and validates them against Pydantic schemas.
 from pathlib import Path
 from typing import Any
 
-import yaml
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
 
+from sbir_etl.config.yaml_io import read_yaml_mapping
 from sbir_etl.exceptions import FileSystemError
 from sbir_etl.models.cet_models import CETArea
 
@@ -125,13 +125,13 @@ class TaxonomyLoader:
             TaxonomyConfig: Validated taxonomy configuration
 
         Raises:
-            FileNotFoundError: If taxonomy.yaml doesn't exist
-            ValueError: If taxonomy fails validation
+            FileSystemError: If taxonomy.yaml doesn't exist
+            ConfigurationError: If taxonomy.yaml is empty, malformed, or not a mapping
+            ValidationError: If taxonomy fails schema validation
         """
         logger.info("Loading CET taxonomy", extra={"file": str(self.taxonomy_path)})
 
-        with open(self.taxonomy_path) as f:
-            raw_config = yaml.safe_load(f)
+        raw_config = read_yaml_mapping(self.taxonomy_path, description="CET taxonomy")
 
         # Convert cet_areas dict entries to CETArea objects
         cet_areas_raw = raw_config.get("cet_areas", [])
@@ -241,13 +241,15 @@ class TaxonomyLoader:
             ClassificationConfig: Validated classification configuration
 
         Raises:
-            FileNotFoundError: If classification.yaml doesn't exist
-            ValueError: If configuration fails validation
+            FileSystemError: If classification.yaml doesn't exist
+            ConfigurationError: If classification.yaml is empty, malformed, or not a mapping
+            ValidationError: If configuration fails schema validation
         """
         logger.info("Loading classification config", extra={"file": str(self.classification_path)})
 
-        with open(self.classification_path) as f:
-            raw_config = yaml.safe_load(f)
+        raw_config = read_yaml_mapping(
+            self.classification_path, description="classification config"
+        )
 
         config = ClassificationConfig(**raw_config)
 

--- a/sbir_etl/config/yaml_io.py
+++ b/sbir_etl/config/yaml_io.py
@@ -1,0 +1,62 @@
+"""Strict YAML reads for files that must contain a mapping.
+
+Several loaders read a YAML document and immediately treat it as a mapping —
+``raw.get("version")``, ``Model(**raw)``. When the file is empty, ``safe_load``
+returns ``None`` and those lines fail with ``AttributeError`` or ``TypeError``
+naming neither the file nor the real problem. When it holds a list, they fail
+just as opaquely.
+
+``read_yaml_mapping`` is the one shared implementation of that check. It is
+deliberately narrow: it does not merge, resolve environments, apply defaults, or
+validate a schema. Pipeline configuration resolution belongs in
+``loader.get_config``; per-file schema validation stays with the caller that
+owns the schema.
+
+Callers that treat an empty file as a valid empty mapping want ``or {}`` at the
+call site instead — that is a different policy, not a bug this helper fixes.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..exceptions import ConfigurationError
+
+
+__all__ = ["read_yaml_mapping"]
+
+
+def read_yaml_mapping(path: Path, *, description: str = "YAML file") -> dict[str, Any]:
+    """Read ``path`` and return its top-level mapping.
+
+    Args:
+        path: File to read.
+        description: What the file is, used in error messages (e.g. "CET
+            taxonomy"). Keep it a noun phrase — it is interpolated directly.
+
+    Returns:
+        The parsed top-level mapping.
+
+    Raises:
+        ConfigurationError: The file is missing, unreadable, not valid YAML,
+            empty, or does not hold a mapping at the top level.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ConfigurationError(f"cannot read {description}: {path} ({exc})") from exc
+
+    try:
+        payload = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ConfigurationError(f"{description} is not valid YAML: {path} ({exc})") from exc
+
+    if payload is None:
+        raise ConfigurationError(f"{description} is empty: {path}")
+    if not isinstance(payload, dict):
+        raise ConfigurationError(
+            f"{description} must hold a mapping at the top level, "
+            f"found {type(payload).__name__}: {path}"
+        )
+    return payload

--- a/sbir_etl/quality/study_manifest.py
+++ b/sbir_etl/quality/study_manifest.py
@@ -4,8 +4,9 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Literal
 
-import yaml
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ..config.yaml_io import read_yaml_mapping
 
 
 class EvidenceStatus(StrEnum):
@@ -89,9 +90,7 @@ class StudyManifest(BaseModel):
 def load_study_manifest(path: Path) -> StudyManifest:
     """Load and validate a study manifest from YAML."""
 
-    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(raw, dict):
-        raise ValueError(f"study manifest must contain a YAML mapping: {path}")
+    raw = read_yaml_mapping(path, description="study manifest")
     return StudyManifest.model_validate(raw)
 
 

--- a/sbir_etl/reporting/defense_taxonomy_crosswalk.py
+++ b/sbir_etl/reporting/defense_taxonomy_crosswalk.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-import yaml
+from ..config.yaml_io import read_yaml_mapping
 
 
 DEFAULT_CROSSWALK_PATH = (
@@ -47,17 +46,8 @@ class DefenseTaxonomyCrosswalk:
         return [dict(mapping) for mapping in entry[target_taxonomy]]
 
 
-def _load_yaml(path: Path) -> dict[str, Any]:
-    if not path.exists():
-        raise FileNotFoundError(f"taxonomy configuration does not exist: {path}")
-    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
-    if not isinstance(payload, dict):
-        raise ValueError(f"taxonomy configuration must be a mapping: {path}")
-    return payload
-
-
 def _canonical_ids(taxonomy_path: Path) -> tuple[str, set[str]]:
-    payload = _load_yaml(taxonomy_path)
+    payload = read_yaml_mapping(taxonomy_path, description="CET taxonomy")
     version = str(payload.get("version") or "")
     areas = payload.get("cet_areas")
     if not version or not isinstance(areas, list):
@@ -76,7 +66,7 @@ def load_defense_crosswalk(
 
     source_path = crosswalk_path or DEFAULT_CROSSWALK_PATH
     canonical_path = taxonomy_path or DEFAULT_TAXONOMY_PATH
-    payload = _load_yaml(source_path)
+    payload = read_yaml_mapping(source_path, description="defense crosswalk")
     canonical_version, canonical_ids = _canonical_ids(canonical_path)
 
     version = str(payload.get("version") or "")

--- a/sbir_etl/reporting/local_cet_classifier.py
+++ b/sbir_etl/reporting/local_cet_classifier.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-import yaml
+
+from ..config.yaml_io import read_yaml_mapping
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -128,8 +129,8 @@ def load_local_cet_rule_classifier(
 ) -> LocalCETRuleClassifier:
     """Load and validate the local classifier and canonical taxonomy."""
 
-    taxonomy = yaml.safe_load(taxonomy_path.read_text(encoding="utf-8"))
-    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    taxonomy = read_yaml_mapping(taxonomy_path, description="CET taxonomy")
+    config = read_yaml_mapping(config_path, description="local rule classifier config")
     if taxonomy.get("version") != config.get("taxonomy_version"):
         raise ValueError(
             f"classifier expects taxonomy {config.get('taxonomy_version')!r}, "

--- a/scripts/ci/validate_study_manifests.py
+++ b/scripts/ci/validate_study_manifests.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pydantic import ValidationError
 
+from sbir_etl.exceptions import ConfigurationError
 from sbir_etl.quality.study_manifest import StudyManifest, load_study_manifest
 
 
@@ -103,7 +104,7 @@ def validate_manifest_file(
 
     try:
         manifest = load_study_manifest(path)
-    except (OSError, ValueError, ValidationError) as exc:
+    except (OSError, ValueError, ValidationError, ConfigurationError) as exc:
         return [f"invalid manifest: {exc}"]
     return validate_manifest_references(
         manifest,

--- a/tests/unit/config/test_yaml_io.py
+++ b/tests/unit/config/test_yaml_io.py
@@ -1,0 +1,79 @@
+"""Tests for the strict YAML mapping reader."""
+
+from pathlib import Path
+
+import pytest
+
+from sbir_etl.config.yaml_io import read_yaml_mapping
+from sbir_etl.exceptions import ConfigurationError
+
+
+def test_reads_a_mapping(tmp_path: Path) -> None:
+    path = tmp_path / "ok.yaml"
+    path.write_text("version: NSTC-2025Q1\ncount: 3\n", encoding="utf-8")
+
+    assert read_yaml_mapping(path) == {"version": "NSTC-2025Q1", "count": 3}
+
+
+def test_missing_file_names_the_path(tmp_path: Path) -> None:
+    path = tmp_path / "absent.yaml"
+
+    with pytest.raises(ConfigurationError, match="cannot read") as excinfo:
+        read_yaml_mapping(path, description="CET taxonomy")
+
+    assert "CET taxonomy" in str(excinfo.value)
+    assert str(path) in str(excinfo.value)
+
+
+def test_empty_file_is_rejected(tmp_path: Path) -> None:
+    """An empty file parses to None, which callers would hit as AttributeError."""
+    path = tmp_path / "empty.yaml"
+    path.write_text("", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="is empty"):
+        read_yaml_mapping(path)
+
+
+def test_comment_only_file_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "comments.yaml"
+    path.write_text("# nothing but a comment\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="is empty"):
+        read_yaml_mapping(path)
+
+
+@pytest.mark.parametrize(
+    ("content", "type_name"),
+    [("- one\n- two\n", "list"), ("just a string\n", "str"), ("42\n", "int")],
+)
+def test_non_mapping_top_level_is_rejected(tmp_path: Path, content: str, type_name: str) -> None:
+    path = tmp_path / "wrong.yaml"
+    path.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="must hold a mapping") as excinfo:
+        read_yaml_mapping(path)
+
+    assert type_name in str(excinfo.value)
+
+
+def test_malformed_yaml_is_rejected(tmp_path: Path) -> None:
+    path = tmp_path / "bad.yaml"
+    path.write_text("key: [unclosed\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="not valid YAML"):
+        read_yaml_mapping(path)
+
+
+def test_description_appears_in_every_failure(tmp_path: Path) -> None:
+    """The description is what tells an operator which file to go fix."""
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    listed = tmp_path / "list.yaml"
+    listed.write_text("- a\n", encoding="utf-8")
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("key: [unclosed\n", encoding="utf-8")
+
+    for path in (empty, listed, bad, tmp_path / "absent.yaml"):
+        with pytest.raises(ConfigurationError) as excinfo:
+            read_yaml_mapping(path, description="study manifest")
+        assert "study manifest" in str(excinfo.value)

--- a/tests/unit/ml/test_taxonomy_loader.py
+++ b/tests/unit/ml/test_taxonomy_loader.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from sbir_etl.exceptions import FileSystemError
+from sbir_etl.exceptions import ConfigurationError, FileSystemError
 from sbir_ml.ml.config.taxonomy_loader import ClassificationConfig, TaxonomyConfig, TaxonomyLoader
 
 
@@ -96,6 +96,35 @@ analytics: {}
 
         with pytest.raises(FileSystemError, match="Classification config not found"):
             TaxonomyLoader(config_dir=cet_dir)
+
+    def test_empty_taxonomy_file_reports_the_file(self, tmp_path: Path) -> None:
+        """An empty taxonomy previously failed as AttributeError on None.get()."""
+        cet_dir = tmp_path / "cet"
+        cet_dir.mkdir()
+        (cet_dir / "taxonomy.yaml").write_text("", encoding="utf-8")
+        (cet_dir / "classification.yaml").write_text("model_version: v1.0.0\n", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="CET taxonomy is empty"):
+            TaxonomyLoader(config_dir=cet_dir).load_taxonomy()
+
+    def test_non_mapping_taxonomy_file_reports_the_file(self, tmp_path: Path) -> None:
+        cet_dir = tmp_path / "cet"
+        cet_dir.mkdir()
+        (cet_dir / "taxonomy.yaml").write_text("- not-a-mapping\n", encoding="utf-8")
+        (cet_dir / "classification.yaml").write_text("model_version: v1.0.0\n", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="must hold a mapping"):
+            TaxonomyLoader(config_dir=cet_dir).load_taxonomy()
+
+    def test_empty_classification_file_reports_the_file(self, tmp_path: Path) -> None:
+        """An empty classification config previously failed as TypeError on **None."""
+        cet_dir = tmp_path / "cet"
+        cet_dir.mkdir()
+        (cet_dir / "taxonomy.yaml").write_text("version: v1.0.0\n", encoding="utf-8")
+        (cet_dir / "classification.yaml").write_text("", encoding="utf-8")
+
+        with pytest.raises(ConfigurationError, match="classification config is empty"):
+            TaxonomyLoader(config_dir=cet_dir).load_classification_config()
 
     def test_load_taxonomy(self) -> None:
         """Test loading the real taxonomy configuration."""

--- a/tests/unit/reporting/test_local_cet_classifier.py
+++ b/tests/unit/reporting/test_local_cet_classifier.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 import yaml
 
+from sbir_etl.exceptions import ConfigurationError
 from sbir_etl.reporting.local_cet_classifier import load_local_cet_rule_classifier
 
 
@@ -68,3 +69,24 @@ def test_loader_rejects_taxonomy_version_mismatch(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="expects taxonomy"):
         load_local_cet_rule_classifier(config_path=config_path)
+
+
+def test_empty_taxonomy_reports_the_file(tmp_path: Path) -> None:
+    """An empty taxonomy previously failed as AttributeError on None.get()."""
+    taxonomy = tmp_path / "taxonomy.yaml"
+    taxonomy.write_text("", encoding="utf-8")
+    config = tmp_path / "config.yaml"
+    config.write_text(yaml.safe_dump({"taxonomy_version": "v1"}), encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="CET taxonomy is empty"):
+        load_local_cet_rule_classifier(taxonomy_path=taxonomy, config_path=config)
+
+
+def test_non_mapping_classifier_config_reports_the_file(tmp_path: Path) -> None:
+    taxonomy = tmp_path / "taxonomy.yaml"
+    taxonomy.write_text(yaml.safe_dump({"version": "v1", "cet_areas": []}), encoding="utf-8")
+    config = tmp_path / "config.yaml"
+    config.write_text("- not-a-mapping\n", encoding="utf-8")
+
+    with pytest.raises(ConfigurationError, match="must hold a mapping"):
+        load_local_cet_rule_classifier(taxonomy_path=taxonomy, config_path=config)


### PR DESCRIPTION
## Description

Follow-up to #509, which listed "config primitive consolidation — 15 `yaml.safe_load` sites routed through `sbir_etl/config/loader.py`" as the next step. **That framing was wrong**, and this PR does the smaller, real thing instead.

### Why the mass consolidation isn't the fix

I read all 15 sites. They are not 15 copies of one concept. Two are `loader.py` itself — that *is* the pipeline-config resolution path. The other thirteen load **domain data** — CET taxonomies, defense crosswalks, study manifests, census profiles, BEA fallbacks, feature configs, baselines — with deliberately different error policies:

| Policy | Sites |
|---|---|
| `or {}` — empty/absent file is a valid state | `tech_census` ×2, `transition_report_paths`, `fiscal_bea_mapper`, `patent_features`, `baselines` |
| swallow → `{}`, documented graceful degradation | `cet_vocabulary` |
| strict — must be a mapping, hand-rolled | `defense_taxonomy_crosswalk`, `study_manifest` |
| **strict by assumption, unchecked** | `local_cet_classifier` ×2, `taxonomy_loader` ×2 |

Routing these through `loader.get_config` would be actively wrong — that function returns a validated `PipelineConfig`, which a CET taxonomy is not. And a single helper covering all four policies would need a policy flag, turning a three-line check into a configuration surface. That's the "configurable everything" red flag in `scope-guard`'s own list.

### What this PR actually does

Adds `sbir_etl/config/yaml_io.read_yaml_mapping` — one implementation of the narrow concept the last two rows share: *read a YAML file that must contain a mapping, and fail with a message naming the file*. Six call sites now use it.

**The bottom row was a live bug.** Four calls did a bare `safe_load` and immediately treated the result as a mapping. On an empty or comment-only file `safe_load` returns `None`:

- `load_local_cet_rule_classifier` → `AttributeError: 'NoneType' object has no attribute 'get'`
- `TaxonomyLoader.load_taxonomy` → same
- `TaxonomyLoader.load_classification_config` → `TypeError` on `ClassificationConfig(**None)`

None of those named the offending file. Both `TaxonomyLoader` docstrings also promised `FileNotFoundError` / `ValueError`, neither of which the code could raise — corrected to what actually comes out (`FileSystemError`, `ConfigurationError`, `ValidationError`).

The two sites that already hand-rolled the `isinstance` check are a straight substitution, and `defense_taxonomy_crosswalk._load_yaml` goes away entirely.

### Deliberately unchanged

The ten remaining `yaml.safe_load` sites. `loader.py`'s two are the config-resolution path; the rest treat an absent or empty file as valid and would change behavior for no gain. Under the tier framing in #509 this is the `primitives` rule working as intended: one implementation per *concept*, and "read a taxonomy for graceful degradation" is a different concept from "read and strictly validate a manifest."

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- **5414 unit tests pass**, 7 skipped (`pytest tests/unit/ -m "not slow"`).
- **9 new tests.** `tests/unit/config/test_yaml_io.py` covers the helper: valid mapping, missing file, empty file, comment-only file, three non-mapping top-level types, malformed YAML, and that the description reaches every failure message.
- **3 regression tests** pin the crash sites — empty taxonomy, non-mapping taxonomy, and empty classification config now raise `ConfigurationError` naming the file instead of `AttributeError`/`TypeError`.
- Confirmed no existing test depended on the old exception types, and no caller catches `FileNotFoundError` around the changed functions.
- `ruff check`, `ruff format --check`, and `mypy` clean (239 source files).
- All four CI guards pass, including the identity boundary guard newly wired up in #509.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Note on #509

#509's follow-up list should be corrected — item 1 describes a consolidation that shouldn't happen. Happy to amend that PR body, or leave this one as the record.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FH27aKYTeWK8wEKq7YHBxd)_