### PR TITLE
docs: generalize self-hosted server runbook

### DIFF
--- a/.env.server.example
+++ b/.env.server.example
@@ -1,4 +1,4 @@
-# .env.server.example — Tailscale-only Mac mini server profile
+# .env.server.example — Tailscale-only self-hosted server profile
 #
 # Copy to `.env.server` and fill in real secrets. Never commit `.env.server`.
 #   cp .env.server.example .env.server
@@ -16,7 +16,7 @@ ENVIRONMENT=prod
 PYTHONUNBUFFERED=1
 SERVICE_STARTUP_TIMEOUT=120
 
-# Image coordinates (published multi-arch by CI; pull the arm64 manifest on M-series).
+# Image coordinates. Use a manifest compatible with the server host's architecture.
 IMAGE_NAME=ghcr.io/hollomancer/sbir-analytics
 IMAGE_TAG=latest
 
@@ -45,8 +45,8 @@ NEO4J_server_memory_heap_initial__size=512M
 NEO4J_server_memory_pagecache_size=512M
 
 # -----------------------------------------------------------------------------
-# Storage — defaults are repository-local. On the Mac mini, point these at the
-# external SSD, e.g. /Volumes/SSDmini/sbir-analytics/... (see the device guide).
+# Storage — defaults are repository-local. On the self-hosted server, point these at
+# durable host storage (see the server runbook).
 # -----------------------------------------------------------------------------
 SERVER_DATA_DIR=./data
 SERVER_REPORTS_DIR=./reports
@@ -96,7 +96,7 @@ SBIR_ETL__TRANSITION__CONTRACTS__USE_AWARD_ARCHIVE=false
 #   /app/data/raw/source-a.zip:/app/data/raw/source-b.zip
 # Leave ANALYSIS_DATE empty to use the current UTC date. Pin it for every
 # reproducible run. The production output defaults are persistent bind mounts;
-# use the dated canary overrides in the Mac mini runbook for a first run.
+# use the dated canary overrides in the self-hosted server runbook for a first run.
 # -----------------------------------------------------------------------------
 SBIR_ETL__NSF_DEFENSE_LINEAGE__ANALYSIS_DATE=
 SBIR_ETL__NSF_DEFENSE_LINEAGE__OUTPUT_DIR=/app/data/processed/nsf_sbir_defense_lineage

--- a/.github/actions/README.md
+++ b/.github/actions/README.md
@@ -4,7 +4,7 @@ This directory contains reusable composite actions for GitHub workflows. These a
 
 `ci.yml` is the only workflow in the repository — it runs lint, type checks, and
 tests. Everything else (data extraction, enrichment, reporting, image
-publishing) runs on the Mac mini as Dagster schedules or cron, so actions that
+publishing) runs on the self-hosted server as Dagster schedules or cron, so actions that
 existed to serve those workflows have been removed along with them.
 
 ## Available Actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 # GitHub Actions runs the test suite and nothing else. Data-plane work
-# (extraction, enrichment, reporting, image publishing) runs on the Mac mini
-# as Dagster schedules or cron — see docs/deployment/mac-mini-server.md.
+# (extraction, enrichment, reporting, image publishing) runs on the self-hosted server
+# as Dagster schedules or cron — see docs/deployment/self-hosted-server.md.
 
 permissions:
   contents: read
@@ -199,7 +199,7 @@ jobs:
       # tests/mocks, and tests/utils ran nowhere at all.
       #
       # USE_REAL_SBIR_DATA is deliberately unset — the real_data fixtures fall
-      # back to sample data, and the bulk corpora live on the server's SSD
+      # back to sample data, and the bulk corpora live on persistent server storage
       # where no runner can reach them.
       #
       # Two exclusions, both for tests that no CI job has ever executed and
@@ -353,8 +353,8 @@ jobs:
 
       # amd64 only, on the runner's native architecture. The question this job
       # answers is "does the image still build and start", and arm64 emulation
