### PR TITLE
docs: enforce integrity and refresh navigation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run MyPy type checker
         run: uv run python -m mypy sbir_etl packages/sbir-graph/sbir_graph
 
-      - name: Run architecture and repository hygiene guards
+      - name: Run architecture, documentation, and repository hygiene guards
         run: |
           uv run python scripts/ci/check_architecture_boundaries.py
           uv run python scripts/ci/check_removed_src_references.py

--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,11 @@ lint-boundaries: ## Enforce package and archive dependency boundaries
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
 
+.PHONY: docs-check
+docs-check: ## Check documentation links, anchors, stale commands, and spec registration
+	@$(call info,Checking documentation integrity)
+	$(call run,uv run python scripts/ci/check_removed_src_references.py)
+
 .PHONY: format
 format: ## Format code
 	@$(call info,Formatting code)

--- a/Makefile
+++ b/Makefile
@@ -213,8 +213,8 @@ lint-boundaries: ## Enforce package and archive dependency boundaries
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
 
 .PHONY: docs-check
-docs-check: ## Check documentation links, anchors, stale commands, and spec registration
-	@$(call info,Checking documentation integrity)
+docs-check: ## Run the repository hygiene guard (doc links/anchors, stale commands, spec registry, removed-src and archived-script references)
+	@$(call info,Running repository hygiene checks)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 
 .PHONY: format

--- a/docs/_template.md
+++ b/docs/_template.md
@@ -23,5 +23,5 @@ Status: <active|draft|deprecated|archived>
 
 ## See Also
 
-- [Main README](/README.md)
+- [Main README](../README.md)
 - [Documentation Index](index.md)

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
-# API Reference
+# Code Reference
 
-Code documentation for the SBIR ETL pipeline.
+Use this page to find the main parts of the SBIR data pipeline.
 
 ## Module Structure
 
@@ -49,10 +49,9 @@ packages/sbir-ml/sbir_ml/
 
 ## Generated documentation
 
-The repository does not currently publish or commit generated API documentation.
-This page is the maintained code map; source modules and their tests are the API
-reference. If a generated site becomes useful, add its generator to a documented
-dependency group and expose it through a Make target before documenting the command.
+We do not publish generated API documentation. Use this page as a map, then read
+the source code and tests for details. If we add generated documentation later,
+its tool and Make command should be part of the repository first.
 
 ## Related
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -47,12 +47,12 @@ packages/sbir-ml/sbir_ml/
 - `sbir_etl.transformers` - Business logic transformations
 - `sbir_graph.loaders` - Neo4j graph loading
 
-## Generating Docs
+## Generated documentation
 
-```bash
-# Generate API documentation
-uv run pdoc sbir_etl/ -o docs/api/generated/
-```
+The repository does not currently publish or commit generated API documentation.
+This page is the maintained code map; source modules and their tests are the API
+reference. If a generated site becomes useful, add its generator to a documented
+dependency group and expose it through a Make target before documenting the command.
 
 ## Related
 

--- a/docs/archive/deployment/actions-migration-plan.md
+++ b/docs/archive/deployment/actions-migration-plan.md
@@ -12,8 +12,8 @@ fast unit tests on PRs, the full suite on `main`.
 which deletes the workflows described here. Until that merges, the workflows
 still exist (though `weekly.yml` has been in an invalid state and not running).
 
-See [the Mac mini runbook](mac-mini-server.md) for the target host, and
-[the AWS decommission plan](aws-decommission-plan.md) for the earlier phase that
+See [the Mac mini runbook](../../deployment/mac-mini-server.md) for the target host, and
+[the AWS decommission plan](../../deployment/aws-decommission-plan.md) for the earlier phase that
 moved ingestion off Actions. This plan finishes that job.
 
 ## What is already done
@@ -229,7 +229,7 @@ together, because they were never the same thing.
 
 **Publishing is genuinely optional.** `make server-up` falls back to building
 `Dockerfile.python-base` locally when GHCR has no manifest for the Mac's
