### PR TITLE
Enable opt-in Neo4j access over Tailscale

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -29,11 +29,14 @@ SERVER_LOOPBACK=127.0.0.1
 # Host ports (all hard-bound to 127.0.0.1)
 NEO4J_HTTP_PORT=7474
 NEO4J_BOLT_PORT=7687
+# TLS-terminated Tailscale Serve port for trusted Neo4j operators.
+NEO4J_TAILNET_BOLT_ENABLED=false
+NEO4J_TAILNET_BOLT_PORT=17687
 DAGSTER_PORT=3000
 SBIR_ANALYTICS_API_PORT=8010
 
 # -----------------------------------------------------------------------------
-# Neo4j credentials (private to the host; never exposed to the tailnet)
+# Neo4j credentials (used by the tailnet Bolt route; rotate and restrict carefully)
 # -----------------------------------------------------------------------------
 NEO4J_USER=neo4j
 # Required — the compose file fails fast if this is empty.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,9 @@ materialization state belongs there, not in tracked documentation.
 The only live checkout is `/Users/conradhollomon/projects/sbir-analytics-server`;
 never operate the live stack from the development checkout. Preserve
 `.env.server`, `/Volumes/SSDmini/sbir-analytics`, and the Docker `dagster_home`
-volume. Ingress must remain Tailscale Serve over tailnet-only HTTPS; never enable
-Funnel and never expose server ports to the LAN or public internet.
+volume. Ingress must remain Tailscale Serve over tailnet-only HTTPS or explicitly
+enabled TLS-terminated TCP; never enable Funnel and never expose server ports to
+the LAN or public internet.
 
 Treat materialization as a live-data mutation: confirm the SSD is mounted, the
 deployment checkout is clean, and the stack is healthy before running one. Keep

--- a/Makefile
+++ b/Makefile
@@ -638,7 +638,7 @@ server-backup: server-env-check ## Dump Neo4j to $(SERVER_BACKUP_DIR) (default .
 	$(call run,SERVER_ENV_FILE=$(SERVER_ENV_FILE) COMPOSE_FILE=$(SERVER_COMPOSE_FILE) ./scripts/server/backup.sh)
 
 .PHONY: server-tailscale-up
-server-tailscale-up: server-env-check ## Configure persistent Tailscale Serve routes (443->Dagster, 8443->API)
+server-tailscale-up: server-env-check ## Configure persistent Tailscale Serve routes
 	@$(call info,Configuring Tailscale Serve routes)
 	$(call run,SERVER_ENV_FILE=$(SERVER_ENV_FILE) ./scripts/server/tailscale-serve.sh up)
 
@@ -648,7 +648,7 @@ server-tailscale-status: ## Show Tailscale Serve configuration
 	$(call run,./scripts/server/tailscale-serve.sh status)
 
 .PHONY: server-tailscale-down
-server-tailscale-down: server-env-check ## Remove ONLY the SBIR Tailscale Serve routes (443, 8443)
+server-tailscale-down: server-env-check ## Remove ONLY the managed SBIR Tailscale Serve routes
 	@$(call info,Removing SBIR Tailscale Serve routes)
 	$(call run,SERVER_ENV_FILE=$(SERVER_ENV_FILE) ./scripts/server/tailscale-serve.sh down)
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -11,10 +11,10 @@
 # Security boundary:
 #   * Every host port is hardcoded to 127.0.0.1. Nothing binds to 0.0.0.0, so
 #     no service is reachable over the LAN.
-#   * Tailscale Serve is the ONLY ingress (tailnet-only HTTPS):
+#   * Tailscale Serve is the ONLY ingress (tailnet-only HTTPS/TLS):
 #       443  -> Dagster (127.0.0.1:3000)
 #       8443 -> analytics API (127.0.0.1:8010)
-#     Neo4j is NEVER exposed through Tailscale.
+#       17687 -> Neo4j Bolt (127.0.0.1:7687; trusted operators only)
 #   * Tailscale Funnel is prohibited (see docs/deployment/mac-mini-server.md).
 #
 # Usage:
@@ -33,7 +33,7 @@ x-server-environment: &server-environment
   PYTHONPATH: /app
   PYTHONUNBUFFERED: 1
   SERVICE_STARTUP_TIMEOUT: ${SERVICE_STARTUP_TIMEOUT:-120}
