### PR TITLE
docs: align tier guidance with current enforcement

### DIFF
--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -718,9 +718,13 @@ the `evidence/` boundary is that it is expensive to cross and visibly so; the
 point of `exploratory/` is that useful throwaway work gets a home where its
 status is legible instead of being laundered by proximity to rigorous work.
 
-The Phase III census already meets the `evidence/` bar
-(`specs/phase-iii-census/`, `packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/`).
-It is the reference implementation for what that tier requires.
+The Phase III census
+(`specs/phase-iii-census/`, `packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/`)
+is the reference implementation for the evidence-tier machinery: frozen
+artifacts, SHA enforcement, a declared estimand, and a blocking asset check.
+Its study manifest currently classifies it as `reproducible`, not citable; it
+does not enter the `evidence/` tier until complete audit tables and post-write
+checks make its results citable.
 
 ### 10.3 Shared primitives: status
 
@@ -749,16 +753,14 @@ Two gaps remain, and they are narrower than "consolidate the primitive":
    for the census control frame?" now has an answer: a named, versioned
    profile. That answer is not written down anywhere a reader of the census
    would find it. It belongs in the census spec, next to the estimand.
-2. **The boundary checker is not wired into CI.** It is exercised by
-   `tests/unit/scripts/test_identity_boundaries.py` and nothing else — it
-   appears in no workflow, Makefile target, or pre-commit hook. A guard that
-   runs only when someone runs its unit test is a guard against accidents,
-   not against drift.
+2. **The boundary checker is wired into CI.** The quality job runs
+   `scripts/ci/check_identity_boundaries.py`, so direct scorer drift fails the
+   normal PR check as well as its unit test.
 
-Configuration has the same shape of problem, unaddressed: 15 separate
-`yaml.safe_load` call sites across `sbir_etl/` and `packages/`, alongside the
-merge-and-validate path in `sbir_etl/config/loader.py` that is supposed to be
-the way configuration gets read.
+Configuration has a narrower remaining problem: nine direct `yaml.safe_load`
+call sites remain outside `sbir_etl/config/loader.py` and the shared strict
+mapping reader. Several intentionally accept an empty file as an empty mapping;
+they are not duplicates of pipeline configuration resolution.
 
 ### 10.4 `scripts/` is an unbounded annex
 
@@ -777,6 +779,13 @@ Under §10.2 this resolves without a mass migration: most of `scripts/` is
 already `exploratory/` and only needs to be labeled as such. The subtrees
 carrying analytical weight get promoted to `pipelines/` or `evidence/` and
 acquire the corresponding contract.
+
+The source-download jobs are a documented temporary exception: package wrappers
+currently import five download CLIs from `scripts/`. This is a migration bridge,
+not an implicit promotion of the scripts; the implementation must move behind a
+package API before the exception can be removed. The architecture guard names
+the exact allowed imports, and evidence-tier artifacts may not depend on this
+bridge.
 
 ### 10.5 What this is not
 

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -742,20 +742,19 @@ folk history suggests:
   inputs, `tools/phase0/resolve_entities`, the vendor crosswalk and resolver,
   and the phase3 groundtruth scripts.
 - `scripts/ci/check_identity_boundaries.py` walks the AST for direct
-  `rapidfuzz` scorer imports outside an explicit reviewed-file allowlist.
+  `rapidfuzz` scorer imports outside an explicit reviewed-file allowlist. The
+  quality job runs the checker, so direct scorer drift fails the normal PR
+  check as well as its unit test.
 
-Two gaps remain, and they are narrower than "consolidate the primitive":
+One gap remains, and it is narrower than "consolidate the primitive":
 
-1. **The profiles preserve divergent recall by design.** They are
-   compatibility policies — the module's own docstring is explicit that this
-   is not a claim that all name-matching should behave identically. So the
-   question "which normalization decides a firm never received an SBIR award,
-   for the census control frame?" now has an answer: a named, versioned
-   profile. That answer is not written down anywhere a reader of the census
-   would find it. It belongs in the census spec, next to the estimand.
-2. **The boundary checker is wired into CI.** The quality job runs
-   `scripts/ci/check_identity_boundaries.py`, so direct scorer drift fails the
-   normal PR check as well as its unit test.
+**The profiles preserve divergent recall by design.** They are compatibility
+policies — the module's own docstring is explicit that this is not a claim that
+all name-matching should behave identically. So the question "which
+normalization decides a firm never received an SBIR award, for the census
+control frame?" now has an answer: a named, versioned profile. That answer is
+not written down anywhere a reader of the census would find it. It belongs in
+the census spec, next to the estimand.
 
 Configuration has a narrower remaining problem: nine direct `yaml.safe_load`
 call sites remain outside `sbir_etl/config/loader.py` and the shared strict

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -79,9 +79,12 @@ All four of these are required. There is no partial admission:
 4. **Declared estimand** — a written statement of what quantity is being
    estimated, and what would make the estimate wrong.
 