-architecture (see [Bring-up](mac-mini-server.md#bring-up)), and the server compose profile builds
+architecture (see [Bring-up](../../deployment/mac-mini-server.md#bring-up)), and the server compose profile builds
 its app images locally with a `:local` tag rather than pulling. Nothing is
 broken today; a first build just takes several minutes. The amd64 half of the
 multi-arch manifest existed to serve CI, which no longer builds images — so if

--- a/docs/archive/development/cleanup-inventory.md
+++ b/docs/archive/development/cleanup-inventory.md
@@ -14,7 +14,7 @@ Status: archived
 This inventory tracks codebase simplification work: live specs, stale docs,
 archived scripts, test drift, and CI drift. It is not a feature spec. Use it as
 the starting point for cleanup PRs, and use
-[`docs/research-questions.md`](../research-questions.md) as the scope gate.
+[`docs/research-questions.md`](../../research-questions.md) as the scope gate.
 
 ## Cleanup Rules
 

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -103,6 +103,8 @@ vintages, and failure reasons rather than relying on static numbers in documenta
 
 Related references:
 
+- [Weekly awards report](weekly-awards-report.md)
+- [SBIR weekly ingestion checks](sbir-weekly-checks.md)
 - [Data quality contract](../steering/data-quality.md)
 - [Configuration](../configuration.md)
 - [SBIR awards columns](sbir_awards_columns.json)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -20,12 +20,14 @@ Use this page as a router; commands and rules have one canonical owner.
 
 - [Exception Handling](exception-handling.md) - Custom exception hierarchy and patterns
 - [Logging Standards](logging-standards.md) - When to use logger vs console.print
+- [Pre-commit and CI consistency](pre-commit-ci-consistency.md) - What runs locally and in CI
 
 ## Planning and architecture
 
 - [Spec Workflow Guide](spec-workflow-guide.md) - Using specifications
 - [Architecture overview](../architecture/detailed-overview.md) - Package and deployment boundaries
 - [Steering documents](../steering/) - Durable identity, evidence, orchestration, and quality rules
+- `make docs-check` - Documentation links, anchors, stale commands, and spec-registry coverage
 
 ---
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -27,7 +27,9 @@ Use this page as a router; commands and rules have one canonical owner.
 - [Spec Workflow Guide](spec-workflow-guide.md) - Using specifications
 - [Architecture overview](../architecture/detailed-overview.md) - Package and deployment boundaries
 - [Steering documents](../steering/) - Durable identity, evidence, orchestration, and quality rules
-- `make docs-check` - Documentation links, anchors, stale commands, and spec-registry coverage
+- `make docs-check` - Repository hygiene guard: documentation links and anchors, stale
+  paths and commands, spec-registry coverage, and references to removed `src/` modules or
+  archived scripts (so a failure here is not always a documentation problem)
 
 ---
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -7,7 +7,8 @@ Status: active
 
 # Development Documentation
 
-Use this page as a router; commands and rules have one canonical owner.
+Use this page to find the current development guides. Each command or rule should
+be explained in one place so the instructions do not drift apart.
 
 ## Start here
 
@@ -26,10 +27,11 @@ Use this page as a router; commands and rules have one canonical owner.
 
 - [Spec Workflow Guide](spec-workflow-guide.md) - Using specifications
 - [Architecture overview](../architecture/detailed-overview.md) - Package and deployment boundaries
-- [Steering documents](../steering/) - Durable identity, evidence, orchestration, and quality rules
-- `make docs-check` - Repository hygiene guard: documentation links and anchors, stale
-  paths and commands, spec-registry coverage, and references to removed `src/` modules or
-  archived scripts (so a failure here is not always a documentation problem)
+- [Steering documents](../steering/) - Project rules for identity matching, evidence,
+  pipelines, and data quality
+- `make docs-check` - Check links, section links, old commands, the spec list, and
+  references to removed code or archived scripts. A failure may come from code or
+  configuration, not only from documentation.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,17 +49,33 @@ Use these before quoting a result or starting a feature from an old spec.
 
 - [Data sources](data/index.md)
 - [Dagster pipelines](architecture/dagster-pipelines.md)
+- [Asset naming](architecture/asset-naming-standards.md)
+- [Private analytics API](architecture/private-analytics-api.md)
+- [DuckDB CET analysis](architecture/duckdb-cet-analysis.md)
 - [Transition detection](transition/README.md)
 - [Machine learning](ml/README.md)
 - [Fiscal pipeline](fiscal/sbir-fiscal-pipeline-guide.md)
 - [Neo4j schema](schemas/neo4j.md)
+- [Other Transaction consortium tiers](ot-consortium/tiers.md)
 - [Statistical reporting utility](guides/statistical-reporting.md)
 - [API](api/README.md)
 
+## Durable engineering contracts
+
+- [Company identity](steering/company-identity.md)
+- [Data quality](steering/data-quality.md)
+- [Enrichment patterns](steering/enrichment-patterns.md)
+- [Pipeline orchestration](steering/pipeline-orchestration.md)
+- [Neo4j patterns](steering/neo4j-patterns.md)
+- [Repository structure](steering/structure.md) and [technology choices](steering/tech.md)
+- [Glossary](steering/glossary.md)
+- [ML methodology review](steering/ml-methodology-review.md)
+
 ## Research outputs
 
-Detailed methods and dated analyses live under [`docs/research/`](research/). Technology-area
-briefs pair an audience-facing summary with technical findings:
+Use the [research-output index](research/README.md) to map analyses to research questions,
+evidence posture, and data cuts. Technology-area briefs pair an audience-facing summary with
+technical findings:
 
 - [Nanotechnology brief](nanotech_sbir_policy_brief.md) and
   [technical findings](nanotech_sbir_transition_findings.md)

--- a/docs/ml/README.md
+++ b/docs/ml/README.md
@@ -1,14 +1,16 @@
 # Machine Learning Documentation
 
-Two ML systems: CET classification (predicts applicability to 21 NSTC critical & emerging technology areas) and ModernBert embeddings (semantic similarity between awards and patents).
+This project has two machine-learning systems. CET classification decides which
+of 21 critical and emerging technology areas may apply to a record. ModernBERT
+embeddings measure how similar award and patent text is.
 
 ## CET Classification
 
 | Doc | Purpose |
 |-----|---------|
-| [cet-integration.md](cet-integration.md) | Canonical taxonomy, assets, data flow, validation, and known limitations |
-| [cet-classifier.md](cet-classifier.md) | Patent classifier: feature extraction, vectorizers, training/inference flow |
-| [cet-rule-engine.md](cet-rule-engine.md) | Rule-engine layer: negative keywords, context rules, agency/branch priors (YAML tuning) |
+| [cet-integration.md](cet-integration.md) | Technology categories, pipeline steps, checks, and known limits |
+| [cet-classifier.md](cet-classifier.md) | How the patent classifier prepares text, trains, and makes predictions |
+| [cet-rule-engine.md](cet-rule-engine.md) | Keyword and context rules, including agency and service-branch settings |
 
 **Run the complete CET pipeline:**
 
@@ -20,7 +22,7 @@ make cet-run
 
 | Doc | Purpose |
 |-----|---------|
-| [modernbert.md](modernbert.md) | Full guide: inference modes, config, Dagster assets, optimization, troubleshooting |
+| [modernbert.md](modernbert.md) | Setup, run options, Dagster assets, performance, and troubleshooting |
 
 **Run the complete embeddings pipeline:**
 
@@ -28,15 +30,18 @@ make cet-run
 make modernbert-run
 ```
 
-The Make targets own the Dagster module and job names. Use the subsystem guides
-only when materializing a narrower asset selection.
+Use the Make commands above for a full run. They keep the Dagster module and job
+names in one place. Follow the linked guides when you need to run only part of a
+pipeline.
 
 ## Configuration
 
-- **ModernBert**: `config/base.yaml` § `ml.modernbert` — inference mode, batch sizes, similarity thresholds; `HF_TOKEN` env var for HuggingFace API
-- **CET**: `config/cet/` — taxonomy (`taxonomy.yaml`), classification thresholds (`classification.yaml`)
+- **ModernBERT**: `config/base.yaml` under `ml.modernbert` sets the run mode,
+  batch sizes, and similarity limits. Set `HF_TOKEN` to use the Hugging Face API.
+- **CET**: `config/cet/taxonomy.yaml` defines the technology areas, and
+  `config/cet/classification.yaml` sets the classification limits.
 
 ## Related
 
-- [Transition Detection](../transition/) — consumes CET classifications as one of its signals
-- [Architecture](../architecture/) — system-level overview
+- [Transition Detection](../transition/) — uses CET classifications as one input
+- [Architecture](../architecture/) — shows how the system fits together

--- a/docs/ml/README.md
+++ b/docs/ml/README.md
@@ -10,11 +10,10 @@ Two ML systems: CET classification (predicts applicability to 21 NSTC critical &
 | [cet-classifier.md](cet-classifier.md) | Patent classifier: feature extraction, vectorizers, training/inference flow |
 | [cet-rule-engine.md](cet-rule-engine.md) | Rule-engine layer: negative keywords, context rules, agency/branch priors (YAML tuning) |
 
-**Run award classification:**
+**Run the complete CET pipeline:**
 
 ```bash
-dagster asset materialize -m sbir_analytics.definitions --select ml/enriched_cet_award_classifications
-dagster job execute -m sbir_analytics.definitions -j cet_full_pipeline_job
+make cet-run
 ```
 
 ## ModernBert Embeddings
@@ -23,12 +22,14 @@ dagster job execute -m sbir_analytics.definitions -j cet_full_pipeline_job
 |-----|---------|
 | [modernbert.md](modernbert.md) | Full guide: inference modes, config, Dagster assets, optimization, troubleshooting |
 
-**Run embeddings:**
+**Run the complete embeddings pipeline:**
 
 ```bash
-dagster asset materialize -m sbir_analytics.definitions --select "modernbert*"
-dagster job execute -m sbir_analytics.definitions -j modernbert_job
+make modernbert-run
 ```
+
+The Make targets own the Dagster module and job names. Use the subsystem guides
+only when materializing a narrower asset selection.
 
 ## Configuration
 

--- a/docs/ml/cet-integration.md
+++ b/docs/ml/cet-integration.md
@@ -47,7 +47,7 @@ the definitions in Dagster rather than relying on a copied asset list when chang
 Run the complete job only after installing the full stack and providing its local inputs:
 
 ```bash
-uv run dagster job execute -m sbir_analytics.definitions -j cet_full_pipeline_job
+make cet-run
 ```
 
 Heavy CET assets are not scheduled by default on the Mac mini. Follow the

--- a/docs/ml/modernbert.md
+++ b/docs/ml/modernbert.md
@@ -127,14 +127,12 @@ export HF_TOKEN="your_huggingface_token"
 ### Running via CLI
 
 ```bash
-# Materialize all embedding assets
-dagster asset materialize -m sbir_analytics.definitions --select "modernbert*"
+# Run the complete embedding job through the canonical target
+make modernbert-run
 
-# Materialize specific asset
-dagster asset materialize -m sbir_analytics.definitions --select modernbert_embeddings_awards
-
-# Run the complete embedding job
-dagster job execute -m sbir_analytics.definitions -j modernbert_job
+# Or materialize one asset from the heavy-asset definitions module
+uv run dagster asset materialize -m sbir_analytics.definitions_ml \
+  --select modernbert_embeddings_awards
 ```
 
 ### Programmatic Usage

--- a/docs/procurement-transition-report.md
+++ b/docs/procurement-transition-report.md
@@ -75,8 +75,9 @@ limits the detail requests, the job keeps the descriptions already retrieved,
 records the partial coverage, and continues with explicit missing-text labels.
 
 Pass the preceding public award snapshot with `--previous-awards` to distinguish
-new and changed records. The scheduled workflow restores that snapshot from the
-prior monthly run and retains the report and evidence artifacts for 90 days.
+new and changed records. No GitHub Actions workflow schedules this pipeline; an
+operator or future Mac mini Dagster job must preserve and supply that snapshot
+explicitly. Record any retention policy with the job that owns the materialization.
 When `OPENAI_API_KEY` is absent, `--ai` degrades to deterministic packet text.
 AI receives only retrieved public fields, is invoked only when both technical
 texts are available, and is capped at 10 priority leads by default. It cannot
@@ -86,3 +87,8 @@ change candidate scores, and uncited output is discarded. Use
 Representative distribution remains a human-controlled step. The generated
 `audit_sample.csv` supports the required hand audit; each HIGH signal class must
 reach at least 85% precision before its main packet section is distributed.
+
+Related implemented design records:
+
+- [Awardee-first packet design](superpowers/specs/2026-07-29-awardee-first-procurement-packet-design.md)
+- [Anchored “why it connects” design](superpowers/specs/2026-07-30-why-it-connects-explanation-design.md)

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -565,9 +565,9 @@ statutory goal is Phase III commercialization.*
   Implementation on `main`: `scripts/run_benchmark.py` (evaluate / sensitivity /
   company-level CLI) backed by `sbir_etl/models/benchmark_models.py`, with tests
   in `tests/unit/test_benchmark_evaluator.py`.
-  *Caveat:* additional per-firm audit infrastructure and a fuller methodology doc
-  exist as local-only, uncommitted work — see
-  [Output products](#commercialization-benchmark-methodology-in-progress-not-yet-committed).
+  *Caveat:* the fuller methodology is committed, but its additional per-firm audit
+  infrastructure and FY2026 audited cohort remain local-only — see
+  [Output products](#commercialization-benchmark-methodology-committed-audit-harness-remains-local).
   *Deps: ER, ID, transitions, SEC EDGAR · Spec: [../specs/archive/completed-features/commercialization-benchmark/](../specs/archive/completed-features/commercialization-benchmark/)*
 
 ### B4. Predictive (Tier 4)
@@ -1022,15 +1022,14 @@ program-wide private-capital leverage.
 **Pulls from:** F1 (Form D profile), F3 (private-to-SBIR leverage), A1/A4
 (DoD-specific firm-health and acquisition decomposition).
 
-### Commercialization-benchmark methodology (in progress, not yet committed)
+### Commercialization-benchmark methodology (committed; audit harness remains local)
 
 **Audience:** SBA program oversight, statutory compliance reviewers, GAO.
 
-**Format:** `docs/commercialization-benchmark-methodology.md` — locally present
-but **not committed** to the repo. Documents the §638(qq)(3) statutory
-framework, the FY2026 evaluation methodology, the data-source provenance
-(FPDS/USAspending contracts, SEC Form D investment, SBIR.gov FABS grants), and
-the per-firm audit protocol.
+**Format:** [Commercialization benchmark methodology](commercialization-benchmark-methodology.md)
+is committed and documents the §638(qq)(3) statutory framework, FY2026 evaluation
+method, data-source provenance (FPDS/USAspending contracts, SEC Form D investment,
+and SBIR.gov FABS grants), and per-firm audit protocol.
 
 The methodology doc pairs with a per-firm audit harness
 (`scripts/archive/data/run_commercialization_benchmark.py` and
@@ -1040,8 +1039,9 @@ counterpart on `main` is `scripts/run_benchmark.py` plus
 `sbir_etl/models/benchmark_models.py`, which implements the same statutory
 framework through a different CLI shape.
 
-**The methodology doc and audit harness should be committed once stabilized** —
-the untracked status is itself a coverage gap worth closing.
+The methodology is reviewable, but the local audit harness and FY2026 audited
+cohort are still not reproducible from `main`. Migrating that harness into the
+maintained CLI remains the coverage gap.
 
 **Pulls from:** B3 (transition effectiveness and the §638(qq) benchmark
 question), F1 (Form D investment signal), F2 (NVCA-baseline comparison).

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,77 @@
+---
+Type: Overview
+Owner: research@project
+Last-Reviewed: 2026-08-03
+Status: active
+---
+
+# Research Outputs
+
+This index maps research notes and reports to the questions they support, the
+data cut they describe, and the weight their findings may carry. The canonical
+question inventory remains [research-questions.md](../research-questions.md).
+
+Unless a row links to a `studies/<study-id>/study.yaml` manifest with an explicit
+`citable` status, treat it as exploratory or reproducible-but-non-citable. A
+working pipeline, a dated report, or a provisional policy brief is not by itself
+validated evidence. See [epistemic tiers](../steering/epistemic-tiers.md) and
+[study contracts](../../studies/README.md).
+
+## Capital formation, exits, and firm pathways
+
+| Artifact | Questions | Evidence posture | Data cut or scope |
+| --- | --- | --- | --- |
+| [Form D fundraising analysis](sbir-form-d-fundraising-analysis.md) | F1, F3 | Dated research analysis; no citable study manifest | Form D and SBIR spending, 2009–2024; methodology revised 2026-04-23 |
+| [DoD Form D leverage](dod-form-d-leverage.md) | A3, A4, F3 | Dated decomposition and follow-up analysis | Consolidated 2026-06-21 |
+| [Form D data dictionary](form-d-data-dictionary.md) | F1, F3 | Field and confidence-tier reference | Current on-disk Form D artifact contract |
+| [Agency private-capital Phase 2 method](agency-private-capital-phase2-form-d.md) | B2, B3, F3 | Descriptive matched-cohort method, not a causal estimate | No fixed published run |
+| [M&A exit analysis](sbir-ma-exit-analysis.md) | A4, F1, F2 | Dated research analysis; public-filer lower bound | Run documented 2026-04-23 |
+| [Capital-pathway cohorts](sbir-pathway-cohorts.md) | F1, F2 | Dated cohort analysis | High-confidence 3,639-firm cohort; 2026-06-23 |
+| [UCC-1 pilot](sbir-ucc1-pilot.md) | F1 | Partial, state-specific exploratory pilot | California subset; 2026-05-16 |
+| [California UCC API notes](ucc1-bizfileonline-api.md) | E5, F1 | Source-interface reference, not a result | Endpoints captured 2026-05-16 |
+| [SEC EDGAR learnings](sec-edgar-sbir-learnings.md) | E5, F1, F2 | Implementation and source-behavior note | Observations from 2026-04-19/22 |
+
+## Procurement, transition, and industrial-base research
+
+| Artifact | Questions | Evidence posture | Data cut or scope |
+| --- | --- | --- | --- |
+| [DoD industrial-base concentration](dod_supply_chain_initial_analysis.md) | A1–A3 | Exploratory descriptive baseline | FY2012–FY2025; headline window FY2021–FY2025 |
+| [GSA and OTSB Phase III analysis](sbir-phase3-gsa-otsb-analysis.md) | B2, B3 | Working keyword-discoverable analysis; known coding undercount | FY2008–FY2026 source universe built 2026-06-28 |
+| [Phase II→III latency method](../phase-transition-latency.md) | B3 | Implemented pipeline method; not a citable result | Uses the configured materialization data cut |
+| [Follow-on multiplier method](../follow-on-multiplier-analysis.md) | A3 | Implemented analytical method; empirical validation remains open | Uses configured SBIR and USAspending inputs |
+| [Multiplier reproducibility fixture](../follow-on-multiplier-reproducibility.md) | A3 | Deterministic fixture verification, not a population estimate | Synthetic edge-case fixture |
+| [Commercialization benchmark method](../commercialization-benchmark-methodology.md) | B3 | Methodology record; local audit harness is not reproducible from this repository | FY2026 local audit described in the document |
+| [Monthly procurement-transition report](../procurement-transition-report.md) | B4, E6 | Operator/report contract, not research evidence | Current public-source pipeline |
+
+The label-free Phase III census is tracked separately because it has a formal
+study contract: [manifest](../../studies/phase-iii-census/study.yaml),
+[February 2026 materialization audit](../../studies/phase-iii-census/materialization-2026-02-06.md),
+and [August 2026 control-identity eligibility audit](../../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md).
+Its status is reproducible, not citable; control construction, matching, and the
+placebo remain unresolved.
+
+## Economic and fiscal methods
+
+| Artifact | Questions | Evidence posture | Data cut or scope |
+| --- | --- | --- | --- |
+| [Open-source tax-impact modeling](open-source-tax-impact-modeling.md) | D2, D3 | Research/pre-spec comparison | Dated 2026-04-19 |
+
+The maintained pipeline guide is [SBIR fiscal analysis](../fiscal/sbir-fiscal-pipeline-guide.md).
+
+## Technology-area reports
+
+Each policy brief is the audience-facing entry point; its technical findings and
+methodology preserve cohort definitions and limitations.
+
+| Area | Questions | Evidence posture | Data cut |
+| --- | --- | --- | --- |
+| Nanotechnology: [brief](../nanotech_sbir_policy_brief.md), [findings](../nanotech_sbir_transition_findings.md), [method](../nano_phase3_methodology.md) | A1, A2, B2, B3, C1 | Provisional bounded estimates, not final program rates | SBIR.gov FY2025; USAspending FY2024; PatentsView March 2026 |
+| Hypersonics: [brief](../hypersonics_sbir_policy_brief.md), [findings](../hypersonics_sbir_transition_findings.md) | A1, A2, B2, B3, C1 | Provisional cohort and triangulation; outcome-channel rates unavailable | SBIR.gov through FY2025 |
+| Quantum information science: [brief](../quantum_information_science_sbir_policy_brief.md), [findings](../quantum_information_science_sbir_transition_findings.md) | A1, A2, B2, B3, C1 | Provisional cohort and triangulation; outcome-channel rates unavailable | SBIR.gov through FY2025 |
+
+## Research planning and communication
+
+- [Literature map and citation audit](literature-map/README.md) — 2019–2026
+  literature coverage and gaps across question areas A–F.
+- [Government-policy demo plan](../guides/government-policy-demo-plan.md) —
+  audience framing and demonstration sequence; not an evidence source.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -7,71 +7,70 @@ Status: active
 
 # Research Outputs
 
-This index maps research notes and reports to the questions they support, the
-data cut they describe, and the weight their findings may carry. The canonical
-question inventory remains [research-questions.md](../research-questions.md).
+This page shows which questions each research note or report helps answer, how
+much confidence to place in it, and which data it covers. See
+[research-questions.md](../research-questions.md) for the full list of questions.
 
-Unless a row links to a `studies/<study-id>/study.yaml` manifest with an explicit
-`citable` status, treat it as exploratory or reproducible-but-non-citable. A
-working pipeline, a dated report, or a provisional policy brief is not by itself
-validated evidence. See [epistemic tiers](../steering/epistemic-tiers.md) and
-[study contracts](../../studies/README.md).
+Do not cite an output as a validated finding unless its linked
+`studies/<study-id>/study.yaml` file says `citable`. A working pipeline or a dated
+report may still be early research. See [evidence levels](../steering/epistemic-tiers.md)
+and [study requirements](../../studies/README.md) for the review rules.
 
 ## Capital formation, exits, and firm pathways
 
-| Artifact | Questions | Evidence posture | Data cut or scope |
+| Output | Questions | Evidence status | Data covered |
 | --- | --- | --- | --- |
-| [Form D fundraising analysis](sbir-form-d-fundraising-analysis.md) | F1, F3 | Dated research analysis; no citable study manifest | Form D and SBIR spending, 2009–2024; methodology revised 2026-04-23 |
-| [DoD Form D leverage](dod-form-d-leverage.md) | A3, A4, F3 | Dated decomposition and follow-up analysis | Consolidated 2026-06-21 |
-| [Form D data dictionary](form-d-data-dictionary.md) | F1, F3 | Field and confidence-tier reference | Current on-disk Form D artifact contract |
-| [Agency private-capital Phase 2 method](agency-private-capital-phase2-form-d.md) | B2, B3, F3 | Descriptive matched-cohort method, not a causal estimate | No fixed published run |
-| [M&A exit analysis](sbir-ma-exit-analysis.md) | A4, F1, F2 | Dated research analysis; public-filer lower bound | Run documented 2026-04-23 |
-| [Capital-pathway cohorts](sbir-pathway-cohorts.md) | F1, F2 | Dated cohort analysis | High-confidence 3,639-firm cohort; 2026-06-23 |
-| [UCC-1 pilot](sbir-ucc1-pilot.md) | F1 | Partial, state-specific exploratory pilot | California subset; 2026-05-16 |
-| [California UCC API notes](ucc1-bizfileonline-api.md) | E5, F1 | Source-interface reference, not a result | Endpoints captured 2026-05-16 |
-| [SEC EDGAR learnings](sec-edgar-sbir-learnings.md) | E5, F1, F2 | Implementation and source-behavior note | Observations from 2026-04-19/22 |
+| [Form D fundraising analysis](sbir-form-d-fundraising-analysis.md) | F1, F3 | Dated analysis; not approved for citation | Form D and SBIR spending, 2009–2024; method revised 2026-04-23 |
+| [DoD Form D leverage](dod-form-d-leverage.md) | A3, A4, F3 | Dated breakdown and follow-up analysis | Combined 2026-06-21 |
+| [Form D data dictionary](form-d-data-dictionary.md) | F1, F3 | Reference for fields and confidence levels | Form D files currently produced by the pipeline |
+| [Agency private-capital Phase 2 method](agency-private-capital-phase2-form-d.md) | B2, B3, F3 | Compares matched groups; does not prove cause and effect | No fixed published run |
+| [M&A exit analysis](sbir-ma-exit-analysis.md) | A4, F1, F2 | Dated analysis; likely understates exits because it uses public filings | Run documented 2026-04-23 |
+| [Capital-pathway cohorts](sbir-pathway-cohorts.md) | F1, F2 | Dated group analysis | 3,639 firms with high-confidence matches; 2026-06-23 |
+| [UCC-1 pilot](sbir-ucc1-pilot.md) | F1 | Early, partial pilot for one state | California subset; 2026-05-16 |
+| [California UCC API notes](ucc1-bizfileonline-api.md) | E5, F1 | Reference for the data source; not a research result | Web addresses recorded 2026-05-16 |
+| [SEC EDGAR learnings](sec-edgar-sbir-learnings.md) | E5, F1, F2 | Notes on implementation and source behavior | Observations from 2026-04-19 and 2026-04-22 |
 
 ## Procurement, transition, and industrial-base research
 
-| Artifact | Questions | Evidence posture | Data cut or scope |
+| Output | Questions | Evidence status | Data covered |
 | --- | --- | --- | --- |
-| [DoD industrial-base concentration](dod_supply_chain_initial_analysis.md) | A1–A3 | Exploratory descriptive baseline | FY2012–FY2025; headline window FY2021–FY2025 |
-| [GSA and OTSB Phase III analysis](sbir-phase3-gsa-otsb-analysis.md) | B2, B3 | Working keyword-discoverable analysis; known coding undercount | FY2008–FY2026 source universe built 2026-06-28 |
-| [Phase II→III latency method](../phase-transition-latency.md) | B3 | Implemented pipeline method; not a citable result | Uses the configured materialization data cut |
-| [Follow-on multiplier method](../follow-on-multiplier-analysis.md) | A3 | Implemented analytical method; empirical validation remains open | Uses configured SBIR and USAspending inputs |
-| [Multiplier reproducibility fixture](../follow-on-multiplier-reproducibility.md) | A3 | Deterministic fixture verification, not a population estimate | Synthetic edge-case fixture |
-| [Commercialization benchmark method](../commercialization-benchmark-methodology.md) | B3 | Methodology record; local audit harness is not reproducible from this repository | FY2026 local audit described in the document |
-| [Monthly procurement-transition report](../procurement-transition-report.md) | B4, E6 | Operator/report contract, not research evidence | Current public-source pipeline |
+| [DoD industrial-base concentration](dod_supply_chain_initial_analysis.md) | A1–A3 | Early descriptive starting point | FY2012–FY2025; main results use FY2021–FY2025 |
+| [GSA and OTSB Phase III analysis](sbir-phase3-gsa-otsb-analysis.md) | B2, B3 | Working keyword analysis; known to miss some award codes | FY2008–FY2026 sources assembled 2026-06-28 |
+| [Phase II→III latency method](../phase-transition-latency.md) | B3 | Method works in the pipeline; not an approved finding | Uses the data selected for each pipeline run |
+| [Follow-on multiplier method](../follow-on-multiplier-analysis.md) | A3 | Method works; testing against real outcomes is still open | Uses the selected SBIR and USAspending inputs |
+| [Multiplier repeatability test](../follow-on-multiplier-reproducibility.md) | A3 | Automated test with made-up edge cases; not a program estimate | Test data only |
+| [Commercialization benchmark method](../commercialization-benchmark-methodology.md) | B3 | Method is documented; this repository cannot recreate the local audit | FY2026 local audit described in the document |
+| [Monthly procurement-transition report](../procurement-transition-report.md) | B4, E6 | Instructions for producing a report; not research evidence | Current public-source pipeline |
 
-The label-free Phase III census is tracked separately because it has a formal
-study contract: [manifest](../../studies/phase-iii-census/study.yaml),
-[February 2026 materialization audit](../../studies/phase-iii-census/materialization-2026-02-06.md),
-and [August 2026 control-identity eligibility audit](../../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md).
-Its status is reproducible, not citable; control construction, matching, and the
-placebo remain unresolved.
+The Phase III census has its own formal study record: the
+[study file](../../studies/phase-iii-census/study.yaml),
+[February 2026 data-build review](../../studies/phase-iii-census/materialization-2026-02-06.md),
+and [August 2026 control-group identity review](../../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md).
+The work can be repeated, but it is not yet approved for citation. The comparison
+group, matching, and placebo test are not finished.
 
 ## Economic and fiscal methods
 
-| Artifact | Questions | Evidence posture | Data cut or scope |
+| Output | Questions | Evidence status | Data covered |
 | --- | --- | --- | --- |
-| [Open-source tax-impact modeling](open-source-tax-impact-modeling.md) | D2, D3 | Research/pre-spec comparison | Dated 2026-04-19 |
+| [Open-source tax-impact modeling](open-source-tax-impact-modeling.md) | D2, D3 | Early comparison written before a formal spec | Dated 2026-04-19 |
 
 The maintained pipeline guide is [SBIR fiscal analysis](../fiscal/sbir-fiscal-pipeline-guide.md).
 
 ## Technology-area reports
 
-Each policy brief is the audience-facing entry point; its technical findings and
-methodology preserve cohort definitions and limitations.
+Start with the policy brief for a plain summary. The findings and method documents
+explain how firms were selected and what the results cannot show.
 
-| Area | Questions | Evidence posture | Data cut |
+| Area | Questions | Evidence status | Data covered |
 | --- | --- | --- | --- |
-| Nanotechnology: [brief](../nanotech_sbir_policy_brief.md), [findings](../nanotech_sbir_transition_findings.md), [method](../nano_phase3_methodology.md) | A1, A2, B2, B3, C1 | Provisional bounded estimates, not final program rates | SBIR.gov FY2025; USAspending FY2024; PatentsView March 2026 |
-| Hypersonics: [brief](../hypersonics_sbir_policy_brief.md), [findings](../hypersonics_sbir_transition_findings.md) | A1, A2, B2, B3, C1 | Provisional cohort and triangulation; outcome-channel rates unavailable | SBIR.gov through FY2025 |
-| Quantum information science: [brief](../quantum_information_science_sbir_policy_brief.md), [findings](../quantum_information_science_sbir_transition_findings.md) | A1, A2, B2, B3, C1 | Provisional cohort and triangulation; outcome-channel rates unavailable | SBIR.gov through FY2025 |
+| Nanotechnology: [brief](../nanotech_sbir_policy_brief.md), [findings](../nanotech_sbir_transition_findings.md), [method](../nano_phase3_methodology.md) | A1, A2, B2, B3, C1 | Early estimates with stated bounds; not final program rates | SBIR.gov FY2025; USAspending FY2024; PatentsView March 2026 |
+| Hypersonics: [brief](../hypersonics_sbir_policy_brief.md), [findings](../hypersonics_sbir_transition_findings.md) | A1, A2, B2, B3, C1 | Early firm group built from several signals; outcome rates are unavailable | SBIR.gov through FY2025 |
+| Quantum information science: [brief](../quantum_information_science_sbir_policy_brief.md), [findings](../quantum_information_science_sbir_transition_findings.md) | A1, A2, B2, B3, C1 | Early firm group built from several signals; outcome rates are unavailable | SBIR.gov through FY2025 |
 
 ## Research planning and communication
 
-- [Literature map and citation audit](literature-map/README.md) — 2019–2026
-  literature coverage and gaps across question areas A–F.
+- [Literature map and citation audit](literature-map/README.md) — research published
+  from 2019–2026 and missing coverage across question areas A–F.
 - [Government-policy demo plan](../guides/government-policy-demo-plan.md) —
-  audience framing and demonstration sequence; not an evidence source.
+  what to show each audience and in what order; not an evidence source.

--- a/docs/specifications/README.md
+++ b/docs/specifications/README.md
@@ -1,8 +1,0 @@
-# Specifications
-
-Use the [Specification Workflow](../development/spec-workflow-guide.md) for scope, required files,
-epistemic tiers, lifecycle, and evidence promotion. Before starting any spec, check the
-[status registry](../../specs/status.md).
-
-Active and gated specifications live in `specs/`; historical material lives in `specs/archive/`.
-Archived OpenSpec content is provenance only and is not an implementation source of truth.

--- a/docs/superpowers/specs/2026-07-29-awardee-first-procurement-packet-design.md
+++ b/docs/superpowers/specs/2026-07-29-awardee-first-procurement-packet-design.md
@@ -1,8 +1,8 @@
 # Awardee-First Procurement Transition Packet — Design
 
 **Date:** 2026-07-29
-**Status:** Approved (design), pending implementation
-**Branch:** `feat/awardee-first-procurement-packet` (built on PR #464 branch, which contains all of PR #450)
+**Status:** Implemented; retained as the design record
+**Original branch:** `feat/awardee-first-procurement-packet` (merged through PR #466 follow-ups)
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-30-why-it-connects-explanation-design.md
+++ b/docs/superpowers/specs/2026-07-30-why-it-connects-explanation-design.md
@@ -1,8 +1,8 @@
 # "Why it connects" — Anchored Evidence Narrative (Phase 1)
 
 **Date:** 2026-07-30
-**Status:** Approved (design), Phase 1 only
-**Branch:** `feat/awardee-first-procurement-packet` (PR #466)
+**Status:** Implemented; retained as the Phase 1/2 design record
+**Original branch:** `feat/awardee-first-procurement-packet` (PR #466 and follow-up phases)
 
 ## Problem
 

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 import re
 import subprocess
@@ -51,8 +52,10 @@ ARCHIVE_REFERENCE_PATTERNS = (
     re.compile(r"scripts\.archive(?:\.|\b)"),
 )
 MARKDOWN_LINK_RE = re.compile(r"!?\[[^\]]+\]\(([^)]+)\)")
+MARKDOWN_REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(\S+)")
 MARKDOWN_HEADING_RE = re.compile(r"^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$")
 MARKDOWN_EXPLICIT_ANCHOR_RE = re.compile(r'<a\s+(?:[^>]*?\s)?(?:id|name)=["\']([^"\']+)["\']', re.I)
+SPEC_STATUS_ENTRY_RE = re.compile(r"^- \*\*`([^`]+)`\s+—", re.MULTILINE)
 
 
 @dataclass(frozen=True)
@@ -83,7 +86,8 @@ def tracked_files() -> list[Path]:
         capture_output=True,
         text=True,
     )
-    return [REPOSITORY_ROOT / relative for relative in result.stdout.splitlines()]
+    paths = [REPOSITORY_ROOT / relative for relative in result.stdout.splitlines()]
+    return [path for path in paths if path.exists()]
 
 
 def __file_relative__() -> str:
@@ -110,6 +114,13 @@ def _is_live_doc_file(relative: str) -> bool:
     if relative.startswith("docs/"):
         return True
     return relative.startswith("specs/")
+
+
+def _is_documentation_file(relative: str) -> bool:
+    """Return whether a tracked Markdown file belongs to project documentation."""
+    return relative == "README.md" or (
+        relative.endswith(".md") and relative.startswith(("docs/", "specs/"))
+    )
 
 
 def _is_archive_guard_file(relative: str) -> bool:
@@ -243,21 +254,22 @@ def _markdown_anchors(path: Path) -> set[str]:
     return anchors
 
 
-def scan_missing_live_doc_links(
-    paths: list[Path], *, root: Path = REPOSITORY_ROOT
-) -> list[Violation]:
-    """Find local Markdown links or fragments in live docs/specs that point nowhere."""
+def scan_missing_doc_links(paths: list[Path], *, root: Path = REPOSITORY_ROOT) -> list[Violation]:
+    """Find local Markdown links or fragments in project docs that point nowhere."""
     violations: list[Violation] = []
     anchors_by_path: dict[Path, set[str]] = {}
-    live_docs = [path for path in paths if _is_live_doc_file(_relative_to_repository(path, root))]
-    for path in live_docs:
+    docs = [path for path in paths if _is_documentation_file(_relative_to_repository(path, root))]
+    for path in docs:
         lines = _read_text_lines(path)
         if lines is None:
             continue
         relative = _relative_to_repository(path, root)
         for line_number, line in enumerate(lines, 1):
-            for match in MARKDOWN_LINK_RE.finditer(line):
-                target = _extract_markdown_link_target(match.group(1))
+            raw_targets = [match.group(1) for match in MARKDOWN_LINK_RE.finditer(line)]
+            if reference_match := MARKDOWN_REFERENCE_LINK_RE.match(line):
+                raw_targets.append(reference_match.group(1))
+            for raw_target in raw_targets:
+                target = _extract_markdown_link_target(raw_target)
                 if _is_external_link(target):
                     continue
                 resolved = _resolve_markdown_target(path, target, root)
@@ -289,6 +301,59 @@ def scan_missing_live_doc_links(
     return violations
 
 
+def scan_spec_registry(*, root: Path = REPOSITORY_ROOT) -> list[Violation]:
+    """Require every top-level feature spec to appear exactly once in the status registry."""
+    specs_root = root / "specs"
+    registry_path = specs_root / "status.md"
+    if not registry_path.exists():
+        return [Violation("specs/status.md", 1, "missing specification status registry", "")]
+
+    tracked_specs = {
+        path.name
+        for path in specs_root.iterdir()
+        if (path.is_dir() and path.name != "archive")
+        or (
+            path.is_file()
+            and path.suffix == ".md"
+            and path.name not in {"REQUIREMENTS_TEMPLATE.md", "status.md"}
+        )
+    }
+    registry_text = registry_path.read_text(encoding="utf-8")
+    registered_entries = SPEC_STATUS_ENTRY_RE.findall(registry_text)
+    registered_specs = set(registered_entries)
+
+    violations: list[Violation] = []
+    for name in sorted(tracked_specs - registered_specs):
+        violations.append(
+            Violation(
+                "specs/status.md",
+                1,
+                f"top-level spec is missing from status registry: {name}",
+                name,
+            )
+        )
+    for name in sorted(registered_specs - tracked_specs):
+        violations.append(
+            Violation(
+                "specs/status.md",
+                1,
+                f"status registry references a missing top-level spec: {name}",
+                name,
+            )
+        )
+    for name, count in sorted(Counter(registered_entries).items()):
+        if count > 1:
+            violations.append(
+                Violation(
+                    "specs/status.md",
+                    1,
+                    f"status registry contains duplicate entries for: {name}",
+                    name,
+                )
+            )
+    return violations
+
+
 def _print_section(title: str, violations: list[Violation]) -> None:
     if not violations:
         return
@@ -311,8 +376,12 @@ def main() -> int:
             scan_live_doc_stale_content(paths),
         ),
         (
-            "Missing local Markdown links were found in live docs/specs:",
-            scan_missing_live_doc_links(paths),
+            "Missing local Markdown links were found in project documentation:",
+            scan_missing_doc_links(paths),
+        ),
+        (
+            "The specification status registry is incomplete:",
+            scan_spec_registry(),
         ),
         (
             "Operational files reference archived scripts:",

--- a/specs/archive/README.md
+++ b/specs/archive/README.md
@@ -1,21 +1,20 @@
 # Archived Specifications
 
-Archived specifications preserve implementation history and rationale. They are
-provenance, not current commands or architecture guidance. Start with the
-[status registry](../status.md) and [specification workflow](../../docs/development/spec-workflow-guide.md)
-before reviving any archived work.
+These old specifications explain what was built and why. Do not use their commands
+or design notes as current instructions. Before restarting old work, check the
+[status list](../status.md) and [specification workflow](../../docs/development/spec-workflow-guide.md).
 
 ## Categories
 
 | Directory | Meaning |
 | --- | --- |
-| [`completed-features/`](completed-features/) | Delivered feature specifications and completion records |
-| [`completed-migrations/`](completed-migrations/) | Finished repository or workflow migrations |
-| [`superseded/`](superseded/) | Designs replaced by a different approach or intentionally dropped |
+| [`completed-features/`](completed-features/) | Features that were delivered, with records of their completion |
+| [`completed-migrations/`](completed-migrations/) | Finished changes to the repository or development process |
+| [`superseded/`](superseded/) | Designs that were replaced or intentionally dropped |
 
-Other directories are historical snapshots retained for context. Their paths,
-commands, dependencies, and task states may describe the repository at the time
-they were written. Use current documentation under `docs/` to operate the system.
+The other directories are old snapshots kept for context. Their paths, commands,
+dependencies, and task lists may no longer be correct. Use the current guides in
+`docs/` when running the system.
 
 When archiving a spec, add a completion or supersession record, update
 `specs/status.md`, and repair inbound links in the same change.

--- a/specs/archive/README.md
+++ b/specs/archive/README.md
@@ -1,48 +1,21 @@
 # Archived Specifications
 
-This directory contains completed specifications that have been fully implemented and integrated into the codebase.
+Archived specifications preserve implementation history and rationale. They are
+provenance, not current commands or architecture guidance. Start with the
+[status registry](../status.md) and [specification workflow](../../docs/development/spec-workflow-guide.md)
+before reviving any archived work.
 
-## Completed Specifications
+## Categories
 
-### SBIR Fiscal Returns Analysis (sbir-fiscal-returns-analysis/)
-**Completed:** November 2025
-**Status:** ✅ Fully Implemented
+| Directory | Meaning |
+| --- | --- |
+| [`completed-features/`](completed-features/) | Delivered feature specifications and completion records |
+| [`completed-migrations/`](completed-migrations/) | Finished repository or workflow migrations |
+| [`superseded/`](superseded/) | Designs replaced by a different approach or intentionally dropped |
 
-A comprehensive fiscal returns analysis system that calculates the return on investment (ROI) of SBIR program funding by estimating federal tax receipts generated from economic impacts.
+Other directories are historical snapshots retained for context. Their paths,
+commands, dependencies, and task states may describe the repository at the time
+they were written. Use current documentation under `docs/` to operate the system.
 
-**Key Features:**
-- Multi-stage ETL pipeline with data preparation, economic modeling, and tax calculation
-- Integration with StateIO/USEEIO economic models via R interface
-- Sensitivity analysis and uncertainty quantification
-- Comprehensive audit trails and quality gates
-- 13 Dagster assets with full test coverage
-
-**Implementation Highlights:**
-- Complete pipeline: `src/assets/fiscal_assets.py` (13 assets, 7 asset checks)
-- Core transformers: `src/transformers/fiscal_*.py` (6 components)
-- Data enrichers: `src/enrichers/fiscal_*.py` (3 services)
-- Job definitions: `src/assets/jobs/fiscal_returns_job.py` (3 variants)
-- Test coverage: 10 test files (unit, integration, validation)
-- Configuration: `config/base.yaml` fiscal_analysis section
-
-**Usage:**
-```bash
-# Run MVP pipeline (core functionality)
-dagster job execute -f src/definitions.py -j fiscal_returns_mvp_job
-
-# Run full pipeline with sensitivity analysis
-dagster job execute -f src/definitions.py -j fiscal_returns_full_job
-```
-
-**Documentation:**
-- Requirements: Comprehensive EARS-compliant requirements with 9 user stories
-- Design: Detailed architecture with economic modeling approach
-- Implementation: Complete task breakdown with all 9 major tasks completed
-
-This specification demonstrates the full spec-driven development workflow from requirements gathering through design to complete implementation and testing.
-
-## Superseded Specifications
-
-See `superseded/README.md` for specs that were archived because they were replaced or deferred:
-- **mcp_interface** — Superseded by `mcp_agent_tools` (2026-03-12)
-- **web_search_enrichment** — Deferred, no implementation built (2026-03-12)
+When archiving a spec, add a completion or supersession record, update
+`specs/status.md`, and repair inbound links in the same change.

--- a/specs/archive/completed-features/commercialization-benchmark/requirements.md
+++ b/specs/archive/completed-features/commercialization-benchmark/requirements.md
@@ -4,7 +4,7 @@
 > `sbir_etl/models/benchmark_models.py`. Evaluator:
 > `packages/sbir-ml/sbir_ml/transition/analysis/benchmark_evaluator.py`.
 > Tests: `tests/unit/test_benchmark_evaluator.py`.
-> Supports inventory question **B3** in [docs/research-questions.md](../../docs/research-questions.md).
+> Supports inventory question **B3** in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** B3 — which Phase II awardees subject to §638(qq)(3)
 Increased Performance Standards meet the statutory Commercialization Benchmark?

--- a/specs/archive/completed-features/follow-on-multiplier-analysis/requirements.md
+++ b/specs/archive/completed-features/follow-on-multiplier-analysis/requirements.md
@@ -1,7 +1,7 @@
 # Follow-on Funding Multiplier Analysis — Requirements
 
-> **Status:** Implemented in this PR — see the [specification validation, semantics, execution guide, and requirement map](../../docs/follow-on-multiplier-analysis.md).
-> Anchors inventory question **A3** in [docs/research-questions.md](../../docs/research-questions.md).
+> **Status:** Implemented in this PR — see the [specification validation, semantics, execution guide, and requirement map](../../../../docs/follow-on-multiplier-analysis.md).
+> Anchors inventory question **A3** in [docs/research-questions.md](../../../../docs/research-questions.md).
 >
 > NASEM's reviews of DoD SBIR call this quantity the *leverage ratio*. This codebase
 > uses *follow-on funding multiplier* for the same calculation to avoid the debt

--- a/specs/archive/completed-features/form-d-pipeline/requirements.md
+++ b/specs/archive/completed-features/form-d-pipeline/requirements.md
@@ -1,8 +1,8 @@
 # Requirements — Form D Private Capital Pipeline
 
 > **Status:** Implemented on `main`. PR #286 merged. Methodology commit `f65abb89`.
-> Canonical analysis: [`docs/research/sbir-form-d-fundraising-analysis.md`](../../docs/research/sbir-form-d-fundraising-analysis.md).
-> Supports inventory questions **F1** and **F3** in [docs/research-questions.md](../../docs/research-questions.md).
+> Canonical analysis: [`docs/research/sbir-form-d-fundraising-analysis.md`](../../../../docs/research/sbir-form-d-fundraising-analysis.md).
+> Supports inventory questions **F1** and **F3** in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** F1 (Form D fundraising profile of SBIR awardees), F3 (private-to-SBIR leverage ratio)
 **Answers for:** entrepreneurial finance researchers, defense industrial base analysts

--- a/specs/archive/completed-features/load-contract-nodes/requirements.md
+++ b/specs/archive/completed-features/load-contract-nodes/requirements.md
@@ -1,7 +1,7 @@
 # Requirements: Make `RESULTED_IN` resolve (CONTRACT FinancialTransaction nodes)
 
 > **Status:** Not yet started.
-> Supports inventory question **A3** (SBIR → follow-on contract linkage) in [docs/research-questions.md](../../docs/research-questions.md).
+> Supports inventory question **A3** (SBIR → follow-on contract linkage) in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** A3 — SBIR award → follow-on federal contract linkage
 **Answers for:** defense industrial base analysts, pipeline engineers

--- a/specs/archive/completed-features/merger_acquisition_detection/design.md
+++ b/specs/archive/completed-features/merger_acquisition_detection/design.md
@@ -2,5 +2,5 @@
 
 Implemented and merged. The SBIR-firm M&A / exit-detection approach is
 summarized in research area A4 of
-[`../../docs/research-questions.md`](../../docs/research-questions.md);
+[`docs/research-questions.md`](../../../../docs/research-questions.md);
 detection runs over SEC EDGAR 8-K and Form D filings.

--- a/specs/archive/completed-features/merger_acquisition_detection/requirements.md
+++ b/specs/archive/completed-features/merger_acquisition_detection/requirements.md
@@ -1,6 +1,6 @@
 # Requirements — M&A Detection
 
 > **Status:** Implemented and merged. Candidate for archiving to `specs/archive/completed-features/`.
-> See research question **A4** in [docs/research-questions.md](../../docs/research-questions.md).
+> See research question **A4** in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 Implementation is complete. See `sbir_etl/enrichers/sec_edgar/`, `scripts/archive/data/detect_sbir_ma_events.py`, and `data/sbir_ma_events.jsonl` for the delivered artifacts. Published findings in `docs/research/sbir-ma-exit-analysis.md`.

--- a/specs/archive/completed-features/merger_acquisition_detection/tasks.md
+++ b/specs/archive/completed-features/merger_acquisition_detection/tasks.md
@@ -2,4 +2,4 @@
 
 Implemented and merged. M&A / exit detection lives in the SEC EDGAR
 enrichers and supporting scripts; see research question A4 in
-[`../../docs/research-questions.md`](../../docs/research-questions.md).
+[`docs/research-questions.md`](../../../../docs/research-questions.md).

--- a/specs/archive/completed-features/sbir-cohort-design/design.md
+++ b/specs/archive/completed-features/sbir-cohort-design/design.md
@@ -2,4 +2,4 @@
 
 Implemented and merged. The SBIR capital-cohort definition is described in
 research area F (capital formation & entrepreneurial finance) of
-[`../../docs/research-questions.md`](../../docs/research-questions.md).
+[`docs/research-questions.md`](../../../../docs/research-questions.md).

--- a/specs/archive/completed-features/sbir-cohort-design/requirements.md
+++ b/specs/archive/completed-features/sbir-cohort-design/requirements.md
@@ -1,6 +1,6 @@
 # Requirements — SBIR Cohort Design
 
 > **Status:** Implemented and merged. Candidate for archiving to `specs/archive/completed-features/`.
-> See research area **F** (capital formation & entrepreneurial finance) in [docs/research-questions.md](../../docs/research-questions.md).
+> See research area **F** (capital formation & entrepreneurial finance) in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 Implementation is complete. Cohort design logic lives in the Form D and M&A exit analysis pipeline; see `docs/research/sbir-form-d-fundraising-analysis.md` and `docs/research/sbir-ma-exit-analysis.md` for findings.

--- a/specs/archive/completed-features/sbir-cohort-design/tasks.md
+++ b/specs/archive/completed-features/sbir-cohort-design/tasks.md
@@ -2,4 +2,4 @@
 
 Implemented and merged. See research area F (capital formation &
 entrepreneurial finance) in
-[`../../docs/research-questions.md`](../../docs/research-questions.md).
+[`docs/research-questions.md`](../../../../docs/research-questions.md).

--- a/specs/archive/completed-features/sbir-identification/requirements.md
+++ b/specs/archive/completed-features/sbir-identification/requirements.md
@@ -1,8 +1,8 @@
 # Requirements — SBIR/STTR Award Identification
 
 > **Status:** Implemented on `main`. Classifier: `sbir_etl/extractors/sbir_classifier.py`.
-> Methodology: [`docs/sbir-identification-methodology.md`](../../docs/sbir-identification-methodology.md).
-> Supports inventory question **E1** in [docs/research-questions.md](../../docs/research-questions.md).
+> Methodology: [`docs/sbir-identification-methodology.md`](../../../../docs/sbir-identification-methodology.md).
+> Supports inventory question **E1** in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** E1 — which federal awards are SBIR/STTR vs. non-SBIR, and with what confidence?
 **Answers for:** pipeline engineers, SBA oversight analysts

--- a/specs/archive/completed-features/transition_detection/requirements.md
+++ b/specs/archive/completed-features/transition_detection/requirements.md
@@ -1,7 +1,7 @@
 # Requirements — SBIR Transition Detection (Archive)
 
-> **Status:** Implemented and merged (October 30, 2025). Current live spec stub:
-> [`specs/transition-detection/requirements.md`](../../../transition-detection/requirements.md).
+> **Status:** Implemented and merged (October 30, 2025). See the current
+> [transition documentation](../../../../docs/transition/README.md).
 > Supports inventory questions **B2** and **B3** in
 > [docs/research-questions.md](../../../../docs/research-questions.md).
 

--- a/specs/archive/completed-features/unify-company-into-organization/requirements.md
+++ b/specs/archive/completed-features/unify-company-into-organization/requirements.md
@@ -1,7 +1,7 @@
 # Requirements — Unify :Company onto :Organization (Phase 2)
 
 > **Status:** Not yet started. Stacks on Phase 1 (PR #379).
-> Phase 2 of graph label unification. Supports inventory question **E2** (graph schema correctness) in [docs/research-questions.md](../../docs/research-questions.md).
+> Phase 2 of graph label unification. Supports inventory question **E2** (graph schema correctness) in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** E2 — graph label unification (Phase 2: :Company → :Organization)
 **Answers for:** pipeline engineers

--- a/specs/archive/completed-features/unify-graph-node-labels/requirements.md
+++ b/specs/archive/completed-features/unify-graph-node-labels/requirements.md
@@ -1,7 +1,7 @@
 # Requirements — Unify :Award onto :FinancialTransaction (Phase 1)
 
 > **Status:** Implemented — PR #379 merged.
-> Phase 1 of graph label unification. Supports inventory question **E2** (graph schema correctness) in [docs/research-questions.md](../../docs/research-questions.md).
+> Phase 1 of graph label unification. Supports inventory question **E2** (graph schema correctness) in [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** E2 — graph label unification (Phase 1: :Award → :FinancialTransaction)
 **Answers for:** pipeline engineers

--- a/specs/status.md
+++ b/specs/status.md
@@ -1,12 +1,16 @@
 # Specification Status Registry
 
-Reviewed: 2026-08-01
+Reviewed: 2026-08-03
 
 This registry is the cleanup checkpoint for top-level specs. It does not replace
 the requirements, design, or tasks files; it records whether a spec is a current
 implementation target, a gated backlog item, a deferred design, or an archive
 candidate. Use `docs/research-questions.md` as the scope gate before promoting
 any gated or deferred spec back into active work.
+
+The repository-hygiene guard requires every top-level feature spec to appear in
+this registry. That coverage check prevents new spec directories from silently
+bypassing lifecycle review; the status and rationale still require human judgment.
 
 ## Status Categories
 
@@ -22,15 +26,24 @@ any gated or deferred spec back into active work.
 
 ## Top-Level Specs
 
+- **`actions-migration-followups` — Maintenance.** Setup verification and the
+  blocking security scan are restored. The remaining decisions concern periodic
+  scanning and whether the large pre-existing Markdown-formatting backlog is worth
+  addressing; do not restore the old broad lint job by default.
 - **`agency-private-capital-comparison` — Gated backlog.** Phase 1 is
   implemented. Phase 2 depends on prioritizing the Form D / private-capital
   control-cohort comparison.
+- **`bea-nipa-tax-rates` — Active.** The NIPA provider exists; the remaining
+  work is the on-disk cache and removal of hardcoded effective-rate consumers.
 - **`company-categorization` — Maintenance.** About 80% complete. Evaluate the
   remaining Neo4j loader and docs against the current `:Organization` graph
   schema before implementation.
 - **`cross-agency-taxonomy` — Gated backlog.** M3 research target. Prerequisite
   classifier/tools exist, but this spec's batch run, report, and Dagster wiring
   are not implemented.
+- **`dark-majority-resolution` — Maintenance.** Core contract, identity,
+  liveness, and recovery work is implemented. Remaining work is a bounded web
+  liveness sweep plus blocked/deferred external-registry checks.
 - **`data-imputation` — Gated backlog.** Foundational E4 work, but zero
   implementation. Start only when missing-field recovery becomes the next
   data-quality priority.
@@ -41,17 +54,25 @@ any gated or deferred spec back into active work.
   test are accepted; and weekly-report refactor T2.3 plus the injected,
   typed-return work in T3.2 are complete. Offline, full-context, and shadow
   gates still precede any production integration.
+- **`fiscal-tax-impact-v2.md` — Gated backlog.** Valid D2 methodology upgrade.
+  Leave inactive until fiscal-model refresh is selected.
 - **`follow-on-multiplier-validation` — Active.** Design-only follow-up to the
   completed multiplier asset. Still called out as an immediate research-plan
   gap.
 - **`iterative_api_enrichment` — Maintenance.** USAspending refresh is live.
   Remaining source expansion should be split or scheduled intentionally.
+- **`ma-discovery-integration` — Deferred.** The design depends on an unmerged
+  discovery toolkit and missing press-enrichment glue. Revisit only when M&A
+  recall becomes a selected research priority.
 - **`modernbert_analysis_layer` — Maintenance.** Core embeddings and similarity
   are implemented. Neo4j loading, quality metrics, and Bayesian routing remain
   scoped follow-ups.
 - **`naics-enricher-consolidation` — Maintenance.** Consolidation is largely
   complete. Remaining obsolete audit/golden-file tasks should not be revived as
   written.
+- **`nvca-yearbook-benchmarks` — Gated backlog.** The baseline registry exists,
+  but all remaining work is blocked on verified NVCA Yearbook source access and
+  an implementation-priority decision.
 - **`ot-consortium-subaward-attribution` — Gated backlog.** Valid A2 research
   question, but the T0 coverage probe must run before implementation.
 - **`patent-cost-spillover` — Gated backlog.** M2 analytical layer remains
@@ -59,17 +80,47 @@ any gated or deferred spec back into active work.
   sprint.
 - **`phase-3-solicitation-alerts` — Maintenance.** Retrospective S1 work is
   implemented. SAM.gov Opportunities S2/S3 paths remain backlog.
+- **`phase-iii-census` — Active.** Phase 1 is implemented and materialized under
+  a reproducible study contract, and the control-identity eligibility gate passed.
+  Control construction/matching, placebo tests, and labeled validation remain
+  required before any undercount or statutory Phase III claim.
+- **`phase-iii-source-materialization` — Maintenance.** The schema-verified
+  USAspending and SBIR.gov source layer is implemented. Keep it aligned with the
+  census and other transition consumers rather than extending it with scoring policy.
+- **`phase3-candidate-enrichment` — Active.** The source-coverage gate stopped
+  the text assembler, while the firm-ranking/lineage experiment found a useful
+  but hand-weighted lift. Learned weights and a larger independent validation set
+  remain before production use.
+- **`phase3-match-benchmark` — Maintenance.** Corrected estimator and cohort
+  rules are implemented; empirical reruns remain blocked on the required inputs.
+  Its results remain provisional portfolio-linkage evidence.
+- **`phase3-notice-corpus-fusion` — Maintenance.** Award-grain recovery,
+  reproduction, frozen coefficients, and packet integration landed. Reconcile
+  the remaining documentation task and the explicitly missing second label channel.
+- **`phase3-transition-groundtruth` — Maintenance.** The independent corpus,
+  T6 results, and T7 decision memo landed, but the requirements header still
+  describes the work as unimplemented. Reconcile the spec before any extension.
+- **`phase3-undercount-extension` — Gated backlog.** Valid B3 follow-up, but it
+  depends on reusable resolution/self-label components and must keep contract
+  undercount separate from provisional non-contract vehicle counts.
+- **`procurement-transition-p1-remediation` — Active.** Award identity and path
+  attribution landed. Cold-start bounds, source-normalization provenance, and
+  ranking/auditability phases remain.
 - **`sbir_ma_match_rate_by_fy` — Gated backlog.** Analysis-only F2 follow-up on
   completed M&A detection. Start only when FY match-rate reporting is requested.
 - **`state-local-tax-rates` — Maintenance.** Existing hardcoded 2024 provider
   works. Remaining work is data-file/provenance cleanup for fiscal v2.
+- **`tech-area-transition-report` — Maintenance.** The parameterized cohort and
+  report pattern is implemented across nanotechnology, QIS, and hypersonics.
+  The remaining task is to add richer headline channels when their evidence exists.
+- **`transition-coverage-expansion` — Active.** Initial access and coverage
+  spikes are recorded. Credible grant/subaward attribution, OT resolution, and a
+  channel-by-channel wire-in decision remain.
 - **`ucc1-financing-analysis` — Archive candidate.** CA-only pilot is complete
   and extension is explicitly deferred by the research memo.
 - **`weekly-awards-report-refactor` — Maintenance.** Monolith is already split
   into weekly reporting modules. Remaining work is injection, coverage, and
   alias cleanup.
-- **`fiscal-tax-impact-v2.md` — Gated backlog.** Valid D2 methodology upgrade.
-  Leave inactive until fiscal-model refresh is selected.
 
 ## Archive Candidates
 

--- a/tests/unit/scripts/test_repository_hygiene.py
+++ b/tests/unit/scripts/test_repository_hygiene.py
@@ -30,7 +30,7 @@ def test_live_doc_stale_content_scans_all_non_archived_docs(tmp_path: Path):
     assert violations[0].path == "docs/transition/example.md"
 
 
-def test_live_doc_link_audit_resolves_relative_links(tmp_path: Path):
+def test_scan_missing_doc_links_resolves_relative_links(tmp_path: Path):
     source = _write(
         tmp_path,
         "docs/development/example.md",
@@ -45,7 +45,7 @@ def test_live_doc_link_audit_resolves_relative_links(tmp_path: Path):
     assert violations[0].path == "docs/development/example.md"
 
 
-def test_live_doc_link_audit_validates_file_and_same_page_anchors(tmp_path: Path):
+def test_scan_missing_doc_links_validates_file_and_same_page_anchors(tmp_path: Path):
     source = _write(
         tmp_path,
         "docs/development/example.md",

--- a/tests/unit/scripts/test_repository_hygiene.py
+++ b/tests/unit/scripts/test_repository_hygiene.py
@@ -38,7 +38,7 @@ def test_live_doc_link_audit_resolves_relative_links(tmp_path: Path):
     )
     target = _write(tmp_path, "docs/target.md", "ok\n")
 
-    violations = hygiene.scan_missing_live_doc_links([source, target], root=tmp_path)
+    violations = hygiene.scan_missing_doc_links([source, target], root=tmp_path)
 
     assert len(violations) == 1
     assert violations[0].message == "missing local Markdown link ../missing.md"
@@ -64,11 +64,54 @@ def test_live_doc_link_audit_validates_file_and_same_page_anchors(tmp_path: Path
         '<a id="stable-id"></a>\n',
     )
 
-    violations = hygiene.scan_missing_live_doc_links([source, target], root=tmp_path)
+    violations = hygiene.scan_missing_doc_links([source, target], root=tmp_path)
 
     assert len(violations) == 1
     assert violations[0].message == "missing Markdown anchor #old-heading in ../target.md"
     assert hygiene._github_heading_slug("Research & development") == "research--development"
+
+
+def test_doc_link_audit_includes_archived_docs_and_root_readme(tmp_path: Path):
+    readme = _write(tmp_path, "README.md", "[missing](docs/missing.md)\n")
+    archive = _write(tmp_path, "docs/archive/example.md", "[missing](../missing.md)\n")
+
+    violations = hygiene.scan_missing_doc_links([readme, archive], root=tmp_path)
+
+    assert [violation.path for violation in violations] == [
+        "README.md",
+        "docs/archive/example.md",
+    ]
+
+
+def test_doc_link_audit_checks_reference_style_links(tmp_path: Path):
+    source = _write(tmp_path, "docs/example.md", "[details]: missing.md\n")
+
+    violations = hygiene.scan_missing_doc_links([source], root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].message == "missing local Markdown link missing.md"
+
+
+def test_spec_registry_requires_each_top_level_spec(tmp_path: Path):
+    _write(
+        tmp_path,
+        "specs/status.md",
+        "- **`registered` — Active.** Current work.\n"
+        "- **`missing-on-disk` — Deferred.** Historical entry.\n",
+    )
+    _write(tmp_path, "specs/registered/tasks.md", "# Tasks\n")
+    _write(tmp_path, "specs/unregistered/requirements.md", "# Requirements\n")
+    _write(tmp_path, "specs/standalone.md", "# Standalone spec\n")
+    _write(tmp_path, "specs/REQUIREMENTS_TEMPLATE.md", "# Template\n")
+    _write(tmp_path, "specs/archive/old/tasks.md", "# Old\n")
+
+    violations = hygiene.scan_spec_registry(root=tmp_path)
+
+    assert [violation.message for violation in violations] == [
+        "top-level spec is missing from status registry: standalone.md",
+        "top-level spec is missing from status registry: unregistered",
+        "status registry references a missing top-level spec: missing-on-disk",
+    ]
 
 
 def test_archive_guard_ignores_archive_scripts_and_flags_live_references(tmp_path: Path):


### PR DESCRIPTION
## Summary

- expand the repository hygiene guard to validate links and anchors across the README, docs, and specs—including archives—and require complete spec-registry coverage
- repair archived links and replace stale spec/archive navigation
- add a research-output index mapping outputs to research questions, evidence status, and data cuts; ensure every maintained document has an inbound route
- centralize ML run commands through Make targets and correct stale API, procurement, and research-status text

## Why

The previous consolidation established canonical owners, but archive links, spec-registry coverage, orphaned research docs, and duplicated executable commands could still drift. This makes those constraints visible and mechanically enforced without enabling the noisy whole-tree Markdown-formatting backlog.

## Impact

- `make docs-check` provides a focused local entry point
- CI fails when a project-document link or anchor breaks, or a top-level spec is missing, stale, or duplicated in the registry
- no runtime pipeline or deployment behavior changes

## Validation

- `python3 scripts/ci/check_removed_src_references.py`
- `pytest tests/unit/scripts/test_repository_hygiene.py -q` — 10 passed
- Ruff check and format check for the modified Python and test files
- architecture-boundary check
- study-manifest validation
- company-identity boundary check
- `git diff --check`