-      # roughly triples the time without changing the answer. The mini builds
-      # its own arm64 images; see docs/deployment/mac-mini-server.md.
+      # roughly triples the time without changing the answer. The server builds
+      # images for its native architecture; see docs/deployment/self-hosted-server.md.
       - name: Build the ETL image
         uses: docker/build-push-action@v7
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -196,8 +196,8 @@ dagster_home/
 docker/*.local.*
 docker-compose.override.yml
 
-# Host-specific Mac mini deployment state (procedures stay in the runbook)
-/docs/deployment/mac-mini-status.local.md
+# Host-specific server deployment state (procedures stay in the runbook)
+/docs/deployment/*-status.local.md
 
 # Poetry backups
 poetry.lock.bak

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Then, depending on the work:
 | Doing | Read |
 |---|---|
 | Anything at all | [CLAUDE.md](CLAUDE.md) |
-| Deployment, server operations, or live Dagster materialization | [the Mac mini runbook](docs/deployment/mac-mini-server.md#live-instance-on-this-mac-mini) — **before** acting, not after — plus the live-deployment section of CLAUDE.md |
+| Deployment, server operations, or live Dagster materialization | [the self-hosted server runbook](docs/deployment/self-hosted-server.md#live-instance-on-the-server-host) — **before** acting, not after — plus the live-deployment section of CLAUDE.md |
 | Implementing a spec | [the status registry](specs/status.md), [the spec workflow](docs/development/spec-workflow-guide.md), [the tier contract](docs/steering/epistemic-tiers.md), then the spec directory in `specs/` |
 | Judging whether work is in scope | [docs/research-questions.md](docs/research-questions.md) |
 | Architecture context | [docs/architecture/detailed-overview.md](docs/architecture/detailed-overview.md), patterns in `docs/steering/` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,22 +41,23 @@ behavior); config goes through `sbir_etl/config/loader.py`.
 
 ## Live deployment
 
-Before any deployment, server operation, or live Dagster materialization, read
-[the Mac mini runbook](docs/deployment/mac-mini-server.md#live-instance-on-this-mac-mini).
+Before any deployment, server operation, or live Dagster materialization, read the
+[self-hosted server runbook](docs/deployment/self-hosted-server.md#live-instance-on-the-server-host).
 On the live host, also read the ignored
-`docs/deployment/mac-mini-status.local.md` file when it exists; current
+`docs/deployment/server-status.local.md` file when it exists; host-specific
+checkout and storage paths as well as current
 materialization state belongs there, not in tracked documentation.
-The only live checkout is `/Users/conradhollomon/projects/sbir-analytics-server`;
-never operate the live stack from the development checkout. Preserve
-`.env.server`, `/Volumes/SSDmini/sbir-analytics`, and the Docker `dagster_home`
-volume. Ingress must remain Tailscale Serve over tailnet-only HTTPS or explicitly
-enabled TLS-terminated TCP; never enable Funnel and never expose server ports to
-the LAN or public internet.
+Operate the live stack only from the dedicated deployment checkout recorded in
+that local file, never from a development checkout. Preserve `.env.server`, the
+configured persistent application data, and the Docker `dagster_home` volume.
+Ingress must remain Tailscale Serve over tailnet-only HTTPS or explicitly enabled
+TLS-terminated TCP; never enable Funnel and never expose server ports to the LAN
+or public internet.
 
-Treat materialization as a live-data mutation: confirm the SSD is mounted, the
-deployment checkout is clean, and the stack is healthy before running one. Keep
-schedules disabled until their jobs have completed successfully by hand with the
-inputs available on this host.
+Treat materialization as a live-data mutation: confirm persistent storage is
+mounted, the deployment checkout is clean, and the stack is healthy before
+running one. Keep schedules disabled until their jobs have completed successfully
+by hand with the inputs available on this host.
 
 ## Agents
 

--- a/Makefile
+++ b/Makefile
@@ -584,7 +584,7 @@ validate: lint test ## Run linting, type checking, and tests
 	@$(call success,All validation checks passed)
 
 # -----------------------------------------------------------------------------
-# Tailscale-only Mac mini server profile
+# Tailscale-only self-hosted server profile
 # -----------------------------------------------------------------------------
 
 SERVER_COMPOSE_FILE ?= docker-compose.server.yml

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ scripts/               One-off analysis and operational scripts
 studies/                Reproducible analytical studies and evidence artifacts
 ```
 
-The live deployment is running Docker Compose behind Tailscale. 
+The live deployment runs Docker Compose behind Tailscale.
 See the [deployment overview](docs/deployment/README.md) for the current model.
 
 ## Suggested reading path

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -1,6 +1,7 @@
-# Tailscale-Only Mac mini Server Compose Configuration
+# Tailscale-Only Self-Hosted Server Compose Configuration
 #
-# An ARM64-native, private server profile for a single always-on Mac mini.
+# A private server profile for a single always-on host. Images are built for the
+# container runtime's native architecture.
 # It runs only the services needed to serve the graph and orchestration UI:
 #   - neo4j              (private graph store; host port bound to loopback only)
 #   - dagster-code-server (shared internal Dagster code location)
@@ -13,7 +14,7 @@
 #   * Tailscale Serve is the ONLY ingress (tailnet-only HTTPS/TLS):
 #       443  -> Dagster (127.0.0.1:3000)
 #       17687 -> Neo4j Bolt (127.0.0.1:7687; trusted operators only)
-#   * Tailscale Funnel is prohibited (see docs/deployment/mac-mini-server.md).
+#   * Tailscale Funnel is prohibited (see docs/deployment/self-hosted-server.md).
 #
 # Usage:
 #   cp .env.server.example .env.server
@@ -68,10 +69,10 @@ x-server-environment: &server-environment
   # actionable message rather than a Compose interpolation error.
   SAM_GOV_API_KEY: ${SAM_GOV_API_KEY:-}
   USPTO_ODP_API_KEY: ${USPTO_ODP_API_KEY:-}
-  # Data root for downloads; the server profile points this at the SSD.
+  # Data root for downloads; the server profile points this at persistent storage.
   SBIR_ETL__PATHS__DATA_ROOT: ${SBIR_ETL__PATHS__DATA_ROOT:-/app/data}
   # NSF defense-lineage release inputs and file-only outputs. Path lists use
-  # the container's colon separator; see the Mac mini runbook before editing.
+  # the container's colon separator; see the self-hosted server runbook before editing.
   SBIR_ETL__NSF_DEFENSE_LINEAGE__ANALYSIS_DATE: ${SBIR_ETL__NSF_DEFENSE_LINEAGE__ANALYSIS_DATE:-}
   SBIR_ETL__NSF_DEFENSE_LINEAGE__OUTPUT_DIR: ${SBIR_ETL__NSF_DEFENSE_LINEAGE__OUTPUT_DIR:-/app/data/processed/nsf_sbir_defense_lineage}
   SBIR_ETL__NSF_DEFENSE_LINEAGE__SBIR_AWARDS_PATH: ${SBIR_ETL__NSF_DEFENSE_LINEAGE__SBIR_AWARDS_PATH:-/app/data/raw/sbir/award_data.csv}

--- a/docs/architecture/dagster-pipelines.md
+++ b/docs/architecture/dagster-pipelines.md
@@ -24,7 +24,7 @@ uv run dagster job execute -m sbir_analytics.definitions_ml -j fiscal_returns_mv
 ### Heavy-asset gating
 
 `DAGSTER_LOAD_HEAVY_ASSETS` (default `"true"`) controls whether memory-hungry
-modules load. When it is `false` (the Mac-mini/server profile), the four heavy
+modules load. When it is `false` (the self-hosted server profile), the four heavy
 jobs — `cet_full_pipeline_job`, `fiscal_returns_*`, `modernbert_job`,
 `uspto_ai_extraction_job` — and their assets are skipped in the primary location;
 run them from `definitions_ml` instead. If an upstream asset module fails to

--- a/docs/architecture/dagster-reorganization-plan.md
+++ b/docs/architecture/dagster-reorganization-plan.md
@@ -360,7 +360,7 @@ Goal: remove ambiguity only after the new path is routine.
 
 - run two successful approved cadences through the new jobs;
 - remove superseded jobs, schedules, sensors, dynamic discovery, and compatibility wrappers;
-- update the Mac mini runbook with the final job names and rollback procedures.
+- update the self-hosted server runbook with the final job names and rollback procedures.
 
 Exit gate: no production schedule, sensor, or runbook command references a legacy definition.
 
@@ -389,16 +389,16 @@ changes persisted data semantics.
 - Blocking semantic checks gate sensors and publishing jobs.
 - Neo4j can be rebuilt from canonical assets and restored without data loss.
 - Product and graph parity are demonstrated against the Phase 0 baseline.
-- The Mac mini runbook describes only the new definitions and their rollback path.
+- The self-hosted server runbook describes only the new definitions and their rollback path.
 
 ## Non-goals
 
 This effort does not:
 
 - rewrite working extractors or research algorithms merely to move files;
-- enable heavy or experimental analyses on the Mac mini;
+- enable heavy or experimental analyses on the self-hosted server;
 - change the research methodology or the canonical research-question inventory;
-- move canonical data away from the current Mac mini storage architecture;
+- move canonical data away from the current self-hosted server storage architecture;
 - require a multi-process Dagster deployment before logical boundaries are proven;
 - combine the full migration into one pull request.
 
@@ -410,4 +410,4 @@ This effort does not:
 - [Company Identity Contract](../steering/company-identity.md)
 - [Epistemic Tiers](../steering/epistemic-tiers.md)
 - [Neo4j Graph Database Patterns](../steering/neo4j-patterns.md)
-- [Mac mini server runbook](../deployment/mac-mini-server.md)
+- [Self-hosted server runbook](../deployment/self-hosted-server.md)

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -99,13 +99,14 @@ compute it.
 
 ## Deployment boundary
 
-The only live data plane is the Mac mini checkout at
-`/Users/conradhollomon/projects/sbir-analytics-server`. Docker Compose runs Dagster and Neo4j;
-persistent data lives under `/Volumes/SSDmini/sbir-analytics`; ingress is Tailscale Serve only.
-GitHub Actions performs CI and never materializes live data.
+The only live data plane is the dedicated checkout on the self-hosted server.
+Docker Compose runs Dagster and Neo4j; persistent data lives under the host
+paths configured in `.env.server`; ingress is Tailscale Serve only. GitHub
+Actions performs CI and never materializes live data. The ignored
+`docs/deployment/server-status.local.md` records current host paths and state.
 
 Before any live operation, read the
-[Mac mini runbook](../deployment/mac-mini-server.md#live-instance-on-this-mac-mini). AWS Batch,
+[self-hosted server runbook](../deployment/self-hosted-server.md#live-instance-on-the-server-host). AWS Batch,
 Lambda, Step Functions, and S3 are not part of the current architecture.
 
 ## Sources of truth
@@ -117,7 +118,7 @@ Lambda, Step Functions, and S3 are not part of the current architecture.
 | Configuration keys and load order | [Configuration reference](../configuration.md) |
 | Local commands and containers | [Getting started](../getting-started/README.md), [Docker](../development/docker.md) |
 | CI and tests | [Testing index](../testing/index.md) |
-| Live operations | [Mac mini runbook](../deployment/mac-mini-server.md) |
+| Live operations | [self-hosted server runbook](../deployment/self-hosted-server.md) |
 | Graph model | [Neo4j schema](../schemas/neo4j.md) and [migrations](../migrations.md) |
 | Evidence and citability | [Epistemic tiers](../steering/epistemic-tiers.md), [study contracts](../../studies/README.md) |
 

--- a/docs/archive/deployment/actions-migration-plan.md
+++ b/docs/archive/deployment/actions-migration-plan.md
@@ -1,25 +1,25 @@
 # GitHub Actions Migration Plan (Completed)
 
-> Historical record. Scheduled operational workloads now run on the Mac mini;
+> Historical record. Scheduled operational workloads now run on the self-hosted server;
 > GitHub Actions is CI only. Use the current
 > [deployment documentation](../../deployment/README.md) for operations.
 
 Move the five scheduled workloads that used to run in GitHub Actions onto the
-Mac mini, as Dagster schedules or host cron. GitHub Actions is now tests only:
+self-hosted server, as Dagster schedules or host cron. GitHub Actions is now tests only:
 fast unit tests on PRs, the full suite on `main`.
 
 **Depends on** [#501](https://github.com/hollomancer/sbir-analytics/pull/501),
 which deletes the workflows described here. Until that merges, the workflows
 still exist (though `weekly.yml` has been in an invalid state and not running).
 
-See [the Mac mini runbook](../../deployment/mac-mini-server.md) for the target host, and
+See [the self-hosted server runbook](../../deployment/self-hosted-server.md) for the target host, and
 [the AWS decommission plan](../../deployment/aws-decommission-plan.md) for the earlier phase that
 moved ingestion off Actions. This plan finishes that job.
 
 ## What is already done
 
 The hard part — ingestion — landed in the AWS decommission. Four source-download
-jobs and three chaining sensors run on the mini, and `monthly_phase_transition`
+jobs and three chaining sensors run on the server, and `monthly_phase_transition`
 already carries the phase-transition half of `monthly-analysis.yml`. This plan
 covers what was left behind.
 
@@ -49,7 +49,7 @@ archive already solves this by writing dated directories under
 `<data_root>/processed/phase_transition/history/<date>/`. Each migration needs
 an equivalent or its output series is lost.
 
-**Document each schedule** in a runbook table in `mac-mini-server.md`, matching
+**Document each schedule** in a runbook table in `self-hosted-server.md`, matching
 the existing "Source-data downloads" and "Monthly analysis" sections.
 
 ## Cross-cutting work
@@ -70,7 +70,7 @@ secrets in GitHub settings — `NEO4J_USER`, `NEO4J_PASSWORD`, `S3_BUCKET`, and
 `AWS_ROLE_ARN` have no remaining consumer.
 
 **Keep crons in UTC.** Every workflow cron below is UTC and Dagster's
-`ScheduleDefinition` is UTC here too, so times port unchanged. The mini is on
+`ScheduleDefinition` is UTC here too, so times port unchanged. The server is on
 local time; do not convert.
 
 ## The five workloads
@@ -180,7 +180,7 @@ Establish what the successful runs actually produced — pull a recent
 then port the behaviour you want rather than the behaviour you have.
 
 The `actions/cache` of `usaspending_api_cache.json` becomes a plain file on the
-SSD, which is strictly better: no cache-key churn, no eviction.
+persistent storage, which is strictly better: no cache-key churn, no eviction.
 
 Note the phase-transition half of this workflow is already migrated
 (`monthly_phase_transition`); only the benchmark job remains.
@@ -205,11 +205,11 @@ Reproduce on the host before writing any Dagster code.
 
 Two simplifications the move makes available:
 
-- The step curls `data.www.sbir.gov/…/award_data.csv` directly. On the mini,
+- The step curls `data.www.sbir.gov/…/award_data.csv` directly. On the server,
   `sbir_awards_download_job` already fetches that CSV weekly. Consume that
   vintage instead of re-downloading, and the failing step disappears.
 - The month-over-month diff uses `actions/cache` to carry
-  `latest_awards.csv` forward as `previous_awards.csv`. On the SSD that is just
+  `latest_awards.csv` forward as `previous_awards.csv`. On persistent storage that is just
   two paths and a copy — no cache key, no chance of a silent restore-key miss
   producing a diff against the wrong month.
 
@@ -222,24 +222,24 @@ it as new work with a reference implementation rather than as a port.
 |---|---|
 | Was | `build-images.yml` (Sunday 04:00 + push paths) and `ci.yml`'s container-build-test |
 | Built | `python-base` (amd64 + arm64), `etl`, `full` → GHCR; plus a compose smoke test |
-| Target | **split**: a path-filtered CI job for validation, the mini for the images it runs |
+| Target | **split**: a path-filtered CI job for validation, the server for the images it runs |
 
 These two concerns got deleted together, and they should not be restored
 together, because they were never the same thing.
 
 **Publishing is genuinely optional.** `make server-up` falls back to building
-`Dockerfile.python-base` locally when GHCR has no manifest for the Mac's
-architecture (see [Bring-up](../../deployment/mac-mini-server.md#bring-up)), and the server compose profile builds
+`Dockerfile.python-base` locally when GHCR has no manifest for the host's
+architecture (see [Bring-up](../../deployment/self-hosted-server.md#bring-up)), and the server compose profile builds
 its app images locally with a `:local` tag rather than pulling. Nothing is
 broken today; a first build just takes several minutes. The amd64 half of the
 multi-arch manifest existed to serve CI, which no longer builds images — so if
-the weekly refresh comes back at all, an arm64-only local build on the mini is
+the weekly refresh comes back at all, a native-architecture local build on the server is
 enough.
 
 **Validation is not optional, and is currently missing.** With no image build
 anywhere, nothing checks that `Dockerfile`, `Dockerfile.python-base`,
 `Dockerfile.full`, or the compose files still work. A broken Dockerfile is now
-discovered at deploy time on the mini, which is the worst place to find it.
+discovered at deploy time on the server, which is the worst place to find it.
 `tests/` cannot cover this: the ETL image is what the tests would run *inside*.
 
 **Implemented in this PR:** a **path-filtered `docker` job in `ci.yml`**, gated on
@@ -258,9 +258,9 @@ That is roughly a 5–10 minute job that runs on a handful of PRs a month. It
 keeps the "GitHub Actions is tests only" line honest — it is a test, of the
 build — without restoring a 20-minute job on every merge.
 
-The alternative, building on the mini via cron, catches the same breakage but
-only after it lands on `main`, and only on arm64. Worth doing *as well* if you
-want the arm64 path covered, but it is not a substitute for a pre-merge gate.
+The alternative, building on the server via cron, catches the same breakage but
+only after it lands on `main`, and only on the host's architecture. Worth doing
+*as well* if you want that path covered, but it is not a substitute for a pre-merge gate.
 
 ## Deliberately not migrated
 
@@ -269,7 +269,7 @@ Recorded so these are not resurrected by accident.
 | Dropped | Why |
 |---|---|
 | Performance regression check | PR-scoped, gated on a baseline cached against a git ref. Meaningless outside CI, and it was `continue-on-error` so it blocked nothing. |
-| Transition MVP gate | Already `workflow_dispatch`-only because runners cannot reach the bulk data. If the gate is wanted, the data is local on the mini and it becomes a Dagster job — but it was gating nothing in practice. |
+| Transition MVP gate | Already `workflow_dispatch`-only because runners cannot reach the bulk data. If the gate is wanted, the data is local on the server and it becomes a Dagster job — but it was gating nothing in practice. |
 | Container build + smoke, E2E docker job | Covered by `test-full` on `main`, which runs the whole suite against a real Neo4j. |
 | PR test-summary comment, CI summary job | GitHub's own checks UI shows which job failed. |
 | Weekly auto-repair chain | Never fired once in nine months — no `ci:triage` issue and no `bot/ci-fix/*` branch ever existed. `ruff --fix` is a pre-commit concern. |

--- a/docs/archive/research/research-plan-alignment.md
+++ b/docs/archive/research/research-plan-alignment.md
@@ -153,6 +153,6 @@ Audit completed 2026-03-13 (statuses re-verified 2026-07-02). Status: **ready fo
 - [x] **Entity resolution:** Hybrid 6-step pipeline: UEI exact → DUNS exact → CAGE code → Name+State+NAICS deterministic → rapidfuzz (75-90 thresholds) → LLM tiebreaker. 85%+ deterministic match rate. Gold set calibration. Confidence scoring (1.0 deterministic, 0.5-0.95 fuzzy). (`packages/sbir-analytics/sbir_analytics/tools/phase0/resolve_entities.py`, 376 lines)
 - [x] **Classifier state:** CET classifier trained on 21 NSTC Critical & Emerging Technology categories. TF-IDF + keyword boosting + logistic regression with probability calibration. Production-ready with ≥60% high-confidence target. Full training pipeline in `packages/sbir-analytics/sbir_analytics/assets/cet/training.py`.
 - [x] **FPDS data:** Pulled via USAspending PostgreSQL dump streaming. Linked to entities via vendor crosswalk. Refresh: daily (FPDS), monthly (USAspending bulk). Follow-on contract analytics now live in `packages/sbir-analytics/sbir_analytics/assets/follow_on_multiplier/`; the unused legacy DuckDB implementation was removed in the 2026-07 repo cleanup. (`packages/sbir-analytics/sbir_analytics/tools/phase0/extract_fpds_contracts.py`)
-- [x] **Infrastructure:** Docker Compose and Dagster run on the Mac mini with local SSD storage;
+- [x] **Infrastructure:** Docker Compose and Dagster run on the self-hosted server with persistent local storage;
   GitHub Actions is CI only. The earlier CDK, Batch, S3, and data-refresh workflow infrastructure
   has been retired.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,7 +48,7 @@ uv run python -c 'from sbir_etl.config import get_config; print(get_config().pip
 Use double underscores to mirror a YAML path:
 
 ```bash
-export SBIR_ETL__PATHS__DATA_ROOT=/Volumes/SSDmini/sbir-analytics
+export SBIR_ETL__PATHS__DATA_ROOT=/path/to/persistent-storage/sbir-analytics
 export SBIR_ETL__LOGGING__LEVEL=DEBUG
 export SBIR_ETL__ENRICHMENT__PERFORMANCE__CHUNK_SIZE=10000
 ```
@@ -71,7 +71,7 @@ export NEO4J_DATABASE=neo4j
 ```
 
 Keep secrets out of committed YAML. The live server uses `.env.server`; preserve that file and
-follow the [Mac mini runbook](deployment/mac-mini-server.md) before any live operation.
+follow the [self-hosted server runbook](deployment/self-hosted-server.md) before any live operation.
 
 ## Using configuration in Python
 
@@ -108,7 +108,7 @@ output = config.paths.resolve_path("scripts_output", create_parent=True)
 
 `resolve_path()` expands shell environment variables and `~`, accepts absolute paths, and can
 create the resolved path's parent directory. Pipeline storage is local filesystem storage; the
-live deployment mounts `/Volumes/SSDmini/sbir-analytics` into the containers.
+live deployment mounts the host paths configured by `SERVER_*_DIR` into the containers.
 
 ## Main sections
 
@@ -152,7 +152,7 @@ make docker-down
 ```
 
 See [Docker development](development/docker.md) for local workflows and the
-[Mac mini runbook](deployment/mac-mini-server.md) for the live instance.
+[self-hosted server runbook](deployment/self-hosted-server.md) for the live instance.
 
 ## Adding a setting
 

--- a/docs/data/awards-refresh.md
+++ b/docs/data/awards-refresh.md
@@ -3,10 +3,10 @@
 Automation keeps the canonical SBIR.gov awards CSV current on the server's data
 root, which downstream pipelines consume.
 
-This runs on the Mac mini, not GitHub Actions. Actions runners cannot reach the
+This runs on the self-hosted server, not GitHub Actions. Actions runners cannot reach the
 tailnet-only host, so the machine that stores the data is the machine that
 fetches it. See the
-[Mac mini runbook](../deployment/mac-mini-server.md#source-data-downloads).
+[self-hosted server runbook](../deployment/self-hosted-server.md#source-data-downloads).
 
 ## Job summary
 
@@ -33,7 +33,7 @@ fetches it. See the
 ```
 
 `<data_root>` comes from `SBIR_ETL__PATHS__DATA_ROOT`, which the server profile
-points at the SSD.
+points at persistent server storage.
 
 The `history/` series matters: SBIR.gov serves only the current snapshot, so a
 past vintage exists nowhere else once upstream overwrites it. Do not prune it.
@@ -55,7 +55,7 @@ uv run dagster job execute -m sbir_analytics.definitions -j sbir_awards_download
 
 # Or invoke the script directly
 uv run python scripts/data/download_sbir.py \
-  --dest /Volumes/SSDmini/sbir-analytics/data/raw/sbir
+  --dest "$SERVER_DATA_DIR/raw/sbir"
 ```
 
 ### Run validation locally (optional)
@@ -95,7 +95,7 @@ been reviewed.
 
 ## Related
 
-- [Mac mini runbook](../deployment/mac-mini-server.md#source-data-downloads) —
+- [self-hosted server runbook](../deployment/self-hosted-server.md#source-data-downloads) —
   all four source-download schedules and their prerequisites
 - [AWS decommission plan](../deployment/aws-decommission-plan.md) — why this
   moved off GitHub Actions and S3

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -11,8 +11,8 @@ No SBIR/STTR award data is committed to this repository. Full reproduction requi
 the public source datasets, supplying API credentials where required, and provisioning local disk
 and services such as Neo4j.
 
-The live data plane runs on the Mac mini. Source-download jobs write to the local data root on the
-attached SSD; GitHub Actions is CI only. All source schedules default to stopped until a manual run
+The live data plane runs on the self-hosted server. Source-download jobs write to
+the local data root on persistent storage; GitHub Actions is CI only. All source schedules default to stopped until a manual run
 succeeds on that host.
 
 ## Primary sources
@@ -26,12 +26,13 @@ succeeds on that host.
 
 Schedule times are defaults from `sbir_analytics/definitions.py` and can be overridden with the
 corresponding `SBIR_ETL__DAGSTER__SCHEDULES__...` variables. Follow the
-[Mac mini runbook](../deployment/mac-mini-server.md#source-data-downloads) before enabling or
+[self-hosted server runbook](../deployment/self-hosted-server.md#source-data-downloads) before enabling or
 triggering any live download.
 
 ## Storage layout
 
-The root comes from `SBIR_ETL__PATHS__DATA_ROOT`; the live profile maps it to the SSD.
+The root comes from `SBIR_ETL__PATHS__DATA_ROOT`; the live profile maps it to
+persistent host storage.
 
 ```text
 <data_root>/

--- a/docs/data/uspto-data-refresh.md
+++ b/docs/data/uspto-data-refresh.md
@@ -7,12 +7,12 @@ Status: active
 
 # USPTO Data Refresh
 
-The USPTO refresh runs on the Mac mini and writes to local storage. The Dagster
+The USPTO refresh runs on the self-hosted server and writes to local storage. The Dagster
 `uspto_download_job` replaces the retired GitHub Actions/S3 handoff and downloads the three patent
 datasets consumed by the pipeline.
 
 Before operating the live job, read the
-[Mac mini runbook](../deployment/mac-mini-server.md#source-data-downloads).
+[self-hosted server runbook](../deployment/self-hosted-server.md#source-data-downloads).
 
 ## Datasets
 
@@ -87,6 +87,6 @@ CSV files in place.
 | Presigned URL expired | Download did not start promptly | Re-run once; avoid wasting the annual mint allowance |
 | Assignment job returns partial files | Browser download failure | Inspect each reported error and rerun after fixing browser/session access |
 | Downstream assets find no assignments | ZIPs were not extracted | Run the Dagster job or extract into `raw/uspto/assignments/` |
-| Disk-space failure | Archives plus extracted data exceed available space | Check the SSD before retrying; do not redirect live data into the checkout |
+| Disk-space failure | Archives plus extracted data exceed available space | Check persistent storage before retrying; do not redirect live data into the checkout |
 
 For source fields and graph mappings, see [USPTO Patents](../schemas/uspto-patents.md).

--- a/docs/data/weekly-awards-report.md
+++ b/docs/data/weekly-awards-report.md
@@ -58,5 +58,5 @@ press-wire feeds) improve diligence but degrade gracefully — see the
 - **Output:** a single Markdown document written to `--output` (or stdout).
 
 Live reports are written under `<data_root>/reports/weekly_awards/<report-date>/`. See the
-[Mac mini runbook](../deployment/mac-mini-server.md#weekly-awards-report) before
+[self-hosted server runbook](../deployment/self-hosted-server.md#weekly-awards-report) before
 operating the live job.

--- a/docs/decisions/dspy-evaluation.md
+++ b/docs/decisions/dspy-evaluation.md
@@ -54,7 +54,7 @@ recurring production LM workflow with a narrow output purpose:
 - [`WeeklyAwardsReportBuilder`](../../sbir_etl/reporting/weekly/orchestrator.py)
   runs synopsis and award descriptions in a thread pool as part of a pipeline
   with a 720-second internal timeout. The recurring job now runs through
-  Dagster on the Mac mini; GitHub Actions is CI only.
+  Dagster on the self-hosted server; GitHub Actions is CI only.
 - The weekly report golden test runs with `--no-ai`; current OpenAI client tests
   exercise transport behavior, not semantic accuracy or grounding.
 - The existing weekly-report refactor still tracks injected LM dependencies and

--- a/docs/decisions/s3-files-evaluation.md
+++ b/docs/decisions/s3-files-evaluation.md
@@ -4,7 +4,7 @@
 **Status:** Superseded / Not Recommended
 
 > Historical evaluation. The S3/AWS data plane described below was retired;
-> the current architecture uses local storage on the Mac mini. This document
+> the current architecture uses local storage on the self-hosted server. This document
 > preserves the decision context and is not an operational reference.
 
 ## What Is S3 Files?

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,7 +1,7 @@
 ---
 Type: Overview
 Owner: docs@project
-Last-Reviewed: 2026-08-03
+Last-Reviewed: 2026-08-04
 Status: active
 ---
 
@@ -19,15 +19,15 @@ implying a production-grade service.
 |------|-----|
 | Run the pipeline locally, iterate on code | [Docker guide](../development/docker.md) — `make docker-up-dev` |
 | Run a one-off job without Docker | [Getting started](../getting-started/README.md) — `make dev` + Dagster UI |
-| Private always-on server on a Mac mini (tailnet-only) | [Mac mini server](mac-mini-server.md) — `make server-up` |
-| Scheduled runs or live-state operations | [Mac mini runbook](mac-mini-server.md) |
-| Heavy ML or fiscal jobs | [Heavy assets](mac-mini-server.md#heavy-assets); run manually and measure first |
+| Private always-on server (tailnet-only) | [Self-hosted server](self-hosted-server.md) — `make server-up` |
+| Scheduled runs or live-state operations | [Self-hosted server runbook](self-hosted-server.md) |
+| Heavy ML or fiscal jobs | [Heavy assets](self-hosted-server.md#heavy-assets); run manually and measure first |
 
 ## Current boundary
 
-Everything runs on one always-on Mac mini; GitHub Actions is CI only.
+Everything runs on one always-on self-hosted server; GitHub Actions is CI only.
 
-1. **Mac mini (Dagster)** — source downloads, ETL pipelines, and Neo4j
+1. **Self-hosted server (Dagster)** — source downloads, ETL pipelines, and Neo4j
 2. **GitHub Actions** — lint, typecheck, tests. No data plane, no scheduled work, no image publishing.
 3. **Docker (development)** — local development and testing
 
@@ -45,14 +45,14 @@ moved off GitHub Actions. The remaining account-level teardown checklist is trac
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
-│              Mac mini — tailnet-only, always on              │
+│          Self-hosted server — tailnet-only, always on        │
 │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐       │
 │  │  downloads   │─▶│  pipelines   │─▶│    Neo4j     │       │
 │  │ (schedules)  │  │  (sensors)   │  │              │       │
 │  └──────────────┘  └──────────────┘  └──────┬───────┘       │
 │         │                                                   │
 │         ▼                                                   │
-│  /Volumes/SSDmini/sbir-analytics                            │
+│       persistent application data                            │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -60,15 +60,15 @@ moved off GitHub Actions. The remaining account-level teardown checklist is trac
 
 | Guide | Description |
 |-------|-------------|
-| [Mac mini runbook](mac-mini-server.md) | Live checkout, services, schedules, backups, and recovery |
+| [Self-hosted server runbook](self-hosted-server.md) | Live checkout, services, schedules, backups, and recovery |
 | [Docker development](../development/docker.md) | Local Compose profiles and troubleshooting |
 | [Neo4j migrations](../migrations.md) | Versioned graph schema and data migrations |
 | [AWS decommission plan](aws-decommission-plan.md) | Remaining external teardown only |
 
 ## Live credentials
 
-Server credentials live in `.env.server` on the mini (see
-[Mac mini server](mac-mini-server.md)), not in GitHub secrets:
+Server credentials live in `.env.server` on the server host (see the
+[self-hosted server runbook](self-hosted-server.md)), not in GitHub secrets:
 
 | Variable | Description |
 |----------|-------------|

--- a/docs/deployment/aws-decommission-plan.md
+++ b/docs/deployment/aws-decommission-plan.md
@@ -1,10 +1,10 @@
 # AWS Decommission Plan
 
-Retire the AWS data plane and make the Mac mini the single host for ingestion,
+Retire the AWS data plane and make the self-hosted server the single host for ingestion,
 processing, and serving. GitHub Actions is reduced to pure CI (lint, typecheck,
 tests, image builds).
 
-See [the Mac mini runbook](mac-mini-server.md) for the target deployment.
+See [the self-hosted server runbook](self-hosted-server.md) for the target deployment.
 
 ## Why this is mostly subtractive
 
@@ -17,9 +17,9 @@ The server profile is already AWS-free:
 
 Nothing currently served depends on AWS. The one load-bearing piece is
 **ingestion**: GitHub Actions fetches external data and uses S3 as the handoff.
-Actions runners cannot reach the mini (Tailscale-only, no self-hosted runner), so
+Actions runners cannot reach the server (Tailscale-only, no self-hosted runner), so
 `data-refresh.yml` has no destination once S3 is gone. That work must move onto
-the mini before the workflow can be deleted.
+the server before the workflow can be deleted.
 
 ## Sequencing constraints
 
@@ -41,14 +41,14 @@ layout, and git history preserves that.
 **Status: operator action. The bucket is live.**
 
 Most of `s3://sbir-etl-prod-data/` is a **cache, not a system of record.** Once
-Phase 2 lands, the mini fetches from the original upstreams, so `raw/sam_gov/`,
+Phase 2 lands, the server fetches from the original upstreams, so `raw/sam_gov/`,
 `raw/usaspending/`, `raw/uspto/`, `raw/transition/`, and everything derived under
 `enriched/` and `processed/sbir/` are re-fetchable or re-computable. Copying them
 is optional insurance.
 
 Two prefixes hold dated history that **cannot** be rebuilt:
 
-| S3 prefix | Why it is irreplaceable | SSD destination |
+| S3 prefix | Why it is irreplaceable | Persistent-storage destination |
 |---|---|---|
 | `raw/awards/{YYYY-MM-DD}/award_data.csv` | A vintage series of SBIR.gov snapshots, each carrying a `sha256` in object metadata written by the former `_upload_to_s3()` path in `scripts/data/download_sbir.py`. SBIR.gov serves only the current file; past vintages do not exist upstream. | `data/raw/sbir/history/` |
 | `processed/phase_transition/{YYYY-MM-DD}/` | Dated analysis outputs (`monthly-analysis.yml:360`). Recomputable only if the matching input vintage survives, which depends on the row above. | `data/processed/phase_transition/history/` |
@@ -57,7 +57,7 @@ Treat the dated keys under `raw/usaspending/recipient_lookup/` and
 `naics_lookup/` as probably irreplaceable as well — confirm what USAspending
 retains upstream before assuming either way.
 
-Verify: every dated key under the two prefixes above exists on the SSD with
+Verify: every dated key under the two prefixes above exists on persistent storage with
 matching byte size. This is a small copy, not a multi-gigabyte haul; the bulk
 caches do not need to move.
 
@@ -84,11 +84,11 @@ once those callers are removed.
 
 Verify: `rg -i 'cdk|aws-actions|batch submit-job'` returns nothing; CI green.
 
-## Phase 2 — Rehost ingestion on the mini
+## Phase 2 — Rehost ingestion on the server
 
 **Status: done.** All four downloaders write locally by default and four Dagster
 schedules carry `data-refresh.yml`'s cron times. See
-[Source-data downloads](mac-mini-server.md#source-data-downloads).
+[Source-data downloads](self-hosted-server.md#source-data-downloads).
 
 The substantive work. Convert the four download scripts to local-first output and
 drive them from the Dagster daemon already running in the server profile.
@@ -101,21 +101,21 @@ as needing "no AWS credentials or boto3". Use it as the template for the rest.
 | `scripts/data/download_sbir.py` | 142 | S3-only today; add local output |
 | `scripts/data/download_sam_gov.py` | 610 | S3-only today; add local output |
 | `scripts/data/download_uspto.py` | 485 | `--local` exists; make it the default |
-| `scripts/usaspending/download_database.py` | 637 | Checkpoints currently live in S3 under `.checkpoints/`; move to the SSD |
+| `scripts/usaspending/download_database.py` | 637 | Checkpoints currently live in S3 under `.checkpoints/`; move to persistent storage |
 
-USAspending bulk processing moves from AWS Batch onto the mini as a long-running
-Dagster job. It needs resumable checkpointing on the SSD and a free-space guard
+USAspending bulk processing moves from AWS Batch onto the server as a long-running
+Dagster job. It needs resumable checkpointing on persistent storage and a free-space guard
 before download, since the dump is large and the run may take hours.
 
 Then replace the four cron schedules in `data-refresh.yml` with
 `ScheduleDefinition`s alongside the existing ones in `definitions.py:92-155`,
 feeding `sbir_weekly_refresh_job`.
 
-This also closes the gap recorded at `mac-mini-server.md:46` — that job is
+This also closes the gap recorded in the self-hosted server runbook — that job is
 disabled today precisely because SAM.gov and USAspending inputs are not on the
 host.
 
-Verify: each source materializes to the SSD from a cold start; schedules tick in
+Verify: each source materializes to persistent storage from a cold start; schedules tick in
 the Dagster daemon; `sbir_weekly_refresh_job` completes by hand before any
 schedule is enabled, per the runbook.
 
@@ -132,7 +132,7 @@ Retain, reduced to local behavior:
 - `resolve_data_path` — collapses to a local existence check
 - `find_latest_sbir_awards`, `find_latest_usaspending_dump`,
   `find_latest_recipient_lookup_parquet`, `find_latest_sam_gov_parquet` — read the
-  SSD tree
+  persistent-storage tree
 - `SbirAwardsSource`, `resolve_sbir_awards_csv`, `check_sbir_data_freshness`
 
 Delete: `is_s3_path`, `get_s3_bucket_from_env`, `build_s3_path`,
@@ -154,8 +154,8 @@ Then remove the S3 surface elsewhere:
   `usaspending_database_enrichment.py`, `transition/contracts.py`,
   `modernbert/embeddings.py`, and `sbir_etl/reporting/weekly/fetching.py`
 
-Verify: full test suite green; a cold materialization on the mini reads only from
-the SSD.
+Verify: full test suite green; a cold materialization on the server reads only from
+persistent storage.
 
 ## Phase 4 — Rescope CI to containers and tests
 
@@ -165,7 +165,7 @@ GitHub Actions becomes lint, typecheck, test, and image build only.
 
 - **Delete** `.github/workflows/data-refresh.yml` (802 lines) and
   `.github/workflows/etl-pipeline.yml` (473 lines). Both are data-plane workflows
-  whose work now belongs to the mini. Do not delete until Phase 2 has landed.
+  whose work now belongs to the server. Do not delete until Phase 2 has landed.
 - `ci.yml` — remove the S3 data job (the OIDC block with `AWS_ROLE_ARN`,
   `S3_BUCKET: sbir-etl-prod-data`, `AWS_REGION: us-east-2`) and the `s3` path
   filter at lines 98-100. Note this job uses `continue-on-error` and falls back to

--- a/docs/deployment/self-hosted-server.md
+++ b/docs/deployment/self-hosted-server.md
@@ -1,40 +1,49 @@
-# Tailscale-Only Mac mini Server
+# Tailscale-Only Self-Hosted Server
 
-A private, always-on deployment of SBIR Analytics on a single Apple-silicon
-Mac mini. The stack is ARM64-native and reachable **only** over your Tailscale
-tailnet — there is no public DNS, no port forwarding, and no LAN exposure.
+A private, always-on deployment of SBIR Analytics on a single server host. The
+stack runs in containers and is reachable **only** over your Tailscale tailnet
+— there is no public DNS, no port forwarding, and no LAN exposure. The host's
+hardware, operating system, container runtime, checkout path, and storage mount
+are deployment details supplied locally; they are not part of this contract.
 
-## Live instance on this Mac mini
+## Live instance on the server host
 
-This machine hosts the live SBIR Analytics deployment.
+The designated server host runs the live SBIR Analytics deployment. Before any
+operation, read `docs/deployment/server-status.local.md` on that host when it
+exists. It records the actual checkout and storage paths for that installation.
+Create it from `server-status.example.md` during first-time setup and keep it
+untracked. On an upgraded installation, migrate any differently named
+`*-status.local.md` file to this standard name before the next operation.
 
-- **Deployment checkout:** `/Users/conradhollomon/projects/sbir-analytics-server`
-- **Development checkout:** `/Users/conradhollomon/projects/sbir-analytics` —
-  never operate the live stack from here.
-- **Installed version:** record it in `mac-mini-status.local.md`. Always verify
+- **Deployment checkout:** use the path recorded in `server-status.local.md`.
+  It must be a dedicated clean checkout, separate from development worktrees.
+- **Development checkout:** never operate the live stack from a development
+  checkout or worktree.
+- **Installed version:** record it in `server-status.local.md`. Always verify
   the deployment checkout with `git status --short` and
   `git describe --tags --always --dirty`; do not infer the live version from
   another checkout or from the image tag.
-- **Persistent application data:** `/Volumes/SSDmini/sbir-analytics`
+- **Persistent application data:** use the durable root configured by the
+  `SERVER_*_DIR` values in `.env.server`; record the host path locally.
 - **Local secrets:** `.env.server` in the deployment checkout. It is ignored,
   mode `0600`, and must never be printed, committed, or replaced.
 - **Dagster metadata:** the Docker `dagster_home` named volume. Preserve it
-  alongside SSD data; never use `docker compose down -v`.
+  alongside persistent application data; never use `docker compose down -v`.
 - **Ingress:** Tailscale Serve over tailnet-only HTTPS/TLS. Tailscale Funnel,
   public port exposure, and LAN exposure are prohibited.
 - **Current host state:** record data vintages, materialized subsets, Dagster
   run IDs, and temporary blockers in
-  `docs/deployment/mac-mini-status.local.md`. That file is intentionally
+  `docs/deployment/server-status.local.md`. That file is intentionally
   ignored; tracked documentation describes the operating contract, not a
-  point-in-time snapshot of this machine.
+  point-in-time snapshot of a particular host.
 
 Run every `make server-*` command and shell-driven live materialization from
 the clean deployment checkout. Use the documented Make targets; do not run
 `git clean`, destructive resets, or hand-written Compose teardown commands
-there. Treat materialization as a live-data mutation: confirm the SSD is
-mounted and the stack is healthy first. Keep schedules disabled until their
-jobs have completed successfully by hand with the inputs available on this
-host.
+there. Treat materialization as a live-data mutation: confirm persistent
+storage is mounted and the stack is healthy first. Keep schedules disabled
+until their jobs have completed successfully by hand with the inputs available
+on this host.
 
 ## What runs here
 
@@ -74,32 +83,36 @@ caveat and [Workload placement](#workload-placement).
 
 ## One-time device setup
 
-### 1. External SSD
+### 1. Persistent storage
 
-Prepare a directory tree on the external SSD and point the storage variables at
-it in `.env.server`:
+Prepare a directory tree on persistent storage and point the storage variables
+at it in `.env.server`. Replace `/path/to/persistent-storage` with an absolute
+host path; do not copy this placeholder literally:
 
 ```bash
-mkdir -p /Volumes/SSDmini/sbir-analytics/{data,reports,logs,artifacts,neo4j,backups}
+mkdir -p /path/to/persistent-storage/sbir-analytics/{data,reports,logs,artifacts,neo4j,backups}
 ```
 
 ```dotenv
-SERVER_DATA_DIR=/Volumes/SSDmini/sbir-analytics/data
-SERVER_REPORTS_DIR=/Volumes/SSDmini/sbir-analytics/reports
-SERVER_LOGS_DIR=/Volumes/SSDmini/sbir-analytics/logs
-SERVER_ARTIFACTS_DIR=/Volumes/SSDmini/sbir-analytics/artifacts
-SERVER_NEO4J_DIR=/Volumes/SSDmini/sbir-analytics/neo4j
-SERVER_BACKUP_DIR=/Volumes/SSDmini/sbir-analytics/backups
+SERVER_DATA_DIR=/path/to/persistent-storage/sbir-analytics/data
+SERVER_REPORTS_DIR=/path/to/persistent-storage/sbir-analytics/reports
+SERVER_LOGS_DIR=/path/to/persistent-storage/sbir-analytics/logs
+SERVER_ARTIFACTS_DIR=/path/to/persistent-storage/sbir-analytics/artifacts
+SERVER_NEO4J_DIR=/path/to/persistent-storage/sbir-analytics/neo4j
+SERVER_BACKUP_DIR=/path/to/persistent-storage/sbir-analytics/backups
 ```
 
-> The external SSD is **not a backup by itself.** Run `make server-backup`
-> regularly and copy the dump to a second location.
+> Persistent storage is **not a backup by itself.** Run `make server-backup`
+> regularly and copy the dump to a second failure domain.
 
-### 2. Start-at-login
+### 2. Start at boot
 
-- **OrbStack** (recommended Docker runtime on macOS): enable *Start at login*.
-- **Tailscale**: enable *Run at login* / *Start on boot* so the tailnet and
-  Serve routes come back after a reboot.
+- Configure the host's Docker-compatible runtime to start automatically.
+- Configure Tailscale to start automatically so the tailnet and Serve routes
+  come back after a reboot.
+
+On macOS, OrbStack's *Start at login* and Tailscale's *Run at login* settings
+satisfy these requirements. On other hosts, use the native service manager.
 
 ### 3. One-time Tailscale HTTPS consent
 
@@ -164,7 +177,7 @@ prefer a quiet window.
 
 ## Tailscale grant (least privilege)
 
-Restrict who can reach the server. Tag the Mac mini `tag:sbir-server`, grant
+Restrict who can reach the server. Tag the server node `tag:sbir-server`, grant
 analysts access to the Dagster UI, and grant Neo4j separately to trusted
 operators. Grants are the recommended current policy mechanism
 ([docs](https://tailscale.com/docs/reference/syntax/grants)). Apply this from
@@ -282,8 +295,8 @@ variables are lists and use the container's colon (`:`) path separator:
 - `SUBAWARD_SOURCES`
 
 Use the full `SBIR_ETL__NSF_DEFENSE_LINEAGE__` prefix for each name. Do not use
-commas, macOS `/Volumes/...` paths, or paths outside a mounted container
-directory. For example, two subaward inputs are configured as:
+commas, host-side paths, or paths outside a mounted container directory. For
+example, two subaward inputs are configured as:
 
 ```dotenv
 SBIR_ETL__NSF_DEFENSE_LINEAGE__SUBAWARD_SOURCES=/app/data/raw/usaspending/fy2025.zip:/app/data/raw/usaspending/fy2026.zip
@@ -340,7 +353,7 @@ That aggregate result requires all of these gates:
 Also confirm that the dated `network.json` and its sibling CSV downloads exist
 under `SERVER_ARTIFACTS_DIR`. Record the Dagster run ID, analysis date, input
 vintages and checksums, output paths, row counts, and gate result in
-`mac-mini-status.local.md`. If any gate or output check fails, retain the dated
+`server-status.local.md`. If any gate or output check fails, retain the dated
 canary files for diagnosis and keep the monthly schedule stopped. Only after a
 clean canary should an operator restore the persistent production destinations,
 recreate the containers, and run the job manually once more. Keep the monthly
@@ -353,7 +366,7 @@ Pinned canary inputs must never become a recurring schedule configuration.
 Treat Dagster completion as an execution signal, not proof that an output is
 research-ready. Before enabling any schedule or sensor, record the run ID,
 input vintage, output path, row grain, cardinality, and semantic checks in
-`mac-mini-status.local.md`. In particular:
+`server-status.local.md`. In particular:
 
 - Compare source rows at their declared grain with the corresponding Neo4j
   nodes. The SBIR award grain is `award_id` plus phase; duplicate
@@ -380,7 +393,7 @@ but expand to several CSV members, so they must be streamed and filtered rather
 than loaded into Pandas as a whole.
 
 Run these commands from the deployment checkout. They write only below the
-SSD-backed `/app/data` mount:
+persistent `/app/data` mount:
 
 ```bash
 # Build the complete vendor frame from the current SBIR.gov source in bounded chunks.
@@ -435,14 +448,14 @@ Before enabling, note:
 - **USAspending** is the long pole. The dump is large and the job may run for
   hours. It checks free space before downloading and resumes from a sidecar
   checkpoint next to the partial file, so an interrupted run is re-runnable
-  rather than restarted. Confirm SSD headroom first.
+  rather than restarted. Confirm storage headroom first.
 - **USPTO** needs `USPTO_ODP_API_KEY` and a working Playwright/Chromium install.
   Anonymous downloads from data.uspto.gov ended 2026-06-18 and now return an
   HTML shell with HTTP 200, so the job fetches PatentsView and AI patents
   through the ODP mint flow and assignments through browser automation. A
   size/HTML guard fails the run rather than saving an error page as data.
 - Downloads land under `SBIR_ETL__PATHS__DATA_ROOT`, which the server profile
-  points at the SSD.
+  points at persistent host storage.
 
 ### Pipeline chaining
 
@@ -508,14 +521,15 @@ to `false` if the code server starts hitting its limit.
 
 ## Recovery
 
-- **After reboot:** OrbStack and Tailscale start at login; containers use
-  `restart: unless-stopped` and Serve routes persist (`--bg`). Verify with
-  `make server-status` and `make server-tailscale-status`.
+- **After reboot:** the container runtime and Tailscale start automatically;
+  containers use `restart: unless-stopped` and Serve routes persist (`--bg`).
+  Verify with `make server-status` and `make server-tailscale-status`.
 - **After Tailscale reconnect:** routes resume automatically. If missing,
   re-run `make server-tailscale-up`.
-- **After container restart:** Neo4j and Dagster metadata persist on the SSD /
-  `dagster_home` volume; no data loss.
-- **After external-drive failure:** re-mount the SSD, then `make server-up`.
+- **After container restart:** Neo4j and Dagster metadata persist on host
+  storage and the `dagster_home` volume; no data loss.
+- **After storage failure:** restore or re-mount the configured storage, then
+  `make server-up`.
   Restore Neo4j from the latest `server-backup` dump if the store is damaged.
 
 ## Verifying isolation
@@ -524,7 +538,7 @@ From a **non-Tailscale** device on the same LAN, the services must be
 unreachable (connection refused/timeout):
 
 ```bash
-curl -m 5 http://<mac-lan-ip>:3000/        # fails
+curl -m 5 http://<server-lan-ip>:3000/        # fails
 ```
 
 From a Tailscale analyst device, Dagster succeeds on 443 while Neo4j remains
@@ -544,5 +558,5 @@ connections to 7474/7687 remain unreachable.
   Proposed external services are not part of the current architecture until
   code, credentials, durable rebuild inputs, and an owning runbook exist.
 
-The Mac mini is the only data plane. Do not route work through retired AWS
-Batch, Fargate, Lambda, Step Functions, or S3 components.
+The self-hosted server is the only data plane. Do not route work through
+retired AWS Batch, Fargate, Lambda, Step Functions, or S3 components.

--- a/docs/deployment/server-status.example.md
+++ b/docs/deployment/server-status.example.md
@@ -1,0 +1,25 @@
+# Self-Hosted Server Status
+
+Copy this file to `server-status.local.md` on the live host and fill it in. The
+local copy is ignored by Git because it contains installation-specific paths and
+point-in-time operational state.
+
+## Installation
+
+- Host identifier:
+- Deployment checkout:
+- Persistent storage root:
+- Container runtime and host architecture:
+- Installed version (`git describe --tags --always --dirty`):
+
+## Current state
+
+- Last verified:
+- Data vintages and checksums:
+- Materialized subsets and Dagster run IDs:
+- Backup location and last successful backup:
+- Enabled schedules and sensors:
+- Temporary blockers or recovery notes:
+
+Do not put passwords, API keys, bearer tokens, or other secret values in this
+file. Secrets remain in the deployment checkout's mode-`0600` `.env.server`.

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -6,12 +6,12 @@
 
 **Last-Reviewed**: 2026-08-03
 
-Docker Compose is the standard local service environment and the live Mac mini deployment
+Docker Compose is the standard local service environment and the live self-hosted server deployment
 mechanism. GitHub Actions builds an image only as a conditional CI smoke test; it does not deploy
 or run the data plane.
 
 This guide covers the root `docker-compose.yml` development and test profiles. For the separate
-live compose file and server-only targets, use the [Mac mini runbook](../deployment/mac-mini-server.md).
+live compose file and server-only targets, use the [self-hosted server runbook](../deployment/self-hosted-server.md).
 
 ## Quick start
 
@@ -138,15 +138,16 @@ make docker-build
 docker build -f Dockerfile.full -t sbir-analytics-full:latest .
 ```
 
-The Mac mini builds native arm64 images locally. It may use the published Python base when a
-matching manifest exists and otherwise builds `Dockerfile.python-base` from source. GitHub Actions
+The self-hosted server builds images for its container runtime's native
+architecture. It may use the published Python base when a matching manifest
+exists and otherwise builds `Dockerfile.python-base` from source. GitHub Actions
 does not publish application images.
 
 ## Data and volumes
 
 Local development uses named volumes and bind mounts declared in `docker-compose.yml`. The live
-server uses bind mounts under `/Volumes/SSDmini/sbir-analytics` plus the Docker `dagster_home`
-volume. Never point a development compose command at those live paths.
+server uses the bind mounts configured by `SERVER_*_DIR` plus the Docker
+`dagster_home` volume. Never point a development compose command at those live paths.
 
 Back up data before intentionally resetting a local graph. `make neo4j-reset` is destructive to the
 local Neo4j volume.
@@ -173,5 +174,5 @@ published port in `.env`. If a bind mount is empty, verify the host path and Doc
 sharing permissions.
 
 For live failures, stop here and switch to the
-[server runbook](../deployment/mac-mini-server.md#live-instance-on-this-mac-mini); do not improvise
+[server runbook](../deployment/self-hosted-server.md#live-instance-on-the-server-host); do not improvise
 against the development checkout.

--- a/docs/enrichment/sam-gov-integration.md
+++ b/docs/enrichment/sam-gov-integration.md
@@ -49,7 +49,7 @@ you intend to use strategy 2 or 3. SAM.gov keys expire periodically, commonly ar
 authentication failures on those fallbacks should prompt key rotation rather than blind retries.
 
 The live key belongs in `.env.server`, never committed YAML. Before running the live download, read
-the [Mac mini runbook](../deployment/mac-mini-server.md#source-data-downloads).
+the [self-hosted server runbook](../deployment/self-hosted-server.md#source-data-downloads).
 
 ## Dagster job and schedule
 

--- a/docs/getting-started/README.md
+++ b/docs/getting-started/README.md
@@ -121,4 +121,4 @@ and [data documentation](../data/index.md) before running larger materialization
 - [Development guides](../development/README.md) — code standards and workflows
 - [Testing index](../testing/index.md) — local and CI validation
 - [Configuration reference](../configuration.md) — YAML and environment overrides
-- [Deployment guide](../deployment/README.md) — Mac mini and local deployment
+- [Deployment guide](../deployment/README.md) — self-hosted server and local deployment

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,7 +42,7 @@ Use these before quoting a result or starting a feature from an old spec.
 | Versioning and releases | [Versioning policy](steering/versioning.md) |
 | Performance measurement | [Performance runbook](performance.md) |
 | Deployment navigation | [Deployment index](deployment/README.md) |
-| Live Mac mini operations | [Mac mini runbook](deployment/mac-mini-server.md) |
+| Live self-hosted server operations | [self-hosted server runbook](deployment/self-hosted-server.md) |
 | Neo4j migrations | [Migration guide](migrations.md) |
 | Decisions | [Architecture decision records](decisions/README.md) |
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -66,7 +66,7 @@ python scripts/neo4j/migrate.py downgrade --target 001
 ```
 
 Before upgrading the live graph, take and verify a backup using `make server-backup` from the live
-checkout as described in the [Mac mini runbook](deployment/mac-mini-server.md#day-2-operations).
+checkout as described in the [self-hosted server runbook](deployment/self-hosted-server.md#day-2-operations).
 Review data migrations particularly
 carefully: 003 merges duplicate organizations, 006 re-homes legacy `Award` nodes into
 `FinancialTransaction`, and 007 re-homes legacy `Company` nodes into `Organization`.

--- a/docs/ml/cet-integration.md
+++ b/docs/ml/cet-integration.md
@@ -50,8 +50,8 @@ Run the complete job only after installing the full stack and providing its loca
 make cet-run
 ```
 
-Heavy CET assets are not scheduled by default on the Mac mini. Follow the
-[capacity guidance](../deployment/mac-mini-server.md#heavy-assets) before a live run.
+Heavy CET assets are not scheduled by default on the self-hosted server. Follow the
+[capacity guidance](../deployment/self-hosted-server.md#heavy-assets) before a live run.
 
 ## Model and rule boundary
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -63,8 +63,8 @@ script's default path as an official baseline.
 
 ## Live-server boundary
 
-Heavy assets on the Mac mini are manual and capacity-gated. Check current container limits and
-follow [Heavy assets](deployment/mac-mini-server.md#heavy-assets) before profiling there. Never run
+Heavy assets on the self-hosted server are manual and capacity-gated. Check current container limits and
+follow [Heavy assets](deployment/self-hosted-server.md#heavy-assets) before profiling there. Never run
 a benchmark from the development checkout against the live graph or overwrite live source data.
 
 ## Reporting results

--- a/docs/procurement-transition-report.md
+++ b/docs/procurement-transition-report.md
@@ -76,7 +76,7 @@ records the partial coverage, and continues with explicit missing-text labels.
 
 Pass the preceding public award snapshot with `--previous-awards` to distinguish
 new and changed records. No GitHub Actions workflow schedules this pipeline; an
-operator or future Mac mini Dagster job must preserve and supply that snapshot
+operator or future self-hosted server Dagster job must preserve and supply that snapshot
 explicitly. Record any retention policy with the job that owns the materialization.
 When `OPENAI_API_KEY` is absent, `--ai` degrades to deterministic packet text.
 AI receives only retrieved public fields, is invoked only when both technical

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -18,7 +18,7 @@ testing, configuration, or deployment commands; use the linked operational refer
 - Dagster for assets, jobs, schedules, sensors, and run metadata.
 - Neo4j 5 for the linked analytical graph.
 - scikit-learn and, only where justified, PyTorch/Transformers for ML.
-- Docker Compose for local development, tests, and the Mac mini data plane.
+- Docker Compose for local development, tests, and the self-hosted server data plane.
 - pytest, Ruff, and MyPy for verification.
 
 The [architecture overview](../architecture/detailed-overview.md) owns component placement and
@@ -45,4 +45,4 @@ can be described as architecture.
 - Configuration: [Configuration reference](../configuration.md)
 - Local containers: [Docker development](../development/docker.md)
 - Testing and CI: [Testing index](../testing/index.md)
-- Live deployment: [Mac mini runbook](../deployment/mac-mini-server.md)
+- Live deployment: [self-hosted server runbook](../deployment/self-hosted-server.md)

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -61,7 +61,7 @@ make neo4j-check
 This instance uses the credentials in `.env` and persists its development volume. The Compose
 `ci` profile used by the Docker E2E targets is isolated and disposable. GitHub Actions starts its
 own authenticated Neo4j service for the full post-merge suite; pull-request unit shards do not
-start Neo4j. None of these test environments use the live Mac mini graph.
+start Neo4j. None of these test environments use the live self-hosted server graph.
 
 Supported scenarios are:
 

--- a/docs/testing/test-scheduling.md
+++ b/docs/testing/test-scheduling.md
@@ -72,10 +72,10 @@ For E2E scenario selection, use the commands in [End-to-End Testing](e2e-testing
 
 ## Scheduled operational work
 
-Production extraction, enrichment, reporting, and materialization are scheduled on the Mac mini
+Production extraction, enrichment, reporting, and materialization are scheduled on the self-hosted server
 through Dagster or cron. They are operational data-plane work, not GitHub Actions tests. Before
 inspecting or running them, read the
-[Mac mini runbook](../deployment/mac-mini-server.md#live-instance-on-this-mac-mini).
+[self-hosted server runbook](../deployment/self-hosted-server.md#live-instance-on-the-server-host).
 
 If a periodic regression suite is added later, document its trigger and prerequisites here only
 after the workflow or server schedule exists. Do not describe proposed schedules as current CI.

--- a/docs/testing/validation-testing.md
+++ b/docs/testing/validation-testing.md
@@ -77,7 +77,7 @@ option list.
 
 `--load-neo4j` is write-producing and requires a reachable Neo4j instance and valid credentials.
 Do not point an exploratory validation run at the live database. Before any live operation, use the
-[Mac mini runbook](../deployment/mac-mini-server.md#live-instance-on-this-mac-mini).
+[self-hosted server runbook](../deployment/self-hosted-server.md#live-instance-on-the-server-host).
 
 ## Automated coverage
 

--- a/docs/transition/overview.md
+++ b/docs/transition/overview.md
@@ -47,7 +47,7 @@ uv run dagster job execute -m sbir_analytics.definitions -j transition_mvp_job
 ```
 
 Use `transition_full_job` only when Neo4j and the downstream assets are configured. These heavy
-jobs are not scheduled on the live Mac mini by default.
+jobs are not scheduled on the live self-hosted server by default.
 
 ## Library path
 

--- a/packages/sbir-analytics/sbir_analytics/assets/jobs/source_downloads.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/jobs/source_downloads.py
@@ -1,14 +1,14 @@
 """Source-data download jobs that run on the always-on server.
 
 These replace the GitHub Actions `data-refresh.yml` workflow. Actions runners
-cannot reach the Mac mini (tailnet-only, no self-hosted runner), so the host
+cannot reach the self-hosted server (tailnet-only, no self-hosted runner), so the host
 that stores the data is the host that fetches it.
 
 Each op wraps the corresponding `scripts/` downloader, which writes to the
 local data root by default. Destinations come from the config paths so the
-server profile's SSD bind mounts are honoured without hardcoding them here.
+server profile's persistent bind mounts are honoured without hardcoding them here.
 
-Schedules for these jobs default to STOPPED. Per the Mac mini runbook, an
+Schedules for these jobs default to STOPPED. Per the self-hosted server runbook, an
 operator confirms a manual run succeeds on this host before enabling one.
 """
 

--- a/scripts/data/run_weekly_workflow_local.sh
+++ b/scripts/data/run_weekly_workflow_local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Legacy local validation helper for an SBIR awards refresh.
-# The live download is now sbir_awards_download_job on the Mac mini; this script
+# The live download is now sbir_awards_download_job on the self-hosted server; this script
 # remains useful for an explicit download-and-validation rehearsal in a dev checkout.
 
 set -euo pipefail

--- a/scripts/server/backup.sh
+++ b/scripts/server/backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Offline-consistent Neo4j backup for the Mac mini server profile.
+# Offline-consistent Neo4j backup for the self-hosted server profile.
 
 set -eu
 

--- a/scripts/server/check-prerequisites.sh
+++ b/scripts/server/check-prerequisites.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # sbir-analytics/scripts/server/check-prerequisites.sh
 #
-# Preflight checks for the Tailscale-only Mac mini server profile.
+# Preflight checks for the Tailscale-only self-hosted server profile.
 #
 # Validates, before `make server-up`:
 #   * .env.server present and required secrets set (not placeholders)

--- a/scripts/server/tailscale-serve.sh
+++ b/scripts/server/tailscale-serve.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# Manage the tailnet-only routes for the Mac mini server profile.
+# Manage the tailnet-only routes for the self-hosted server profile.
 
 set -eu
 

--- a/tests/unit/assets/test_source_download_jobs.py
+++ b/tests/unit/assets/test_source_download_jobs.py
@@ -1,7 +1,7 @@
 """Tests for the source-download jobs that replace data-refresh.yml.
 
 Verifies the jobs are discoverable, that their schedules inherit the crons the
-workflow used, and that they default to STOPPED per the Mac mini runbook.
+workflow used, and that they default to STOPPED per the self-hosted server runbook.
 """
 
 import pytest


### PR DESCRIPTION
## Summary

- rename the hardware-specific deployment runbook to `self-hosted-server.md`
- describe the live deployment in terms of its operating contract instead of a particular computer model, CPU architecture, checkout path, or storage mount
- move installation-specific paths and current state into an ignored `server-status.local.md`, with a tracked example template
- update documentation links, operational comments, and archived deployment references

## Why

The deployment documentation mixed portable safety requirements with details of the current host. That made the documented architecture appear tied to a Mac mini and encouraged host-specific paths to spread across the repository.

This keeps the important constraints explicit—dedicated clean checkout, persistent storage, preserved `.env.server` and Dagster metadata, loopback-only binds, Tailscale-only ingress, and no Funnel—while allowing the host implementation to change independently.

## Validation

- `make docs-check`
- `git diff --check`
- repository-wide scan confirms no Mac mini-specific wording or stale renamed anchors remain
