### PR TITLE
feat: add Massachusetts unmanned-systems SBIR/STTR report

### DIFF
--- a/config/tech_census/unmanned_systems_manufacturing.yaml
+++ b/config/tech_census/unmanned_systems_manufacturing.yaml
@@ -1,0 +1,287 @@
+area_id: unmanned_systems_manufacturing
+version: "1.0.0"
+display_name: Physical Unmanned Systems Manufacturing
+description: >-
+  SBIR and STTR awards funding physical aerial, ground, surface, or undersea
+  unmanned platforms, components, materials, or manufacturing processes.
+  Software-only, service-led, generic platform-use, and counter-UAS
+  detection/defeat work are outside this profile.
+programs: [SBIR, STTR]
+overrides_file: drone_manufacturing_overrides.yaml
+
+gate:
+  min_abstract_only_occurrences: 3
+  terms:
+    - '\bdrone[s]?\b'
+    - '\bUAV[s]?\b'
+    - '\bUAS\b'
+    - '\bsUAS\b'
+    - '\bunmanned aerial vehicle[s]?\b'
+    - '\bunmanned aerial system[s]?\b'
+    - '\bunmanned aircraft\b'
+    - '\bunmanned aerial\b'
+    - '\buncrewed (?:aircraft|aerial vehicle|aerial system)s?\b'
+    - '\bremotely piloted aircraft\b'
+    - '\bquadcopter[s]?\b'
+    - '\bquadrotor[s]?\b'
+    - '\bhexacopter[s]?\b'
+    - '\bmulti-?rotor[s]?\b'
+    - '\bmicro air vehicle[s]?\b'
+    - '\bfixed-wing (?:UAS|UAV|drone)s?\b'
+    - '\b(?:VTOL|vertical take-?off and landing) (?:UAS|UAV|drone)s?\b'
+    - '\bloitering munition[s]?\b'
+    - '\bone-way attack (?:aircraft|drone)s?\b'
+    - '\btarget drone[s]?\b'
+    - '\bloyal wingm[ae]n\b'
+    - '\bcollaborative combat aircraft\b'
+    - '\bCCA(?:s)?\b(?=[\s\S]{0,80}\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|autonom\w*|munition|air dominance)\b)'
+    - '\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|autonom\w*|munition|air dominance)\b[\s\S]{0,80}\bCCA(?:s)?\b'
+    - '\bautonomous collaborative platform[s]?\b'
+    - '\bACP\b(?=[\s\S]{0,80}\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|drone|UAS|UAV)\b)'
+    - '\b(?:aircraft|airframe|aerial|air vehicle|wing|flight|propulsion|avionics|drone|UAS|UAV)\b[\s\S]{0,80}\bACP\b'
+    - '\battritable (?:aircraft|airframe|platform)s?\b'
+    - '\bair-launched effect[s]?\b'
+    - '\bhigh[- ]altitude pseudo-?satellite[s]?\b'
+    - '\bhigh[- ]altitude platform (?:system|station)s?\b'
+    - '\bHAPS\b(?=[\s\S]{0,80}\b(?:high[- ]altitude|stratospher\w*|aircraft|aerial|flight|propulsion|payload|imaging|demonstrator)\b)'
+    - '\b(?:high[- ]altitude|stratospher\w*|aircraft|aerial|flight|propulsion|payload|imaging|demonstrator)\b[\s\S]{0,80}\bHAPS\b'
+    - '\bUCAV[s]?\b'
+    - '\bVTUAV[s]?\b'
+    - '\bTUAV[s]?\b'
+    - '\bunmanned (?:ground|underwater|undersea|surface) (?:vehicle|system)s?\b'
+    - '\bautonomous (?:underwater|undersea|surface) (?:vehicle|system)s?\b'
+    - '\buncrewed (?:ground|underwater|undersea|surface) (?:vehicle|system)s?\b'
+    - '\bground robot(?:ic vehicle)?s?\b'
+    # Acronyms require nearby platform context. This prevents USV from matching
+    # "ultrasonic vocalizations (USVs)" and similar unrelated abbreviations.
+    - '\b(?:UGV|UUV|USV|AUV)s?\b(?=[\s\S]{0,100}\b(?:vehicle|robot|autonom\w*|underwater|undersea|surface|maritime|marine|boat|craft|mission|operations|payload|propulsion|sensor|sonar|ocean|launch|recovery|motion)s?\b)'
+    - '\b(?:vehicle|robot|autonom\w*|underwater|undersea|surface|maritime|marine|boat|craft|mission|operations|payload|propulsion|sensor|sonar|ocean|launch|recovery|motion)s?\b[\s\S]{0,100}\b(?:UGV|UUV|USV|AUV)s?\b'
+
+physical_gate:
+  title_term_always_passes: true
+  max_relationship_distance: 180
+  max_relevance_distance: 200
+  abstract_terms:
+    - '\baircraft\b'
+  title_terms:
+    - '\b(?:UAS|UAV|drone)s?\b'
+    - '\bunmanned aerial (?:vehicle|system)s?\b'
+    - '\bsensor[s]?\b'
+    - '\bradar[s]?\b'
+    - '\b(?:receiver|transmitter|transceiver)s?\b'
+    - '\bunmanned (?:ground|underwater|undersea|surface) (?:vehicle|system)s?\b'
+    - '\bautonomous (?:underwater|undersea|surface) (?:vehicle|system)s?\b'
+    - '\buncrewed (?:ground|underwater|undersea|surface) (?:vehicle|system)s?\b'
+    - '\bground robot(?:ic vehicle)?s?\b'
+    - '\b(?:UGV|UUV|USV|AUV)s?\b(?=[\s\S]{0,100}\b(?:vehicle|robot|autonom\w*|underwater|undersea|surface|maritime|marine|boat|craft|mission|operations|payload|propulsion|sensor|sonar|ocean|launch|recovery|motion)s?\b)'
+    - '\b(?:vehicle|robot|autonom\w*|underwater|undersea|surface|maritime|marine|boat|craft|mission|operations|payload|propulsion|sensor|sonar|ocean|launch|recovery|motion)s?\b[\s\S]{0,100}\b(?:UGV|UUV|USV|AUV)s?\b'
+  terms:
+    - '\b(?:unmanned|uncrewed) aircraft\b'
+    - '\bcollaborative combat aircraft\b'
+    - '\battritable aircraft\b'
+    - '\btarget drone[s]?\b'
+    - '\b(?:UAS|UAV|drone) (?:platform|system|vehicle|aircraft)s?\b'
+    - '\bair vehicle[s]?\b'
+    - '\bairframe[s]?\b'
+    - '\bfuselage[s]?\b'
+    - '\bwing[s]?\b'
+    - '\brotor[s]?\b'
+    - '\bpropeller[s]?\b'
+    - '\bpropulsion (?:system|unit)s?\b'
+    - '\bengine[s]?\b'
+    - '\bmotor[s]?\b'
+    - '\bactuator[s]?\b'
+    - '\bflight control computer[s]?\b'
+    - '\bavionics\b'
+    - '\bautopilot hardware\b'
+    - '\binertial measurement unit[s]?\b'
+    - '\bIMU[s]?\b'
+    - '\bGNSS receiver[s]?\b'
+    - '\bbatter(?:y|ies)\b'
+    - '\bfuel cell[s]?\b'
+    - '\bpower electronic[s]?\b'
+    - '\bthermal management\b'
+    - '\bdata ?link hardware\b'
+    - '\bradio[s]?\b'
+    - '\bantenna[s]?\b'
+    - '\bgimbal[s]?\b'
+    - '\bEO/?IR\b'
+    - '\bpayload hardware\b'
+    - '\bcomposite structure[s]?\b'
+    - '\bstructural component[s]?\b'
+    - '\bcoating[s]?\b'
+    - '\bprinted circuit board[s]?\b'
+    - '\bprototype (?:aircraft|vehicle|platform|system)s?\b'
+    - '\bmanufacturing (?:process|technology|method|tooling|cell|line)s?\b'
+    - '\bflight computer[s]?\b'
+    - '\bmission computer[s]?\b'
+    - '\b(?:power source|power system|powerplant|turbogenerator|generator)s?\b'
+    - '\b(?:launch|recovery) system[s]?\b'
+    - '\blanding gear\b'
+    - '\blauncher[s]?\b'
+    - '\bwinch\b'
+    - '\bhoist\b'
+    - '\bpod[s]?\b'
+    - '\bcamera[s]?\b'
+    - '\bimager[s]?\b'
+  relationship_terms:
+    - '\bdevelop(?:ed|ing|ment)?\b'
+    - '\bdesign(?:ed|ing)?\b'
+    - '\bfabricat(?:e|ed|ing|ion)\b'
+    - '\bmanufactur(?:e|ed|ing|able|ability)\b'
+    - '\bproduc(?:e|ed|ing|tion)\b'
+    - '\bbuild(?:ing|s|t)?\b'
+    - '\bprototype(?:d|s|ing)?\b'
+    - '\bintegrat(?:e|ed|ing|ion)\b'
+    - '\bassembl(?:e|ed|ing|y)\b'
+    - '\btest(?:ed|ing)?\b'
+    - '\bqualif(?:y|ied|ication)\b'
+    - '\bcoat(?:ed|s)?\b'
+    - '\bminiaturi[sz](?:e|ed|ing|ation)\b'
+    - '\brepair(?:ed|ing)?\b'
+
+exclusions:
+  - name: counter_uas
+    display_name: Counter-UAS Detection or Defeat
+    reason: Detect, track, jam, or defeat work is not manufacture of an unmanned platform.
+    terms:
+      - '\bcounter[- ]?(?:UAS|sUAS|UAV|drone)s?\b'
+      - '\bc[- ]?UAS\b'
+      - '\banti[- ]drone\b'
+      - '\b(?:UAS|UAV|drone) (?:detect|detection|counter|defen[cs]e|threat)\b'
+      - '\bdrone[- ]defen[cs]e\b'
+      - '\b(?:detect|track|identify|jam|defeat|neutralize) hostile (?:UAS|UAV|drone)s?\b'
+    unless_terms:
+      - '\binterceptor (?:UAS|UAV|drone|aircraft)s?\b'
+      - '\b(?:UAS|UAV|drone) interceptor[s]?\b'
+      - '\bkinetic interceptor drone[s]?\b'
+  - name: counter_uas
+    display_name: Counter-UAS Detection or Defeat
+    reason: The title makes detection, tracking, or defeat of UAS the funded objective.
+    title_only: true
+    terms:
+      - '\b(?:UAS|UAV|drone)s?\b[\s\S]{0,80}\b(?:detect|track|identify|defeat|counter|threat)\w*\b'
+      - '\b(?:detect|track|identify|defeat|counter|threat)\w*\b[\s\S]{0,80}\b(?:UAS|UAV|drone)s?\b'
+    unless_terms:
+      - '\binterceptor (?:UAS|UAV|drone|aircraft)s?\b'
+      - '\b(?:UAS|UAV|drone) interceptor[s]?\b'
+  - name: nonphysical_primary
+    display_name: Software, Analysis, or Service-Led Unmanned-System Work
+    reason: The title identifies a nonphysical funded deliverable.
+    title_only: true
+    unless_title_only: true
+    terms:
+      - '\bsoftware\b'
+      - '\bdigital twin\b'
+      - '\bmachine learning\b'
+      - '\bartificial intelligence\b'
+      - '\bAI[- ](?:enabled|enhanced|driven|based)\b'
+      - '\balgorithm[s]?\b'
+      - '\banalysis\b'
+      - '\banalytic[s]?\b'
+      - '\bsimulation\b'
+      - '\bmission planning\b'
+      - '\bnavigation\b'
+      - '\btracking\b'
+      - '\bdetection\b'
+      - '\binspection\b'
+      - '\bmanagement\b'
+      - '\bservice[s]?\b'
+      - '\bframework\b'
+      - '\bsituational awareness\b'
+      - '\bmission planner\b'
+      - '\blocalization\b'
+      - '\bfeasibility stud(?:y|ies)\b'
+      - '\bcommunication[s]?\b'
+      - '\bdata transfer\b'
+      - '\bmonitoring\b'
+      - '\bdata collection\b'
+      - '\bremote[- ]sensing\b'
+      - '\bgeolocation\b'
+      - '\bcommand and control\b'
+      - '\bvoice control\b'
+      - '\bprotocol[s]?\b'
+      - '\boptimization\b'
+      - '\bvalidation\b'
+      - '\bdecision making\b'
+      - '\bteaming\b'
+      - '\bcoordination\b'
+      - '\bsensor fusion\b'
+    unless_terms:
+      - '\b(?:airframes?|fuselages?|wings?|rotors?|propellers?|engines?|motors?|batter(?:y|ies)|avionics|flight computers?|mission computers?|radios?|antennas?|gimbals?|cameras?|imagers?|payloads?|sensors?|radars?|receivers?|transmitters?|transceivers?|navigation) (?:hardware|components?|assembl(?:y|ies)|prototypes?)\b'
+      - '\bmanufactur\w*\b'
+      - '\bfabricat\w*\b'
+      - '\bproduc(?:e|ed|ing|tion)\b'
+      - '\b3D[- ]print\w*\b'
+
+subsets:
+  - name: Structures, Materials & Manufacturing
+    terms:
+      - '\bairframe[s]?\b'
+      - '\bfuselage[s]?\b'
+      - '\bwing structure[s]?\b'
+      - '\bcomposite[s]?\b'
+      - '\bstructural component[s]?\b'
+      - '\badditive manufactur\w*\b'
+      - '\b3D[- ]print\w*\b'
+      - '\btooling\b'
+      - '\bcoating[s]?\b'
+      - '\bhull[s]?\b'
+      - '\bchassis\b'
+      - '\bpressure vessel[s]?\b'
+  - name: Propulsion, Mobility & Actuation
+    terms:
+      - '\bpropulsion\b'
+      - '\bengine[s]?\b'
+      - '\bmotor[s]?\b'
+      - '\bpropeller[s]?\b'
+      - '\brotor[s]?\b'
+      - '\bactuator[s]?\b'
+      - '\bgearbox(?:es)?\b'
+      - '\bthruster[s]?\b'
+      - '\bdrivetrain[s]?\b'
+      - '\btrack[s]?\b'
+      - '\bwheel[s]?\b'
+  - name: Power, Energy Storage & Thermal
+    terms:
+      - '\bbatter(?:y|ies)\b'
+      - '\bfuel cell[s]?\b'
+      - '\bpower electronic[s]?\b'
+      - '\benergy storage\b'
+      - '\bthermal management\b'
+      - '\bpower source[s]?\b'
+      - '\bpower system[s]?\b'
+      - '\bpowerplant[s]?\b'
+      - '\bturbogenerator[s]?\b'
+      - '\bgenerator[s]?\b'
+  - name: Avionics, Vehicle-Control & Navigation Hardware
+    terms:
+      - '\bavionics\b'
+      - '\bflight control computer[s]?\b'
+      - '\bautopilot hardware\b'
+      - '\binertial measurement unit[s]?\b'
+      - '\bIMU[s]?\b'
+      - '\bGNSS receiver[s]?\b'
+      - '\bnavigation hardware\b'
+      - '\bflight computer[s]?\b'
+      - '\bmission computer[s]?\b'
+  - name: Communications, Data Links & Payload Hardware
+    terms:
+      - '\bdata ?link hardware\b'
+      - '\bradio[s]?\b'
+      - '\bantenna[s]?\b'
+      - '\bgimbal[s]?\b'
+      - '\bEO/?IR\b'
+      - '\bpayload hardware\b'
+      - '\bprinted circuit board[s]?\b'
+      - '\bcamera[s]?\b'
+      - '\bimager[s]?\b'
+      - '\bsensor[s]?\b'
+      - '\bradar[s]?\b'
+      - '\b(?:receiver|transmitter|transceiver)s?\b'
+      - '\bsonar[s]?\b'
+      - '\bacoustic modem[s]?\b'
+      - '\btransducer[s]?\b'
+
+fallback_subset: Complete Platforms & Systems Integration
+fallback_scope_class: Physical Hardware & Manufacturing