-  # Neo4j connection settings (in-network; never exposed to the tailnet)
+  # Neo4j connection settings (in-network; tailnet access uses Tailscale Serve)
   SBIR_ETL__NEO4J__HOST: ${SBIR_ETL__NEO4J__HOST:-neo4j}
   SBIR_ETL__NEO4J__PORT: ${SBIR_ETL__NEO4J__PORT:-7687}
   NEO4J_URI: ${NEO4J_URI:-bolt://neo4j:7687}
@@ -72,7 +72,7 @@ x-server-environment: &server-environment
 
 services:
   # ===========================================================================
-  # Neo4j graph database (private to the host and Compose network)
+  # Neo4j graph database (loopback-only; Tailscale Serve terminates remote TLS)
   # ===========================================================================
   neo4j:
     image: neo4j:${NEO4J_VERSION:-5.20.0}

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -92,7 +92,7 @@ services:
       - NEO4J_server_memory_pagecache_size=${NEO4J_server_memory_pagecache_size:-512M}
       - NEO4J_db_logs_query_enabled=${NEO4J_db_logs_query_enabled:-OFF}
     ports:
-      # Loopback-only. Neo4j is intentionally NOT exposed through Tailscale.
+      # Loopback-only. Remote Bolt is available only through the opt-in Tailscale TLS route.
       - "127.0.0.1:${NEO4J_HTTP_PORT:-7474}:7474"
       - "127.0.0.1:${NEO4J_BOLT_PORT:-7687}:7687"
     volumes:

--- a/docs/deployment/mac-mini-server.md
+++ b/docs/deployment/mac-mini-server.md
@@ -20,7 +20,7 @@ This machine hosts the live SBIR Analytics deployment.
   mode `0600`, and must never be printed, committed, or replaced.
 - **Dagster metadata:** the Docker `dagster_home` named volume. Preserve it
   alongside SSD data; never use `docker compose down -v`.
-- **Ingress:** Tailscale Serve over tailnet-only HTTPS. Tailscale Funnel,
+- **Ingress:** Tailscale Serve over tailnet-only HTTPS/TLS. Tailscale Funnel,
   public port exposure, and LAN exposure are prohibited.
 - **Current host state:** record data vintages, materialized subsets, Dagster
   run IDs, and temporary blockers in
@@ -43,7 +43,7 @@ services:
 
 | Service | Purpose | Host bind | Tailnet ingress |
 |---------|---------|-----------|-----------------|
-| `neo4j` | Graph store | `127.0.0.1:7474` / `7687` | **none** (private) |
+| `neo4j` | Graph store | `127.0.0.1:7474` / `7687` | TLS Bolt `17687` (opt-in) |
 | `dagster-code-server` | Shared Dagster code location | none | none |
 | `analytics-api` | Read-only API (bearer token) | `127.0.0.1:8010` | HTTPS `8443` |
 | `dagster-webserver` | Orchestration UI (prod mode) | `127.0.0.1:3000` | HTTPS `443` |
@@ -60,13 +60,15 @@ caveat and [Workload placement](#workload-placement).
   the stack is invisible to other machines on the same LAN.
   Compose hardcodes this address; `make server-check` also rejects a legacy
   `SERVER_LOOPBACK` value that is anything other than loopback.
-- **Tailscale Serve is the only ingress.** It provides tailnet-only HTTPS and
-  terminates TLS automatically
+- **Tailscale Serve is the only ingress.** It provides tailnet-only HTTPS/TCP
+  and terminates TLS automatically
   ([docs](https://tailscale.com/docs/features/tailscale-serve)):
   - `https://<host>/` → Dagster (`127.0.0.1:3000`)
   - `https://<host>:8443/` → analytics API (`127.0.0.1:8010`)
-- **Neo4j is never served over Tailscale.** It stays private to the host and
-  the Compose network.
+  - `bolt+s://<host>:17687` → Neo4j Bolt (`127.0.0.1:7687`, opt-in)
+- **Neo4j remains loopback-only at the host boundary.** Tailscale Serve is the
+  sole proxy to Bolt, and a separate least-privilege grant restricts that route
+  to trusted operators. Neo4j Browser's HTTP port `7474` is never served.
 - **Tailscale Funnel is prohibited.** The helper never enables Funnel; the
   services must never be reachable from the public internet.
 - **Defense in depth.** The API keeps its bearer-token auth even behind
@@ -113,7 +115,8 @@ make server-tailscale-status
 ```
 
 `--bg` keeps the routes active after Tailscale or the device restarts. Setup
-**refuses to replace** an existing route on port 443 or 8443.
+**refuses to replace** an existing route on port 443, 8443, or an enabled
+17687 route. Neo4j tailnet access defaults to disabled.
 
 ### 4. MagicDNS URLs
 
@@ -121,6 +124,7 @@ With MagicDNS enabled the services are reachable at your node's DNS name:
 
 - Dagster: `https://<node>.<tailnet>.ts.net/`
 - API: `https://<node>.<tailnet>.ts.net:8443/` (send `Authorization: Bearer <token>`)
+- Neo4j: `bolt+s://<node>.<tailnet>.ts.net:17687` (trusted operators only)
 
 `make server-tailscale-up` prints the exact URLs for this node.
 
@@ -160,9 +164,9 @@ prefer a quiet window.
 
 ## Tailscale grant (least privilege)
 
-Restrict who can reach the server. Tag the Mac mini `tag:sbir-server` and grant
-only selected users/groups access to `tcp:443` and `tcp:8443`. Grants are the
-recommended current policy mechanism
+Restrict who can reach the server. Tag the Mac mini `tag:sbir-server`, grant
+analysts access to the web services, and grant Neo4j separately to trusted
+operators. Grants are the recommended current policy mechanism
 ([docs](https://tailscale.com/docs/reference/syntax/grants)). Apply this from
 the admin console manually:
 
@@ -173,6 +177,11 @@ the admin console manually:
       "src": ["group:sbir-analysts"],
       "dst": ["tag:sbir-server"],
       "ip":  ["tcp:443", "tcp:8443"]
+    },
+    {
+      "src": ["group:sbir-neo4j-operators"],
+      "dst": ["tag:sbir-server"],
+      "ip":  ["tcp:17687"]
     }
   ],
   "tagOwners": {
@@ -181,8 +190,45 @@ the admin console manually:
 }
 ```
 
-Neo4j's ports (7474/7687) are deliberately absent — they are never reachable
-over the tailnet.
+Define `group:sbir-neo4j-operators` in the same policy, or replace it with the
+exact operator login email for a single-user grant.
+
+Neo4j's host ports (`7474`/`7687`) remain absent. Operators reach only the
+TLS-terminated Serve port `17687`; no grant should expose Browser HTTP or the
+loopback Bolt port directly.
+
+Apply the operator grant before enabling the route. Then set this in the live
+`.env.server` and rerun `make server-tailscale-up`:
+
+```dotenv
+NEO4J_TAILNET_BOLT_ENABLED=true
+NEO4J_TAILNET_BOLT_PORT=17687
+```
+
+Leave the flag false unless direct operator access is actively required.
+
+## iPhone graph access
+
+Install Tailscale and
+[PocketGraph](https://apps.apple.com/us/app/pocketgraph/id1604368926) on the
+iPhone. Sign in to the tailnet as a member of `group:sbir-neo4j-operators`,
+enable the route only after its grant is active, then configure PocketGraph
+with:
+
+```text
+Protocol: bolt+s
+Host: <node>.<tailnet>.ts.net
+Port: 17687
+Database: neo4j
+Username: neo4j
+Password: <current rotated Neo4j password>
+```
+
+PocketGraph is a third-party client and can execute arbitrary Cypher. The
+Community Edition deployment does not provide the repository's API-level
+read-only guard for this direct connection, so restrict the grant and
+credentials to trusted operators. Do not configure `7474`, use `bolt://`, or
+enable Funnel.
 
 ## Day-2 operations
 
@@ -196,7 +242,7 @@ over the tailnet.
 
 `make server-down` stops containers but **preserves** the `dagster_home` volume
 and all bind-mounted data. `make server-tailscale-down` removes **only** the
-443/8443 routes and never runs the destructive global
+443/8443/17687 routes and never runs the destructive global
 `tailscale serve reset`.
 
 Neo4j Community Edition cannot create an online `neo4j-admin` dump. The backup
@@ -369,8 +415,9 @@ curl -m 5 http://<mac-lan-ip>:3000/        # fails
 curl -m 5 http://<mac-lan-ip>:8010/health  # fails
 ```
 
-From a Tailscale device with the grant, Dagster (443) and the API (8443, with a
-bearer token) succeed, while Neo4j remains unreachable over the tailnet.
+From a Tailscale analyst device, Dagster (443) and the API (8443, with a bearer
+token) succeed while Neo4j remains unreachable. From a trusted operator device,
+TLS Bolt succeeds on 17687; direct connections to 7474/7687 remain unreachable.
 
 ## Workload placement
 

--- a/scripts/server/tailscale-route-state.py
+++ b/scripts/server/tailscale-route-state.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Classify ownership of one Tailscale Serve HTTPS route."""
+"""Classify ownership of one Tailscale Serve route."""
 
 import json
 import sys
@@ -21,7 +21,7 @@ def _references_port(value: Any, port: str) -> bool:
     return False
 
 
-def classify(config: dict[str, Any], port: str, target: str) -> str:
+def classify(config: dict[str, Any], port: str, target: str, tls_host: str | None = None) -> str:
     tcp = config.get("TCP", {})
     web = config.get("Web", {})
     funnel = config.get("AllowFunnel", {})
@@ -34,14 +34,22 @@ def classify(config: dict[str, Any], port: str, target: str) -> str:
     funnel_entries = {key: value for key, value in funnel.items() if _matches_port(str(key), port)}
     foreground_uses_port = _references_port(foreground, port)
 
-    expected_handlers = {"Handlers": {"/": {"Proxy": target}}}
-    owned = (
-        tcp_entry == {"HTTPS": True}
-        and len(web_entries) == 1
-        and next(iter(web_entries.values())) == expected_handlers
-        and not any(bool(value) for value in funnel_entries.values())
-        and not foreground_uses_port
-    )
+    if tls_host is None:
+        expected_handlers = {"Handlers": {"/": {"Proxy": target}}}
+        owned = (
+            tcp_entry == {"HTTPS": True}
+            and len(web_entries) == 1
+            and next(iter(web_entries.values())) == expected_handlers
+            and not any(bool(value) for value in funnel_entries.values())
+            and not foreground_uses_port
+        )
+    else:
+        owned = (
+            tcp_entry == {"TCPForward": target, "TerminateTLS": tls_host}
+            and not web_entries
+            and not any(bool(value) for value in funnel_entries.values())
+            and not foreground_uses_port
+        )
     if owned:
         return "owned"
 
@@ -51,8 +59,8 @@ def classify(config: dict[str, Any], port: str, target: str) -> str:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        print("usage: tailscale-route-state.py PORT TARGET", file=sys.stderr)
+    if len(sys.argv) not in (3, 4):
+        print("usage: tailscale-route-state.py PORT TARGET [TLS_HOST]", file=sys.stderr)
         return 2
     try:
         config = json.load(sys.stdin)
@@ -62,7 +70,8 @@ def main() -> int:
     if not isinstance(config, dict):
         print("invalid Tailscale Serve JSON: expected an object", file=sys.stderr)
         return 2
-    print(classify(config, sys.argv[1], sys.argv[2]))
+    tls_host = sys.argv[3] if len(sys.argv) == 4 else None
+    print(classify(config, sys.argv[1], sys.argv[2], tls_host))
     return 0
 
 

--- a/scripts/server/tailscale-serve.sh
+++ b/scripts/server/tailscale-serve.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Manage the two tailnet-only HTTPS routes for the Mac mini server profile.
+# Manage the tailnet-only routes for the Mac mini server profile.
 
 set -eu
 
@@ -9,18 +9,27 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 . "$SCRIPT_DIR/env-file.sh"
 load_env_key DAGSTER_PORT
 load_env_key SBIR_ANALYTICS_API_PORT
+load_env_key NEO4J_BOLT_PORT
+load_env_key NEO4J_TAILNET_BOLT_ENABLED
+load_env_key NEO4J_TAILNET_BOLT_PORT
 
 DAGSTER_PORT="${DAGSTER_PORT:-3000}"
 API_PORT="${SBIR_ANALYTICS_API_PORT:-8010}"
+NEO4J_BOLT_PORT="${NEO4J_BOLT_PORT:-7687}"
+NEO4J_TAILNET_BOLT_ENABLED="${NEO4J_TAILNET_BOLT_ENABLED:-false}"
+NEO4J_TAILNET_BOLT_PORT="${NEO4J_TAILNET_BOLT_PORT:-17687}"
 DAGSTER_TARGET="http://127.0.0.1:${DAGSTER_PORT}"
 API_TARGET="http://127.0.0.1:${API_PORT}"
+NEO4J_TARGET="127.0.0.1:${NEO4J_BOLT_PORT}"
 STATE_HELPER="$SCRIPT_DIR/tailscale-route-state.py"
 MUTATION_OUTPUT=""
 LAST_MUTATION_OUTPUT=""
 PENDING_PORT=""
 PENDING_TARGET=""
+PENDING_TLS_HOST=""
 CREATED_443=0
 CREATED_8443=0
+CREATED_NEO4J=0
 ROLLBACK_ON_EXIT=0
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
@@ -64,14 +73,37 @@ require_tailscale() {
   fi
 }
 
+neo4j_tailnet_enabled() {
+  case "$NEO4J_TAILNET_BOLT_ENABLED" in
+    1|true|TRUE|yes|YES) return 0 ;;
+    0|false|FALSE|no|NO) return 1 ;;
+    *)
+      error "NEO4J_TAILNET_BOLT_ENABLED must be true or false."
+      exit 2
+      ;;
+  esac
+}
+
+tailscale_dns_name() {
+  tailscale status --json 2>/dev/null | python3 -c '
+import json, sys
+print(json.load(sys.stdin).get("Self", {}).get("DNSName", "").rstrip("."))
+'
+}
+
 route_state() {
   port="$1"
   target="$2"
+  tls_host="${3:-}"
   if ! json=$(tailscale serve status --json 2>/dev/null); then
     error "Could not inspect the current Tailscale Serve configuration."
     return 1
   fi
-  printf '%s' "$json" | python3 "$STATE_HELPER" "$port" "$target"
+  if [ -n "$tls_host" ]; then
+    printf '%s' "$json" | python3 "$STATE_HELPER" "$port" "$target" "$tls_host"
+  else
+    printf '%s' "$json" | python3 "$STATE_HELPER" "$port" "$target"
+  fi
 }
 
 run_tailscale_mutation() {
@@ -149,18 +181,45 @@ configure_route() {
   PENDING_TARGET=""
 }
 
+configure_neo4j_route() {
+  port="$1"
+  target="$2"
+  tls_host="$3"
+  PENDING_PORT="$port"
+  PENDING_TARGET="$target"
+  PENDING_TLS_HOST="$tls_host"
+  if ! run_tailscale_mutation serve --yes --bg "--tls-terminated-tcp=$port" "tcp://$target"; then
+    return 1
+  fi
+
+  state=$(route_state "$port" "$target" "$tls_host") || return 1
+  if [ "$state" != "owned" ]; then
+    error "Tailscale did not install the expected TLS/TCP $port route."
+    return 1
+  fi
+  CREATED_NEO4J=1
+  PENDING_PORT=""
+  PENDING_TARGET=""
+  PENDING_TLS_HOST=""
+}
+
 remove_owned_route() {
   port="$1"
   target="$2"
-  state=$(route_state "$port" "$target") || return 1
+  tls_host="${3:-}"
+  state=$(route_state "$port" "$target" "$tls_host") || return 1
   if [ "$state" != "owned" ]; then
-    error "HTTPS $port changed ownership; refusing to remove it."
+    error "Serve port $port changed ownership; refusing to remove it."
     return 1
   fi
-  run_tailscale_mutation serve --yes "--https=$port" off || return 1
-  state=$(route_state "$port" "$target") || return 1
+  if [ -n "$tls_host" ]; then
+    run_tailscale_mutation serve --yes "--tls-terminated-tcp=$port" off || return 1
+  else
+    run_tailscale_mutation serve --yes "--https=$port" off || return 1
+  fi
+  state=$(route_state "$port" "$target" "$tls_host") || return 1
   if [ "$state" != "free" ]; then
-    error "HTTPS $port was not removed cleanly."
+    error "Serve port $port was not removed cleanly."
     return 1
   fi
 }
@@ -168,20 +227,21 @@ remove_owned_route() {
 rollback_expected_route() {
   port="$1"
   target="$2"
-  if ! state=$(route_state "$port" "$target"); then
-    warn "Could not inspect HTTPS $port during rollback; inspect it manually."
+  tls_host="${3:-}"
+  if ! state=$(route_state "$port" "$target" "$tls_host"); then
+    warn "Could not inspect Serve port $port during rollback; inspect it manually."
     return 1
   fi
   case "$state" in
     owned)
-      warn "Rolling back the newly-created HTTPS $port route."
-      remove_owned_route "$port" "$target" || {
-        warn "Could not roll back HTTPS $port; inspect it manually."
+      warn "Rolling back the newly-created Serve port $port route."
+      remove_owned_route "$port" "$target" "$tls_host" || {
+        warn "Could not roll back Serve port $port; inspect it manually."
         return 1
       }
       ;;
     free) ;;
-    *) warn "HTTPS $port changed after creation; leaving it untouched." ;;
+    *) warn "Serve port $port changed after creation; leaving it untouched." ;;
   esac
 }
 
@@ -189,9 +249,14 @@ rollback_transaction() {
   # Disable recursive rollback before issuing any further Tailscale commands.
   ROLLBACK_ON_EXIT=0
   if [ -n "$PENDING_PORT" ]; then
-    rollback_expected_route "$PENDING_PORT" "$PENDING_TARGET" || true
+    rollback_expected_route "$PENDING_PORT" "$PENDING_TARGET" "$PENDING_TLS_HOST" || true
     PENDING_PORT=""
     PENDING_TARGET=""
+    PENDING_TLS_HOST=""
+  fi
+  if [ "$CREATED_NEO4J" -eq 1 ]; then
+    rollback_expected_route "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST" || true
+    CREATED_NEO4J=0
   fi
   if [ "$CREATED_8443" -eq 1 ]; then
     rollback_expected_route 8443 "$API_TARGET" || true
@@ -205,18 +270,42 @@ rollback_transaction() {
 
 cmd_up() {
   require_tailscale
+  NEO4J_TLS_HOST=$(tailscale_dns_name || true)
+  if [ -z "$NEO4J_TLS_HOST" ]; then
+    error "Could not determine this node's Tailscale DNS name for Neo4j TLS."
+    exit 1
+  fi
   state_443=$(route_state 443 "$DAGSTER_TARGET") || exit 1
   state_8443=$(route_state 8443 "$API_TARGET") || exit 1
+  state_neo4j=$(
+    route_state "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST"
+  ) || exit 1
+  enable_neo4j=0
+  if neo4j_tailnet_enabled; then
+    enable_neo4j=1
+  fi
 
   for pair in "443:$state_443" "8443:$state_8443"; do
     port=${pair%%:*}
     state=${pair#*:}
     if [ "$state" = "occupied" ]; then
-      error "HTTPS $port has a different Serve owner or target; refusing to overwrite it."
+      error "Serve port $port has a different owner or target; refusing to overwrite it."
       error "Inspect with: tailscale serve status"
       exit 1
     fi
   done
+  if [ "$state_neo4j" = "occupied" ]; then
+    error "Serve port $NEO4J_TAILNET_BOLT_PORT has a different owner or target."
+    error "Inspect with: tailscale serve status"
+    exit 1
+  fi
+  if [ "$enable_neo4j" -eq 0 ]; then
+    if [ "$state_neo4j" = "owned" ]; then
+      remove_owned_route "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST"
+      success "Removed the disabled Neo4j TLS/TCP route."
+    fi
+    state_neo4j="disabled"
+  fi
 
   ROLLBACK_ON_EXIT=1
   if [ "$state_443" = "free" ]; then
@@ -233,13 +322,19 @@ cmd_up() {
     success "HTTPS 8443 already has the expected API route."
   fi
 
-  host=$(tailscale status --json 2>/dev/null | python3 -c '
-import json, sys
-print(json.load(sys.stdin).get("Self", {}).get("DNSName", "").rstrip("."))
-' || true)
-  if [ -n "$host" ]; then
-    info "Dagster: https://${host}/"
-    info "API:     https://${host}:8443/"
+  if [ "$state_neo4j" = "disabled" ]; then
+    info "Neo4j tailnet access is disabled in $ENV_FILE."
+  elif [ "$state_neo4j" = "free" ]; then
+    info "Configuring TLS/TCP $NEO4J_TAILNET_BOLT_PORT -> $NEO4J_TARGET..."
+    configure_neo4j_route "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST" || exit 1
+  else
+    success "TLS/TCP $NEO4J_TAILNET_BOLT_PORT already has the expected Neo4j route."
+  fi
+
+  info "Dagster: https://${NEO4J_TLS_HOST}/"
+  info "API:     https://${NEO4J_TLS_HOST}:8443/"
+  if [ "$state_neo4j" != "disabled" ]; then
+    info "Neo4j:  bolt+s://${NEO4J_TLS_HOST}:${NEO4J_TAILNET_BOLT_PORT}"
   fi
   ROLLBACK_ON_EXIT=0
   success "Tailscale Serve routes are active (Funnel remains disabled)."
@@ -253,15 +348,27 @@ cmd_status() {
 
 cmd_down() {
   require_tailscale
+  NEO4J_TLS_HOST=$(tailscale_dns_name || true)
+  if [ -z "$NEO4J_TLS_HOST" ]; then
+    error "Could not determine this node's Tailscale DNS name for Neo4j TLS."
+    exit 1
+  fi
   state_443=$(route_state 443 "$DAGSTER_TARGET") || exit 1
   state_8443=$(route_state 8443 "$API_TARGET") || exit 1
+  state_neo4j=$(route_state "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST") || exit 1
 
-  if [ "$state_443" = "occupied" ] || [ "$state_8443" = "occupied" ]; then
+  if [ "$state_443" = "occupied" ] || [ "$state_8443" = "occupied" ] || [ "$state_neo4j" = "occupied" ]; then
     error "A requested port has a different Serve owner or target; nothing was removed."
     error "Inspect with: tailscale serve status"
     exit 1
   fi
 
+  if [ "$state_neo4j" = "owned" ]; then
+    remove_owned_route "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST"
+    success "Removed the SBIR Neo4j TLS/TCP route."
+  else
+    warn "No SBIR Neo4j TLS/TCP route to remove."
+  fi
   if [ "$state_443" = "owned" ]; then
     remove_owned_route 443 "$DAGSTER_TARGET"
     success "Removed the SBIR HTTPS 443 route."

--- a/scripts/server/tailscale-serve.sh
+++ b/scripts/server/tailscale-serve.sh
@@ -84,6 +84,23 @@ neo4j_tailnet_enabled() {
   esac
 }
 
+validate_neo4j_tailnet_port() {
+  case "$NEO4J_TAILNET_BOLT_PORT" in
+    ''|*[!0-9]*|??????*)
+      error "NEO4J_TAILNET_BOLT_PORT must be an integer between 1 and 65535."
+      exit 2
+      ;;
+  esac
+  if [ "$NEO4J_TAILNET_BOLT_PORT" -lt 1 ] || [ "$NEO4J_TAILNET_BOLT_PORT" -gt 65535 ]; then
+    error "NEO4J_TAILNET_BOLT_PORT must be an integer between 1 and 65535."
+    exit 2
+  fi
+  if [ "$NEO4J_TAILNET_BOLT_PORT" -eq 443 ] || [ "$NEO4J_TAILNET_BOLT_PORT" -eq 8443 ]; then
+    error "NEO4J_TAILNET_BOLT_PORT must not conflict with managed Serve ports 443 or 8443."
+    exit 2
+  fi
+}
+
 tailscale_dns_name() {
   tailscale status --json 2>/dev/null | python3 -c '
 import json, sys
@@ -270,6 +287,7 @@ rollback_transaction() {
 
 cmd_up() {
   require_tailscale
+  validate_neo4j_tailnet_port
   NEO4J_TLS_HOST=$(tailscale_dns_name || true)
   if [ -z "$NEO4J_TLS_HOST" ]; then
     error "Could not determine this node's Tailscale DNS name for Neo4j TLS."
@@ -325,6 +343,7 @@ cmd_up() {
   if [ "$state_neo4j" = "disabled" ]; then
     info "Neo4j tailnet access is disabled in $ENV_FILE."
   elif [ "$state_neo4j" = "free" ]; then
+    warn "Confirm the group:sbir-neo4j-operators Tailscale grant is active before exposing Bolt."
     info "Configuring TLS/TCP $NEO4J_TAILNET_BOLT_PORT -> $NEO4J_TARGET..."
     configure_neo4j_route "$NEO4J_TAILNET_BOLT_PORT" "$NEO4J_TARGET" "$NEO4J_TLS_HOST" || exit 1
   else
@@ -348,6 +367,7 @@ cmd_status() {
 
 cmd_down() {
   require_tailscale
+  validate_neo4j_tailnet_port
   NEO4J_TLS_HOST=$(tailscale_dns_name || true)
   if [ -z "$NEO4J_TLS_HOST" ]; then
     error "Could not determine this node's Tailscale DNS name for Neo4j TLS."

--- a/tests/unit/test_server_ops.py
+++ b/tests/unit/test_server_ops.py
@@ -308,6 +308,7 @@ def _run_tailscale(
     apply_then_fail_8443: bool = False,
     apply_then_fail_neo4j: bool = False,
     neo4j_enabled: bool = True,
+    neo4j_tailnet_port: str = "17687",
     hang_443: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], dict[str, object], list[list[str]]]:
     bin_dir = tmp_path / "bin"
@@ -322,7 +323,7 @@ def _run_tailscale(
         "SBIR_ANALYTICS_API_PORT=8010\n"
         "NEO4J_BOLT_PORT=7687\n"
         f"NEO4J_TAILNET_BOLT_ENABLED={'true' if neo4j_enabled else 'false'}\n"
-        "NEO4J_TAILNET_BOLT_PORT=17687\n"
+        f"NEO4J_TAILNET_BOLT_PORT={neo4j_tailnet_port}\n"
     )
     extra = {"CALL_LOG": str(call_log), "STATE_FILE": str(state_file)}
     if fail_8443:
@@ -376,6 +377,34 @@ def test_tailscale_down_refuses_funnel_enabled_route(tmp_path):
     assert not any("off" in call for call in calls)
 
 
+def test_tailscale_down_refuses_funnel_enabled_neo4j_route(tmp_path):
+    original = _tls_tcp_state("17687", "127.0.0.1:7687")
+    original["AllowFunnel"] = {"node.test.ts.net:17687": True}
+
+    result, state, calls = _run_tailscale(tmp_path, "down", original)
+
+    assert result.returncode != 0
+    assert state == original
+    assert not any("off" in call for call in calls)
+
+
+@pytest.mark.parametrize("port", ["not-a-port", "0", "65536", "443", "8443"])
+def test_tailscale_up_rejects_invalid_neo4j_port_without_mutation(tmp_path, port):
+    original = _serve_state("443", "http://127.0.0.1:3000")
+
+    result, state, calls = _run_tailscale(
+        tmp_path,
+        "up",
+        original,
+        neo4j_tailnet_port=port,
+    )
+
+    assert result.returncode == 2
+    assert state == original
+    assert "NEO4J_TAILNET_BOLT_PORT" in result.stderr
+    assert not any(call[:1] == ["serve"] for call in calls)
+
+
 def test_tailscale_up_rolls_back_new_route_if_second_fails(tmp_path):
     result, state, calls = _run_tailscale(tmp_path, "up", {}, fail_8443=True)
 
@@ -424,6 +453,7 @@ def test_tailscale_up_configures_tls_neo4j_route(tmp_path):
         for call in calls
     )
     assert "bolt+s://node.test.ts.net:17687" in result.stdout
+    assert "group:sbir-neo4j-operators" in result.stdout
 
 
 def test_tailscale_up_leaves_neo4j_private_when_opt_in_is_disabled(tmp_path):

--- a/tests/unit/test_server_ops.py
+++ b/tests/unit/test_server_ops.py
@@ -35,6 +35,9 @@ def _run_script(
         "DAGSTER_PORT",
         "SBIR_ANALYTICS_API_PORT",
         "NEO4J_DATABASE",
+        "NEO4J_BOLT_PORT",
+        "NEO4J_TAILNET_BOLT_ENABLED",
+        "NEO4J_TAILNET_BOLT_PORT",
     ):
         env.pop(key, None)
     env.update(
@@ -227,15 +230,19 @@ def _install_fake_tailscale(bin_dir: Path) -> None:
             print(state_path.read_text())
             raise SystemExit(0)
 
-        port_arg = next(item for item in args if item.startswith("--https="))
+        port_arg = next(
+            item
+            for item in args
+            if item.startswith("--https=") or item.startswith("--tls-terminated-tcp=")
+        )
         port = port_arg.split("=", 1)[1]
+        tls_tcp = port_arg.startswith("--tls-terminated-tcp=")
         if port == "443" and os.environ.get("HANG_443") == "1" and "off" not in args:
             print("Serve is not enabled on your tailnet: https://example.test/consent", flush=True)
             time.sleep(60)
         if port == "8443" and os.environ.get("FAIL_8443") == "1" and "off" not in args:
             print("forced failure", file=sys.stderr)
             raise SystemExit(8)
-
         state = json.loads(state_path.read_text())
         host_key = f"node.test.ts.net:{port}"
         if "off" in args:
@@ -244,14 +251,27 @@ def _install_fake_tailscale(bin_dir: Path) -> None:
             state.get("AllowFunnel", {}).pop(host_key, None)
         else:
             target = args[-1]
-            state.setdefault("TCP", {})[port] = {"HTTPS": True}
-            state.setdefault("Web", {})[host_key] = {
-                "Handlers": {"/": {"Proxy": target}}
-            }
+            if tls_tcp:
+                state.setdefault("TCP", {})[port] = {
+                    "TCPForward": target.removeprefix("tcp://"),
+                    "TerminateTLS": "node.test.ts.net",
+                }
+            else:
+                state.setdefault("TCP", {})[port] = {"HTTPS": True}
+                state.setdefault("Web", {})[host_key] = {
+                    "Handlers": {"/": {"Proxy": target}}
+                }
         state_path.write_text(json.dumps(state))
         if (
             port == "8443"
             and os.environ.get("APPLY_THEN_FAIL_8443") == "1"
+            and "off" not in args
+        ):
+            print("forced late failure", file=sys.stderr)
+            raise SystemExit(8)
+        if (
+            port == "17687"
+            and os.environ.get("APPLY_THEN_FAIL_NEO4J") == "1"
             and "off" not in args
         ):
             print("forced late failure", file=sys.stderr)
@@ -268,6 +288,17 @@ def _serve_state(port: str, target: str) -> dict[str, object]:
     }
 
 
+def _tls_tcp_state(port: str, target: str) -> dict[str, object]:
+    return {
+        "TCP": {
+            port: {
+                "TCPForward": target,
+                "TerminateTLS": "node.test.ts.net",
+            }
+        }
+    }
+
+
 def _run_tailscale(
     tmp_path: Path,
     command: str,
@@ -275,6 +306,8 @@ def _run_tailscale(
     *,
     fail_8443: bool = False,
     apply_then_fail_8443: bool = False,
+    apply_then_fail_neo4j: bool = False,
+    neo4j_enabled: bool = True,
     hang_443: bool = False,
 ) -> tuple[subprocess.CompletedProcess[str], dict[str, object], list[list[str]]]:
     bin_dir = tmp_path / "bin"
@@ -284,12 +317,20 @@ def _run_tailscale(
     state_file.write_text(json.dumps(state))
     call_log = tmp_path / "tailscale-calls"
     env_file = tmp_path / ".env.server"
-    env_file.write_text("DAGSTER_PORT=3000\nSBIR_ANALYTICS_API_PORT=8010\n")
+    env_file.write_text(
+        "DAGSTER_PORT=3000\n"
+        "SBIR_ANALYTICS_API_PORT=8010\n"
+        "NEO4J_BOLT_PORT=7687\n"
+        f"NEO4J_TAILNET_BOLT_ENABLED={'true' if neo4j_enabled else 'false'}\n"
+        "NEO4J_TAILNET_BOLT_PORT=17687\n"
+    )
     extra = {"CALL_LOG": str(call_log), "STATE_FILE": str(state_file)}
     if fail_8443:
         extra["FAIL_8443"] = "1"
     if apply_then_fail_8443:
         extra["APPLY_THEN_FAIL_8443"] = "1"
+    if apply_then_fail_neo4j:
+        extra["APPLY_THEN_FAIL_NEO4J"] = "1"
     if hang_443:
         extra["HANG_443"] = "1"
         extra["TAILSCALE_SERVE_TIMEOUT"] = "1"
@@ -366,6 +407,79 @@ def test_tailscale_up_rolls_back_route_applied_before_cli_failure(tmp_path):
 
     assert result.returncode != 0
     assert state.get("TCP", {}) == {}
+    assert any("--https=8443" in call and "off" in call for call in calls)
+    assert any("--https=443" in call and "off" in call for call in calls)
+
+
+def test_tailscale_up_configures_tls_neo4j_route(tmp_path):
+    result, state, calls = _run_tailscale(tmp_path, "up", {})
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert state["TCP"]["17687"] == {
+        "TCPForward": "127.0.0.1:7687",
+        "TerminateTLS": "node.test.ts.net",
+    }
+    assert any(
+        "--tls-terminated-tcp=17687" in call and "tcp://127.0.0.1:7687" in call and "--bg" in call
+        for call in calls
+    )
+    assert "bolt+s://node.test.ts.net:17687" in result.stdout
+
+
+def test_tailscale_up_leaves_neo4j_private_when_opt_in_is_disabled(tmp_path):
+    result, state, calls = _run_tailscale(tmp_path, "up", {}, neo4j_enabled=False)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "17687" not in state["TCP"]
+    assert not any("--tls-terminated-tcp=17687" in call for call in calls)
+    assert "Neo4j tailnet access is disabled" in result.stdout
+
+
+def test_tailscale_up_removes_owned_neo4j_route_when_opt_in_is_disabled(tmp_path):
+    result, state, calls = _run_tailscale(
+        tmp_path,
+        "up",
+        _tls_tcp_state("17687", "127.0.0.1:7687"),
+        neo4j_enabled=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "17687" not in state["TCP"]
+    assert any("--tls-terminated-tcp=17687" in call and "off" in call for call in calls)
+
+
+def test_tailscale_down_removes_owned_tls_neo4j_route(tmp_path):
+    result, state, calls = _run_tailscale(
+        tmp_path,
+        "down",
+        _tls_tcp_state("17687", "127.0.0.1:7687"),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert state.get("TCP", {}) == {}
+    assert any("--tls-terminated-tcp=17687" in call and "off" in call for call in calls)
+
+
+def test_tailscale_up_refuses_foreign_neo4j_route(tmp_path):
+    original = _tls_tcp_state("17687", "127.0.0.1:9999")
+    result, state, calls = _run_tailscale(tmp_path, "up", original)
+
+    assert result.returncode != 0
+    assert state == original
+    assert not any("off" in call for call in calls)
+
+
+def test_tailscale_up_rolls_back_all_routes_after_late_neo4j_failure(tmp_path):
+    result, state, calls = _run_tailscale(
+        tmp_path,
+        "up",
+        {},
+        apply_then_fail_neo4j=True,
+    )
+
+    assert result.returncode != 0
+    assert state.get("TCP", {}) == {}
+    assert any("--tls-terminated-tcp=17687" in call and "off" in call for call in calls)
     assert any("--https=8443" in call and "off" in call for call in calls)
     assert any("--https=443" in call and "off" in call for call in calls)
 


### PR DESCRIPTION
## Summary

- add an opt-in, TLS-terminated Tailscale Serve route from tailnet port `17687` to loopback Neo4j Bolt
- preserve localhost-only Docker bindings and keep Neo4j Browser HTTP private
- manage route ownership, conflict detection, rollback, disable reconciliation, and removal through the existing server helper
- document the least-privilege operator grant and PocketGraph iPhone connection

## Why

The Mac mini currently exposes only Dagster and the read-only analytics API over Tailscale. A native iPhone graph client needs Bolt connectivity, but a manual Serve command would contradict the runbook and create untracked configuration drift.

This change keeps direct Neo4j access disabled by default. An operator must first apply the narrow tailnet grant, then set `NEO4J_TAILNET_BOLT_ENABLED=true` in the live `.env.server`. Setting it back to false removes the managed route on the next `server-tailscale-up` reconciliation.

## Validation

- `uv run pytest -q tests/unit/test_server_ops.py tests/unit/test_server_runtime_contract.py` — 28 passed
- `uv run ruff check scripts/server/tailscale-route-state.py tests/unit/test_server_ops.py`
- `uv run ruff format --check scripts/server/tailscale-route-state.py tests/unit/test_server_ops.py`
- `sh -n scripts/server/tailscale-serve.sh`
- `git diff --check`

No live deployment or Tailscale policy was changed.