### PR TITLE
ci: narrow the execution guard and accept capitalized tier typos

### DIFF
--- a/scripts/ci/check_architecture_boundaries.py
+++ b/scripts/ci/check_architecture_boundaries.py
@@ -123,30 +123,87 @@ def _is_subprocess_call(node: ast.Call) -> bool:
     )
 
 
-def _path_literal_parts(node: ast.AST) -> list[str]:
+def _literal_assignments(tree: ast.AST) -> dict[str, ast.AST]:
+    """Map single-target assigned names to their value expressions.
+
+    Callers routinely build the command in a local before spawning it
+    (``cmd = [sys.executable, str(script)]``; ``subprocess.run(cmd)``), so
+    inspecting only the call arguments would miss the path. A name assigned
+    more than once is dropped rather than guessed at.
+    """
+
+    assignments: dict[str, ast.AST] = {}
+    shadowed: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        if not isinstance(target, ast.Name):
+            continue
+        if target.id in assignments:
+            shadowed.add(target.id)
+            continue
+        assignments[target.id] = node.value
+    for name in shadowed:
+        del assignments[name]
+    return assignments
+
+
+def _path_literal_parts(
+    node: ast.AST,
+    assignments: dict[str, ast.AST] | None = None,
+    _seen: frozenset[str] = frozenset(),
+) -> list[str]:
     """Return literal pieces of a ``Path`` division or command argument."""
+
+    def recurse(child: ast.AST, seen: frozenset[str] = _seen) -> list[str]:
+        return _path_literal_parts(child, assignments, seen)
 
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return [node.value]
+    if isinstance(node, ast.Name) and assignments is not None:
+        if node.id in _seen or node.id not in assignments:
+            return []
+        return _path_literal_parts(assignments[node.id], assignments, _seen | {node.id})
     if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
-        return _path_literal_parts(node.left) + _path_literal_parts(node.right)
+        return recurse(node.left) + recurse(node.right)
     if isinstance(node, (ast.List, ast.Tuple)):
         parts: list[str] = []
         for element in node.elts:
-            parts.extend(_path_literal_parts(element))
+            parts.extend(recurse(element))
         return parts
     if isinstance(node, ast.Call):
         parts: list[str] = []
         for argument in node.args:
-            parts.extend(_path_literal_parts(argument))
+            parts.extend(recurse(argument))
         return parts
     return []
 
 
-def _script_target(node: ast.AST) -> str | None:
+def _argv_elements(node: ast.AST, assignments: dict[str, ast.AST]) -> list[ast.AST]:
+    """Split a command argument into the expressions worth testing on their own.
+
+    An argv list is one argument but many paths. Flattening it would join the
+    script with the flags that follow it (``scripts/x.py/--area/q``), so each
+    element is tested separately; a bare string command is tested whole.
+    """
+
+    resolved = node
+    seen: set[str] = set()
+    while isinstance(resolved, ast.Name) and resolved.id in assignments:
+        if resolved.id in seen:
+            break
+        seen.add(resolved.id)
+        resolved = assignments[resolved.id]
+    if isinstance(resolved, (ast.List, ast.Tuple)):
+        return list(resolved.elts)
+    return [resolved]
+
+
+def _script_target(node: ast.AST, assignments: dict[str, ast.AST] | None = None) -> str | None:
     """Normalize a literal path expression to a repository ``scripts/*.py`` target."""
 
-    pieces = _path_literal_parts(node)
+    pieces = _path_literal_parts(node, assignments)
     for piece in pieces:
         normalized = piece.replace("\\", "/").strip()
         marker = normalized.find("scripts/")
@@ -162,16 +219,26 @@ def _script_target(node: ast.AST) -> str | None:
 
 
 def executed_script_paths(path: Path) -> list[tuple[str, int]]:
-    """Extract literal repository Python scripts invoked through ``subprocess``."""
+    """Extract literal repository Python scripts invoked through ``subprocess``.
+
+    Only the arguments of a ``subprocess`` call are inspected, resolved through
+    single-assignment locals. Detection stays literal: a path assembled with
+    ``os.path.join``, rebound more than once, or returned from a helper is not
+    visible to static analysis. This accepted limit mirrors the import guard;
+    document any such pattern in the transitional allowlist so it is not
+    mistaken for a gap in the check.
+    """
 
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    if not any(isinstance(node, ast.Call) and _is_subprocess_call(node) for node in ast.walk(tree)):
-        return []
-
+    assignments = _literal_assignments(tree)
     targets: dict[str, int] = {}
     for node in ast.walk(tree):
