### PR TITLE
Improve developer onboarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,11 @@
 # -----------------------
 # Neo4j authentication (username/password). Use a strong password for real deployments.
 NEO4J_USER=neo4j
-NEO4J_PASSWORD=change_me
+NEO4J_PASSWORD=test
+
+# Host-local processes connect through the published Docker port. Compose
+# overrides this with the internal service hostname for container processes.
+NEO4J_URI=bolt://localhost:7687
 
 # Neo4j plugins and memory tuning (optional examples)
 # Use JSON array notation for plugins; keep as example values here.
@@ -30,11 +34,11 @@ DOCKER_IMAGE_NAME=sbir-etl:latest
 # -----------------------
 # SBIR ETL application-specific variables
 # -----------------------
-# Canonical Neo4j Bolt URL used by the application (compose service host in dev)
-SBIR_ETL__NEO4J__BOLT_URL=bolt://neo4j:7687
+# Canonical Neo4j Bolt URL used by host-local application processes
+SBIR_ETL__NEO4J__BOLT_URL=bolt://localhost:7687
 
 # Individual connection pieces (application may prefer either URL or these pieces)
-SBIR_ETL__NEO4J__HOST=neo4j
+SBIR_ETL__NEO4J__HOST=localhost
 SBIR_ETL__NEO4J__PORT=7687
 SBIR_ETL__NEO4J__USERNAME=${NEO4J_USER}
 SBIR_ETL__NEO4J__PASSWORD=${NEO4J_PASSWORD}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing
+
+Thanks for helping improve the SBIR/STTR commercialization analytics project.
+This is an experimental research codebase, so a useful contribution should make
+a research result more trustworthy, reproducible, or understandable without
+adding unnecessary operational complexity.
+
+## Before You Start
+
+Read the [research questions](docs/research-questions.md) first. They are the
+scope gate for features and analyses. For implementation work, also review the
+[architecture overview](docs/architecture/detailed-overview.md) and any relevant
+document under `docs/steering/` or `specs/`.
+
+## Set Up a Development Environment
+
+The supported Python versions are 3.11 and 3.12. From the repository root:
+
+```bash
+make install
+cp .env.example .env
+make setup-local
+make doctor
+make test-smoke
+```
+
+See the full [getting-started guide](docs/getting-started/README.md) to generate
+sample data, start Dagster, or run Neo4j. The synthetic sample workflow does not
+require external API credentials.
+
+## Find the Right Place to Make a Change
+
+| Area | Location |
+|---|---|
+| Reusable extraction, enrichment, validation, and models | `sbir_etl/` |
+| Dagster assets, jobs, and sensors | `packages/sbir-analytics/` |
+| Neo4j loaders and queries | `packages/sbir-graph/` |
+| CET and transition ML or heuristics | `packages/sbir-ml/` |
+| Focused operational and analysis entry points | `scripts/` |
+| Architecture and methodology | `docs/` |
+| Feature requirements and task tracking | `specs/` |
+
+Archived scripts and specifications are historical context, not active
+extension points. If archived behavior needs to become active again, move it to
+the appropriate live directory and add focused tests and documentation.
+
+## Develop and Verify
+
+Keep changes surgical and use the narrowest useful test while iterating:
+
+```bash
+uv run pytest path/to/test_file.py -v
+make test-smoke
+make test-unit
+make lint
+```
+
+Run broader integration or end-to-end suites when the change crosses service or
+pipeline boundaries. Those suites may require Docker, credentials, or local
+datasets; the [testing index](docs/testing/index.md) documents the requirements.
+
+The project uses Ruff for formatting and linting and MyPy for type checking.
+Install the optional local hooks with:
+
+```bash
+uv run pre-commit install
+```
+
+Do not add real credentials, private datasets, or generated research outputs to
+the repository. Prefer fixtures, temporary directories, and the synthetic sample
+generator for reproducible tests.
+
+## Open a Pull Request
+
+A pull request should:
+
+1. Explain the problem and why the change is in scope.
+2. Identify the research question, bug, or maintenance need it supports.
+3. Describe the user or developer impact.
+4. Include focused tests or explain why the change is documentation-only.
+5. Update affected documentation, configuration examples, and data contracts.
+6. Avoid unrelated cleanup.
+
+Use a draft pull request while the implementation or validation is incomplete.
+Document any test that could not be run and the credentials, data, or service it
+requires.

--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,19 @@ install-core: ## Install only the reusable sbir-etl library dependencies
 	@$(call info,Installing core sbir-etl dependencies)
 	$(call run,uv sync)
 