--- a/docs/research/massachusetts_unmanned_systems_sbir_readout.md
+++ b/docs/research/massachusetts_unmanned_systems_sbir_readout.md
@@ -1,0 +1,178 @@
+# Massachusetts Physical Unmanned-Systems SBIR/STTR Readout
+
+- **Data source:** SBIR.gov bulk `award_data.csv` local snapshot
+- **Source timestamp:** 2026-04-01T00:00:06.904233+00:00
+- **Source SHA-256:** `73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd`
+- **Award years represented:** 1992–2026
+- **Geography:** Award record lists Massachusetts as the awardee state
+
+## Result
+
+| Measure | Conservative reviewed result |
+|---|---:|
+| Massachusetts awardees | **76** |
+| Relevant awards | **238** |
+| Awarded dollars | **$109,526,154.89** |
+
+This report includes both **SBIR and STTR** and physical unmanned systems in
+the **aerial, ground, surface, and undersea** domains. It includes complete
+platforms, components, payloads, power systems, materials, and manufacturing
+processes.
+
+The deterministic candidate pass returned 334 award-grain records totaling
+$181,483,765.28 across 100 firm identities. Award-level review removed 96
+records totaling $71,957,610.39 because the funded work was software-only,
+service-led, merely used an unmanned platform, named an unmanned system as one
+generic market, targeted counter-UAS detection/defeat, or had an evident
+title/abstract or awardee/product attribution problem.
+
+## Technology groups
+
+### Platform, vehicle, and systems developers (26)
+
+- AIRBEAMS LLC
+- ARMADA MARINE ROBOTICS INC
+- ATLAS DEVICES, LLC
+- BENTHOS, INC.
+- BLUEFIN ROBOTICS CORP.
+- BOSTON ENGINEERING CORPORATION
+- Crgo Inc
+- CROSS DOMAIN SYSTEMS INC
+- Cyphy Works, Inc.
+- DIVERSIFIED TECHNOLOGIES, INC.
+- EOM OFFSHORE, LLC
+- FOSTER-MILLER, INC.
+- GREENSIGHT INC.
+- IROBOT CORP.
+- KaZaK Composites Incorporated
+- Ocean Acoustical Services and Instrumentation Systems, Inc.
+- RESOLUTE MARINE ENERGY, INC.
+- Riptide Autonomous Solutions, LLC
+- Robotics 88, Inc.
+- ROGUE WOLF ADVANCED RESEARCH LLC
+- SCIENTIFIC SYSTEMS COMPANY, INC.
+- SICDRONE CORPORATION
+- SPECIAL PROJECTS TEAM, LLC
+- TRITON SYSTEMS, INC.
+- VECNA TECHNOLOGIES, INC
+- VISHWA ROBOTICS AND AUTOMATION LLC
+
+### Components, payloads, materials, power, and supporting hardware (50)
+
+- Advanced Mechanical Technology, Inc.
+- AERODYNE RESEARCH INC
+- AGILTRON, INC.
+- Anro Engineering, Inc.
+- APPLIED NANOFEMTO TECHNOLOGIES LLC
+- Atrex Energy, Inc.
+- BODKIN DESIGN & ENGINEERING LLC
+- BROOKE OCEAN TECHNOLOGY USA, INC.
+- BUSEK CO., INC.
+- D-2 Inc
+- Datasonics, Inc.
+- E-CIRCUIT MOTORS INC.
+- FIBERSENSE TECHNOLOGY CORP.
+- Flight Landata, Inc.
+- FloDesign, Inc.
+- GENCORES INC
+- GINER INC
+- GVD CORP
+- Headwall Photonics, Inc.
+- Hittite Microwave Corporation
+- Infoscitex Corporation
+- Intrinsix Corp.
+- MAGIQ TECHNOLOGIES, INC.
+- MASSA PRODUCTS CORPORATION
+- Materials Systems Inc.
+- MATRIXSPACE, INC
+- MAYFLOWER COMMUNICATIONS COMPANY, INC.
+- MC10 Inc.
+- MESODYNE INC
+- MIDE TECHNOLOGY CORP
+- Nanolab, Inc
+- NASCENT TECHNOLOGY CORP.
+- NEXTDROID, INC
+- NOTCH INC.
+- NUCLEUS SCIENTIFIC INC
+- Optra, Inc.
+- PENDAR TECHNOLOGIES LLC
+- PHOTRONIX
+- PHYSICAL SCIENCES INC.
+- PROSENSING INC.
+- PROTONEX TECHNOLOGY CORP.
+- RADIATION MONITORING DEVICES, INC.
+- REMOTE SENSING SOLUTIONS, INC.
+- Scientific Solutions, Inc.
+- SI2 TECHNOLOGIES, INC
+- SPECTRAL SCIENCES, INC
+- SSG, Inc.
+- VISIDYNE, INC.
+- White River Technologies Inc
+- ZULU PODS INC
+
+## Representative non-aerial and STTR evidence
+
+| Awardee | Massachusetts location | Funded physical work |
+|---|---|---|
+| ARMADA Marine Robotics | Falmouth | External payload deployment hardware for cylindrical UUVs |
+| Bluefin Robotics | Cambridge | UUV/USV launch-and-recovery prototypes and pressure-tolerant UUV batteries |
+| NextDroid | Boston | Propulsion units for mine-countermeasures UUVs |
+| MC10 | Cambridge | STTR-funded conformal photovoltaic modules for UAVs |
+| White River Technologies | Newton | UAV electric-field sensor payload and UUV magnetic-sensor module |
+| Resolute Marine Energy | Boston | Wave-powered AUV docking and recharge station |
+| Vecna Technologies | Burlington | ChemBioBEAR UGV and integrated sensing package |
+| Advanced Mechanical Technology | Watertown | STTR-funded wave-energy hardware for USVs |
+| Rogue Wolf Advanced Research | Cohasset | Mechanical adapters, payloads, and components for assembling sUAS |
+| E-Circuit Motors | Newton | PCB-stator axial-flux propulsion motor for deep-operating UUVs |
+
+## Method
+
+1. Load all SBIR.gov award rows and preserve source-row provenance, address,
+   UEI, DUNS, contract, and tracking identifiers.
+2. Collapse revised editions using the repository's `sbir-source-v2` compound
+   award key. Mutable title, abstract, amount, and end date are not identity
+   fields. This reduced 219,500 source rows to 219,445 award-grain records.
+3. Assign conservative firm keys over the full source before applying the
+   Massachusetts filter: UEI first; unambiguous DUNS-to-UEI bridge second;
+   exact normalized company plus state only when no identifier resolves.
+4. Filter the selected award edition to state code `MA`, leaving 27,164
+   Massachusetts award-grain records for classification.
+5. Apply the versioned `unmanned_systems_manufacturing` physical-development
+   profile. Non-aerial acronyms require nearby platform context so, for
+   example, `USV` does not match “ultrasonic vocalizations.”
+6. Review candidate titles and abstracts at award grain. Retain only work that
+   designs, fabricates, prototypes, integrates, or tests a physical platform
+   or platform-specific component.
+
+The deterministic candidate stage can be rerun with:
+
+```bash
+python scripts/data/build_tech_census.py \
+  --area unmanned_systems_manufacturing \
+  --state MA \
+  --awards /absolute/path/to/award_data.csv \
+  --data-vintage 2026-04-01
+```
+
+The 238-award published figure is the conservative reviewed result, not the
+unreviewed classifier total. The source snapshot contains known historical
+title/abstract mismatches, so that distinction is material.
+
+The original award-level review decisions were not retained as a
+machine-readable ledger. This branch preserves the verified aggregate and
+firm readout plus the reproducible 334-award candidate stage; a future audit
+ledger is required to regenerate the 238-award reviewed figure from the raw
+snapshot alone.
+
+## Interpretation limits
+
+- “Massachusetts” means the selected public award record carried a
+  Massachusetts awardee address. It does not establish current headquarters,
+  incorporation, or manufacturing-site location.
+- The award text establishes funded physical development. It does not by
+  itself prove present-day production capacity or continuing commercial
+  operation.
+- Materials Systems' two AUV acoustic-imaging awards have title evidence but
+  `N/A` abstracts and should be treated as provisional.
+- The local file timestamp is provenance, not proof of the SBIR.gov release
+  date. Awards added or revised after this snapshot are absent.

