### PR TITLE
Speed up Dagster CI contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,16 @@ jobs:
       - name: Run MyPy type checker
         run: uv run python -m mypy sbir_etl packages/sbir-graph/sbir_graph
 
+      # Importing and validating the complete graph catches duplicate asset
+      # keys, unresolved jobs, invalid partition mappings, and missing
+      # resources. In-process validation takes about a second once the
+      # environment is installed, so keep it on every PR instead of hiding it
+      # in the slower integration lane.
+      - name: Validate Dagster definitions
+        run: |
+          uv run python -c \
+            "from dagster import Definitions; from sbir_analytics.definitions import defs; Definitions.validate_loadable(defs)"
+
       - name: Run architecture, documentation, and repository hygiene guards
         run: |
           uv run python scripts/ci/check_architecture_boundaries.py
@@ -239,12 +249,59 @@ jobs:
         if: failure()
         run: docker logs test-neo4j --tail 100 || true
 
+  test-integration:
+    name: Neo4j Integration Tests
+    needs: [detect-changes]
+    if: |
+      github.event_name == 'pull_request' &&
+      needs.detect-changes.outputs.integration == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Python and UV
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          install-dev-deps: "true"
+
+      - name: Start Neo4j
+        uses: ./.github/actions/start-neo4j
+        with:
+          container-name: test-neo4j
+          neo4j-image: ${{ env.NEO4J_IMAGE }}
+          neo4j-user: ${{ env.NEO4J_USERNAME }}
+          neo4j-password: ${{ env.NEO4J_PASSWORD }}
+
+      # This lane runs alongside the four unit shards. It is conditional on
+      # graph/storage changes so ordinary asset and documentation PRs do not
+      # pay the container startup cost.
+      - name: Run integration tests
+        env:
+          NEO4J_URI: "bolt://localhost:7687"
+          NEO4J_USER: ${{ env.NEO4J_USERNAME }}
+          NEO4J_PASSWORD: ${{ env.NEO4J_PASSWORD }}
+          REQUIRE_NEO4J: "1"
+        run: uv run pytest tests/integration/ -m "integration and not slow"
+
+      - name: Neo4j logs on failure
+        if: failure()
+        run: docker logs test-neo4j --tail 100 || true
+
+      - name: Stop Neo4j
+        if: always()
+        uses: ./.github/actions/stop-neo4j
+        with:
+          container-name: test-neo4j
+
   detect-changes:
     name: Detect File Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
+      integration: ${{ steps.filter.outputs.integration }}
       setup: ${{ steps.filter.outputs.setup }}
     steps:
       - uses: actions/checkout@v7
@@ -260,6 +317,19 @@ jobs:
             docker:
               - 'Dockerfile*'
               - '.dockerignore'
+            # Run the real Neo4j contract only when graph persistence or its
+            # test harness changes. The full suite still runs after merge.
+            integration:
+              - 'packages/sbir-graph/**'
+              - 'packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py'
+              - 'packages/sbir-analytics/sbir_analytics/assets/transition/loading.py'
+              - 'packages/sbir-analytics/sbir_analytics/assets/uspto/loading.py'
+              - 'tests/integration/**'
+              - 'tests/conftest.py'
+              - 'tests/conftest_shared.py'
+              - 'tests/neo4j_service.py'
+              - 'pyproject.toml'
+              - 'uv.lock'
             # uv.lock and pyproject.toml stay out of the docker filter (#507:
             # the Dockerfile never reads them) but belong here, because
             # setup_dev.sh runs `uv sync` and a lockfile change can genuinely
@@ -297,8 +367,13 @@ jobs:
           cache-from: type=gha,scope=docker-ci
           cache-to: type=gha,mode=max,scope=docker-ci
 
-      - name: Smoke test the entrypoint
-        run: docker run --rm sbir-analytics:ci-${{ github.sha }} dagster --version
+      - name: Smoke test the entrypoint and Dagster definitions
+        run: |
+          docker run --rm sbir-analytics:ci-${{ github.sha }} dagster --version
+          docker run --rm \
+            -e SBIR_ETL__PIPELINE__ENVIRONMENT=test \
+            sbir-analytics:ci-${{ github.sha }} \
+            dagster definitions validate -m sbir_analytics.definitions
 
   verify-setup-script:
     name: Verify Developer Setup Script

