### PR TITLE
ci: enforce epistemic tier declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
       - name: Run architecture, documentation, and repository hygiene guards
         run: |
           uv run python scripts/ci/check_architecture_boundaries.py
+          uv run python scripts/ci/check_epistemic_tiers.py
           uv run python scripts/ci/check_removed_src_references.py
           uv run python scripts/ci/validate_study_manifests.py
           # Guards the company-identity primitive: a direct RapidFuzz scorer

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -167,15 +167,17 @@ What already holds:
 
 What does not:
 
-- The identity boundary checker is enforced by the CI quality job, but no
-  tier-declaration check exists yet.
+- The identity boundary checker is enforced by the CI quality job.
+- Active specs declare a target tier in `requirements.md`; CI rejects missing,
+  duplicate, and invalid declarations.
 - Nine direct `yaml.safe_load` call sites remain outside the configuration
   loader and the shared strict-mapping reader; several intentionally use
   permissive empty-file behavior.
 - `scripts/` carries analytical weight from `phase3_groundtruth/` and
   `validation/` with no contract at all.
-- No existing specs, assets, or modules declare one of these four tiers, so the
-  declaration rule is not yet observable or mechanically enforced.
+- Existing modules are not yet universally declared. An undeclared module is
+  therefore still exploratory until an explicit promotion satisfies its target
+  contract.
 
 The first useful step is labeling, not moving directories. Directory
 reorganization is the last step, and optional.

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -98,11 +98,15 @@ the manifest schema, frozen-artifact hashes, and implementation references.
 ### Transitional Script Dependencies
 
 First-party packages may not add dependencies on `scripts/`. The architecture guard carries
-one exact, temporary exception for the server source-download jobs, which wrap five existing
-download CLIs. This is a migration bridge, not a fifth epistemic tier or an implicit
-promotion of those scripts: it is limited to compatibility wrappers, must not be used by an
-evidence-tier artifact, and is removed when the implementations move behind a package API.
-The CLI modules can then remain as compatibility entry points.
+four exact temporary bridges: one import bridge from the server source-download jobs to five
+existing download CLIs, plus execution bridges from the tech-area, weekly-awards, and
+phase-transition report jobs to their script entry points. These are migration bridges, not a
+fifth epistemic tier or an implicit promotion of those scripts. They are limited to named
+compatibility wrappers, must not be used by an evidence-tier artifact, and are removed when
+the implementations move behind package APIs. The CLI modules can then remain as entry points.
+
+The guard inspects both imports and literal Python-script targets passed to `subprocess`.
+Hiding a package-to-script dependency behind process execution does not change its direction.
 
 ### Separation of Concerns
 

--- a/scripts/ci/check_architecture_boundaries.py
+++ b/scripts/ci/check_architecture_boundaries.py
@@ -44,6 +44,23 @@ TRANSITIONAL_SCRIPT_IMPORTS = {
     )
 }
 
+# Package code also reached three scripts by spawning a Python subprocess. An
+# import-only guard cannot see those dependency edges, so keep the temporary
+# execution bridges just as exact as the import bridge above. Each entry is
+# removed when its script implementation is exposed through a package API and
+# the package caller invokes that API directly.
+TRANSITIONAL_SCRIPT_EXECUTIONS = {
+    "packages/sbir-analytics/sbir_analytics/assets/transition_report.py": frozenset(
+        {"scripts/data/build_tech_area_cohort.py"}
+    ),
+    "packages/sbir-analytics/sbir_analytics/assets/jobs/weekly_awards_report.py": frozenset(
+        {"scripts/data/weekly_awards_report.py"}
+    ),
+    "packages/sbir-analytics/sbir_analytics/assets/jobs/phase_transition_archive.py": (
+        frozenset({"scripts/phase_transition_analysis.py"})
+    ),
+}
+
 
 @dataclass(frozen=True)
 class BoundaryViolation:
@@ -53,10 +70,12 @@ class BoundaryViolation:
     line_number: int
     source_package: str
     imported_module: str
+    dependency_kind: str = "import"
 
     def format(self) -> str:
