### PR TITLE
docs: expand live documentation hygiene audit

### DIFF
--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 ---
 Type: Overview
 Owner: devops@project
-Last-Reviewed: 2025-01-XX
+Last-Reviewed: 2026-08-03
 Status: active
 ---
 

--- a/docs/enrichment/sam-gov-integration.md
+++ b/docs/enrichment/sam-gov-integration.md
@@ -356,8 +356,8 @@ MemoryError: Unable to allocate array
 ## References
 
 - [SAM.gov Entity Information API](https://open.gsa.gov/api/entity-api/)
-- [Cloud Storage Utilities](../sbir_etl/utils/cloud_storage.py)
-- [Configuration Schema](../sbir_etl/config/schemas/data.py)
+- [Cloud Storage Utilities](../../sbir_etl/utils/cloud_storage.py)
+- [Configuration Schema](../../sbir_etl/config/schemas/data.py)
 
 ## Changelog
 

--- a/docs/transition/README.md
+++ b/docs/transition/README.md
@@ -178,7 +178,8 @@ Transition detection configuration:
 - **Coverage** - Detects transitions for ~60% of mature awards
 - **Processing Time** - ~2-3 minutes per 1000 awards
 
-For historical validation reports, see `docs/archive/transition/status-reports/`.
+The repository does not retain historical validation status reports; the
+archived transition guides document the prior implementation context.
 
 ## Research and Development
 

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -23,7 +23,6 @@ REMOVED_SRC_PATTERNS = (
     re.compile(r"\bsrc\.definitions(?:_ml)?\b"),
     re.compile(r"(?:^|[\s'\"(=:/])src/[A-Za-z0-9_.*?/-]+"),
 )
-LIVE_DOC_DIR_PREFIXES = ("docs/steering/", "docs/development/", "docs/testing/")
 LIVE_DOC_STALE_PATTERNS = (
     (
         re.compile(r"--cov=src(?:\b|/)"),
@@ -105,9 +104,7 @@ def _is_live_doc_file(relative: str) -> bool:
         return False
     if relative.startswith(("docs/archive/", "specs/archive/")):
         return False
-    if relative.startswith(LIVE_DOC_DIR_PREFIXES):
-        return True
-    if relative.startswith("docs/") and relative.count("/") == 1:
+    if relative.startswith("docs/"):
         return True
     return relative.startswith("specs/")
 

--- a/tests/unit/scripts/test_repository_hygiene.py
+++ b/tests/unit/scripts/test_repository_hygiene.py
@@ -10,10 +10,10 @@ def _write(root: Path, relative: str, text: str) -> Path:
     return path
 
 
-def test_live_doc_stale_content_scans_live_docs_only(tmp_path: Path):
+def test_live_doc_stale_content_scans_all_non_archived_docs(tmp_path: Path):
     live_doc = _write(
         tmp_path,
-        "docs/development/example.md",
+        "docs/transition/example.md",
         "Run `poetry run old-task` and inspect `src/assets/example.py`.\n",
     )
     archive_doc = _write(
@@ -27,6 +27,7 @@ def test_live_doc_stale_content_scans_live_docs_only(tmp_path: Path):
     assert [violation.message for violation in violations] == [
         "removed source-root file path",
     ]
+    assert violations[0].path == "docs/transition/example.md"
 
 
 def test_live_doc_link_audit_resolves_relative_links(tmp_path: Path):


### PR DESCRIPTION
## Summary

Root/docs audit follow-up with safe, targeted cleanup:

- expands the existing stale-content and local-link audit from a few documentation subtrees to every non-archived `docs/` page
- fixes two broken repository-source links in the SAM.gov guide
- removes a reference to a nonexistent historical transition-report directory
- replaces the placeholder review date in the development index

Historical archive material and tracked operational root files were retained: the audit found them referenced or intentionally preserved.

## Validation

- `uv run python scripts/ci/check_removed_src_references.py`
- `uv run --extra dev pytest tests/unit/scripts/test_repository_hygiene.py -n 0` — 6 passed
- `git diff --check`