--- a/packages/sbir-analytics/sbir_analytics/assets/sensors/usaspending_refresh_sensor.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sensors/usaspending_refresh_sensor.py
@@ -3,9 +3,7 @@
 Triggers refresh job after bulk enrichment completes successfully.
 """
 
-from datetime import datetime
-
-from dagster import RunRequest, SensorEvaluationContext, SensorResult, SkipReason, sensor
+from dagster import RunRequest, SensorEvaluationContext, SkipReason, sensor
 
 from ..jobs.usaspending_iterative_job import usaspending_iterative_enrichment_job
 
@@ -15,7 +13,7 @@ from ..jobs.usaspending_iterative_job import usaspending_iterative_enrichment_jo
     name="usaspending_refresh_sensor",
     description="Sensor that triggers USAspending refresh after bulk enrichment completes",
 )
-def usaspending_refresh_sensor(context: SensorEvaluationContext) -> SensorResult | SkipReason:
+def usaspending_refresh_sensor(context: SensorEvaluationContext) -> RunRequest | SkipReason:
     """Sensor that triggers USAspending iterative refresh.
 
     Checks if bulk enrichment assets are healthy and triggers refresh if:
@@ -39,15 +37,17 @@ def usaspending_refresh_sensor(context: SensorEvaluationContext) -> SensorResult
             enriched_awards_key
         )
 
-        if not enriched_awards_record or not hasattr(enriched_awards_record, "dagster_event"):  # type: ignore[arg-type]
+        if not enriched_awards_record:
             return SkipReason("Bulk enrichment asset not yet materialized")
 
         # Check if materialization was successful
-        if (
-            not enriched_awards_record.dagster_event
-            or not enriched_awards_record.dagster_event.asset_materialization  # type: ignore[attr-defined, truthy-function]
-        ):
+        if not enriched_awards_record.asset_materialization:
             return SkipReason("Bulk enrichment asset materialization not found")
+
+        # A stable event-derived run key lets Dagster deduplicate repeated
+        # evaluations of the same materialization. A wall-clock key generated a
+        # distinct run on every sensor tick.
+        trigger_timestamp = enriched_awards_record.timestamp
 
         # Check freshness ledger to see if refresh is needed
         freshness_key = AssetKey("usaspending_freshness_ledger")
@@ -55,19 +55,17 @@ def usaspending_refresh_sensor(context: SensorEvaluationContext) -> SensorResult
 
         # If freshness ledger exists, check staleness
         # Otherwise, this might be first run - trigger refresh to initialize
-        if freshness_record and hasattr(freshness_record, "dagster_event"):  # type: ignore[arg-type]
+        if freshness_record:
             # Check stale awards asset
             stale_key = AssetKey("stale_usaspending_awards")
             stale_record = context.instance.get_latest_materialization_event(stale_key)  # type: ignore[attr-defined]
 
-            if (
-                stale_record
-                and hasattr(stale_record, "dagster_event")
-                and stale_record.dagster_event
-            ):  # type: ignore[attr-defined]
+            if stale_record:
                 # Check metadata for stale count
-                if stale_record.dagster_event.asset_materialization:  # type: ignore[attr-defined, truthy-function]
-                    metadata = stale_record.dagster_event.asset_materialization.metadata or {}  # type: ignore[attr-defined]
+                stale_materialization = stale_record.asset_materialization
+                if stale_materialization:
+                    trigger_timestamp = stale_record.timestamp
+                    metadata = stale_materialization.metadata or {}
                     stale_count_val = metadata.get("stale_count")
                     # Extract value if it's a MetadataValue, otherwise use directly
                     if hasattr(stale_count_val, "value"):
@@ -84,14 +82,16 @@ def usaspending_refresh_sensor(context: SensorEvaluationContext) -> SensorResult
 
         # Trigger refresh
         context.log.info("Triggering USAspending iterative refresh")
