### PR TITLE
Adopt semantic versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,16 @@ Fixes # (issue)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 
+## Versioning Impact
+
+- [ ] No release impact (internal or unreleased work)
+- [ ] PATCH: backward-compatible fix or documentation correction
+- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
+- [ ] MAJOR: incompatible public change after `1.0.0`
+
+See [the versioning policy](../docs/steering/versioning.md). The release PR applies the selected
+increment across all four packages.
+
 ## Testing
 
 Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,0 +1,30 @@
+name: Version Policy
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+    tags: ["*"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-version:
+    name: Validate synchronized SemVer
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Validate project versions and release tag
+        shell: bash
+        run: |
+          args=()
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            args+=(--tag "${GITHUB_REF_NAME}")
+          fi
+          python scripts/ci/check_versioning.py "${args[@]}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,8 @@ Transition scoring changes must maintain ≥85% precision benchmark.
   [docs/steering/versioning.md](docs/steering/versioning.md).
 - Treat the root project and all packages under `packages/` as one synchronized release.
 - Release tags must be annotated and named `vMAJOR.MINOR.PATCH`; the version stored in every
-  `pyproject.toml` and in `uv.lock` must match the tag without the `v` prefix.
+  `pyproject.toml`, `uv.lock`, `sbir_etl.__version__`, and `config/base.yaml`'s pipeline metadata
+  must match the tag without the `v` prefix.
 - Do not move, replace, or reuse a published tag or version. Release corrections require a new
   version.
 - Before proposing or preparing a release, classify user-visible changes since the latest release,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,19 @@ make docs-check                        # Links, stale commands, and repository h
 
 Transition scoring changes must maintain ≥85% precision benchmark.
 
+## Releases and versioning
+
+- Follow [Semantic Versioning 2.0.0](https://semver.org/) and the repository policy in
+  [docs/steering/versioning.md](docs/steering/versioning.md).
+- Treat the root project and all packages under `packages/` as one synchronized release.
+- Release tags must be annotated and named `vMAJOR.MINOR.PATCH`; the version stored in every
+  `pyproject.toml` and in `uv.lock` must match the tag without the `v` prefix.
+- Do not move, replace, or reuse a published tag or version. Release corrections require a new
+  version.
+- Before proposing or preparing a release, classify user-visible changes since the latest release,
+  select the required version increment, update all version metadata, run `uv lock`, and run
+  `uv run python scripts/ci/check_versioning.py --tag vMAJOR.MINOR.PATCH`.
+
 ## Code Standards
 
 - Line length: 100

--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ brings one up along with the supporting services. See
 > designed to run locally, but full end-to-end reproduction requires source-data
 > downloads, API credentials, and local services such as Neo4j.
 
+## Versioning
+
+The repository follows [Semantic Versioning 2.0.0](https://semver.org/) with synchronized
+versions for the root ETL project and the three packages under `packages/`. Git release tags use
+the form `vMAJOR.MINOR.PATCH`. See the [versioning and release policy](docs/steering/versioning.md)
+for compatibility boundaries, increment rules, and the release checklist.
+
 ## Limitations
 
 - **Entity resolution is probabilistic.** Cross-dataset matches use fuzzy logic

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.1.0"
+  version: "0.1.1"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,7 @@ Use these before quoting a result or starting a feature from an old spec.
 | Developer navigation | [Development index](development/README.md) |
 | Containers | [Docker development](development/docker.md) |
 | Tests and CI | [Testing index](testing/index.md) |
+| Versioning and releases | [Versioning policy](steering/versioning.md) |
 | Performance measurement | [Performance runbook](performance.md) |
 | Deployment navigation | [Deployment index](deployment/README.md) |
 | Live Mac mini operations | [Mac mini runbook](deployment/mac-mini-server.md) |

--- a/docs/steering/versioning.md
+++ b/docs/steering/versioning.md
@@ -1,0 +1,79 @@
+# Versioning and Releases
+
+This repository follows [Semantic Versioning 2.0.0](https://semver.org/). A release version has
+the form `MAJOR.MINOR.PATCH`; Git tags add the conventional `v` prefix, for example `v0.2.0`.
+
+## Release unit
+
+SBIR Analytics is versioned as a synchronized monorepo. These projects always carry the same
+version:
+
+- `sbir-etl` in the root `pyproject.toml`
+- `sbir-analytics` in `packages/sbir-analytics/pyproject.toml`
+- `sbir-graph` in `packages/sbir-graph/pyproject.toml`
+- `sbir-ml` in `packages/sbir-ml/pyproject.toml`
+
+`uv.lock` must record the same version for all four local packages. Independent package versions
+are intentionally out of scope until the packages have separate release cadences or consumers.
+
+## Compatibility surface
+
+Version decisions cover behavior on which a user, downstream script, or deployment can reasonably
+depend:
+
+- documented Python imports, functions, classes, and command-line entry points;
+- configuration keys and their documented meaning;
+- Dagster asset keys, job names, partitions, and materialization contracts;
+- persisted DuckDB, Parquet, and Neo4j schemas and stable identifiers;
+- documented inputs, outputs, and operational commands.
+
+Research findings, internal implementation details, experimental scripts, and explicitly unstable
+specs are not public API. They can still justify a minor release when their change is substantial or
+user-visible.
+
+## Increment rules
+
+The project remains in initial development under major version zero. Until `1.0.0`, use:
+
+- **PATCH** (`0.1.1` → `0.1.2`) for backward-compatible fixes, documentation corrections, and
+  internal maintenance that does not add a compatibility surface.
+- **MINOR** (`0.1.1` → `0.2.0`) for new capabilities, substantial research or pipeline features,
+  deprecations, and breaking changes during initial development. Call out every breaking change in
+  the release notes.
+- **MAJOR** (`0.x.y` → `1.0.0`) when the public compatibility surface is deliberately declared
+  stable. After `1.0.0`, incompatible public changes require a major increment.
+
+When a release contains several change types, choose the largest required increment. Reset lower
+components to zero when incrementing a higher component. Pre-release and build identifiers are
+valid SemVer extensions, but this repository currently uses normal `MAJOR.MINOR.PATCH` releases
+only. Introduce those identifiers only with a corresponding Python-packaging and checker update.
+
+## Historical releases
+
+The first two tag names predate this policy and remain immutable:
+
+- `0.1` represents semantic version `0.1.0`.
+- `v0.11` represents semantic version `0.1.1` (the patch separator was omitted).
+
+Do not rename, move, or delete those published tags. All subsequent release tags must use the full
+`vMAJOR.MINOR.PATCH` form.
+
+## Release checklist
+
+1. Review user-visible changes since the latest release and choose the required increment.
+2. Update all four `pyproject.toml` versions to the same `MAJOR.MINOR.PATCH` value.
+3. Run `uv lock` to update the four local-package entries in `uv.lock`.
+4. Run `uv run python scripts/ci/check_versioning.py --tag vMAJOR.MINOR.PATCH`.
+5. Confirm the relevant test and quality checks are green.
+6. Commit the release preparation before creating an annotated tag:
+
+   ```bash
+   git tag -a vMAJOR.MINOR.PATCH -m "Release vMAJOR.MINOR.PATCH"
+   git push origin vMAJOR.MINOR.PATCH
+   ```
+
+7. Create the GitHub release from that tag and include highlights, compatibility notes, and a full
+   changelog link.
+
+Published versions are immutable. If release notes or artifacts expose a defect, publish the fix
+under a new version instead of changing the tagged contents.

--- a/docs/steering/versioning.md
+++ b/docs/steering/versioning.md
@@ -16,6 +16,12 @@ version:
 `uv.lock` must record the same version for all four local packages. Independent package versions
 are intentionally out of scope until the packages have separate release cadences or consumers.
 
+Runtime release metadata must match that synchronized version as well. The authoritative Python
+runtime marker is `sbir_etl.__version__`; pipeline defaults, HTTP User-Agents, and package-level
+compatibility aliases derive from it. The `pipeline.version` value in `config/base.yaml` is also
+release metadata because deployed configuration can override the Python default. The versioning
+checker validates both static sources against the package metadata.
+
 ## Compatibility surface
 
 Version decisions cover behavior on which a user, downstream script, or deployment can reasonably
@@ -61,8 +67,10 @@ Do not rename, move, or delete those published tags. All subsequent release tags
 ## Release checklist
 
 1. Review user-visible changes since the latest release and choose the required increment.
-2. Update all four `pyproject.toml` versions to the same `MAJOR.MINOR.PATCH` value.
-3. Run `uv lock` to update the four local-package entries in `uv.lock`.
+2. Update all four `pyproject.toml` versions, `sbir_etl.__version__`, and
+   `config/base.yaml`'s `pipeline.version` to the same `MAJOR.MINOR.PATCH` value.
+3. Run `uv lock` to update the four local-package entries in `uv.lock`; runtime defaults and
+   User-Agents derive from `sbir_etl.__version__` and do not need separate edits.
 4. Run `uv run python scripts/ci/check_versioning.py --tag vMAJOR.MINOR.PATCH`.
 5. Confirm the relevant test and quality checks are green.
 6. Commit the release preparation before creating an annotated tag:

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.1.0"
+version = "0.1.1"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-analytics/sbir_analytics/tools/base.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/base.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import pandas as pd
 from loguru import logger
+from sbir_etl import __version__
 
 
 @dataclass
@@ -168,7 +169,7 @@ class BaseTool(ABC):
     """
 
     name: str = "base_tool"
-    version: str = "0.1.0"
+    version: str = __version__
 
     def __init__(self, **kwargs: Any):
         self._config = kwargs

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.1.0"
+version = "0.1.1"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.1.0"
+version = "0.1.1"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-ml/sbir_ml/transition/__init__.py
+++ b/packages/sbir-ml/sbir_ml/transition/__init__.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 import dataclasses
 from typing import Any
 
+from sbir_etl import __version__
+
 from .evaluation.evaluator import ConfusionMatrix, EvaluationResult, TransitionEvaluator
-
-
-__version__ = "0.1.0"
 
 # Default scoring weights / thresholds for transition detection. These are
 # conservative; operational teams should override via the detector pipeline's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.1.0"
+version = "0.1.1"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -1,3 +1,3 @@
 """SBIR ETL Pipeline - Extract, Transform, Load pipeline for SBIR awards data."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/sbir_etl/config/schemas/pipeline.py
+++ b/sbir_etl/config/schemas/pipeline.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ... import __version__
 from .data import (
     CLIConfig,
     CompanyCategorizationConfig,
@@ -36,7 +37,7 @@ class PipelineMetadata(BaseModel, Mapping[str, Any]):
     """Metadata for the configured pipeline with dual dict/attribute access."""
 
     name: str = Field(default="sbir-analytics", description="Pipeline identifier")
-    version: str = Field(default="0.1.0", description="Semantic version of the pipeline")
+    version: str = Field(default=__version__, description="Semantic version of the pipeline")
     environment: str = Field(default="development", description="Active environment name")
 
     model_config = ConfigDict(extra="allow")

--- a/sbir_etl/enrichers/base_client.py
+++ b/sbir_etl/enrichers/base_client.py
@@ -16,6 +16,7 @@ import httpx
 from loguru import logger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from .. import __version__
 from ..exceptions import APIError, ConfigurationError, RateLimitError
 from .rate_limiting import RateLimiter
 
@@ -78,7 +79,7 @@ class BaseAsyncAPIClient:
         """Build default request headers. Override to add auth headers."""
         return {
             "Accept": "application/json",
-            "User-Agent": "SBIR-Analytics/0.1.0",
+            "User-Agent": f"SBIR-Analytics/{__version__}",
         }
 
     async def _request_raw(

--- a/sbir_etl/enrichers/sec_edgar/client.py
+++ b/sbir_etl/enrichers/sec_edgar/client.py
@@ -19,6 +19,7 @@ import httpx
 from loguru import logger
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from ... import __version__
 from ...config.loader import get_config
 from ...exceptions import APIError
 from ..base_client import BaseAsyncAPIClient
@@ -153,7 +154,7 @@ class EdgarAPIClient(BaseAsyncAPIClient):
         """Build headers with SEC-required User-Agent."""
         headers = super()._build_headers()
         if self.contact_email:
-            headers["User-Agent"] = f"SBIR-Analytics/0.1.0 ({self.contact_email})"
+            headers["User-Agent"] = f"SBIR-Analytics/{__version__} ({self.contact_email})"
         return headers
 
     async def _get_json(self, url: str) -> httpx.Response:

--- a/scripts/ci/check_versioning.py
+++ b/scripts/ci/check_versioning.py
@@ -2,6 +2,7 @@
 """Validate synchronized SemVer metadata and an optional Git release tag."""
 
 import argparse
+import ast
 import re
 import sys
 import tomllib
@@ -16,12 +17,47 @@ PROJECTS = {
     "sbir-ml": ROOT / "packages/sbir-ml/pyproject.toml",
 }
 LOCK_FILE = ROOT / "uv.lock"
+RUNTIME_VERSION_FILE = ROOT / "sbir_etl/__init__.py"
+BASE_CONFIG_FILE = ROOT / "config/base.yaml"
 SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
 def load_toml(path: Path) -> dict:
     with path.open("rb") as handle:
         return tomllib.load(handle)
+
+
+def load_python_string(path: Path, variable: str) -> str:
+    """Read a module-level string assignment without importing project code."""
+    module = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == variable for target in node.targets):
+            if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                return node.value.value
+            break
+    raise ValueError(f"{path} does not define {variable} as a string literal")
+
+
+def load_base_pipeline_version(path: Path) -> str:
+    """Read ``pipeline.version`` from the simple top-level YAML mapping."""
+    in_pipeline = False
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if not line[0].isspace():
+            if in_pipeline:
+                break
+            in_pipeline = line == "pipeline:"
+            continue
+        if in_pipeline and line.lstrip().startswith("version:"):
+            value = line.split(":", 1)[1].strip().strip("\"'")
+            if value:
+                return value
+            break
+    raise ValueError(f"{path} does not define pipeline.version")
 
 
 def validate(tag: str | None = None) -> list[str]:
@@ -48,6 +84,20 @@ def validate(tag: str | None = None) -> list[str]:
         locked = lock_packages.get(name)
         if locked != version:
             errors.append(f"uv.lock has {name}={locked!r}; expected {version!r}")
+
+    if len(versions) == 1:
+        expected_version = next(iter(versions))
+        try:
+            runtime_versions = {
+                "sbir_etl.__version__": load_python_string(RUNTIME_VERSION_FILE, "__version__"),
+                "config/base.yaml pipeline.version": load_base_pipeline_version(BASE_CONFIG_FILE),
+            }
+        except (OSError, SyntaxError, ValueError) as exc:
+            errors.append(f"could not read runtime version metadata: {exc}")
+        else:
+            for source, runtime_version in runtime_versions.items():
+                if runtime_version != expected_version:
+                    errors.append(f"{source} is {runtime_version!r}; expected {expected_version!r}")
 
     if tag and len(versions) == 1:
         expected_tag = f"v{next(iter(versions))}"

--- a/scripts/ci/check_versioning.py
+++ b/scripts/ci/check_versioning.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Validate synchronized SemVer metadata and an optional Git release tag."""
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+PROJECTS = {
+    "sbir-etl": ROOT / "pyproject.toml",
+    "sbir-analytics": ROOT / "packages/sbir-analytics/pyproject.toml",
+    "sbir-graph": ROOT / "packages/sbir-graph/pyproject.toml",
+    "sbir-ml": ROOT / "packages/sbir-ml/pyproject.toml",
+}
+LOCK_FILE = ROOT / "uv.lock"
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def load_toml(path: Path) -> dict:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def validate(tag: str | None = None) -> list[str]:
+    errors: list[str] = []
+    project_versions = {
+        name: load_toml(path)["project"]["version"] for name, path in PROJECTS.items()
+    }
+
+    for name, version in project_versions.items():
+        if not SEMVER.fullmatch(version):
+            errors.append(f"{name} has non-SemVer version {version!r}")
+
+    versions = set(project_versions.values())
+    if len(versions) != 1:
+        details = ", ".join(f"{name}={version}" for name, version in project_versions.items())
+        errors.append(f"project versions are not synchronized: {details}")
+
+    lock_packages = {
+        package["name"]: package["version"]
+        for package in load_toml(LOCK_FILE)["package"]
+        if package["name"] in PROJECTS
+    }
+    for name, version in project_versions.items():
+        locked = lock_packages.get(name)
+        if locked != version:
+            errors.append(f"uv.lock has {name}={locked!r}; expected {version!r}")
+
+    if tag and len(versions) == 1:
+        expected_tag = f"v{next(iter(versions))}"
+        if tag != expected_tag:
+            errors.append(f"release tag {tag!r} does not match expected {expected_tag!r}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", help="Release tag to compare with project metadata")
+    args = parser.parse_args()
+
+    errors = validate(args.tag)
+    if errors:
+        for error in errors:
+            print(f"versioning error: {error}", file=sys.stderr)
+        return 1
+
+    version = load_toml(PROJECTS["sbir-etl"])["project"]["version"]
+    suffix = f" and tag {args.tag}" if args.tag else ""
+    print(f"versioning check passed for {version}{suffix}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/test_configuration_environments.py
+++ b/tests/integration/test_configuration_environments.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from sbir_etl import __version__
+
 
 pytestmark = pytest.mark.integration
 
@@ -85,7 +87,7 @@ class TestConfigurationEnvironments:
         # Prod environment should have specific settings
         assert config.neo4j.uri.startswith("bolt://")
         assert config.pipeline.environment == "production"
-        assert config.pipeline.version == "0.1.0"
+        assert config.pipeline.version == __version__
         assert config.duckdb.memory_limit_gb == 8
 
     def test_load_production_alias(self, config_dir, monkeypatch):
@@ -98,7 +100,7 @@ class TestConfigurationEnvironments:
         )
 
         assert config.pipeline.environment == "production"
-        assert config.pipeline.version == "0.1.0"
+        assert config.pipeline.version == __version__
         assert config.duckdb.memory_limit_gb == 8
         assert config.neo4j.database == "analytics"
 

--- a/tests/unit/config/test_schemas.py
+++ b/tests/unit/config/test_schemas.py
@@ -3,6 +3,8 @@
 from pathlib import Path
 
 import pytest
+
+from sbir_etl import __version__
 from pydantic import ValidationError
 
 from sbir_etl.config.schemas import (
@@ -773,7 +775,7 @@ class TestPipelineConfig:
         config = PipelineConfig()
         assert isinstance(config.pipeline, PipelineMetadata)
         assert config.pipeline["name"] == "sbir-analytics"
-        assert config.pipeline["version"] == "0.1.0"
+        assert config.pipeline["version"] == __version__
         assert config.pipeline["environment"] == "development"
         assert isinstance(config.paths, PathsConfig)
         assert isinstance(config.data_quality, DataQualityConfig)

--- a/tests/unit/enrichers/test_base_client.py
+++ b/tests/unit/enrichers/test_base_client.py
@@ -19,6 +19,8 @@ from unittest.mock import AsyncMock, Mock, patch
 import httpx
 import pytest
 
+from sbir_etl import __version__
+
 from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
 from sbir_etl.exceptions import APIError, ConfigurationError, RateLimitError
 
@@ -163,7 +165,7 @@ class TestDefaultHeaders:
     def test_build_headers_contains_defaults(self, client: _StubAPIClient) -> None:
         headers = client._build_headers()
         assert headers["Accept"] == "application/json"
-        assert headers["User-Agent"] == "SBIR-Analytics/0.1.0"
+        assert headers["User-Agent"] == f"SBIR-Analytics/{__version__}"
 
     def test_build_headers_is_override_point(self) -> None:
         """Subclasses can extend ``_build_headers`` to inject auth."""
@@ -277,7 +279,7 @@ class TestMakeRequestSuccess:
         call_headers = mock_http_client.get.call_args[1]["headers"]
         assert call_headers["X-Custom"] == "hello"
         assert call_headers["Accept"] == "application/json"
-        assert call_headers["User-Agent"] == "SBIR-Analytics/0.1.0"
+        assert call_headers["User-Agent"] == f"SBIR-Analytics/{__version__}"
 
     async def test_custom_headers_can_override_defaults(
         self, client: _StubAPIClient, mock_http_client: AsyncMock

--- a/tests/unit/scripts/test_check_versioning.py
+++ b/tests/unit/scripts/test_check_versioning.py
@@ -1,0 +1,65 @@
+"""Tests for synchronized release and runtime version validation."""
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "ci" / "check_versioning.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_versioning", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+
+
+def _configure_fixture(monkeypatch, tmp_path: Path, *, runtime: str, pipeline: str) -> None:
+    project_paths = {}
+    for name in mod.PROJECTS:
+        path = tmp_path / name / "pyproject.toml"
+        path.parent.mkdir()
+        path.write_text(f'[project]\nname = "{name}"\nversion = "0.1.1"\n', encoding="utf-8")
+        project_paths[name] = path
+
+    lock_file = tmp_path / "uv.lock"
+    lock_file.write_text(
+        "".join(f'[[package]]\nname = "{name}"\nversion = "0.1.1"\n' for name in project_paths),
+        encoding="utf-8",
+    )
+    runtime_file = tmp_path / "sbir_etl" / "__init__.py"
+    runtime_file.parent.mkdir()
+    runtime_file.write_text(f'__version__ = "{runtime}"\n', encoding="utf-8")
+    base_config = tmp_path / "config" / "base.yaml"
+    base_config.parent.mkdir()
+    base_config.write_text(
+        f'pipeline:\n  name: "sbir-analytics"\n  version: "{pipeline}"\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(mod, "PROJECTS", project_paths)
+    monkeypatch.setattr(mod, "LOCK_FILE", lock_file)
+    monkeypatch.setattr(mod, "RUNTIME_VERSION_FILE", runtime_file)
+    monkeypatch.setattr(mod, "BASE_CONFIG_FILE", base_config)
+
+
+def test_validate_accepts_synchronized_runtime_versions(monkeypatch, tmp_path: Path) -> None:
+    _configure_fixture(monkeypatch, tmp_path, runtime="0.1.1", pipeline="0.1.1")
+
+    assert mod.validate("v0.1.1") == []
+
+
+def test_validate_rejects_stale_python_runtime_version(monkeypatch, tmp_path: Path) -> None:
+    _configure_fixture(monkeypatch, tmp_path, runtime="0.1.0", pipeline="0.1.1")
+
+    assert "sbir_etl.__version__ is '0.1.0'; expected '0.1.1'" in mod.validate()
+
+
+def test_validate_rejects_stale_pipeline_config_version(monkeypatch, tmp_path: Path) -> None:
+    _configure_fixture(monkeypatch, tmp_path, runtime="0.1.1", pipeline="0.1.0")
+
+    assert "config/base.yaml pipeline.version is '0.1.0'; expected '0.1.1'" in mod.validate()

--- a/tests/utils/config_mocks.py
+++ b/tests/utils/config_mocks.py
@@ -23,6 +23,7 @@ try:
 except ImportError:
     pytest = None  # pytest only needed for fixtures, not factory functions
 
+from sbir_etl import __version__
 from sbir_etl.config.schemas import PipelineConfig
 
 
@@ -52,7 +53,7 @@ def create_mock_pipeline_config(**overrides: Any) -> PipelineConfig:
     config_dict: dict[str, Any] = {
         "pipeline": {
             "name": "sbir-analytics",
-            "version": "0.1.0",
+            "version": __version__,
             "environment": "test",
         },
         "paths": {

--- a/uv.lock
+++ b/uv.lock
@@ -2576,7 +2576,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2603,7 +2603,7 @@ provides-extras = ["r", "modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2740,7 +2740,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -2759,7 +2759,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Summary

- define a synchronized SemVer policy for the root project and all three workspace packages
- document historical tag mappings: `0.1` → `0.1.0` and `v0.11` → `0.1.1`
- align all project metadata and `uv.lock` at `0.1.1`
- add a version checker and GitHub Actions workflow that enforce full `vMAJOR.MINOR.PATCH` tags
- add release guidance to the canonical agent instructions and version-impact choices to the PR template

## Why

The existing tags omit a version component and package metadata remained at `0.1.0`, leaving the repository without an authoritative release convention. This establishes one policy without moving or replacing the published tags.

After this PR, the next fix-only release is `v0.1.2`; the next capability or breaking `0.x` release is `v0.2.0`.

## Validation

- `make docs-check`
- `uv lock --check`
- `uv run --frozen python scripts/ci/check_versioning.py --tag v0.1.1`
- `uv run --frozen --extra dev ruff check scripts/ci/check_versioning.py`
- `uv run --frozen --extra dev ruff format --check scripts/ci/check_versioning.py`
- workflow YAML parse check
- verified that the historical short tag `v0.11` is rejected by the new checker
