### PR TITLE
docs(census): record February materialization

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -488,11 +488,14 @@ statutory goal is Phase III commercialization.*
   matching rules, the agency, and the time window?
   *Method:* the matching rules were written down and frozen before the counts
   were run, so the result cannot be tuned after the fact.
-  **Status:** Built, but not yet run in production. The production tables and the
-  matched comparison group have not been created, and the schema-verified source
-  layer it depends on is under separate review. Until then the count is a
-  plausible proxy, not proof of statutory Phase III.
-  *Deps: ER, ID, NAICS/PSC · Spec: [../specs/phase-iii-census/](../specs/phase-iii-census/)*
+  **Status:** Answerable now for the frozen audit estimand. The complete
+  cumulative ladder and all six pre-specified agency/window cells were
+  materialized from provenance-verified February inputs, and the blocking
+  one-factor sensitivity check passed. No cell is a headline result. The matched
+  comparison group and placebo test remain unresolved, so the tables are an
+  uncoded follow-on proxy, not proof of statutory Phase III or evidence that the
+  criteria discriminate.
+  *Deps: ER, ID, NAICS/PSC · Spec: [../specs/phase-iii-census/](../specs/phase-iii-census/) · Audit: [February 2026 data-cut materialization](../studies/phase-iii-census/materialization-2026-02-06.md)*
 
 - **Research-to-procurement transitions**
   Which SBIR-funded companies transitioned research into federal procurements?
