### PR TITLE
refactor: promote versioned jurisdiction identity

### DIFF
--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -86,6 +86,10 @@ docs/
 Company-name normalization and similarity belong in `sbir_etl/identity`; callers select
 an explicit versioned profile. See [company-identity.md](company-identity.md).
 
+U.S. state, district, and territory normalization belongs in
+`sbir_etl.identity.geography`. Callers use the strict profile unless they explicitly need
+the named permissive compatibility behavior; no caller carries its own jurisdiction map.
+
 ### Study Evidence Contracts
 
 Externally citable studies declare a versioned contract in `studies/<study-id>/study.yaml`.

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_neo4j_loading.py
@@ -19,6 +19,7 @@ from dagster import (
 from loguru import logger
 
 from sbir_etl.config.loader import get_config
+from sbir_etl.identity.geography import normalize_us_jurisdiction
 from sbir_etl.models.award import Award
 from sbir_etl.utils.company_canonicalizer import canonicalize_companies_from_awards
 from sbir_etl.utils.text_normalization import normalize_name
@@ -36,66 +37,6 @@ except ImportError:
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-
-STATE_NAME_TO_CODE = {
-    "alabama": "AL",
-    "alaska": "AK",
-    "arizona": "AZ",
-    "arkansas": "AR",
-    "california": "CA",
-    "colorado": "CO",
-    "connecticut": "CT",
-    "delaware": "DE",
-    "florida": "FL",
-    "georgia": "GA",
-    "hawaii": "HI",
-    "idaho": "ID",
-    "illinois": "IL",
-    "indiana": "IN",
-    "iowa": "IA",
-    "kansas": "KS",
-    "kentucky": "KY",
-    "louisiana": "LA",
-    "maine": "ME",
-    "maryland": "MD",
-    "massachusetts": "MA",
-    "michigan": "MI",
-    "minnesota": "MN",
-    "mississippi": "MS",
-    "missouri": "MO",
-    "montana": "MT",
-    "nebraska": "NE",
-    "nevada": "NV",
-    "new hampshire": "NH",
-    "new jersey": "NJ",
-    "new mexico": "NM",
-    "new york": "NY",
-    "north carolina": "NC",
-    "north dakota": "ND",
-    "ohio": "OH",
-    "oklahoma": "OK",
-    "oregon": "OR",
-    "pennsylvania": "PA",
-    "rhode island": "RI",
-    "south carolina": "SC",
-    "south dakota": "SD",
-    "tennessee": "TN",
-    "texas": "TX",
-    "utah": "UT",
-    "vermont": "VT",
-    "virginia": "VA",
-    "washington": "WA",
-    "west virginia": "WV",
-    "wisconsin": "WI",
-    "wyoming": "WY",
-    "district of columbia": "DC",
-    "puerto rico": "PR",
-    "guam": "GU",
-    "virgin islands": "VI",
-    "american samoa": "AS",
-    "northern mariana islands": "MP",
-}
-
 
 _PHASE_NEXT = {"I": "II", "II": "III"}
 
@@ -266,7 +207,7 @@ def _normalize_row(row: pd.Series) -> dict[str, Any]:
             out[nk] = None
             continue
         if nk == "state" and isinstance(value, str):
-            out[nk] = STATE_NAME_TO_CODE.get(value.strip().lower(), value)
+            out[nk] = normalize_us_jurisdiction(value) or value
         elif nk == "number_employees" and isinstance(value, float) and value.is_integer():
             out[nk] = int(value)
         elif nk == "zip" and isinstance(value, str) and value.strip() == "-":

--- a/sbir_etl/enrichers/geographic_resolver.py
+++ b/sbir_etl/enrichers/geographic_resolver.py
@@ -16,6 +16,11 @@ import pandas as pd
 from loguru import logger
 
 from ..config.loader import get_config
+from ..identity.geography import (
+    US_JURISDICTION_NAMES_V1,
+    US_JURISDICTION_VARIATIONS_V1,
+    VALID_US_JURISDICTION_CODES_V1,
+)
 
 
 @dataclass
@@ -50,112 +55,14 @@ class GeographicResolver:
             self.config = config_obj
         self.quality_thresholds = self.config.quality_thresholds
 
-        # US state mappings (code -> name and name -> code)
-        self.state_mappings = {
-            "AL": "Alabama",
-            "AK": "Alaska",
-            "AZ": "Arizona",
-            "AR": "Arkansas",
-            "CA": "California",
-            "CO": "Colorado",
-            "CT": "Connecticut",
-            "DE": "Delaware",
-            "FL": "Florida",
-            "GA": "Georgia",
-            "HI": "Hawaii",
-            "ID": "Idaho",
-            "IL": "Illinois",
-            "IN": "Indiana",
-            "IA": "Iowa",
-            "KS": "Kansas",
-            "KY": "Kentucky",
-            "LA": "Louisiana",
-            "ME": "Maine",
-            "MD": "Maryland",
-            "MA": "Massachusetts",
-            "MI": "Michigan",
-            "MN": "Minnesota",
-            "MS": "Mississippi",
-            "MO": "Missouri",
-            "MT": "Montana",
-            "NE": "Nebraska",
-            "NV": "Nevada",
-            "NH": "New Hampshire",
-            "NJ": "New Jersey",
-            "NM": "New Mexico",
-            "NY": "New York",
-            "NC": "North Carolina",
-            "ND": "North Dakota",
-            "OH": "Ohio",
-            "OK": "Oklahoma",
-            "OR": "Oregon",
-            "PA": "Pennsylvania",
-            "RI": "Rhode Island",
-            "SC": "South Carolina",
-            "SD": "South Dakota",
-            "TN": "Tennessee",
-            "TX": "Texas",
-            "UT": "Utah",
-            "VT": "Vermont",
-            "VA": "Virginia",
-            "WA": "Washington",
-            "WV": "West Virginia",
-            "WI": "Wisconsin",
-            "WY": "Wyoming",
-            "DC": "District of Columbia",
-            "PR": "Puerto Rico",
-            "VI": "Virgin Islands",
-            "GU": "Guam",
-            "AS": "American Samoa",
-            "MP": "Northern Mariana Islands",
-        }
-
-        # Reverse mapping (name -> code)
+        # Compatibility attributes derived from the one versioned primitive.
+        self.state_mappings = dict(US_JURISDICTION_NAMES_V1)
         self.name_to_code = {name.upper(): code for code, name in self.state_mappings.items()}
-
-        # Common state abbreviations and variations
-        self.state_variations = {
-            "CALIF": "CA",
-            "CALIFORNIA": "CA",
-            "FLA": "FL",
-            "FLORIDA": "FL",
-            "MASS": "MA",
-            "MASSACHUSETTS": "MA",
-            "MICH": "MI",
-            "MICHIGAN": "MI",
-            "PENN": "PA",
-            "PENNSYLVANIA": "PA",
-            "TEXAS": "TX",
-            "TEX": "TX",
-            "WASH": "WA",
-            "WASHINGTON": "WA",
-            "N.Y.": "NY",
-            "NEW YORK": "NY",
-            "N.J.": "NJ",
-            "NEW JERSEY": "NJ",
-            "N.C.": "NC",
-            "NORTH CAROLINA": "NC",
-            "S.C.": "SC",
-            "SOUTH CAROLINA": "SC",
-            "N.D.": "ND",
-            "NORTH DAKOTA": "ND",
-            "S.D.": "SD",
-            "SOUTH DAKOTA": "SD",
-            "W.V.": "WV",
-            "WEST VIRGINIA": "WV",
-            "N.H.": "NH",
-            "NEW HAMPSHIRE": "NH",
-            "N.M.": "NM",
-            "NEW MEXICO": "NM",
-            "R.I.": "RI",
-            "RHODE ISLAND": "RI",
-        }
-
-        # Combine all mappings
+        self.state_variations = dict(US_JURISDICTION_VARIATIONS_V1)
+        # Canonical names remain aliases for compatibility with existing logic.
+        self.state_variations.update(self.name_to_code)
         self.all_state_mappings = {**self.name_to_code, **self.state_variations}
-
-        # Valid state codes set for quick lookup
-        self.valid_state_codes = set(self.state_mappings.keys())
+        self.valid_state_codes = set(VALID_US_JURISDICTION_CODES_V1)
 
         # ZIP prefix (first 3 digits) → state code mapping
         # Based on USPS ZIP code allocation by state

--- a/sbir_etl/identity/__init__.py
+++ b/sbir_etl/identity/__init__.py
@@ -12,17 +12,31 @@ from .company_names import (
     rapidfuzz_token_set_100,
     rapidfuzz_token_sort_100,
 )
+from .geography import (
+    US_JURISDICTION_NAMES_V1,
+    US_JURISDICTION_VARIATIONS_V1,
+    USJurisdictionProfile,
+    VALID_US_JURISDICTION_CODES_V1,
+    normalize_us_jurisdiction,
+    us_jurisdiction_name,
+)
 
 
 __all__ = [
     "ENHANCED_ABBREVIATIONS",
     "SUFFIX_TOKENS",
+    "US_JURISDICTION_NAMES_V1",
+    "US_JURISDICTION_VARIATIONS_V1",
+    "USJurisdictionProfile",
+    "VALID_US_JURISDICTION_CODES_V1",
     "CompanyNameMetric",
     "CompanyNameProfile",
     "company_name_similarity",
     "normalize_company_name",
+    "normalize_us_jurisdiction",
     "rapidfuzz_jaro_winkler_100",
     "rapidfuzz_ratio_100",
     "rapidfuzz_token_set_100",
     "rapidfuzz_token_sort_100",
+    "us_jurisdiction_name",
 ]

--- a/sbir_etl/identity/geography.py
+++ b/sbir_etl/identity/geography.py
@@ -1,0 +1,183 @@
+"""Versioned identity for U.S. states, districts, and territories.
+
+Epistemic tier: primitives. Canonical names and normalization profiles are
+immutable contracts; output-changing behavior requires a new profile version.
+"""
+
+import re
+from collections.abc import Mapping
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+
+EPISTEMIC_TIER = "primitives"
+
+
+class USJurisdictionProfile(StrEnum):
+    """Named U.S. jurisdiction normalization behaviors."""
+
+    STRICT_V1 = "us-jurisdiction-strict-v1"
+    PERMISSIVE_PREFIX_V1 = "us-jurisdiction-permissive-prefix-v1"
+
+
+US_JURISDICTION_NAMES_V1: Mapping[str, str] = MappingProxyType(
+    {
+        "AL": "Alabama",
+        "AK": "Alaska",
+        "AZ": "Arizona",
+        "AR": "Arkansas",
+        "CA": "California",
+        "CO": "Colorado",
+        "CT": "Connecticut",
+        "DE": "Delaware",
+        "FL": "Florida",
+        "GA": "Georgia",
+        "HI": "Hawaii",
+        "ID": "Idaho",
+        "IL": "Illinois",
+        "IN": "Indiana",
+        "IA": "Iowa",
+        "KS": "Kansas",
+        "KY": "Kentucky",
+        "LA": "Louisiana",
+        "ME": "Maine",
+        "MD": "Maryland",
+        "MA": "Massachusetts",
+        "MI": "Michigan",
+        "MN": "Minnesota",
+        "MS": "Mississippi",
+        "MO": "Missouri",
+        "MT": "Montana",
+        "NE": "Nebraska",
+        "NV": "Nevada",
+        "NH": "New Hampshire",
+        "NJ": "New Jersey",
+        "NM": "New Mexico",
+        "NY": "New York",
+        "NC": "North Carolina",
+        "ND": "North Dakota",
+        "OH": "Ohio",
+        "OK": "Oklahoma",
+        "OR": "Oregon",
+        "PA": "Pennsylvania",
+        "RI": "Rhode Island",
+        "SC": "South Carolina",
+        "SD": "South Dakota",
+        "TN": "Tennessee",
+        "TX": "Texas",
+        "UT": "Utah",
+        "VT": "Vermont",
+        "VA": "Virginia",
+        "WA": "Washington",
+        "WV": "West Virginia",
+        "WI": "Wisconsin",
+        "WY": "Wyoming",
+        "DC": "District of Columbia",
+        "PR": "Puerto Rico",
+        "VI": "Virgin Islands",
+        "GU": "Guam",
+        "AS": "American Samoa",
+        "MP": "Northern Mariana Islands",
+    }
+)
+
+VALID_US_JURISDICTION_CODES_V1 = frozenset(US_JURISDICTION_NAMES_V1)
+
+# Explicit source variations used by current production consumers. Canonical
+# names are added separately; aliases remain visible so additions are reviewed
+# as changes to this profile rather than hidden inside callers.
+US_JURISDICTION_VARIATIONS_V1: Mapping[str, str] = MappingProxyType(
+    {
+        "CALIF": "CA",
+        "FLA": "FL",
+        "MASS": "MA",
+        "MICH": "MI",
+        "PENN": "PA",
+        "TEX": "TX",
+        "WASH": "WA",
+        "WASHINGTON DC": "DC",
+        "D.C.": "DC",
+        "N.Y.": "NY",
+        "N.J.": "NJ",
+        "N.C.": "NC",
+        "S.C.": "SC",
+        "N.D.": "ND",
+        "S.D.": "SD",
+        "W.V.": "WV",
+        "N.H.": "NH",
+        "N.M.": "NM",
+        "R.I.": "RI",
+        "U.S. VIRGIN ISLANDS": "VI",
+        "UNITED STATES VIRGIN ISLANDS": "VI",
+        "COMMONWEALTH OF THE NORTHERN MARIANA ISLANDS": "MP",
+    }
+)
+
+
+def _label_key(value: Any) -> str:
+    if value is None:
+        return ""
+    text = str(value).strip().upper()
+    if text.lower() in {"", "nan", "nat", "none", "<na>"}:
+        return ""
+    return re.sub(r"\s+", " ", re.sub(r"[^A-Z0-9]+", " ", text)).strip()
+
+
+def _alias_index() -> dict[str, str]:
+    aliases = {_label_key(name): code for code, name in US_JURISDICTION_NAMES_V1.items()}
+    aliases.update({_label_key(name): code for name, code in US_JURISDICTION_VARIATIONS_V1.items()})
+    return aliases
+
+
+_ALIASES_V1 = MappingProxyType(_alias_index())
+
+
+def normalize_us_jurisdiction(
+    value: Any,
+    *,
+    profile: USJurisdictionProfile = USJurisdictionProfile.STRICT_V1,
+) -> str | None:
+    """Return a two-letter jurisdiction code under an explicit profile.
+
+    ``STRICT_V1`` accepts only canonical codes, names, and declared aliases.
+    ``PERMISSIVE_PREFIX_V1`` preserves the patent transformer's legacy behavior:
+    an arbitrary two-letter alphabetic value passes through, and otherwise the
+    first canonical name beginning with the supplied prefix is selected.
+    """
+
+    key = _label_key(value)
+    if not key:
+        return None
+    if key in VALID_US_JURISDICTION_CODES_V1:
+        return key
+    if key in _ALIASES_V1:
+        return _ALIASES_V1[key]
+    if profile is USJurisdictionProfile.STRICT_V1:
+        return None
+
+    compact = key.replace(" ", "")
+    if len(compact) == 2 and compact.isalpha():
+        return compact
+    for code, name in US_JURISDICTION_NAMES_V1.items():
+        if _label_key(name).startswith(key):
+            return code
+    return None
+
+
+def us_jurisdiction_name(code: Any) -> str | None:
+    """Return the canonical display name for a strict jurisdiction code."""
+
+    normalized = normalize_us_jurisdiction(code)
+    return US_JURISDICTION_NAMES_V1.get(normalized) if normalized else None
+
+
+__all__ = [
+    "EPISTEMIC_TIER",
+    "US_JURISDICTION_NAMES_V1",
+    "US_JURISDICTION_VARIATIONS_V1",
+    "USJurisdictionProfile",
+    "VALID_US_JURISDICTION_CODES_V1",
+    "normalize_us_jurisdiction",
+    "us_jurisdiction_name",
+]

--- a/sbir_etl/identity/geography.py
+++ b/sbir_etl/identity/geography.py
@@ -15,10 +15,20 @@ EPISTEMIC_TIER = "primitives"
 
 
 class USJurisdictionProfile(StrEnum):
-    """Named U.S. jurisdiction normalization behaviors."""
+    """Named U.S. jurisdiction normalization behaviors.
+
+    Profiles are frozen once behavior is relied upon; a change requires a
+    new profile version, never editing an existing member.
+    """
 
     STRICT_V1 = "us-jurisdiction-strict-v1"
     PERMISSIVE_PREFIX_V1 = "us-jurisdiction-permissive-prefix-v1"
+
+    # Note: PERMISSIVE_PREFIX_V1 is a documented bridge preserving the patent
+    # transformer's legacy behavior (arbitrary two-letter pass-through + prefix
+    # matching). It is not a permanent contract. Exit condition: migrate the
+    # patent transformer to STRICT_V1 once its pipeline tolerates rejection of
+    # non-canonical two-letter values.
 
 
 US_JURISDICTION_NAMES_V1: Mapping[str, str] = MappingProxyType(

--- a/sbir_etl/transformers/fiscal/refresh_state_rates.py
+++ b/sbir_etl/transformers/fiscal/refresh_state_rates.py
@@ -19,6 +19,8 @@ from typing import Any
 import httpx
 from loguru import logger
 
+from sbir_etl.identity.geography import normalize_us_jurisdiction
+
 from .state_rates import DEFAULT_CSV_PATH
 
 CSV_COLUMNS = [
@@ -35,63 +37,6 @@ CSV_COLUMNS = [
     "property_source",
 ]
 
-# Full state names as they appear on Tax Foundation pages (before parenthetical notes).
-_STATE_NAME_TO_ABBR: dict[str, str] = {
-    "alabama": "AL",
-    "alaska": "AK",
-    "arizona": "AZ",
-    "arkansas": "AR",
-    "california": "CA",
-    "colorado": "CO",
-    "connecticut": "CT",
-    "delaware": "DE",
-    "district of columbia": "DC",
-    "washington dc": "DC",
-    "d.c.": "DC",
-    "florida": "FL",
-    "georgia": "GA",
-    "hawaii": "HI",
-    "idaho": "ID",
-    "illinois": "IL",
-    "indiana": "IN",
-    "iowa": "IA",
-    "kansas": "KS",
-    "kentucky": "KY",
-    "louisiana": "LA",
-    "maine": "ME",
-    "maryland": "MD",
-    "massachusetts": "MA",
-    "michigan": "MI",
-    "minnesota": "MN",
-    "mississippi": "MS",
-    "missouri": "MO",
-    "montana": "MT",
-    "nebraska": "NE",
-    "nevada": "NV",
-    "new hampshire": "NH",
-    "new jersey": "NJ",
-    "new mexico": "NM",
-    "new york": "NY",
-    "north carolina": "NC",
-    "north dakota": "ND",
-    "ohio": "OH",
-    "oklahoma": "OK",
-    "oregon": "OR",
-    "pennsylvania": "PA",
-    "rhode island": "RI",
-    "south carolina": "SC",
-    "south dakota": "SD",
-    "tennessee": "TN",
-    "texas": "TX",
-    "utah": "UT",
-    "vermont": "VT",
-    "virginia": "VA",
-    "washington": "WA",
-    "west virginia": "WV",
-    "wisconsin": "WI",
-    "wyoming": "WY",
-}
-
 _PERCENT_RE = re.compile(r"(\d+(?:\.\d+)?)\s*%")
 _INCOME_ROW_RE = re.compile(r"^\|\s*(.+?)\s*\|\s*([^|]+)\|")
 
@@ -107,7 +52,7 @@ def _normalize_state_name(raw: str) -> str:
 def state_abbr_from_name(raw: str) -> str | None:
     """Map a Tax Foundation state label to a two-letter abbreviation."""
     key = _normalize_state_name(raw)
-    return _STATE_NAME_TO_ABBR.get(key)
+    return normalize_us_jurisdiction(key)
 
 
 def _parse_percentages(cell: str) -> list[float]:

--- a/sbir_etl/transformers/patent_transformer.py
+++ b/sbir_etl/transformers/patent_transformer.py
@@ -32,6 +32,7 @@ from typing import Any
 
 from loguru import logger
 
+from sbir_etl.identity.geography import USJurisdictionProfile, normalize_us_jurisdiction
 from sbir_etl.utils.identifiers import normalize_uspto_identifier
 
 
@@ -546,80 +547,10 @@ class PatentAssignmentTransformer:
         Returns:
             2-letter state code (uppercase) or None if not recognized
         """
-        if not state:
-            return None
-
-        state_str = str(state).strip().upper()
-
-        # US state mapping
-        state_map = {
-            "ALABAMA": "AL",
-            "ALASKA": "AK",
-            "ARIZONA": "AZ",
-            "ARKANSAS": "AR",
-            "CALIFORNIA": "CA",
-            "COLORADO": "CO",
-            "CONNECTICUT": "CT",
-            "DELAWARE": "DE",
-            "FLORIDA": "FL",
-            "GEORGIA": "GA",
-            "HAWAII": "HI",
-            "IDAHO": "ID",
-            "ILLINOIS": "IL",
-            "INDIANA": "IN",
-            "IOWA": "IA",
-            "KANSAS": "KS",
-            "KENTUCKY": "KY",
-            "LOUISIANA": "LA",
-            "MAINE": "ME",
-            "MARYLAND": "MD",
-            "MASSACHUSETTS": "MA",
-            "MICHIGAN": "MI",
-            "MINNESOTA": "MN",
-            "MISSISSIPPI": "MS",
-            "MISSOURI": "MO",
-            "MONTANA": "MT",
-            "NEBRASKA": "NE",
-            "NEVADA": "NV",
-            "NEW HAMPSHIRE": "NH",
-            "NEW JERSEY": "NJ",
-            "NEW MEXICO": "NM",
-            "NEW YORK": "NY",
-            "NORTH CAROLINA": "NC",
-            "NORTH DAKOTA": "ND",
-            "OHIO": "OH",
-            "OKLAHOMA": "OK",
-            "OREGON": "OR",
-            "PENNSYLVANIA": "PA",
-            "RHODE ISLAND": "RI",
-            "SOUTH CAROLINA": "SC",
-            "SOUTH DAKOTA": "SD",
-            "TENNESSEE": "TN",
-            "TEXAS": "TX",
-            "UTAH": "UT",
-            "VERMONT": "VT",
-            "VIRGINIA": "VA",
-            "WASHINGTON": "WA",
-            "WEST VIRGINIA": "WV",
-            "WISCONSIN": "WI",
-            "WYOMING": "WY",
-            "DISTRICT OF COLUMBIA": "DC",
-        }
-
-        # Check if already a 2-letter code
-        if len(state_str) == 2 and state_str.isalpha():
-            return state_str
-
-        # Try to map full name to abbreviation
-        if state_str in state_map:
-            return state_map[state_str]
-
-        # Try partial matches
-        for full_name, abbrev in state_map.items():
-            if full_name.startswith(state_str):
-                return abbrev
-
-        return None
+        return normalize_us_jurisdiction(
+            state,
+            profile=USJurisdictionProfile.PERMISSIVE_PREFIX_V1,
+        )
 
     @staticmethod
     def _standardize_country_code(country: str | None) -> str | None:

--- a/sbir_etl/ucc/matcher.py
+++ b/sbir_etl/ucc/matcher.py
@@ -32,6 +32,7 @@ from sbir_etl.identity import (  # noqa: E402
     CompanyNameProfile,
     company_name_similarity,
     normalize_company_name,
+    normalize_us_jurisdiction,
 )
 
 from sbir_etl.ucc._common import data_path
@@ -188,72 +189,9 @@ def address_city_state(address: str | None) -> tuple[str, str]:
     return (city, state)
 
 
-# SBIR awards data carries full state names ("Massachusetts"); CA UCC API
-# returns 2-letter postal codes ("MA"). Normalize both before comparison.
-_STATE_TO_POSTAL = {
-    "ALABAMA": "AL",
-    "ALASKA": "AK",
-    "ARIZONA": "AZ",
-    "ARKANSAS": "AR",
-    "CALIFORNIA": "CA",
-    "COLORADO": "CO",
-    "CONNECTICUT": "CT",
-    "DELAWARE": "DE",
-    "FLORIDA": "FL",
-    "GEORGIA": "GA",
-    "HAWAII": "HI",
-    "IDAHO": "ID",
-    "ILLINOIS": "IL",
-    "INDIANA": "IN",
-    "IOWA": "IA",
-    "KANSAS": "KS",
-    "KENTUCKY": "KY",
-    "LOUISIANA": "LA",
-    "MAINE": "ME",
-    "MARYLAND": "MD",
-    "MASSACHUSETTS": "MA",
-    "MICHIGAN": "MI",
-    "MINNESOTA": "MN",
-    "MISSISSIPPI": "MS",
-    "MISSOURI": "MO",
-    "MONTANA": "MT",
-    "NEBRASKA": "NE",
-    "NEVADA": "NV",
-    "NEW HAMPSHIRE": "NH",
-    "NEW JERSEY": "NJ",
-    "NEW MEXICO": "NM",
-    "NEW YORK": "NY",
-    "NORTH CAROLINA": "NC",
-    "NORTH DAKOTA": "ND",
-    "OHIO": "OH",
-    "OKLAHOMA": "OK",
-    "OREGON": "OR",
-    "PENNSYLVANIA": "PA",
-    "RHODE ISLAND": "RI",
-    "SOUTH CAROLINA": "SC",
-    "SOUTH DAKOTA": "SD",
-    "TENNESSEE": "TN",
-    "TEXAS": "TX",
-    "UTAH": "UT",
-    "VERMONT": "VT",
-    "VIRGINIA": "VA",
-    "WASHINGTON": "WA",
-    "WEST VIRGINIA": "WV",
-    "WISCONSIN": "WI",
-    "WYOMING": "WY",
-    "DISTRICT OF COLUMBIA": "DC",
-    "PUERTO RICO": "PR",
-}
-
-
 def to_postal(state: str | None) -> str:
     """Return the 2-letter postal abbreviation for any state input form."""
-    if not state:
-        return ""
-    s = state.strip().upper()
-    if len(s) == 2:
-        return s
-    return _STATE_TO_POSTAL.get(s, s[:2])
+    return normalize_us_jurisdiction(state) or ""
 
 
 def address_overlap_score(

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -16,6 +16,10 @@ from typing import Any, TypedDict
 
 import yaml
 
+from sbir_etl.identity.geography import (
+    normalize_us_jurisdiction,
+)
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONFIG_DIR = REPO_ROOT / "config" / "tech_census"
 
@@ -40,74 +44,10 @@ class CensusAward(TypedDict, total=False):
     source_row: int
 
 
-_US_STATE_NAMES = {
-    "ALABAMA": "AL",
-    "ALASKA": "AK",
-    "ARIZONA": "AZ",
-    "ARKANSAS": "AR",
-    "CALIFORNIA": "CA",
-    "COLORADO": "CO",
-    "CONNECTICUT": "CT",
-    "DELAWARE": "DE",
-    "DISTRICT OF COLUMBIA": "DC",
-    "FLORIDA": "FL",
-    "GEORGIA": "GA",
-    "HAWAII": "HI",
-    "IDAHO": "ID",
-    "ILLINOIS": "IL",
-    "INDIANA": "IN",
-    "IOWA": "IA",
-    "KANSAS": "KS",
-    "KENTUCKY": "KY",
-    "LOUISIANA": "LA",
-    "MAINE": "ME",
-    "MARYLAND": "MD",
-    "MASSACHUSETTS": "MA",
-    "MICHIGAN": "MI",
-    "MINNESOTA": "MN",
-    "MISSISSIPPI": "MS",
-    "MISSOURI": "MO",
-    "MONTANA": "MT",
-    "NEBRASKA": "NE",
-    "NEVADA": "NV",
-    "NEW HAMPSHIRE": "NH",
-    "NEW JERSEY": "NJ",
-    "NEW MEXICO": "NM",
-    "NEW YORK": "NY",
-    "NORTH CAROLINA": "NC",
-    "NORTH DAKOTA": "ND",
-    "OHIO": "OH",
-    "OKLAHOMA": "OK",
-    "OREGON": "OR",
-    "PENNSYLVANIA": "PA",
-    "RHODE ISLAND": "RI",
-    "SOUTH CAROLINA": "SC",
-    "SOUTH DAKOTA": "SD",
-    "TENNESSEE": "TN",
-    "TEXAS": "TX",
-    "UTAH": "UT",
-    "VERMONT": "VT",
-    "VIRGINIA": "VA",
-    "WASHINGTON": "WA",
-    "WEST VIRGINIA": "WV",
-    "WISCONSIN": "WI",
-    "WYOMING": "WY",
-    "AMERICAN SAMOA": "AS",
-    "GUAM": "GU",
-    "NORTHERN MARIANA ISLANDS": "MP",
-    "PUERTO RICO": "PR",
-    "VIRGIN ISLANDS": "VI",
-}
-_US_STATE_CODES = frozenset(_US_STATE_NAMES.values())
-
-
 def normalize_state_code(value: Any) -> str:
     """Normalize a USPS state/territory code or full name for report filtering."""
 
-    normalized = re.sub(r"\s+", " ", str(value or "").strip().upper())
-    if normalized in _US_STATE_CODES:
-        return normalized
-    return _US_STATE_NAMES.get(normalized, "")
+    return normalize_us_jurisdiction(value) or ""
 
 
 def normalize_state_codes(values: Iterable[str]) -> tuple[str, ...]:

--- a/sbir_etl/validators/sbir_awards.py
+++ b/sbir_etl/validators/sbir_awards.py
@@ -10,68 +10,12 @@ from typing import Any
 import pandas as pd
 from loguru import logger
 
+from ..identity.geography import VALID_US_JURISDICTION_CODES_V1
 from ..models.quality import QualityIssue, QualitySeverity
 
 
-# US State codes for validation
-VALID_US_STATES = {
-    "AL",
-    "AK",
-    "AZ",
-    "AR",
-    "CA",
-    "CO",
-    "CT",
-    "DE",
-    "FL",
-    "GA",
-    "HI",
-    "ID",
-    "IL",
-    "IN",
-    "IA",
-    "KS",
-    "KY",
-    "LA",
-    "ME",
-    "MD",
-    "MA",
-    "MI",
-    "MN",
-    "MS",
-    "MO",
-    "MT",
-    "NE",
-    "NV",
-    "NH",
-    "NJ",
-    "NM",
-    "NY",
-    "NC",
-    "ND",
-    "OH",
-    "OK",
-    "OR",
-    "PA",
-    "RI",
-    "SC",
-    "SD",
-    "TN",
-    "TX",
-    "UT",
-    "VT",
-    "VA",
-    "WA",
-    "WV",
-    "WI",
-    "WY",
-    "DC",
-    "PR",
-    "VI",
-    "GU",
-    "AS",
-    "MP",  # Territories
-}
+# Compatibility alias for callers that import the validation set directly.
+VALID_US_STATES = VALID_US_JURISDICTION_CODES_V1
 
 # Email validation regex
 EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$")

--- a/scripts/ci/check_identity_boundaries.py
+++ b/scripts/ci/check_identity_boundaries.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Prevent unreviewed company-name scoring outside ``sbir_etl.identity``."""
+"""Prevent duplicate identity implementations outside ``sbir_etl.identity``."""
 
 import ast
 import subprocess
@@ -20,6 +20,18 @@ REVIEWED_DIRECT_SCORER_FILES = frozenset(
         "scripts/data/find_same_work_awards.py",
         # Contract tests compare shared adapters with the upstream scorer implementation.
         "tests/unit/identity/test_company_names.py",
+    }
+)
+CANONICAL_JURISDICTION_FILE = "sbir_etl/identity/geography.py"
+JURISDICTION_PAIR_MARKERS = frozenset(
+    {
+        ("ALABAMA", "AL"),
+        ("CALIFORNIA", "CA"),
+        ("MASSACHUSETTS", "MA"),
+        ("NEW YORK", "NY"),
+        ("TEXAS", "TX"),
+        ("DISTRICT OF COLUMBIA", "DC"),
+        ("PUERTO RICO", "PR"),
     }
 )
 
@@ -50,29 +62,63 @@ def _uses_direct_rapidfuzz_scorer(node: ast.AST) -> bool:
     )
 
 
+def _jurisdiction_mapping_pairs(node: ast.AST) -> int:
+    """Count recognizable name/code pairs in a literal mapping."""
+
+    if not isinstance(node, ast.Dict):
+        return 0
+    pairs = 0
+    for key, value in zip(node.keys, node.values, strict=True):
+        if not (
+            isinstance(key, ast.Constant)
+            and isinstance(key.value, str)
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+        ):
+            continue
+        literal_pair = (key.value.strip().upper(), value.value.strip().upper())
+        if (
+            literal_pair in JURISDICTION_PAIR_MARKERS
+            or literal_pair[::-1] in JURISDICTION_PAIR_MARKERS
+        ):
+            pairs += 1
+    return pairs
+
+
 def scan_file(
     path: Path, *, repository_root: Path = REPOSITORY_ROOT
 ) -> list[IdentityBoundaryViolation]:
     """Find direct scorer imports in one unreviewed Python file."""
 
     relative = path.resolve().relative_to(repository_root.resolve()).as_posix()
-    if relative in REVIEWED_DIRECT_SCORER_FILES or relative.startswith(
-        ("scripts/archive/", "tests/unit/scripts/archive/")
-    ):
+    if relative.startswith(("scripts/archive/", "tests/unit/scripts/archive/")):
         return []
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    return [
-        IdentityBoundaryViolation(
-            path=relative,
-            line_number=node.lineno,
-            message=(
-                "direct RapidFuzz scorer bypasses sbir_etl.identity; use the shared "
-                "similarity contract or document a reviewed non-company exception"
-            ),
-        )
-        for node in ast.walk(tree)
-        if _uses_direct_rapidfuzz_scorer(node)
-    ]
+    violations: list[IdentityBoundaryViolation] = []
+    for node in ast.walk(tree):
+        if relative not in REVIEWED_DIRECT_SCORER_FILES and _uses_direct_rapidfuzz_scorer(node):
+            violations.append(
+                IdentityBoundaryViolation(
+                    path=relative,
+                    line_number=getattr(node, "lineno", 0),
+                    message=(
+                        "direct RapidFuzz scorer bypasses sbir_etl.identity; use the shared "
+                        "similarity contract or document a reviewed non-company exception"
+                    ),
+                )
+            )
+        if relative != CANONICAL_JURISDICTION_FILE and _jurisdiction_mapping_pairs(node) >= 5:
+            violations.append(
+                IdentityBoundaryViolation(
+                    path=relative,
+                    line_number=getattr(node, "lineno", 0),
+                    message=(
+                        "U.S. jurisdiction map bypasses sbir_etl.identity.geography; "
+                        "use a named normalization profile"
+                    ),
+                )
+            )
+    return violations
 
 
 def tracked_python_files(*, repository_root: Path = REPOSITORY_ROOT) -> list[Path]:

--- a/scripts/data/nano_dark_firm_liveness.py
+++ b/scripts/data/nano_dark_firm_liveness.py
@@ -63,6 +63,7 @@ DATA = REPO / "data"
 RAW = DATA / "raw/uspto/patentsview"
 
 sys.path.insert(0, str(REPO))
+from sbir_etl.identity.geography import normalize_us_jurisdiction  # noqa: E402
 from sbir_etl.utils.text_normalization import normalize_name  # noqa: E402
 from sbir_etl.utils.transition_report_paths import (  # noqa: E402
     add_area_args,
@@ -82,28 +83,9 @@ GENERIC_TOKENS = frozenset(
 )
 
 
-# SBIR.gov stores full state names; USPTO tables store USPS codes. Normalize to codes.
-STATE_TO_CODE = {
-    "ALABAMA": "AL", "ALASKA": "AK", "ARIZONA": "AZ", "ARKANSAS": "AR", "CALIFORNIA": "CA",
-    "COLORADO": "CO", "CONNECTICUT": "CT", "DELAWARE": "DE", "FLORIDA": "FL", "GEORGIA": "GA",
-    "HAWAII": "HI", "IDAHO": "ID", "ILLINOIS": "IL", "INDIANA": "IN", "IOWA": "IA",
-    "KANSAS": "KS", "KENTUCKY": "KY", "LOUISIANA": "LA", "MAINE": "ME", "MARYLAND": "MD",
-    "MASSACHUSETTS": "MA", "MICHIGAN": "MI", "MINNESOTA": "MN", "MISSISSIPPI": "MS",
-    "MISSOURI": "MO", "MONTANA": "MT", "NEBRASKA": "NE", "NEVADA": "NV",
-    "NEW HAMPSHIRE": "NH", "NEW JERSEY": "NJ", "NEW MEXICO": "NM", "NEW YORK": "NY",
-    "NORTH CAROLINA": "NC", "NORTH DAKOTA": "ND", "OHIO": "OH", "OKLAHOMA": "OK",
-    "OREGON": "OR", "PENNSYLVANIA": "PA", "RHODE ISLAND": "RI", "SOUTH CAROLINA": "SC",
-    "SOUTH DAKOTA": "SD", "TENNESSEE": "TN", "TEXAS": "TX", "UTAH": "UT", "VERMONT": "VT",
-    "VIRGINIA": "VA", "WASHINGTON": "WA", "WEST VIRGINIA": "WV", "WISCONSIN": "WI",
-    "WYOMING": "WY", "DISTRICT OF COLUMBIA": "DC", "PUERTO RICO": "PR", "GUAM": "GU",
-    "VIRGIN ISLANDS": "VI", "AMERICAN SAMOA": "AS", "NORTHERN MARIANA ISLANDS": "MP",
-}
-
-
 def state_code(raw: str) -> str:
     """Normalize an SBIR.gov state value (full name or code) to a USPS code."""
-    s = (raw or "").strip().upper()
-    return STATE_TO_CODE.get(s, s if len(s) == 2 else "")
+    return normalize_us_jurisdiction(raw) or ""
 
 
 def pi_last_name(raw: str) -> str:
@@ -233,7 +215,12 @@ def main(argv: list[str] | None = None) -> int:
             if st:
                 loc_state[lid] = st
     firm_assignee_states = {
-        f: {loc_state[l] for l in locs if l in loc_state} for f, locs in firm_loc_ids.items()
+        firm: {
+            loc_state[location_id]
+            for location_id in location_ids
+            if location_id in loc_state
+        }
+        for firm, location_ids in firm_loc_ids.items()
     }
 
     print("Joining filing years for matched patents...")
@@ -332,9 +319,11 @@ def main(argv: list[str] | None = None) -> int:
             if any(d and int(d[:4]) > sub[f]["first_award_year"] for d in b82_by_firm.get(f, []))
         )
         any_hold = sum(1 for f in sub if firm_patents.get(f))
-        def _post(f: str) -> bool:
-            return any(pat_year.get(p, 0) > sub[f]["first_award_year"]
-                       for p in firm_patents.get(f, set()))
+        def _post(f: str, subset: dict = sub) -> bool:
+            return any(
+                pat_year.get(p, 0) > subset[f]["first_award_year"]
+                for p in firm_patents.get(f, set())
+            )
         any_post = sum(1 for f in sub if _post(f))
         print(f"{bucket}: {n} firms")
         print(f"  B82 patents (floor):      hold {b82_hold} ({100*b82_hold/n:.0f}%)   filed post-award {b82_post} ({100*b82_post/n:.0f}%)")

--- a/tests/unit/identity/test_geography.py
+++ b/tests/unit/identity/test_geography.py
@@ -1,0 +1,54 @@
+import pytest
+
+from sbir_etl.identity.geography import (
+    US_JURISDICTION_NAMES_V1,
+    US_JURISDICTION_VARIATIONS_V1,
+    USJurisdictionProfile,
+    VALID_US_JURISDICTION_CODES_V1,
+    normalize_us_jurisdiction,
+    us_jurisdiction_name,
+)
+
+
+def test_every_canonical_code_and_name_round_trips() -> None:
+    assert set(US_JURISDICTION_NAMES_V1) == set(VALID_US_JURISDICTION_CODES_V1)
+    for code, name in US_JURISDICTION_NAMES_V1.items():
+        assert normalize_us_jurisdiction(code.lower()) == code
+        assert normalize_us_jurisdiction(name.lower()) == code
+        assert us_jurisdiction_name(code) == name
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("D.C.", "DC"),
+        ("Washington DC", "DC"),
+        ("U.S. Virgin Islands", "VI"),
+        ("Commonwealth of the Northern Mariana Islands", "MP"),
+        ("Mass", "MA"),
+        ("N.Y.", "NY"),
+    ],
+)
+def test_strict_profile_accepts_only_declared_aliases(value: str, expected: str) -> None:
+    assert normalize_us_jurisdiction(value) == expected
+
+
+@pytest.mark.parametrize("value", [None, "", "XY", "New H", "not a state"])
+def test_strict_profile_rejects_unknown_or_partial_values(value: object) -> None:
+    assert normalize_us_jurisdiction(value) is None
+
+
+def test_permissive_profile_freezes_legacy_patent_behavior() -> None:
+    profile = USJurisdictionProfile.PERMISSIVE_PREFIX_V1
+
+    assert normalize_us_jurisdiction("XY", profile=profile) == "XY"
+    assert normalize_us_jurisdiction("NEW H", profile=profile) == "NH"
+    # First-match behavior is deliberate compatibility, not a strict claim.
+    assert normalize_us_jurisdiction("NEW", profile=profile) == "NH"
+
+
+def test_versioned_maps_are_immutable() -> None:
+    with pytest.raises(TypeError):
+        US_JURISDICTION_NAMES_V1["XX"] = "Example"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        US_JURISDICTION_VARIATIONS_V1["EXAMPLE"] = "XX"  # type: ignore[index]