-        return RunRequest(  # type: ignore[return-value]
-            run_key=f"usaspending_refresh_{datetime.now().isoformat()}",
+        return RunRequest(
+            run_key=f"usaspending_refresh_{trigger_timestamp}",
             tags={
                 "source": "usaspending",
                 "trigger": "sensor",
             },
         )
 
-    except Exception as e:
-        context.log.error(f"Error in refresh sensor: {e}")
-        return SkipReason(f"Sensor error: {e}")
+    except Exception:
+        # Unexpected instance failures should fail the sensor tick visibly;
+        # converting them to SkipReason made an unhealthy sensor look healthy.
+        context.log.exception("Error in refresh sensor")
+        raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -373,22 +373,6 @@ def _check_import(module_name: str) -> bool:
     return importlib.util.find_spec(module_name) is not None
 
 
-def neo4j_running() -> bool:
-    """Check if Neo4j is available and running for testing.
-
-    This is a helper function (not a fixture) for use with pytest.mark.skipif.
-
-    Resolution order:
-    1. Connect to an existing Neo4j (env vars / localhost).
-    2. Start a disposable Neo4j via testcontainers.
-    3. If REQUIRE_NEO4J is set (CI) and neither works, raise so the suite
-       errors out instead of silently skipping.
-    """
-    from tests.neo4j_service import get_neo4j_service
-
-    return get_neo4j_service() is not None
-
-
 @pytest.fixture
 def neo4j_available():
     """Fixture that skips if neo4j driver not available."""

--- a/tests/integration/neo4j/test_multi_key_merge.py
+++ b/tests/integration/neo4j/test_multi_key_merge.py
@@ -17,12 +17,12 @@ style failures from leftover state.
 """
 
 import pytest
-from tests.conftest import neo4j_running as neo4j_available
 
 pytestmark = [
-    pytest.mark.skipif(
-        not neo4j_available(), reason="Neo4j not running - see INTEGRATION_TEST_ANALYSIS.md"
-    ),
+    pytest.mark.integration,
+    # Resolve Neo4j lazily at execution time so collection and deselection do
+    # not start a Docker container.
+    pytest.mark.usefixtures("neo4j_driver"),
     pytest.mark.xdist_group("neo4j_integration"),
 ]
 

--- a/tests/integration/test_neo4j_client.py
+++ b/tests/integration/test_neo4j_client.py
@@ -13,15 +13,14 @@ mid-test on).
 """
 
 import pytest
-from tests.conftest import neo4j_running as neo4j_available
 
 from sbir_graph.loaders.neo4j.client import LoadMetrics, Neo4jClient
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(
-        not neo4j_available(), reason="Neo4j not running - see INTEGRATION_TEST_ANALYSIS.md"
-    ),
+    # Resolve Neo4j when a test executes, not while pytest imports this module.
+    # Import-time availability checks started a testcontainer during collection.
+    pytest.mark.usefixtures("neo4j_driver"),
     pytest.mark.xdist_group("neo4j_integration"),
 ]
 

--- a/tests/unit/assets/test_dagster_definitions.py
+++ b/tests/unit/assets/test_dagster_definitions.py
@@ -1,0 +1,41 @@
+"""Fast contracts for the complete Dagster code location."""
+
+import pytest
+from dagster import DefaultScheduleStatus, Definitions
+
+from sbir_analytics import definitions
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_definitions_are_loadable():
+    """The registered assets, jobs, checks, schedules, and sensors resolve."""
+    Definitions.validate_loadable(definitions.defs)
+
+
+def test_source_download_schedule_contracts():
+    """Host download schedules retain their reviewed cadence and safe status."""
+    expected_crons = {
+        "weekly_sbir_awards_download": "0 9 * * 1",
+        "monthly_sam_gov_download": "0 3 15 * *",
+        "monthly_usaspending_download": "0 2 6 * *",
+        "monthly_uspto_download": "0 9 1 * *",
+        "monthly_phase_transition": "0 14 1 * *",
+        "weekly_awards_report": "0 12 * * 1",
+    }
+    schedules = {schedule.name: schedule for schedule in definitions.source_download_schedules}
+
+    assert schedules.keys() == expected_crons.keys()
+    for name, cron in expected_crons.items():
+        assert schedules[name].cron_schedule == cron
+        assert schedules[name].default_status == DefaultScheduleStatus.STOPPED
+
+
+def test_expected_sensors_are_registered():
+    sensor_names = {sensor.name for sensor in definitions.all_sensors}
+
+    assert "usaspending_refresh_sensor" in sensor_names
+    assert "sbir_pipeline_after_download" in sensor_names
+    assert "uspto_pipeline_after_download" in sensor_names
+    assert "usaspending_pipeline_after_download" in sensor_names