-        if target := _script_target(node):
-            targets.setdefault(target, node.lineno)
+        if not (isinstance(node, ast.Call) and _is_subprocess_call(node)):
+            continue
+        for argument in (*node.args, *(keyword.value for keyword in node.keywords)):
+            for element in _argv_elements(argument, assignments):
+                if target := _script_target(element, assignments):
+                    targets.setdefault(target, node.lineno)
     return sorted(targets.items(), key=lambda item: (item[1], item[0]))
 
 

--- a/scripts/ci/check_epistemic_tiers.py
+++ b/scripts/ci/check_epistemic_tiers.py
@@ -10,7 +10,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 SPECS_ROOT = REPOSITORY_ROOT / "specs"
 VALID_TIERS = frozenset({"primitives", "pipelines", "evidence", "exploratory"})
 TIER_DECLARATION = re.compile(
-    r"^\*\*Target epistemic tier:\*\*\s*`?([a-z]+)`?\s*$",
+    r"^\*\*Target epistemic tier:\*\*\s*`?([A-Za-z]+)`?\s*$",
     flags=re.MULTILINE,
 )
 EXCLUDED_SPEC_DIRECTORIES = frozenset({"archive"})

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -1,6 +1,6 @@
 # SBIR vs. Private-Capital Comparison — Requirements (agency-parameterized; NSF as initial target)
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Phase 1 implemented; Phase 2 is a gated backlog item now that the
 > Form D / M&A infrastructure from PR #286 is available. Do not start Phase 2

--- a/specs/cross-agency-taxonomy/requirements.md
+++ b/specs/cross-agency-taxonomy/requirements.md
@@ -1,6 +1,6 @@
 # Cross-Agency Technology Taxonomy — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Partially implemented as of June 2026 — analytical tools in
 > `packages/sbir-analytics/sbir_analytics/tools/mission_a/` already compute HHI per CET

--- a/specs/data-imputation/requirements.md
+++ b/specs/data-imputation/requirements.md
@@ -1,6 +1,6 @@
 # Data Imputation — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Gated backlog — spec merged via PR #277; implementation not yet
 > started as of July 2026.

--- a/specs/ma-discovery-integration/requirements.md
+++ b/specs/ma-discovery-integration/requirements.md
@@ -1,6 +1,6 @@
 # M&A Discovery Integration — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 The target contract is the confidence-bounded discovery and collision policy
 in [design.md](design.md). Candidate discovery remains non-citable until the

--- a/specs/nvca-yearbook-benchmarks/requirements.md
+++ b/specs/nvca-yearbook-benchmarks/requirements.md
@@ -1,6 +1,6 @@
 # Requirements — NVCA Yearbook Benchmark Reference Data
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** **Partially implemented; spec was mis-framed on first pass.** A
 > 2026-06-29 audit (paralleling #400 and #402) found that

--- a/specs/ot-consortium-subaward-attribution/requirements.md
+++ b/specs/ot-consortium-subaward-attribution/requirements.md
@@ -1,6 +1,6 @@
 # Requirements — OT Consortium Sub-Award Attribution (FFATA/FSRS)
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Gated backlog — not implemented. Run the T0 coverage probe before
 > promoting beyond the OT consortium verification-tiering follow-up.

--- a/specs/patent-cost-spillover/requirements.md
+++ b/specs/patent-cost-spillover/requirements.md
@@ -1,6 +1,6 @@
 # Patent Cost and Spillover Analysis — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Gated backlog — zero cost/citation/spillover analytical-layer
 > implementation as of July 2026.

--- a/specs/phase3-undercount-extension/requirements.md
+++ b/specs/phase3-undercount-extension/requirements.md
@@ -1,6 +1,6 @@
 # Phase III Undercount Extension — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Draft spec. Builds on existing undercount work (M0a + 3-source
 > capture-recapture) and the coverage-expansion sources (#485). Answers the north-star

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -1,6 +1,6 @@
 # Requirements: SBIR M&A Match Rate by Fiscal Year
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
 > **Status:** Gated backlog — analysis-only spec, not yet implemented. Start
 > only when FY match-rate reporting is requested.

--- a/tests/unit/scripts/test_architecture_boundaries.py
+++ b/tests/unit/scripts/test_architecture_boundaries.py
@@ -100,3 +100,76 @@ def test_script_execution_exception_is_exact(tmp_path: Path) -> None:
     violations = boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path)
 
     assert [violation.imported_module for violation in violations] == ["scripts/data/unapproved.py"]