--- a/tests/unit/scripts/test_identity_boundaries.py
+++ b/tests/unit/scripts/test_identity_boundaries.py
@@ -62,5 +62,34 @@ def test_process_submodule_import_is_allowed(tmp_path: Path) -> None:
     assert boundaries.scan_file(path, repository_root=tmp_path) == []
 
 
+def test_duplicate_jurisdiction_map_is_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "STATES = {\n"
+        "    'Alabama': 'AL',\n"
+        "    'California': 'CA',\n"
+        "    'Massachusetts': 'MA',\n"
+        "    'New York': 'NY',\n"
+        "    'Texas': 'TX',\n"
+        "}\n",
+    )
+
+    violations = boundaries.scan_file(path, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "jurisdiction map" in violations[0].message
+
+
+def test_small_state_fixture_is_not_mistaken_for_an_implementation(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "tests/unit/example.py",
+        "SAMPLE = {'Alabama': 'AL', 'California': 'CA'}\n",
+    )
+
+    assert boundaries.scan_file(path, repository_root=tmp_path) == []
+
+
 def test_current_repository_obeys_identity_boundaries() -> None:
     assert boundaries.scan_repository() == []

--- a/tests/unit/ucc/test_matcher.py
+++ b/tests/unit/ucc/test_matcher.py
@@ -8,7 +8,14 @@ from sbir_etl.ucc.matcher import (
     looks_like_person_name,
     match_extraction,
     normalize_name,
+    to_postal,
 )
+
+
+def test_to_postal_uses_strict_jurisdiction_identity() -> None:
+    assert to_postal("Massachusetts") == "MA"
+    assert to_postal("MA") == "MA"
+    assert to_postal("Mystery") == ""
 
 
 # ---- 20-pair test set: 10 matches, 10 non-matches (per plan) ----


### PR DESCRIPTION
## What changed

- add a versioned U.S. jurisdiction identity primitive covering states, DC, and territories
- expose strict and legacy-permissive profiles instead of leaving divergent behavior unnamed
- migrate validation, fiscal refresh, patent transformation, geographic resolution, UCC matching, Neo4j loading, and nanotechnology liveness analysis to the shared contract
- preserve the patent transformer's historical two-letter pass-through and first-prefix behavior only through the named permissive profile
- make strict UCC matching reject unknown jurisdiction text instead of fabricating its first two letters
- extend the identity boundary guard to reject new full jurisdiction maps outside the primitive

## Why

The repository carried independent state tables in validators, transformers, matching, enrichment, graph loading, and research scripts. Their territory coverage, aliases, partial matching, and unknown-value behavior differed invisibly.

This promotes the concept—not merely the table—by making behavior named, immutable, tested, and mechanically single-source.

## Impact

- Canonical codes and names round-trip under `us-jurisdiction-strict-v1`.
- Explicit aliases such as `D.C.`, `Washington DC`, and `U.S. Virgin Islands` are accepted.
- Unknown and partial values fail closed under the strict profile.
- Existing `VALID_US_STATES` and GeographicResolver mapping attributes remain compatibility views over the primitive.
- Archived scripts are intentionally excluded from the active-code boundary.

## Validation

- 317 affected identity, validator, patent, fiscal, UCC, geographic-resolver, and boundary tests passed
- Ruff check passed on all changed Python files
- Ruff format check passed on package, guard, and test files; the exploratory nano script retains its existing formatting
- MyPy passed on the primitive, fiscal/UCC callers, and boundary guard
- identity boundary guard passed with the new file tracked
- `make docs-check`
- `git diff --check`

The Neo4j unit module requires the locally absent Dagster extra; its import and behavior remain covered by CI.