-Reference implementation: the Phase III census
+Reference implementation for the required machinery: the Phase III census
 (`specs/phase-iii-census/`, `packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/`).
-Anything proposed for this tier should be compared against it directly.
+Its frozen specification, SHA enforcement, declared estimand, and blocking
+asset check are the pattern to compare against directly. The census itself is
+currently `reproducible`, not citable: its study manifest keeps results
+non-citable until complete audit tables and post-write checks have passed.
 
 Entering this tier is meant to be expensive and visibly so. The correct default
 answer to "should this be evidence-tier?" is no.
@@ -94,12 +97,23 @@ Everything else.
 |---|---|
 | **Contract** | Labeled non-citable. That is the whole contract. |
 | **Permitted** | No tests, no interface stability, no cleanup, going stale |
-| **Forbidden** | Being depended on by any other tier; producing numbers that leave the repository without relabeling |
+| **Forbidden** | Being depended on by any other tier, except an approved temporary migration bridge; producing numbers that leave the repository without relabeling |
 
 Most of `scripts/` belongs here and there is no shame in it. Exploratory work
 answering a question once is the normal mode of research. The failure is not
 writing it — it is leaving it indistinguishable from work that earned a stronger
 claim.
+
+#### Temporary migration bridges
+
+An approved dependency from a package into `scripts/` is a migration bridge,
+not a fifth tier and not an implicit promotion of the script. It must be named
+in the architecture guard, limited to a compatibility wrapper, and have a
+removal condition: move the implementation behind a package API while retaining
+the CLI as an entry point. No new bridge may be added without those conditions,
+and an `evidence` artifact may not depend on one. See
+[structure.md](structure.md#transitional-script-dependencies) for the current
+bridge.
 
 ## Classifying an artifact
 
@@ -148,16 +162,20 @@ What already holds:
   `packages/`, zero outbound.
 - `sbir_etl/identity/` meets the `primitives` contract, with a boundary checker
   at `scripts/ci/check_identity_boundaries.py`.
-- The Phase III census meets the `evidence` contract.
+- The Phase III census implements the evidence-tier mechanisms: frozen
+  artifacts, SHA enforcement, a declared estimand, and a blocking asset check.
 
 What does not:
 
-- The identity boundary checker runs in no workflow or hook — only in
-  `tests/unit/scripts/test_identity_boundaries.py`.
-- Configuration has 15 `yaml.safe_load` sites outside
-  `sbir_etl/config/loader.py`.
+- The identity boundary checker is enforced by the CI quality job, but no
+  tier-declaration check exists yet.
+- Nine direct `yaml.safe_load` call sites remain outside the configuration
+  loader and the shared strict-mapping reader; several intentionally use
+  permissive empty-file behavior.
 - `scripts/` carries analytical weight from `phase3_groundtruth/` and
   `validation/` with no contract at all.
+- No existing specs, assets, or modules declare one of these four tiers, so the
+  declaration rule is not yet observable or mechanically enforced.
 
 The first useful step is labeling, not moving directories. Directory
 reorganization is the last step, and optional.

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -91,8 +91,10 @@ the manifest schema, frozen-artifact hashes, and implementation references.
 
 First-party packages may not add dependencies on `scripts/`. The architecture guard carries
 one exact, temporary exception for the server source-download jobs, which wrap five existing
-download CLIs. Those implementations should move behind a package API; the CLI modules can
-then remain as compatibility entry points and the exception can be removed.
+download CLIs. This is a migration bridge, not a fifth epistemic tier or an implicit
+promotion of those scripts: it is limited to compatibility wrappers, must not be used by an
+evidence-tier artifact, and is removed when the implementations move behind a package API.
+The CLI modules can then remain as compatibility entry points.
 
 ### Separation of Concerns
 


### PR DESCRIPTION
## Summary

Corrects the tiering documents against the merged repository state.

- records the identity-boundary guard as CI-enforced and updates the YAML-reader inventory
- distinguishes the Phase III census’s evidence-tier mechanisms from its current non-citable `reproducible` status
- defines the existing `packages` → `scripts` exception as a named, temporary migration bridge, with removal criteria and an evidence-tier prohibition
- records that tier declarations and their enforcement remain outstanding work

## Validation

- `git diff --check`
- verified all factual claims against `main` at `9b3805c`

Follow-up PRs will introduce declarations and their enforcement separately.