+
+
+def test_execution_guard_ignores_script_paths_outside_the_subprocess_call(
+    tmp_path: Path,
+) -> None:
+    """A `scripts/` literal is only a bridge when it is what gets spawned.
+
+    The scan used to gate on "this file calls subprocess anywhere", then take
+    any `scripts/*.py` literal in the module as the target — so an unrelated
+    reference in a file that shells out for some other reason was reported.
+    """
+
+    source_root = tmp_path / "packages" / "sbir-analytics" / "sbir_analytics"
+    _write(
+        tmp_path,
+        "packages/sbir-analytics/sbir_analytics/example.py",
+        "import subprocess\n"
+        "from pathlib import Path\n"
+        "DOCS_REFERENCE = Path('scripts') / 'data' / 'unrelated.py'\n"
+        "subprocess.run(['echo', 'hello'])\n",
+    )
+
+    assert boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path) == []
+
+
+def test_execution_guard_resolves_a_command_built_in_a_local(tmp_path: Path) -> None:
+    """Building argv in a local before spawning it is still a bridge."""
+
+    source_root = tmp_path / "packages" / "sbir-analytics" / "sbir_analytics"
+    _write(
+        tmp_path,
+        "packages/sbir-analytics/sbir_analytics/example.py",
+        "import subprocess\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "repo = Path('/repo')\n"
+        "script = repo / 'scripts' / 'data' / 'unapproved.py'\n"
+        "cmd = [sys.executable, str(script), '--area', 'quantum']\n"
+        "subprocess.run(cmd, cwd=str(repo))\n",
+    )
+
+    violations = boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path)
+
+    assert [violation.imported_module for violation in violations] == ["scripts/data/unapproved.py"]
+
+
+def test_execution_guard_does_not_guess_at_a_rebound_command(tmp_path: Path) -> None:
+    """Two assignments to one name means static analysis cannot say which ran."""
+
+    source_root = tmp_path / "packages" / "sbir-analytics" / "sbir_analytics"
+    _write(
+        tmp_path,
+        "packages/sbir-analytics/sbir_analytics/example.py",
+        "import subprocess\n"
+        "cmd = ['python', 'scripts/data/first.py']\n"
+        "cmd = ['python', 'scripts/data/second.py']\n"
+        "subprocess.run(cmd)\n",
+    )
+
+    assert boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path) == []
+
+
+def test_execution_guard_terminates_on_a_self_referential_name(tmp_path: Path) -> None:
+    """Name resolution must not loop on `a = a` or a mutual cycle."""
+
+    source_root = tmp_path / "packages" / "sbir-analytics" / "sbir_analytics"
+    _write(
+        tmp_path,
+        "packages/sbir-analytics/sbir_analytics/example.py",
+        "import subprocess\nfirst = second\nsecond = first\nsubprocess.run(first)\n",
+    )
+
+    assert boundaries.scan_package("sbir_analytics", source_root, repository_root=tmp_path) == []

--- a/tests/unit/scripts/test_epistemic_tiers.py
+++ b/tests/unit/scripts/test_epistemic_tiers.py
@@ -65,3 +65,24 @@ def test_all_valid_tiers_are_accepted(tmp_path: Path) -> None:
 
 def test_current_repository_spec_declarations_are_valid() -> None:
     assert tiers.scan_specs() == []
+
+
+def test_capitalized_tier_is_reported_as_invalid_not_missing(tmp_path: Path) -> None:
+    """A capitalization typo should name the real problem.
+
+    The declaration pattern used to match lowercase only, so `Evidence` fell
+    through to "missing declaration" and sent the author looking for a line
+    that was already there.
+    """
+
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "# Example\n\n**Target epistemic tier:** Evidence\n",
+    )
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "invalid target tier 'Evidence'" in violations[0].message


### PR DESCRIPTION
## Description

Re-lands the review fixes that lived only on `copilot/address-comments-529-up` (commit `a9e56c05`). That branch was cut against #538's branch, carried fixes for six PRs at once, and was deleted after the other five were re-homed onto the PRs they belonged to. Its `#538` content had nowhere to land.

Three changes, plus one correction to the original.

### 1. The execution guard attributed bridges that did not exist

`executed_script_paths()` gated on "this file calls `subprocess` anywhere", then walked the whole module and took any `scripts/*.py`-shaped literal as the spawn target. A module that shells out for one reason and happens to reference a script path for another was reported as an execution bridge it does not have. Targets now come from the `subprocess` call arguments.

### 2. …but narrowing to call arguments alone loses a bridge that exists today