@@ -539,11 +542,12 @@ statutory goal is Phase III commercialization.*
   Corroborated by GAO [L14] and NASEM [L1], [L3]. The protocol depends on
   award-grade identity and record granularity (issue #447 / PR #449); production
   source lifecycle belongs to issue #442.
-  **Status:** Partially answerable. The audit and its source/granularity checks
-  are built, across two separate changes, but have not been run in production.
-  Before the gap can be called an undercount, it still needs a matched comparison
-  group and a hand-labelled sample to check the result against.
-  *Deps: ID · Refs: [L14], [L1], [L3] · Spec: [../specs/phase3-match-benchmark/](../specs/phase3-match-benchmark/) (protocol and current evidence limits), [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/) (solicitation monitoring)*
+  **Status:** Partially answerable. The complete deterministic census tables and
+  one-factor sensitivity diagnostic were materialized from provenance-verified
+  February inputs. Before the proxy can be called an undercount, it still needs
+  matched negative controls, the placebo test, and a hand-labelled sample to
+  check the result against.
+  *Deps: ID · Refs: [L14], [L1], [L3] · Audit: [February 2026 data-cut census materialization](../studies/phase-iii-census/materialization-2026-02-06.md) · Spec: [../specs/phase3-match-benchmark/](../specs/phase3-match-benchmark/) (protocol and current evidence limits), [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/) (solicitation monitoring)*
 
 - **Categorization vs. transition likelihood**
   Are product firms, service firms, or mixed-mode firms (as categorized in
@@ -726,11 +730,11 @@ Foundational — most questions in A–D depend on work here.*
 
 - **SBIR.gov ↔ USAspending/FPDS reconciliation**
   How does SBIR.gov data reconcile with federal USAspending/FPDS records?
-  **Status:** Partially answerable. Federal Phase II transactions are grouped
-  under generated award IDs, so they match SBIR.gov only where a raw PIID or
-  source identifier matches exactly after normalization. Some records match more
-  than one award, and some disagree on how the award is categorized. Coverage
-  beyond that exact-match path has not been validated.
+  **Status:** Partially answerable. The census input path verified the complete
+  available SBIR.gov v2 snapshot and the generated-award Phase II collapse
+  against the selected February USAspending/FPDS snapshot. It reconciles only
+  exact normalized raw PIID/source identifiers and fails closed on ambiguity or
+  taxonomy conflict; broader cross-source completeness remains unvalidated.
   *Deps: none · Refs: [L14], [L1], [L3] (tracking-data limits)*
 
 ### E2. Entity resolution (foundation, Tier 1–2)

--- a/studies/phase-iii-census/materialization-2026-02-06.md
+++ b/studies/phase-iii-census/materialization-2026-02-06.md
@@ -1,0 +1,112 @@
+# Phase III Census Materialization — February 6, 2026 Data Cut
+
+## Interpretation boundary
+
+This is the complete Phase 1 deterministic census audit, not a validated count of
+statutory Phase III awards. Every row and sensitivity cell is reported; no cell is a
+headline result. The matched negative-control study, placebo test, and labeled validation
+remain unresolved, so this record does not establish that the frozen proxy discriminates
+Phase III work from ordinary follow-on federal contracting.
+
+## Run and freeze record
+
+| Item | Recorded value |
+|---|---|
+| Dagster run | `aa0ec6d3-2b8e-4ad5-8de7-18a22495c107` (`SUCCESS`) |
+| Data cut | `2026-02-06` |
+| Census code commit used by the run | `dc524ad995c1574965aa9dd94ae1078c8ddf8934` |
+| Contract-extraction code commit | `48493d59aa2ae61ba6d26da9ba1527dd317e330d` |
+| Frozen revision | `phase-0-r8` |
+| Frozen design SHA-256 | `91b84c67e51a36a56b9d11d1afe997bc9b7de7cef090de12c24619116b6351ff` |
+| Amendment-log SHA-256 | `6168c6e2a685a3b89fa93eae86976d14798d5e6c67f7a8721b764384081ce74c` |
+| Stochastic execution | `false` (seed `null`) |
+| Blocking sensitivity check | Passed: all seven one-factor contrasts reported; no review condition triggered |
+
+The run metadata recorded the same commit tags, data cut, frozen revision and hashes,
+ordered clauses, source paths, and non-stochastic execution record shown above.
+
+## Verified inputs
+
+| Artifact | Rows | Bytes | SHA-256 | Verification |
+|---|---:|---:|---|---|
+| `data/transition/contracts_ingestion.parquet` | 1,879,459 | 416,094,799 | `c1518188ef674f3b301ef61be19f6db796a9389e4d03f1196280080f71803a98` | Canonical `rpt.transaction_search`, physical `rpt.transaction_search_fpds`, February mirror member `5924.dat.gz`; manifest and output checksum passed |
+| `data/processed/phase_iii_census_sbir_awards.parquet` | 219,500 | 207,826,925 | `b46c552f26a9de9ff70bb63f08880a38d9e4d4413c33d23c3e539f4316e1421f` | SBIR.gov v2 manifest passed; 219,503 raw rows with three exact duplicates collapsed |
+| `data/processed/phase_ii_awards.parquet` | 95,313 | 7,793,225 | `4ebace02624b0c3591b01dd8ea1bbe1d9cd2a3828c648c5c7831776810f58b4a` | `phase-ii-awards-v2`, `ok: true`; exact persisted frame matched the in-memory Dagster input |
+
+The contracts manifest pins the 167,887,503,123-byte Internet Archive mirror, archive
+ETag, table-of-contents hash, 374-column schema hash, vendor-filter hash, member CRC32 and
+SHA-256, and output hash. The Phase II manifest proves that its federal rows were built
+from that same contract parquet and that its SBIR.gov rows came from the verified v2
+artifact. The processed SBIR.gov artifact in turn pins the 394,394,570-byte bulk source
+(`award_data.csv`, SHA-256
+`1c4c8b7d7b0928021699722c43bae97d8e2d79d2723857179e7a160255e573db`) and its ordered
+42-column source schema.
+
+## Complete cumulative drop-off ladder
+
+Dollar totals are signed federal action obligations deduplicated at target-transaction
+grain within each row. Pair counts remain prior-award × target-transaction rows, so the
+four measures intentionally diverge.
+
+| Order | Clause | Surviving pairs | Distinct firms | Distinct contracts | Total obligated dollars |
+|---:|---|---:|---:|---:|---:|
+| 0 | All inherited normalized exact-UEI pairs | 53,890,816 | 8,938 | 531,972 | $417,549,185,734.16 |
+| 1 | Prior Phase II end date is observable at the data cut | 35,561,357 | 7,683 | 474,757 | $385,209,098,109.01 |
+| 2 | Target action is strictly after the Phase II end and at the data cut | 16,625,809 | 6,207 | 319,539 | $317,069,714,364.31 |
+| 3 | Target is not affirmatively coded SBIR/STTR Phase I or II | 9,421,711 | 4,756 | 260,158 | $288,631,407,578.18 |
+| 4 | Target is not already coded SBIR/STTR Phase III | 7,821,369 | 4,555 | 249,994 | $260,345,240,108.68 |
+| 5 | Prior and target share an exact full NAICS or PSC code | 727,292 | 2,369 | 28,665 | $55,080,851,466.46 |
+
+## Complete sensitivity grid
+
+| Time window | Agency rule | Surviving pairs | Distinct firms | Distinct contracts | Total obligated dollars |
+|---|---|---:|---:|---:|---:|
+| None | Same agency | 247,548 | 1,693 | 15,297 | $29,905,425,795.33 |
+| None | Same department | 595,689 | 2,129 | 24,585 | $49,300,151,046.27 |
+| 5 years | Same agency | 160,301 | 1,643 | 13,502 | $21,298,051,673.61 |
+| 5 years | Same department | 397,872 | 2,078 | 20,392 | $34,679,849,644.75 |
+| 10 years | Same agency | 221,790 | 1,688 | 14,739 | $25,960,766,045.91 |
+| 10 years | Same department | 543,607 | 2,122 | 23,334 | $43,145,149,401.74 |
+
+## One-factor sensitivity diagnostics
+
+Each comparison varies one dimension while holding the other fixed. Window contrasts are
+adjacent in the nested `none → 10 years → 5 years` order. The blocking check can stop only
+for a window fold in distinct firms or distinct contracts that exceeds both 3× and the
+largest adjacent core-clause fold for the same metric. Pair and agency folds are reported
+for diagnosis but do not decide the check.
+
+| Contrast | Held constant | Pair fold | Firm fold | Contract fold | Review triggered |
+|---|---|---:|---:|---:|---|
+| None → 10 years | Same agency | 1.1161× | 1.0030× | 1.0379× | No |
+| 10 years → 5 years | Same agency | 1.3836× | 1.0274× | 1.0916× | No |
+| None → 10 years | Same department | 1.0958× | 1.0033× | 1.0536× | No |
+| 10 years → 5 years | Same department | 1.3663× | 1.0212× | 1.1443× | No |
+| Same department → same agency | No window | 2.4064× | 1.2575× | 1.6072× | No |
+| Same department → same agency | 10 years | 2.4510× | 1.2571× | 1.5831× | No |
+| Same department → same agency | 5 years | 2.4820× | 1.2648× | 1.5103× | No |
+
+## Persisted outputs
+
+| Artifact | Rows | Bytes | SHA-256 |
+|---|---:|---:|---|
+| `data/processed/phase_iii_census_dropoff.parquet` | 6 | 6,264 | `2e11e0c7dd0feeedc47eeee50e65d3b94eada90ef34ac7dcbbd70f210b8fb3e5` |
+| `data/processed/phase_iii_census_sensitivity.parquet` | 6 | 5,698 | `32b70cc3400bf9d8ab9a6a20b664950a976fb39610f50bc8f5fcb35b98b3aa84` |
+
+Both parquets were reread after materialization. Their schemas and row order matched the
+frozen artifact contract, and the seven diagnostics above were reconstructed from those
+persisted tables rather than from an in-memory pre-write frame.
+
+## Questions explicitly left for later phases
+
+1. Can SAM.gov controls be proven SBIR/STTR-negative over the complete available award
+   history, and how many candidates must be excluded for positive or unreliable status?
+2. Can each SBIR firm obtain one to three controls balanced within 0.1 standardized mean
+   difference on primary NAICS, employee-count band, state, first-contract year, and PSC
+   family without introducing an unapproved numeric cutoff?
+3. When the identical arm-blind filter is run, how much do the per-firm criteria-count
+   distributions overlap, and what is the ratio of firms clearing the full criteria set?
+4. Does a seed-fixed across-firm permutation of Phase II completion dates materially
+   change the complete census tables?
+5. Do labeled or independently documented Phase III awards show that the uncoded proxy is
+   valid enough to support an undercount claim?

--- a/studies/phase-iii-census/study.yaml
+++ b/studies/phase-iii-census/study.yaml
@@ -27,10 +27,11 @@ materialization:
   blockers: []
 permitted_claims:
   - The estimand, criteria, and implementation are frozen and fixture-verified.
+  - The complete February cumulative ladder and all six sensitivity cells were
+    materialized from provenance-verified inputs, and the blocking one-factor check passed.
 limitations:
-  - Production materialization is authorized, but results remain non-citable until the
-    complete audit tables and blocking post-write checks pass.
-  - Negative-control and placebo evidence is unresolved; no headline cell or statutory
-    Phase III interpretation is authorized.
+  - Negative-control, placebo, and labeled-validation evidence is unresolved; no headline
+    cell, discrimination claim, undercount claim, or statutory Phase III interpretation is
+    authorized.
   - Exact UEI matching misses acquisitions, successors, and UEI changes.
   - An uncoded lineage proxy is not proof of a statutory Phase III award.


### PR DESCRIPTION
## What changed

- records the successful February 6, 2026 data-cut census run in an append-only, non-frozen materialization audit
- reports the complete six-row drop-off ladder, all six sensitivity cells, and all seven one-factor diagnostics; no headline cell is selected
- pins the Dagster run, exact census and extractor commits, input/output SHA-256 values, schemas, row counts, data cut, and non-stochastic execution record
- updates B2, B3, and E1 answerability labels only to the extent supported by Phase 1
- lists negative controls, placebo evidence, and labeled validation as explicit later questions

## Validation

- Dagster run `aa0ec6d3-2b8e-4ad5-8de7-18a22495c107` succeeded
- both persisted parquets were reread and hashed
- the blocking sensitivity asset check passed with every one-factor contrast reported and no review condition triggered
- the study-manifest validator passed
- `git diff --check` passed

## Interpretation boundary

This finishes the deterministic Phase 1 census only. It does not claim that the proxy discriminates, quantify Phase III undercount, or identify statutory Phase III awards. Negative controls, the placebo test, and labeled validation remain unresolved.

Follows merged implementation PR #512 and remains a three-file documentation change.