+        action = "import" if self.dependency_kind == "import" else "execute"
         return (
-            f"{self.path}:{self.line_number}: {self.source_package} may not import "
+            f"{self.path}:{self.line_number}: {self.source_package} may not {action} "
             f"{self.imported_module}"
         )
 
@@ -95,6 +114,67 @@ def imported_modules(path: Path) -> list[tuple[str, int]]:
     return imports
 
 
+def _is_subprocess_call(node: ast.Call) -> bool:
+    return (
+        isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "subprocess"
+        and node.func.attr in {"call", "check_call", "check_output", "Popen", "run"}
+    )
+
+
+def _path_literal_parts(node: ast.AST) -> list[str]:
+    """Return literal pieces of a ``Path`` division or command argument."""
+
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return [node.value]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        return _path_literal_parts(node.left) + _path_literal_parts(node.right)
+    if isinstance(node, (ast.List, ast.Tuple)):
+        parts: list[str] = []
+        for element in node.elts:
+            parts.extend(_path_literal_parts(element))
+        return parts
+    if isinstance(node, ast.Call):
+        parts: list[str] = []
+        for argument in node.args:
+            parts.extend(_path_literal_parts(argument))
+        return parts
+    return []
+
+
+def _script_target(node: ast.AST) -> str | None:
+    """Normalize a literal path expression to a repository ``scripts/*.py`` target."""
+
+    pieces = _path_literal_parts(node)
+    for piece in pieces:
+        normalized = piece.replace("\\", "/").strip()
+        marker = normalized.find("scripts/")
+        if marker >= 0 and normalized[marker:].endswith(".py"):
+            return normalized[marker:]
+
+    normalized_parts = [piece.strip("/\\") for piece in pieces if piece.strip("/\\")]
+    if "scripts" not in normalized_parts:
+        return None
+    scripts_index = normalized_parts.index("scripts")
+    candidate = "/".join(normalized_parts[scripts_index:])
+    return candidate if candidate.endswith(".py") else None
+
+
+def executed_script_paths(path: Path) -> list[tuple[str, int]]:
+    """Extract literal repository Python scripts invoked through ``subprocess``."""
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    if not any(isinstance(node, ast.Call) and _is_subprocess_call(node) for node in ast.walk(tree)):
+        return []
+
+    targets: dict[str, int] = {}
+    for node in ast.walk(tree):
+        if target := _script_target(node):
+            targets.setdefault(target, node.lineno)
+    return sorted(targets.items(), key=lambda item: (item[1], item[0]))
+
+
 def scan_package(
     source_package: str,
     source_root: Path,
@@ -125,6 +205,18 @@ def scan_package(
                 violations.append(
                     BoundaryViolation(relative, line_number, source_package, imported_module)
                 )
+        for script_target, line_number in executed_script_paths(path):
+            if script_target in TRANSITIONAL_SCRIPT_EXECUTIONS.get(relative, ()):
+                continue
+            violations.append(
+                BoundaryViolation(
+                    relative,
+                    line_number,
+                    source_package,
+                    script_target,
+                    dependency_kind="execute",
+                )
+            )
     return violations
 
 

--- a/scripts/ci/check_epistemic_tiers.py
+++ b/scripts/ci/check_epistemic_tiers.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Require every active specification to declare a valid epistemic target tier."""
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+SPECS_ROOT = REPOSITORY_ROOT / "specs"
+VALID_TIERS = frozenset({"primitives", "pipelines", "evidence", "exploratory"})
+TIER_DECLARATION = re.compile(
+    r"^\*\*Target epistemic tier:\*\*\s*`?([a-z]+)`?\s*$",
+    flags=re.MULTILINE,
+)
+EXCLUDED_SPEC_DIRECTORIES = frozenset({"archive"})
+
+
+@dataclass(frozen=True)
+class TierDeclarationViolation:
+    """One missing, duplicate, or invalid specification declaration."""
+
+    path: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}: {self.message}"
+
+
+def validate_spec_directory(
+    spec_directory: Path,
+    *,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> list[TierDeclarationViolation]:
+    """Validate the canonical declaration for one active specification."""
+
+    requirements = spec_directory / "requirements.md"
+    relative = requirements.relative_to(repository_root).as_posix()
+    if not requirements.is_file():
+        return [
+            TierDeclarationViolation(
+                relative,
+                "active spec is missing requirements.md and its target epistemic tier",
+            )
+        ]
+
+    declarations = TIER_DECLARATION.findall(requirements.read_text(encoding="utf-8"))
+    if not declarations:
+        return [
+            TierDeclarationViolation(
+                relative,
+                "missing '**Target epistemic tier:** <tier>' declaration",
+            )
+        ]
+    if len(declarations) > 1:
+        return [TierDeclarationViolation(relative, "multiple target tier declarations")]
+
+    tier = declarations[0]
+    if tier not in VALID_TIERS:
+        choices = ", ".join(sorted(VALID_TIERS))
+        return [
+            TierDeclarationViolation(
+                relative,
+                f"invalid target tier {tier!r}; expected one of: {choices}",
+            )
+        ]
+    return []
+
+
+def scan_specs(
+    *,
+    specs_root: Path = SPECS_ROOT,
+    repository_root: Path = REPOSITORY_ROOT,
+) -> list[TierDeclarationViolation]:
+    """Validate every non-archived top-level specification directory."""
+
+    violations: list[TierDeclarationViolation] = []
+    for directory in sorted(path for path in specs_root.iterdir() if path.is_dir()):
+        if directory.name in EXCLUDED_SPEC_DIRECTORIES:
+            continue
+        violations.extend(validate_spec_directory(directory, repository_root=repository_root))
+    return violations
+
+
+def main() -> int:
+    violations = scan_specs()
+    if violations:
+        print("Epistemic tier declaration violations were found:")
+        print("\n".join(violation.format() for violation in violations))
+        return 1
+    print("Epistemic tier declaration checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/actions-migration-followups/requirements.md
+++ b/specs/actions-migration-followups/requirements.md
@@ -1,0 +1,10 @@
+# Actions Migration Follow-ups — Requirements
+
+**Target epistemic tier:** `pipelines`
+
+This operational spec restores deterministic repository and setup checks after
+the scheduled GitHub Actions workflows were retired. The detailed decisions and
+acceptance evidence remain in:
+
+- [repo-checks-restoration.md](repo-checks-restoration.md)
+- [setup-script-verification.md](setup-script-verification.md)

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -1,5 +1,7 @@
 # SBIR vs. Private-Capital Comparison — Requirements (agency-parameterized; NSF as initial target)
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Phase 1 implemented; Phase 2 is a gated backlog item now that the
 > Form D / M&A infrastructure from PR #286 is available. Do not start Phase 2
 > until the private-capital control-cohort comparison is selected as a current

--- a/specs/bea-nipa-tax-rates/requirements.md
+++ b/specs/bea-nipa-tax-rates/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — BEA NIPA Tax Rate Hardening
 
+**Target epistemic tier:** `pipelines`
+
 > **Status:** Partially implemented. `sbir_etl/transformers/fiscal/nipa_rates.py`
 > (`NIPARateProvider`) already fetches BEA NIPA Tables 3.2, 3.3, and 1.5 via the
 > existing BEA API client and produces the eight derived federal + state/local

--- a/specs/company-categorization/requirements.md
+++ b/specs/company-categorization/requirements.md
@@ -1,5 +1,7 @@
 # Company Categorization — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** 77% complete.
 > Anchors inventory question **B1** in [docs/research-questions.md](../../docs/research-questions.md).
 

--- a/specs/cross-agency-taxonomy/requirements.md
+++ b/specs/cross-agency-taxonomy/requirements.md
@@ -1,5 +1,7 @@
 # Cross-Agency Technology Taxonomy — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Partially implemented as of June 2026 — analytical tools in
 > `packages/sbir-analytics/sbir_analytics/tools/mission_a/` already compute HHI per CET
 > area, cross-agency company count, geographic concentration, semantic clustering, gap

--- a/specs/dark-majority-resolution/requirements.md
+++ b/specs/dark-majority-resolution/requirements.md
@@ -1,5 +1,7 @@
 # Dark-Majority Resolution
 
+**Target epistemic tier:** `evidence`
+
 **Problem:** 82.6% of the nanotech Phase II cohort (2,352 of 2,849 awards) has indeterminate
 commercialization status. The findings report (`docs/nanotech_sbir_transition_findings.md`,
 Finding 3) shows this "dark majority" is measurement failure more than proven failure — but

--- a/specs/data-imputation/requirements.md
+++ b/specs/data-imputation/requirements.md
@@ -1,5 +1,7 @@
 # Data Imputation — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Gated backlog — spec merged via PR #277; implementation not yet
 > started as of July 2026.
 > Anchors inventory question **E4** in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/dspy-weekly-awards-prototype/requirements.md
+++ b/specs/dspy-weekly-awards-prototype/requirements.md
@@ -1,5 +1,7 @@
 # DSPy Weekly Award Narratives Prototype — Requirements
 
+**Target epistemic tier:** `exploratory`
+
 > **Status:** Gated backlog; implementation is not authorized until the
 > activation gates below are satisfied. Production adoption remains separately
 > gated on the offline and shadow criteria below. Anchors inventory question **E6** in

--- a/specs/follow-on-multiplier-validation/requirements.md
+++ b/specs/follow-on-multiplier-validation/requirements.md
@@ -1,0 +1,7 @@
+# Follow-on Funding Multiplier Validation — Requirements
+
+**Target epistemic tier:** `evidence`
+
+The target contract is the validation, sensitivity, and review-sampling design
+in [design.md](design.md). The multiplier is externally reportable only after
+the evidence-tier gates described there are implemented and passed.

--- a/specs/iterative_api_enrichment/requirements.md
+++ b/specs/iterative_api_enrichment/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — Iterative API Enrichment Refresh
 
+**Target epistemic tier:** `pipelines`
+
 > **Status:** Partially implemented — USAspending iterative enrichment is live (`packages/sbir-analytics/sbir_analytics/assets/usaspending_iterative_enrichment.py`); other sources (SAM.gov, NIH RePORTER, PatentsView) pending.
 > Supports inventory question **E3** (enrichment freshness infrastructure) in [docs/research-questions.md](../../docs/research-questions.md).
 

--- a/specs/ma-discovery-integration/requirements.md
+++ b/specs/ma-discovery-integration/requirements.md
@@ -1,0 +1,7 @@
+# M&A Discovery Integration — Requirements
+
+**Target epistemic tier:** `evidence`
+
+The target contract is the confidence-bounded discovery and collision policy
+in [design.md](design.md). Candidate discovery remains non-citable until the
+specified validation and provenance requirements are implemented.

--- a/specs/modernbert_analysis_layer/requirements.md
+++ b/specs/modernbert_analysis_layer/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — ModernBert Analysis Layer
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Partially implemented. Core ModernBert client, embedding assets,
 > similarity output, config, and client-level tests exist. Neo4j `SIMILAR_TO`
 > loading, quality/cohesion metrics, fuller asset checks, and Dagster integration

--- a/specs/naics-enricher-consolidation/requirements.md
+++ b/specs/naics-enricher-consolidation/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — NAICS Enricher Consolidation
 
+**Target epistemic tier:** `pipelines`
+
 > **Status:** Largely complete. Shim deletion, canonical mapper consolidation,
 > strategy registration, and Ruff/mypy verification are done. Remaining work is
 > documentation cleanup and deciding whether obsolete audit/golden-file tasks

--- a/specs/nvca-yearbook-benchmarks/requirements.md
+++ b/specs/nvca-yearbook-benchmarks/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — NVCA Yearbook Benchmark Reference Data
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** **Partially implemented; spec was mis-framed on first pass.** A
 > 2026-06-29 audit (paralleling #400 and #402) found that
 > `agency_private_capital/baselines.py` already provides a fully-functional

--- a/specs/ot-consortium-subaward-attribution/requirements.md
+++ b/specs/ot-consortium-subaward-attribution/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — OT Consortium Sub-Award Attribution (FFATA/FSRS)
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Gated backlog — not implemented. Run the T0 coverage probe before
 > promoting beyond the OT consortium verification-tiering follow-up.
 > Supports inventory question **A2** (OT consortium attribution) in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/patent-cost-spillover/requirements.md
+++ b/specs/patent-cost-spillover/requirements.md
@@ -1,5 +1,7 @@
 # Patent Cost and Spillover Analysis — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Gated backlog — zero cost/citation/spillover analytical-layer
 > implementation as of July 2026.
 > Anchors inventory questions **C3a–c** in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/phase-3-solicitation-alerts/requirements.md
+++ b/specs/phase-3-solicitation-alerts/requirements.md
@@ -1,5 +1,7 @@
 # Phase III Solicitation & Award Candidate Alerts — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Partially implemented. S1 retrospective reclassification shipped
 > in PRs #394, #410, and #412; S2/S3 SAM.gov Opportunities candidate paths and
 > final documentation/sign-off remain backlog.

--- a/specs/phase-iii-census/requirements.md
+++ b/specs/phase-iii-census/requirements.md
@@ -1,0 +1,7 @@
+# Label-free Phase III Census — Requirements
+
+**Target epistemic tier:** `evidence`
+
+The frozen criteria, declared estimand, amendments, materialization gates, and
+limitations are defined in [design.md](design.md), [amendments.md](amendments.md),
+and the versioned [`study.yaml`](../../studies/phase-iii-census/study.yaml).

--- a/specs/phase-iii-source-materialization/requirements.md
+++ b/specs/phase-iii-source-materialization/requirements.md
@@ -1,0 +1,7 @@
+# Phase III Source Materialization — Requirements
+
+**Target epistemic tier:** `pipelines`
+
+The deterministic source, schema, grain, fingerprint, and atomic-publication
+contracts are defined in [design.md](design.md). This layer materializes inputs;
+it does not apply Phase III census criteria or produce findings.

--- a/specs/phase3-candidate-enrichment/requirements.md
+++ b/specs/phase3-candidate-enrichment/requirements.md
@@ -1,5 +1,7 @@
 # Phase III Candidate-Text Enrichment — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Draft spec. No implementation. Follow-on to the ground-truth validation
 > (#481), which measured *why* the fusion ranker underperforms.
 > Supports inventory questions **B2 / E1** in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/phase3-match-benchmark/requirements.md
+++ b/specs/phase3-match-benchmark/requirements.md
@@ -1,5 +1,7 @@
 # Phase III match benchmark: requirements
 
+**Target epistemic tier:** `evidence`
+
 Status: **research protocol / draft implementation**. Parent issue: #448.
 Foundation: PR #449 and issue #447. Production source lifecycle: issue #442.
 

--- a/specs/phase3-notice-corpus-fusion/requirements.md
+++ b/specs/phase3-notice-corpus-fusion/requirements.md
@@ -1,5 +1,7 @@
 # Phase III Notice Corpus & Fusion Ranker — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Implemented (T1–T7 done — see `tasks.md`). This branch ships a production
 > scoring path: coefficients are frozen at
 > `packages/sbir-ml/sbir_ml/transition/detection/fusion_coefficients.json` and the monthly

--- a/specs/phase3-transition-groundtruth/requirements.md
+++ b/specs/phase3-transition-groundtruth/requirements.md
@@ -1,5 +1,7 @@
 # Independent Phase III Transition Ground-Truth Set — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Draft spec. No implementation. Validation deliverable for the
 > merged award-grain fusion ranker (#467).
 > Supports inventory questions **B2 / E1** in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/phase3-undercount-extension/requirements.md
+++ b/specs/phase3-undercount-extension/requirements.md
@@ -1,5 +1,7 @@
 # Phase III Undercount Extension — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Draft spec. Builds on existing undercount work (M0a + 3-source
 > capture-recapture) and the coverage-expansion sources (#485). Answers the north-star
 > question **B3**: *"How much undercount exists in Phase III coding?"* — the transition

--- a/specs/procurement-transition-p1-remediation/requirements.md
+++ b/specs/procurement-transition-p1-remediation/requirements.md
@@ -1,0 +1,7 @@
+# Procurement Transition P1 Remediation — Requirements
+
+**Target epistemic tier:** `evidence`
+
+The award-lineage, cold-start, source-matching, enrichment, and ranking safety
+requirements and their acceptance gates are maintained in [plan.md](plan.md).
+The packet remains a human review queue until those evidence gates are met.

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -1,5 +1,7 @@
 # Requirements: SBIR M&A Match Rate by Fiscal Year
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Gated backlog — analysis-only spec, not yet implemented. Start
 > only when FY match-rate reporting is requested.
 > Supports inventory question **F2** (M&A exit rate by vintage) in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/state-local-tax-rates/requirements.md
+++ b/specs/state-local-tax-rates/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — State & Local Tax Rate Reference Data
 
+**Target epistemic tier:** `pipelines`
+
 > **Status:** Requirements 1–3 implemented across PRs #402, #400, and the follow-up
 > refresh CLI PR. The CSV reference file, CSV-backed `StateRateProvider`, BEA NIPA
 > parquet cache, and `uv run refresh-state-rates` are in place. Remaining fiscal-tax

--- a/specs/tech-area-transition-report/requirements.md
+++ b/specs/tech-area-transition-report/requirements.md
@@ -1,5 +1,7 @@
 # Tech-Area Transition Report — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** In progress (v1 cohort parameterization)
 > Anchors inventory questions **B** (commercialization / Phase II→III pathways) and
 > **C1** (cross-agency CET portfolio) in [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/transition-coverage-expansion/requirements.md
+++ b/specs/transition-coverage-expansion/requirements.md
@@ -1,5 +1,7 @@
 # Transition Coverage & Self-Labeling Expansion — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Draft spec. No implementation beyond the exploratory spikes recorded below.
 > Follow-on to #481 (validation) and #484 (enrichment). Supports **B2 / E1** in
 > [docs/research-questions.md](../../docs/research-questions.md).

--- a/specs/ucc1-financing-analysis/requirements.md
+++ b/specs/ucc1-financing-analysis/requirements.md
@@ -1,5 +1,7 @@
 # UCC-1 Financing Analysis — Requirements
 
+**Target epistemic tier:** `evidence`
+
 > **Status:** Pilot complete — PRs #303 / #305 merged. CA-only pilot found
 > equipment-finance and community-bank lender patterns and an absence of venture-debt
 > lenders in the CA-organized channel. See

--- a/specs/weekly-awards-report-refactor/requirements.md
+++ b/specs/weekly-awards-report-refactor/requirements.md
@@ -1,5 +1,7 @@
 # Requirements — Weekly Awards Report Refactor
 
+**Target epistemic tier:** `pipelines`
+
 > **Status:** Substantially complete — see the dated task breakdown in [tasks.md](tasks.md). The 2,807-line monolith is now a 116-line CLI over `sbir_etl/reporting/weekly/` with the golden-file test green; remaining work: T2.3, the typed-dataclass half of T3.2, coverage targets (T5.2), and T5.3.
 > Supports inventory question **E6** (weekly report maintainability) in [docs/research-questions.md](../../docs/research-questions.md).
 

--- a/tests/unit/scripts/test_architecture_boundaries.py
+++ b/tests/unit/scripts/test_architecture_boundaries.py
@@ -68,3 +68,35 @@ def test_script_import_exception_is_exact(tmp_path: Path) -> None:
     violations = boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path)
 
     assert [violation.imported_module for violation in violations] == ["scripts.data.unapproved"]
+
+
+def test_packages_cannot_execute_repository_scripts(tmp_path: Path) -> None:
+    package = tmp_path / "packages" / "sbir-analytics" / "sbir_analytics"
+    _write(
+        tmp_path,
+        "packages/sbir-analytics/sbir_analytics/example.py",
+        "import subprocess\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "script = Path('scripts') / 'data' / 'unapproved.py'\n"
+        "subprocess.run([sys.executable, str(script)])\n",
+    )
+
+    violations = boundaries.scan_package("sbir_analytics", package, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].dependency_kind == "execute"
+    assert violations[0].imported_module == "scripts/data/unapproved.py"
+
+
+def test_script_execution_exception_is_exact(tmp_path: Path) -> None:
+    source_root = tmp_path / "packages" / "sbir-analytics" / "sbir_analytics"
+    _write(
+        tmp_path,
+        "packages/sbir-analytics/sbir_analytics/assets/jobs/weekly_awards_report.py",
+        "import subprocess\nsubprocess.run(['python', 'scripts/data/unapproved.py'])\n",
+    )
+
+    violations = boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path)
+
+    assert [violation.imported_module for violation in violations] == ["scripts/data/unapproved.py"]

--- a/tests/unit/scripts/test_epistemic_tiers.py
+++ b/tests/unit/scripts/test_epistemic_tiers.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from scripts.ci import check_epistemic_tiers as tiers
+
+
+def _write(root: Path, relative: str, text: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_missing_requirements_file_is_rejected(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    spec.mkdir(parents=True)
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "missing requirements.md" in violations[0].message
+
+
+def test_missing_declaration_is_rejected(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(tmp_path, "specs/example/requirements.md", "# Example\n")
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "missing '**Target epistemic tier:** <tier>'" in violations[0].message
+
+
+def test_invalid_or_duplicate_declarations_are_rejected(tmp_path: Path) -> None:
+    invalid = tmp_path / "specs" / "invalid"
+    duplicate = tmp_path / "specs" / "duplicate"
+    _write(
+        tmp_path,
+        "specs/invalid/requirements.md",
+        "# Invalid\n\n**Target epistemic tier:** useful\n",
+    )
+    _write(
+        tmp_path,
+        "specs/duplicate/requirements.md",
+        "# Duplicate\n\n**Target epistemic tier:** pipelines\n"
+        "**Target epistemic tier:** evidence\n",
+    )
+
+    invalid_violations = tiers.validate_spec_directory(invalid, repository_root=tmp_path)
+    duplicate_violations = tiers.validate_spec_directory(duplicate, repository_root=tmp_path)
+
+    assert "invalid target tier" in invalid_violations[0].message
+    assert "multiple target tier" in duplicate_violations[0].message
+
+
+def test_all_valid_tiers_are_accepted(tmp_path: Path) -> None:
+    for tier in sorted(tiers.VALID_TIERS):
+        spec = tmp_path / "specs" / tier
+        _write(
+            tmp_path,
+            f"specs/{tier}/requirements.md",
+            f"# {tier}\n\n**Target epistemic tier:** `{tier}`\n",
+        )
+        assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+
+def test_current_repository_spec_declarations_are_valid() -> None:
+    assert tiers.scan_specs() == []


### PR DESCRIPTION
## What changed

- declare a target epistemic tier in every active specification
- require active spec directories to provide `requirements.md` with exactly one valid declaration
- run the declaration guard in CI
- detect literal package-to-`scripts/*.py` subprocess dependencies in the architecture guard
- name the three existing execution bridges and their removal condition alongside the downloader import bridge

## Why

The tier policy said promotion must be explicit, but no spec declared a tier and CI could not observe that rule. The architecture guard also inspected imports only, allowing three package-to-script dependencies to bypass the documented boundary through `subprocess`.

This PR establishes the enforcement baseline. A target declaration is not itself a promotion: modules and outputs still have to satisfy the selected tier contract in their own changes.

## Impact

New active specs fail CI unless they declare one of `primitives`, `pipelines`, `evidence`, or `exploratory`. New package subprocess calls into repository scripts fail unless an exact temporary bridge is reviewed and recorded.

## Validation

- `pytest -q tests/unit/scripts/test_architecture_boundaries.py tests/unit/scripts/test_epistemic_tiers.py` — 12 passed
- `ruff check` and `ruff format --check` on changed Python files
- `python3 scripts/ci/check_epistemic_tiers.py`
- `python3 scripts/ci/check_architecture_boundaries.py`
- `make docs-check`
- `git diff --check`