This is the correction. `a9e56c05` as written stopped detecting `transition_report.py → build_tech_area_cohort.py`, which is one of the three entries in `TRANSITIONAL_SCRIPT_EXECUTIONS` on `main`. That module builds argv in a local first:

```python
script = repo / "scripts" / "data" / "build_tech_area_cohort.py"
cmd = [sys.executable, str(script), "--area", area_id]
proc = subprocess.run(cmd, cwd=str(repo), ...)
```

The module-wide walk caught it by accident; inspecting only `node.args` sees a bare `Name`. Landing that as-is would have traded a false-positive class for a silent false-negative on a live case — the guard would still pass, because the entry is allowlisted, and would quietly stop noticing if a fourth bridge appeared in the same shape.

So call arguments are resolved through single-assignment locals, and argv elements are tested individually. The second part matters: flattening the list joined the script with the flags after it (`scripts/x.py/--area/q`), which matches nothing. A name assigned more than once is dropped rather than guessed at, and name resolution carries a cycle guard.

Detection is still literal — `os.path.join`, a path returned from a helper, or a rebound name stay invisible. That limit mirrors the import guard and is now stated in the docstring.

### 3. `Evidence` reported as a missing declaration

`TIER_DECLARATION` matched `([a-z]+)`, so a capitalized tier did not match the pattern at all and fell through to "missing '**Target epistemic tier:** &lt;tier&gt;' declaration" — sending the author to look for a line that was already there. It now reports `invalid target tier 'Evidence'`.

### 4. Nine specs reclassified from `evidence` to `pipelines`

`agency-private-capital-comparison`, `cross-agency-taxonomy`, `data-imputation`, `ma-discovery-integration`, `nvca-yearbook-benchmarks`, `ot-consortium-subaward-attribution`, `patent-cost-spillover`, `phase3-undercount-extension`, `sbir_ma_match_rate_by_fy`.

`specs/status.md` records eight as **Gated backlog** and `ma-discovery-integration` as **Deferred**. None has a frozen spec, SHA enforcement, blocking asset checks, or a declared estimand — the four things CLAUDE.md requires for `evidence`. Declaring the heaviest contract on unstarted work invites building above the tier, which CLAUDE.md calls out as the most common form of waste here. Promotion stays explicit work.

This is the one judgment call in the PR rather than a mechanical fix, so it is the part worth disagreeing with. It is also consistent with how #531 declared itself this week.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Versioning Impact

- [x] No release impact (internal or unreleased work)

CI guards and spec metadata only; no runtime code and no public surface.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

Five regression tests, each pinning a behavior that was wrong or that the fix could plausibly break:

| Test | Pins |
|---|---|
| `test_execution_guard_ignores_script_paths_outside_the_subprocess_call` | the original false positive |
| `test_execution_guard_resolves_a_command_built_in_a_local` | the `transition_report.py` shape that the naive narrowing lost |
| `test_execution_guard_does_not_guess_at_a_rebound_command` | two assignments to one name → no target |
| `test_execution_guard_terminates_on_a_self_referential_name` | `a = b; b = a` terminates (an earlier draft of this fix hung here) |
| `test_capitalized_tier_is_reported_as_invalid_not_missing` | the message says invalid, not missing |

Verified against the real repository, not only fixtures — all three `TRANSITIONAL_SCRIPT_EXECUTIONS` entries are still detected when the allowlist is bypassed:

```
transition_report.py        -> ['scripts/data/build_tech_area_cohort.py']
weekly_awards_report.py     -> ['scripts/data/weekly_awards_report.py']
phase_transition_archive.py -> ['scripts/phase_transition_analysis.py']
```

Also checked: bare string command, `Popen` with a tuple, `args=` keyword form, and a module with no `subprocess` call at all.

Full CI unit selection (`pytest tests/unit/ -m "not slow"`): **5694 passed**. All five guards, ruff, ruff-format and mypy clean on CI's exact paths.

Four failures appear locally in `tests/unit/quality/test_dashboard.py` and `test_format_processors.py`. They are unrelated and pre-existing — they reproduce on unmodified `main`, and they arise because this checkout has `plotly` installed while CI's `--extra stack-dev` environment does not, where they skip. `scripts/ci/gate_check.py` is likewise unformatted on `main` and outside CI's lint scope; left alone.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

No documentation change: the guards' behavior is described in their own docstrings, and `docs/steering/epistemic-tiers.md` already describes the declaration rule without enumerating per-spec tiers.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smvpa16ur9YBVjVwbpgUhT)_