--- a/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
@@ -21,6 +21,10 @@ _REQUIRED_COLUMNS = (
 )
 _OPTIONAL_AWARD_COLUMNS = (
     "program",
+    "city",
+    "state",
+    "uei",
+    "duns",
     "agency_tracking_number",
     "contract",
     "source_row",
@@ -62,7 +66,7 @@ class ComputeTechCensusTool(BaseTool):
     """Classify awards into a versioned technology profile and aggregate them."""
 
     name = "compute_tech_census"
-    version = "2.0.0"
+    version = "2.1.0"
 
     def execute(
         self,
@@ -72,29 +76,38 @@ class ComputeTechCensusTool(BaseTool):
         area_id: str = "drone_manufacturing",
         programs: list[str] | tuple[str, ...] | None = None,
         fiscal_years: list[int] | tuple[int, ...] | None = None,
+        states: list[str] | tuple[str, ...] | None = None,
         source_path: str | None = None,
         source_sha256: str | None = None,
         source_timestamp: str | None = None,
         data_vintage: str | None = None,
         **kwargs: Any,
     ) -> ToolResult:
-        """Run one profile, optionally narrowing its program and fiscal-year scope."""
+        """Run one profile, optionally narrowing its program, year, and state scope."""
 
         from sbir_etl.utils.tech_census import (
             CensusAward,
             CompiledCensus,
             load_census_config,
+            normalize_state_code,
+            normalize_state_codes,
             run_census,
         )
 
         selected_fys = (
             sorted({int(year) for year in fiscal_years}) if fiscal_years is not None else []
         )
+        try:
+            selected_states = normalize_state_codes(states or [])
+        except ValueError as exc:
+            metadata.warnings.append(str(exc))
+            return ToolResult(data=self._empty_result(area_id), metadata=metadata)
         metadata.parameters_used.update(
             {
                 "area_id": area_id,
                 "programs": list(programs) if programs is not None else None,
                 "fiscal_years": selected_fys or None,
+                "states": list(selected_states) or None,
                 "data_vintage": data_vintage,
             }
         )
@@ -113,6 +126,8 @@ class ComputeTechCensusTool(BaseTool):
         required_columns = list(_REQUIRED_COLUMNS)
         if effective_programs:
             required_columns.append("program")
+        if selected_states:
+            required_columns.append("state")
         missing = [column for column in required_columns if column not in awards_df.columns]
         if missing:
             metadata.warnings.append(f"awards_df missing required columns: {missing}")
@@ -128,6 +143,9 @@ class ComputeTechCensusTool(BaseTool):
         if selected_fys:
             numeric_years = pd.to_numeric(reporting_df["award_year"], errors="coerce")
             reporting_df = reporting_df[numeric_years.isin(selected_fys)]
+        if selected_states:
+            state_codes = reporting_df["state"].map(normalize_state_code)
+            reporting_df = reporting_df[state_codes.isin(selected_states)]
 
         columns = list(_REQUIRED_COLUMNS) + [
             column for column in _OPTIONAL_AWARD_COLUMNS if column in reporting_df.columns
@@ -141,6 +159,10 @@ class ComputeTechCensusTool(BaseTool):
                     "title": _as_text(raw.get("title")),
                     "abstract": _as_text(raw.get("abstract")),
                     "company": _as_text(raw.get("company")),
+                    "city": _as_text(raw.get("city")),
+                    "state": _as_text(raw.get("state")),
+                    "uei": _as_text(raw.get("uei")),
+                    "duns": _as_text(raw.get("duns")),
                     "agency": _as_text(raw.get("agency")),
                     "program": _as_text(raw.get("program")),
                     "phase": _as_text(raw.get("phase")),
@@ -177,6 +199,7 @@ class ComputeTechCensusTool(BaseTool):
             "rejection_counts": result["rejection_counts"],
             "reporting_window": {
                 "fiscal_years": selected_fys or None,
+                "states": list(selected_states) or None,
                 "programs": result["programs"],
             },
             "provenance": {
@@ -227,7 +250,7 @@ class ComputeTechCensusTool(BaseTool):
                 "adjacent_counts": {},
                 "program_exclusion_counts": {},
                 "rejection_counts": {},
-                "reporting_window": {"fiscal_years": None, "programs": []},
+                "reporting_window": {"fiscal_years": None, "states": None, "programs": []},
                 "provenance": {},
             },
         }

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -26,6 +26,10 @@ class CensusAward(TypedDict, total=False):
     title: str
     abstract: str
     company: str
+    city: str
+    state: str
+    uei: str
+    duns: str
     agency: str
     program: str
     phase: str
@@ -34,6 +38,88 @@ class CensusAward(TypedDict, total=False):
     agency_tracking_number: str
     contract: str
     source_row: int
+
+
+_US_STATE_NAMES = {
+    "ALABAMA": "AL",
+    "ALASKA": "AK",
+    "ARIZONA": "AZ",
+    "ARKANSAS": "AR",
+    "CALIFORNIA": "CA",
+    "COLORADO": "CO",
+    "CONNECTICUT": "CT",
+    "DELAWARE": "DE",
+    "DISTRICT OF COLUMBIA": "DC",
+    "FLORIDA": "FL",
+    "GEORGIA": "GA",
+    "HAWAII": "HI",
+    "IDAHO": "ID",
+    "ILLINOIS": "IL",
+    "INDIANA": "IN",
+    "IOWA": "IA",
+    "KANSAS": "KS",
+    "KENTUCKY": "KY",
+    "LOUISIANA": "LA",
+    "MAINE": "ME",
+    "MARYLAND": "MD",
+    "MASSACHUSETTS": "MA",
+    "MICHIGAN": "MI",
+    "MINNESOTA": "MN",
+    "MISSISSIPPI": "MS",
+    "MISSOURI": "MO",
+    "MONTANA": "MT",
+    "NEBRASKA": "NE",
+    "NEVADA": "NV",
+    "NEW HAMPSHIRE": "NH",
+    "NEW JERSEY": "NJ",
+    "NEW MEXICO": "NM",
+    "NEW YORK": "NY",
+    "NORTH CAROLINA": "NC",
+    "NORTH DAKOTA": "ND",
+    "OHIO": "OH",
+    "OKLAHOMA": "OK",
+    "OREGON": "OR",
+    "PENNSYLVANIA": "PA",
+    "RHODE ISLAND": "RI",
+    "SOUTH CAROLINA": "SC",
+    "SOUTH DAKOTA": "SD",
+    "TENNESSEE": "TN",
+    "TEXAS": "TX",
+    "UTAH": "UT",
+    "VERMONT": "VT",
+    "VIRGINIA": "VA",
+    "WASHINGTON": "WA",
+    "WEST VIRGINIA": "WV",
+    "WISCONSIN": "WI",
+    "WYOMING": "WY",
+    "AMERICAN SAMOA": "AS",
+    "GUAM": "GU",
+    "NORTHERN MARIANA ISLANDS": "MP",
+    "PUERTO RICO": "PR",
+    "VIRGIN ISLANDS": "VI",
+}
+_US_STATE_CODES = frozenset(_US_STATE_NAMES.values())
+
+
+def normalize_state_code(value: Any) -> str:
+    """Normalize a USPS state/territory code or full name for report filtering."""
+
+    normalized = re.sub(r"\s+", " ", str(value or "").strip().upper())
+    if normalized in _US_STATE_CODES:
+        return normalized
+    return _US_STATE_NAMES.get(normalized, "")
+
+
+def normalize_state_codes(values: Iterable[str]) -> tuple[str, ...]:
+    """Return unique normalized codes, rejecting unknown filter values."""
+
+    codes = []
+    for value in values:
+        code = normalize_state_code(value)
+        if not code:
+            raise ValueError(f"unknown US state or territory: {value!r}")
+        codes.append(code)
+    return tuple(sorted(set(codes)))
 
 
 def load_census_config(area_id: str, config_dir: Path | None = None) -> dict[str, Any]:
@@ -336,6 +422,10 @@ def _audit_identity(award: CensusAward) -> dict[str, Any]:
     return {
         "title": award.get("title", ""),
         "company": award.get("company", ""),
+        "city": award.get("city", ""),
+        "state": award.get("state", ""),
+        "uei": award.get("uei", ""),
+        "duns": award.get("duns", ""),
         "program": award.get("program", ""),
         "agency_tracking_number": award.get("agency_tracking_number", ""),
         "contract": award.get("contract", ""),
@@ -545,6 +635,10 @@ def load_award_data_csv(path: Path) -> list[CensusAward]:
                     "title": row.get("Award Title", "") or "",
                     "abstract": row.get("Abstract", "") or "",
                     "company": row.get("Company", "") or "",
+                    "city": row.get("City", "") or "",
+                    "state": row.get("State", "") or "",
+                    "uei": row.get("UEI", "") or "",
+                    "duns": row.get("Duns", "") or "",
                     "agency": row.get("Agency", "") or "",
                     "program": row.get("Program", "") or "",
                     "phase": row.get("Phase", "") or "",

--- a/scripts/data/build_tech_census.py
+++ b/scripts/data/build_tech_census.py
@@ -12,6 +12,7 @@ fiscal year." All phases in the profile's configured program scope are included.
 Usage:
   python scripts/data/build_tech_census.py --area drone_manufacturing
   python scripts/data/build_tech_census.py --area drone_manufacturing --recent-fys 3
+  python scripts/data/build_tech_census.py --area unmanned_systems_manufacturing --state MA
 """
 
 from __future__ import annotations
@@ -32,6 +33,8 @@ from sbir_etl.utils.tech_census import (  # noqa: E402
     CompiledCensus,
     load_award_data_csv,
     load_census_config,
+    normalize_state_code,
+    normalize_state_codes,
     run_census,
 )
 
@@ -77,6 +80,12 @@ def main() -> int:
         help="Limit the report to a fiscal year; repeat for multiple years",
     )
     parser.add_argument(
+        "--state",
+        dest="states",
+        action="append",
+        help="Limit by awardee state name or USPS code; repeat for multiple states",
+    )
+    parser.add_argument(
         "--data-vintage",
         help="Optional source-data release/download vintage (not inferred from local file mtime)",
     )
@@ -96,11 +105,21 @@ def main() -> int:
     print(f"  {len(awards):,} total awards")
 
     selected_fys = sorted(set(args.fiscal_years or []))
-    reporting_awards = (
-        [award for award in awards if award.get("award_year") in selected_fys]
-        if selected_fys
-        else awards
-    )
+    try:
+        selected_states = normalize_state_codes(args.states or [])
+    except ValueError as exc:
+        parser.error(str(exc))
+    reporting_awards = awards
+    if selected_fys:
+        reporting_awards = [
+            award for award in reporting_awards if award.get("award_year") in selected_fys
+        ]
+    if selected_states:
+        reporting_awards = [
+            award
+            for award in reporting_awards
+            if normalize_state_code(award.get("state")) in selected_states
+        ]
     result = run_census(reporting_awards, compiled, programs=args.programs)
     grand = result["grand_total"]
     print(f"\nIn-scope awards: {grand['n']:,}  (${grand['usd'] / 1e6:,.1f}M)")
@@ -169,6 +188,10 @@ def main() -> int:
     rows = result["classified_awards"]
     preferred_columns = [
         "company",
+        "city",
+        "state",
+        "uei",
+        "duns",
         "title",
         "agency",
         "program",
@@ -213,6 +236,7 @@ def main() -> int:
         "scope_totals": result["scope_totals"],
         "reporting_window": {
             "fiscal_years": selected_fys or None,
+            "states": list(selected_states) or None,
             "programs": result["programs"],
         },
         "provenance": {

--- a/tests/unit/tools/test_tech_census.py
+++ b/tests/unit/tools/test_tech_census.py
@@ -9,6 +9,10 @@ def _award(
     title="",
     abstract="",
     company="Acme",
+    city="Boston",
+    state="MA",
+    uei="UEI-1",
+    duns="DUNS-1",
     agency="Department of Defense",
     program="SBIR",
     phase="Phase II",
@@ -19,6 +23,10 @@ def _award(
         "title": title,
         "abstract": abstract,
         "company": company,
+        "city": city,
+        "state": state,
+        "uei": uei,
+        "duns": duns,
         "agency": agency,
         "program": program,
         "phase": phase,
@@ -129,12 +137,45 @@ class TestComputeTechCensusTool:
         }
         assert result.metadata.data_sources[0].version == "2026-07-14"
 
+    def test_state_filter_accepts_name_and_reports_normalized_scope(self):
+        tool = ComputeTechCensusTool()
+        df = pd.DataFrame(
+            [
+                _award(title="Drone airframe", state="Massachusetts", amount=100_000),
+                _award(title="Drone airframe", state="CA", amount=200_000),
+            ]
+        )
+        result = tool.run(
+            awards_df=df,
+            area_id="drone_manufacturing",
+            states=["Massachusetts"],
+        )
+        assert result.data["award_count"] == 1
+        assert result.data["award_dollars"] == 100_000.0
+        assert result.data["summary"]["reporting_window"]["states"] == ["MA"]
+        assert result.data["summary"]["provenance"]["reporting_row_count"] == 1
+
+    def test_invalid_state_filter_warns_without_running(self):
+        result = ComputeTechCensusTool().run(
+            awards_df=pd.DataFrame([_award(title="Drone airframe")]),
+            area_id="drone_manufacturing",
+            states=["Atlantis"],
+        )
+        assert result.data["award_count"] == 0
+        assert any(
+            "unknown US state or territory" in warning for warning in result.metadata.warnings
+        )
+
     def test_result_rows_include_audit_columns(self):
         result = ComputeTechCensusTool().run(
             awards_df=pd.DataFrame([_award(title="Drone avionics")]),
             area_id="drone_manufacturing",
         )
         assert set(result.data["results"].columns) >= {
+            "city",
+            "state",
+            "uei",
+            "duns",
             "program",
             "agency_tracking_number",
             "contract",
@@ -144,6 +185,11 @@ class TestComputeTechCensusTool:
             "scope_class",
             "classification_source",
         }
+        row = result.data["results"].iloc[0]
+        assert row["city"] == "Boston"
+        assert row["state"] == "MA"
+        assert row["uei"] == "UEI-1"
+        assert row["duns"] == "DUNS-1"
 
     def test_nullable_and_string_years_are_normalized_before_aggregation(self):
         tool = ComputeTechCensusTool()

--- a/tests/unit/utils/test_tech_census.py
+++ b/tests/unit/utils/test_tech_census.py
@@ -13,6 +13,8 @@ from sbir_etl.utils.tech_census import (
     load_census_config,
     matched_adjacent,
     matched_exclusion,
+    normalize_state_code,
+    normalize_state_codes,
     passes_gate,
     run_census,
 )
@@ -23,6 +25,10 @@ def _award(
     abstract: str = "",
     *,
     company: str = "Acme",
+    city: str = "Boston",
+    state: str = "MA",
+    uei: str = "UEI-1",
+    duns: str = "DUNS-1",
     agency: str = "Department of Defense",
     program: str = "SBIR",
     phase: str = "Phase II",
@@ -36,6 +42,10 @@ def _award(
         "title": title,
         "abstract": abstract,
         "company": company,
+        "city": city,
+        "state": state,
+        "uei": uei,
+        "duns": duns,
         "agency": agency,
         "program": program,
         "phase": phase,
@@ -80,11 +90,34 @@ def _compiled() -> CompiledCensus:
 def test_profiles_keep_broad_relevance_separate_from_strict_manufacturing() -> None:
     strict = load_census_config("drone_manufacturing")
     broad = load_census_config("uas_relevance")
+    all_domain = load_census_config("unmanned_systems_manufacturing")
     assert strict["programs"] == ["SBIR"]
     assert broad["programs"] == ["SBIR", "STTR"]
+    assert all_domain["programs"] == ["SBIR", "STTR"]
     assert strict["physical_gate"]["terms"]
+    assert all_domain["physical_gate"]["terms"]
     assert "physical_gate" not in broad
     assert strict["version"] == "2.0.0"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("MA", "MA"),
+        ("ma", "MA"),
+        ("Massachusetts", "MA"),
+        ("  District   of Columbia ", "DC"),
+        (None, ""),
+    ],
+)
+def test_normalize_state_code(value: object, expected: str) -> None:
+    assert normalize_state_code(value) == expected
+
+
+def test_normalize_state_codes_deduplicates_and_rejects_unknown_values() -> None:
+    assert normalize_state_codes(["Massachusetts", "MA", "California"]) == ("CA", "MA")
+    with pytest.raises(ValueError, match="unknown US state or territory"):
+        normalize_state_codes(["Not a state"])
 
 
 def test_load_missing_config_raises() -> None:
@@ -181,6 +214,51 @@ def test_broad_profile_includes_software_that_strict_profile_rejects() -> None:
     assert broad["classified_awards"][0]["scope_class"] == "Software, Autonomy & Analytics"
     assert strict["grand_total"]["n"] == 0
     assert strict["exclusion_counts"] == {"nonphysical_primary": 1}
+
+
+@pytest.mark.parametrize(
+    ("title", "program", "expected_subset"),
+    [
+        (
+            "STTR Autonomous Underwater Vehicle Thruster Prototype",
+            "STTR",
+            "Propulsion, Mobility & Actuation",
+        ),
+        (
+            "Unmanned Ground Vehicle Chassis",
+            "SBIR",
+            "Structures, Materials & Manufacturing",
+        ),
+        (
+            "USV Marine Vehicle Propulsion Prototype",
+            "SBIR",
+            "Propulsion, Mobility & Actuation",
+        ),
+    ],
+)
+def test_all_domain_profile_includes_sttr_and_nonaerial_hardware(
+    title: str, program: str, expected_subset: str
+) -> None:
+    result = run_census(
+        [_award(title=title, program=program)],
+        CompiledCensus.from_area("unmanned_systems_manufacturing"),
+    )
+    assert result["grand_total"]["n"] == 1
+    assert result["classified_awards"][0]["subset"] == expected_subset
+
+
+def test_all_domain_profile_rejects_software_only_and_ambiguous_usv_acronym() -> None:
+    compiled = CompiledCensus.from_area("unmanned_systems_manufacturing")
+    result = run_census(
+        [
+            _award(title="UUV Underwater Vehicle Navigation Software", tracking="T-1"),
+            _award(title="Rodent Ultrasonic Vocalizations (USVs)", tracking="T-2"),
+        ],
+        compiled,
+    )
+    assert result["grand_total"]["n"] == 0
+    assert result["exclusion_counts"] == {"nonphysical_primary": 1}
+    assert result["rejection_counts"] == {"relevance_gate": 1}
 
 
 def test_nonphysical_title_is_excluded_even_with_incidental_hardware_evidence() -> None:
@@ -323,6 +401,10 @@ def test_classified_rows_preserve_audit_evidence_and_source_ids() -> None:
     assert row["agency_tracking_number"] == "TRACK"
     assert row["contract"] == "CONTRACT"
     assert row["source_row"] == 42
+    assert row["city"] == "Boston"
+    assert row["state"] == "MA"
+    assert row["uei"] == "UEI-1"
+    assert row["duns"] == "DUNS-1"
     assert row["gate_evidence"] and row["physical_evidence"]
     assert "subset_evidence" in row and "scope_evidence" in row
     assert row["classification_source"] == "rules"
@@ -371,9 +453,10 @@ def test_versioned_override_ledger_can_include_and_exclude(tmp_path: Path) -> No
 def test_csv_loader_preserves_program_identifiers_and_source_row(tmp_path: Path) -> None:
     path = tmp_path / "awards.csv"
     path.write_text(
-        "Award Title,Abstract,Company,Agency,Program,Phase,Award Year,Award Amount,"
-        "Agency Tracking Number,Contract\n"
-        'Drone Airframe,"Build it",Acme,DOD,SBIR,Phase II,2024,"$1,250",TRACK,CONTRACT\n',
+        "Award Title,Abstract,Company,City,State,UEI,Duns,Agency,Program,Phase,Award Year,"
+        "Award Amount,Agency Tracking Number,Contract\n"
+        'Drone Airframe,"Build it",Acme,Boston,MA,UEI-1,DUNS-1,DOD,SBIR,Phase II,2024,'
+        '"$1,250",TRACK,CONTRACT\n',
         encoding="utf-8",
     )
     award = load_award_data_csv(path)[0]
@@ -382,3 +465,7 @@ def test_csv_loader_preserves_program_identifiers_and_source_row(tmp_path: Path)
     assert award["contract"] == "CONTRACT"
     assert award["source_row"] == 2
     assert award["award_amount"] == 1_250.0
+    assert award["city"] == "Boston"
+    assert award["state"] == "MA"
+    assert award["uei"] == "UEI-1"
+    assert award["duns"] == "DUNS-1"


### PR DESCRIPTION
## Summary

- add a versioned physical unmanned-systems manufacturing profile covering SBIR and STTR awards across aerial, ground, surface, and undersea domains
- add normalized state filtering and preserve city, state, UEI, and DUNS in tech-census audit output
- expose the profile through the existing tech-census CLI and analytics tool
- publish the reviewed Massachusetts readout: 76 awardees, 238 awards, and $109,526,154.89

## Why

The existing `drone_manufacturing` profile intentionally covers aerial SBIR hardware only. This adds a separate profile for the broader question without changing that established definition, and makes state-scoped reports reusable through the existing census tool.

## Compatibility with current main

The branch is rebased onto `v0.3.0`. Snapshot publishing and private-API changes from the original branch were dropped because #536 retired that interface before this PR merged. The census profile, state/audit support, CLI/tool path, report, and their focused tests remain.

## Verification

- focused tech-census tests: 56 passed
- Ruff checks on all changed Python and test files: passed
- `make docs-check`: passed
- `git diff --check`: passed
- real-data candidate run from the original review reproduces 334 Massachusetts awards totaling $181,483,765.28
- report list checks at 26 platform/integrator firms plus 50 component/hardware firms

## Evidence boundary

The 238-award figure is the conservative human-reviewed result, distinct from the 334-award deterministic candidate stage. The original award-level review decisions were not persisted as a machine-readable ledger; the report calls this out explicitly so the reproducibility boundary is clear.