--- a/tests/unit/enrichers/conftest.py
+++ b/tests/unit/enrichers/conftest.py
@@ -4,6 +4,22 @@ import pandas as pd
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def disable_production_retry_waits(monkeypatch):
+    """Keep unit tests from paying real API retry backoff delays.
+
+    Tests that assert a sleep call replace these stubs with their own mocks.
+    Integration tests retain the production waits because this fixture is
+    scoped to ``tests/unit/enrichers``.
+    """
+
+    async def no_async_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("sbir_etl.enrichers.base_client.asyncio.sleep", no_async_sleep)
+    monkeypatch.setattr("sbir_etl.enrichers.openai_client.time.sleep", lambda _seconds: None)
+
+
 @pytest.fixture
 def enricher_sbir_df():
     """Sample SBIR DataFrame for enricher tests.

--- a/tests/unit/sensors/test_usaspending_refresh_sensor.py
+++ b/tests/unit/sensors/test_usaspending_refresh_sensor.py
@@ -1,0 +1,89 @@
+"""Behavioral contracts for the USAspending refresh sensor."""
+
+from unittest.mock import Mock
+
+import pytest
+from dagster import (
+    AssetKey,
+    AssetMaterialization,
+    DagsterInstance,
+    RunRequest,
+    SkipReason,
+    build_sensor_context,
+)
+
+from sbir_analytics.assets.sensors.usaspending_refresh_sensor import (
+    usaspending_refresh_sensor,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.fixture
+def instance():
+    with DagsterInstance.ephemeral() as ephemeral:
+        yield ephemeral
+
+
+def _materialize(instance, key: str, **metadata):
+    instance.report_runless_asset_event(
+        AssetMaterialization(asset_key=AssetKey(key), metadata=metadata)
+    )
+
+
+def test_skips_before_bulk_enrichment_is_materialized(instance):
+    result = usaspending_refresh_sensor(build_sensor_context(instance=instance))
+
+    assert isinstance(result, SkipReason)
+    assert result.skip_message == "Bulk enrichment asset not yet materialized"
+
+
+def test_skips_when_no_awards_are_stale(instance):
+    _materialize(instance, "enriched_sbir_awards")
+    _materialize(instance, "usaspending_freshness_ledger")
+    _materialize(instance, "stale_usaspending_awards", stale_count=0)
+
+    result = usaspending_refresh_sensor(build_sensor_context(instance=instance))
+
+    assert isinstance(result, SkipReason)
+    assert result.skip_message == "No stale awards found - refresh not needed"
+
+
+def test_stale_materialization_produces_a_stable_deduplicating_run_key(instance):
+    _materialize(instance, "enriched_sbir_awards")
+    _materialize(instance, "usaspending_freshness_ledger")
+    _materialize(instance, "stale_usaspending_awards", stale_count=3)
+    context = build_sensor_context(instance=instance)
+    stale_record = instance.get_latest_materialization_event(AssetKey("stale_usaspending_awards"))
+    assert stale_record is not None
+
+    first = usaspending_refresh_sensor(context)
+    second = usaspending_refresh_sensor(context)
+
+    assert isinstance(first, RunRequest)
+    assert isinstance(second, RunRequest)
+    assert first.run_key == second.run_key == f"usaspending_refresh_{stale_record.timestamp}"
+    assert first.tags == {"source": "usaspending", "trigger": "sensor"}
+
+
+def test_first_refresh_uses_enrichment_materialization_for_run_key(instance):
+    _materialize(instance, "enriched_sbir_awards")
+    enrichment_record = instance.get_latest_materialization_event(AssetKey("enriched_sbir_awards"))
+    assert enrichment_record is not None
+
+    result = usaspending_refresh_sensor(build_sensor_context(instance=instance))
+
+    assert isinstance(result, RunRequest)
+    assert result.run_key == f"usaspending_refresh_{enrichment_record.timestamp}"
+
+
+def test_instance_errors_fail_the_sensor_tick(instance, monkeypatch):
+    monkeypatch.setattr(
+        instance,
+        "get_latest_materialization_event",
+        Mock(side_effect=RuntimeError("storage down")),
+    )
+
+    with pytest.raises(RuntimeError, match="storage down"):
+        usaspending_refresh_sensor(build_sensor_context(instance=instance))


### PR DESCRIPTION
## Summary

- validate the complete Dagster definitions graph, schedule defaults, and sensor registration on every PR
- make the USAspending refresh sensor deduplicate ticks with a stable materialization-derived run key and surface instance failures
- add a path-filtered Neo4j integration lane that runs alongside the existing four duration-balanced unit shards
- defer Neo4j startup until integration-test execution instead of starting a container during collection
- remove real retry backoff sleeps from enricher unit tests only
- validate Dagster definitions inside the built runtime image
- leave weekly CI/materialization behavior unchanged

## Why

The repo already had a good four-shard PR unit-test matrix, but expensive waits and import-time service startup made local and CI feedback slower than necessary. It also lacked fast Dagster repository contracts and a PR-time real Neo4j contract for graph persistence changes.

The new integration and Docker work remains conditional, so ordinary PRs keep the fast path.

## Performance

- retry-heavy enricher tests: 203 tests reduced from about 76s to 0.55s
- full non-slow unit suite: 5,553 passed in 51.88s serial
- four duration-balanced unit shards: all passed concurrently in about 16s locally per shard
- conditional integration suite: 153 passed, 2 skipped in 91.93s

## Validation

- Ruff check and format
- MyPy (239 source files)
- architecture, repository hygiene, study manifest, and identity guards
- actionlint and both Docker Compose configurations
- focused Dagster definition/sensor contracts after rebasing: 8 passed
- local Python 3.11 image build
- containerized `dagster --version`
- containerized `dagster definitions validate -m sbir_analytics.definitions`