+.PHONY: doctor
+doctor: ## Verify the local Python development environment
+	@$(call info,Checking local development environment)
+	@command -v uv >/dev/null 2>&1 || { \
+	  printf "$(RED)✖$(RESET) uv is not installed\n"; \
+	  exit 1; \
+	}
+	$(call run,uv run --no-sync python -c 'import sys; assert sys.version_info.major == 3 and 11 <= sys.version_info.minor < 13')
+	$(call run,uv run --no-sync python -c 'import dagster; import pytest; import sbir_analytics; import sbir_etl; import sbir_graph; import sbir_ml')
+	$(call run,uv run --no-sync ruff --version)
+	$(call run,uv run --no-sync mypy --version)
+	@$(call success,Development environment is ready)
+
 .PHONY: test
 test: ## Run all tests
 	@$(call info,Running tests)
@@ -168,6 +181,11 @@ test: ## Run all tests
 test-unit: ## Run unit tests only
 	@$(call info,Running unit tests)
 	$(call run,uv run pytest tests/unit/ -v)
+
+.PHONY: test-smoke
+test-smoke: ## Run a fast, data-free onboarding smoke test
+	@$(call info,Running onboarding smoke tests)
+	$(call run,uv run pytest -n 0 tests/unit/test_models.py tests/unit/assets/test_asset_discovery.py -v)
 
 .PHONY: test-integration
 test-integration: ## Run integration tests only

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,11 @@ x-common-environment: &common-environment
   PYTHONUNBUFFERED: 1
   SERVICE_STARTUP_TIMEOUT: ${SERVICE_STARTUP_TIMEOUT:-120}
   # Neo4j connection settings
-  SBIR_ETL__NEO4J__HOST: ${SBIR_ETL__NEO4J__HOST:-neo4j}
-  SBIR_ETL__NEO4J__PORT: ${SBIR_ETL__NEO4J__PORT:-7687}
-  NEO4J_URI: ${NEO4J_URI:-bolt://neo4j:7687}
+  # Container processes always use the Compose service hostname. `.env.example`
+  # uses localhost for Python processes running directly on the host.
+  SBIR_ETL__NEO4J__HOST: neo4j
+  SBIR_ETL__NEO4J__PORT: 7687
+  NEO4J_URI: bolt://neo4j:7687
   NEO4J_USER: ${NEO4J_USER:-neo4j}
   NEO4J_PASSWORD: ${NEO4J_PASSWORD:-password}
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,7 +1,7 @@
 ---
 Type: Overview
 Owner: devops@project
-Last-Reviewed: 2026-08-03
+Last-Reviewed: 2026-08-04
 Status: active
 ---
 
@@ -12,6 +12,7 @@ be explained in one place so the instructions do not drift apart.
 
 ## Start here
 
+- [Contributing](../../CONTRIBUTING.md) - Scope, setup, verification, and pull requests
 - [Getting started](../getting-started/README.md) - Installation and first local run
 - [Docker development](docker.md) - Compose profiles, data, and troubleshooting
 - [Testing index](../testing/index.md) - Local, Docker, E2E, and CI verification

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -1,93 +1,124 @@
 # Getting Started
 
-> **Operational data caveat.** No SBIR/STTR award data is committed to this repository. The setup commands below install dependencies and start local development services; they do not recreate the full research dataset by themselves. Full dataset reproduction requires downloading source/bulk data, adding your own API credentials to `.env`, and running supporting services such as Neo4j, so reproducing the analyses end-to-end is non-trivial.
+This guide gets a new developer from a fresh clone to a tested local environment
+and a successful Dagster materialization using generated sample data.
 
-
-Quick setup guide for the SBIR ETL pipeline.
+> **Data caveat:** No operational SBIR/STTR award data is committed to this
+> repository. The sample-data path below is intentionally small and synthetic.
+> Reproducing the research analyses requires source downloads, API credentials,
+> and additional local services.
 
 ## Prerequisites
 
 - Python 3.11 or 3.12
-- [`uv`](https://github.com/astral-sh/uv) for dependency management
-- Docker (optional, for local Neo4j)
+- [`uv`](https://docs.astral.sh/uv/getting-started/installation/)
+- `make`
+- Docker with Compose V2 if you want Neo4j or the containerized stack
 
-## Local Development
+## Local Python Quick Start
 
-The project supports Python 3.11 or 3.12 and uses `uv` for dependency management. The recommended
-local flow mirrors the repository README:
+From a fresh clone:
 
 ```bash
-# Clone and install
-git clone https://github.com/hollomancer/sbir-analytics
+git clone https://github.com/hollomancer/sbir-analytics.git
 cd sbir-analytics
-make install  # full stack: sbir_etl + Dagster + ML + graph packages
 
-# Copy environment template
+# Install the ETL library, Dagster application, graph and ML packages, and dev tools.
+make install
+
+# Create and verify local configuration.
 cp .env.example .env
+make setup-local
 
-# Start Dagster UI
+# Verify imports and run a small, data-free test selection.
+make doctor
+make test-smoke
+
+# Create ten synthetic awards plus small SAM.gov, USPTO, and USAspending inputs.
+make sample-data
+
+# Start Dagster and open http://localhost:3000.
 make dev
-# Open http://localhost:3000
 ```
 
-If you prefer to run the underlying commands directly, `make install` is
-equivalent to `uv sync --extra stack-dev`, and `make dev` runs:
+In the Dagster UI, materialize `raw_sbir_awards`. A successful sample run reads
+10 awards from `data/raw/sbir/award_data.csv` and reports them in the asset
+materialization metadata. This asset does not require Neo4j.
+
+`make install` is equivalent to `uv sync --extra stack-dev`. Consumers who only
+need the reusable `sbir_etl` library can use `make install-core` instead.
+
+## Neo4j
+
+Start only Neo4j while running Dagster locally on the host:
 
 ```bash
-uv run dagster dev -m sbir_analytics.definitions
+make neo4j-up
 ```
 
-## Environment Setup
+- Browser: <http://localhost:7474>
+- Bolt: `bolt://localhost:7687`
+- Default local credentials: `neo4j` / `test`
 
-Create `.env` from template:
+The checked-in `.env.example` uses host-local addresses. Docker Compose
+overrides those addresses inside containers so services connect to the `neo4j`
+service hostname.
+
+To run the complete development stack in containers instead:
 
 ```bash
-cp .env.example .env
+make docker-check-prerequisites
+make docker-up-dev
+make docker-verify
 ```
 
-Required variables:
+See the [Docker guide](../development/docker.md) for service profiles, logs, and
+troubleshooting.
+
+## Everyday Development
 
 ```bash
-NEO4J_URI=bolt://localhost:7687
-NEO4J_USER=neo4j
-NEO4J_PASSWORD=password
+make help          # list supported commands
+make test-smoke    # fast local confidence check
+make test-unit     # complete unit suite
+make lint          # Ruff and MyPy
+make docs-check    # repository documentation hygiene
+make format        # apply Ruff formatting and safe lint fixes
 ```
 
-## Neo4j Setup
+The complete testing strategy, markers, and Docker workflows are documented in
+the [testing index](../testing/index.md). Contribution expectations are in
+[CONTRIBUTING.md](../../CONTRIBUTING.md).
 
-Start Neo4j locally with Docker:
+## Optional Credentials and Real Data
 
-```bash
-docker compose --profile dev up neo4j -d
-# Access at http://localhost:7474 (neo4j/password)
-```
+The sample workflow needs no external API credentials. Add credentials to `.env`
+only for the data sources you intend to use. `.env.example` documents the
+supported variables and must remain safe to commit; never commit `.env`.
 
-The equivalent Make target is `make neo4j-up`. Container profiles and lifecycle commands belong in
-the [Docker guide](../development/docker.md).
+For real SBIR award ingestion, place the source CSV at the configured path or
+override `extraction.sbir.csv_path`. See the [configuration reference](../configuration.md)
+and [data documentation](../data/index.md) before running larger materializations.
 
-## First Steps
+## Common Problems
 
-1. **Materialize assets** - In Dagster UI, materialize `raw_sbir_awards`
-2. **View data** - Check Neo4j Browser at <http://localhost:7474>
-3. **Run tests** - `uv run pytest tests/unit/ -v`
+- **`dagster`, `pytest`, or a first-party package is missing:** run `make install`,
+  not `make install-core`, then run `make doctor`.
+- **Unsupported Python version:** use Python 3.11 or 3.12; the project currently
+  excludes Python 3.13.
+- **`raw_sbir_awards` cannot find its CSV:** run `make sample-data` and confirm
+  `data/raw/sbir/award_data.csv` exists.
+- **Neo4j connection fails from host Python:** use `bolt://localhost:7687`.
+- **Neo4j connection fails in Compose:** inspect `make docker-logs SERVICE=neo4j`;
+  containers use `bolt://neo4j:7687` automatically.
+- **Memory pressure:** reduce `SBIR_ETL__ENRICHMENT__PERFORMANCE__CHUNK_SIZE` and
+  confirm the setting in the [configuration reference](../configuration.md).
 
-## Development Workflow
+## Where to Go Next
 
-```bash
-make test-unit
-make check
-```
-
-## Common Issues
-
-- **Neo4j connection failed**: Check `.env` credentials
-- **Import errors**: Run `make install` (or `uv sync --extra stack-dev`) to update the full stack
-- **Memory issues**: Reduce `SBIR_ETL__ENRICHMENT__PERFORMANCE__CHUNK_SIZE`; confirm the setting in
-  the [configuration reference](../configuration.md) before adding another override
-
-## Next Steps
-
-- [Docker Setup](../development/docker.md) - Container-based development
-- [Deployment Guide](../deployment/README.md) - Mac mini and local deployment
-- [Testing Guide](../testing/index.md) - Running tests
-- [Configuration](../configuration.md) - YAML configuration
+- [Research questions](../research-questions.md) — why the repository exists
+- [Architecture overview](../architecture/detailed-overview.md) — package and data flow
+- [Development guides](../development/README.md) — code standards and workflows
+- [Testing index](../testing/index.md) — local and CI validation
+- [Configuration reference](../configuration.md) — YAML and environment overrides
+- [Deployment guide](../deployment/README.md) — Mac mini and local deployment

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -16,16 +16,21 @@ Use Python 3.11 or 3.12 and install the full workspace:
 
 ```bash
 make install
+make doctor
 ```
+
+`make test-smoke` is the fastest data-free check of a new environment.
 
 ## Common commands
 
 ```bash
+make test-smoke
 make test-unit
 make test-integration
 make test-functional
 make test
-make check
+make lint
+make docs-check
 ```
 
 Use pytest directly for focused work:

--- a/packages/sbir-analytics/README.md
+++ b/packages/sbir-analytics/README.md
@@ -8,12 +8,21 @@ tools that don't belong in the reusable ETL library.
 
 ## Installation
 
+From a package index:
+
 ```bash
 # Full pipeline (Dagster + ML + Neo4j)
 pip install sbir-analytics
 
 # ETL library only (no Dagster, ML, or Neo4j)
 pip install sbir-etl
+```
+
+From a repository checkout with development tools:
+
+```bash
+make install       # full workspace; uv sync --extra stack-dev
+make install-core  # reusable sbir-etl library only; uv sync
 ```
 
 ## What's Included

--- a/scripts/setup_dev.sh
+++ b/scripts/setup_dev.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Development Environment Setup Script
-# Run this to set up or verify your development environment
+# CI compatibility setup script. New developers should use `make install` and
+# the canonical walkthrough in docs/getting-started/README.md.
 
 set -e  # Exit on error
 
@@ -77,7 +77,7 @@ echo -e "${GREEN}✓ uv is available${NC}"
 echo ""
 echo "5️⃣  Installing dependencies..."
 echo "   This may take a minute..."
-uv sync --extra dev
+uv sync --extra stack-dev
 
 # Verify installation
 echo ""


### PR DESCRIPTION
## Summary

Improve the fresh-clone developer experience without changing pipeline or research behavior.

- add `make doctor` and a 33-test, data-free `make test-smoke` target
- add `CONTRIBUTING.md` with repository scope, package boundaries, and verification guidance
- separate host-local and Compose-internal Neo4j addressing and unify development credentials
- rewrite the getting-started tutorial around `make sample-data` before the first Dagster materialization
- correct stale testing commands and document package-index versus repository-checkout installation
- reposition `scripts/setup_dev.sh` as a CI-compatibility path aligned with the `stack-dev` environment

## Developer impact

A new contributor now has one canonical sequence:

```bash
make install
cp .env.example .env
make setup-local
make doctor
make test-smoke
make sample-data
make dev
```

The tutorial's first `raw_sbir_awards` materialization uses ten generated awards and does not require external credentials or Neo4j. Host Python connects to `bolt://localhost:7687`; Compose services use `bolt://neo4j:7687`.

Package-index consumers retain normal installation commands:

```bash
pip install sbir-analytics
pip install sbir-etl
```

## Validation

- `make test-smoke` — 33 passed
- `make docs-check` — passed
- `docker compose --env-file .env.example --profile dev config --quiet` — passed
- `bash -n scripts/setup_dev.sh` — passed
- `git diff --check origin/main...HEAD` — passed
- GitHub CI, CodeQL, version policy, and setup-script verification — passed at `fe3d76f`

## Scope

This PR contains onboarding and developer-documentation changes only. The full-stack behavior of `make install` was already present on `main`; this PR adds diagnostics, smoke coverage, clearer environment boundaries, and a reproducible first-run path.