### PR TITLE
test: execute the five host jobs as graphs; validate the archive before copying

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/jobs/phase_transition_archive.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/jobs/phase_transition_archive.py
@@ -72,12 +72,12 @@ def archive_phase_transition_outputs_op(context: OpExecutionContext, started: fl
     Every expected output must exist and have been written by this run. A
     missing or stale file fails the op rather than producing an archive that
     silently mixes fresh parquet with an old report.
-    """
-    date_str = datetime.now(UTC).strftime("%Y-%m-%d")
-    archive_dir = _data_root() / "processed" / "phase_transition" / "history" / date_str
-    archive_dir.mkdir(parents=True, exist_ok=True)
 
-    copied: list[str] = []
+    The whole set is validated before anything is copied. Validating while
+    copying still failed the run, but only after leaving the files it had
+    already reached in the dated directory — a partial snapshot that a later
+    reader cannot distinguish from a complete one.
+    """
     missing: list[str] = []
     stale: list[str] = []
     # Filesystem timestamps can round down relative to time.time(); allow a
@@ -88,12 +88,8 @@ def archive_phase_transition_outputs_op(context: OpExecutionContext, started: fl
         src = Path(rel)
         if not src.is_file():
             missing.append(rel)
-            continue
-        if src.stat().st_mtime < cutoff:
+        elif src.stat().st_mtime < cutoff:
             stale.append(rel)
-            continue
-        shutil.copy2(src, archive_dir / src.name)
-        copied.append(src.name)
 
     if missing or stale:
         raise FileNotFoundError(
@@ -101,6 +97,16 @@ def archive_phase_transition_outputs_op(context: OpExecutionContext, started: fl
             f"Missing: {', '.join(missing) or 'none'}. "
             f"Not written by this run: {', '.join(stale) or 'none'}."
         )
+
+    date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+    archive_dir = _data_root() / "processed" / "phase_transition" / "history" / date_str
+    archive_dir.mkdir(parents=True, exist_ok=True)
+
+    copied: list[str] = []
+    for rel in ARCHIVED_OUTPUTS:
+        src = Path(rel)
+        shutil.copy2(src, archive_dir / src.name)
+        copied.append(src.name)
 
     context.log.info(f"Archived {len(copied)} file(s) to {archive_dir}")
     context.add_output_metadata(

--- a/tests/unit/assets/jobs/test_phase_transition_archive_execution.py
+++ b/tests/unit/assets/jobs/test_phase_transition_archive_execution.py
@@ -1,0 +1,140 @@
+"""Layer-3 execution tests for phase_transition_archive_job.
+
+The job had no test at any layer while `sbir_etl/reporting/phase_transition_analysis.py`
+was promoted out of `scripts/` and the op rewired to call it directly.
+
+What is worth pinning here is the staleness guard rather than the copy itself.
+The archive replaces an S3 publish step that gave the analysis a dated history,
+and the op's own docstring states the risk: without a freshness check it would
+"capture whatever stale report happened to be on disk", producing a dated
+snapshot that silently mixes fresh parquet with an old report. A dated archive
+that looks complete but isn't is worse than a failed run, because nothing
+downstream can tell the difference later.
+
+The op resolves its *sources* relative to the working directory and its
+*destination* through the data root, so these tests chdir into a tmp path and
+set the data-root env var.
+"""
+
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def _write_outputs(root: Path, *, names=None) -> None:
+    """Create the archived output set under `root`."""
+    from sbir_analytics.assets.jobs import phase_transition_archive as mod
+
+    for relative in names if names is not None else mod.ARCHIVED_OUTPUTS:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}")
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """Run the job with sources under cwd and the archive under the data root."""
+    from sbir_analytics.assets.jobs import phase_transition_archive as mod
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(mod.DATA_ROOT_ENV, str(tmp_path / "data-root"))
+    return tmp_path
+
+
+def _archive_dir(workspace: Path) -> Path:
+    date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+    return workspace / "data-root" / "processed" / "phase_transition" / "history" / date_str
+
+
+def test_job_archives_every_output_the_run_produced(workspace, monkeypatch):
+    from sbir_analytics.assets.jobs import phase_transition_archive as mod
+
+    monkeypatch.setattr(
+        mod, "generate_phase_transition_report", lambda *args: _write_outputs(workspace)
+    )
+
+    result = mod.phase_transition_archive_job.execute_in_process()
+
+    assert result.success
+    archived = sorted(p.name for p in _archive_dir(workspace).iterdir())
+    assert archived == sorted(Path(rel).name for rel in mod.ARCHIVED_OUTPUTS)
+
+
+def test_job_copies_rather_than_moves(workspace, monkeypatch):
+    """Canonical paths stay put; the archive is an additional snapshot."""
+    from sbir_analytics.assets.jobs import phase_transition_archive as mod
+
+    monkeypatch.setattr(
+        mod, "generate_phase_transition_report", lambda *args: _write_outputs(workspace)
+    )
+
+    assert mod.phase_transition_archive_job.execute_in_process().success
+
+    for relative in mod.ARCHIVED_OUTPUTS:
+        assert (workspace / relative).is_file(), f"{relative} was moved, not copied"
+
+
+def test_job_fails_when_an_expected_output_is_missing(workspace, monkeypatch):
+    from sbir_analytics.assets.jobs import phase_transition_archive as mod
+
+    incomplete = [rel for rel in mod.ARCHIVED_OUTPUTS if not rel.endswith("_report.json")]
+    monkeypatch.setattr(
+        mod,
+        "generate_phase_transition_report",
+        lambda *args: _write_outputs(workspace, names=incomplete),
+    )
+
+    result = mod.phase_transition_archive_job.execute_in_process(raise_on_error=False)
+
+    assert not result.success
+    message = result.failure_data_for_node(
+        "archive_phase_transition_outputs_op"
+    ).error.cause.message
+    # Assert the op's own refusal, not just the filename: a plain crash from
+    # stat() or copy2() also names the missing path, so matching on the path
+    # alone cannot tell a deliberate guard from an incidental traceback.
+    assert "Refusing to archive an incomplete or stale phase-transition snapshot" in message
+    assert "Missing: reports/phase_transition/phase_transition_report.json" in message
+    # Nothing is copied until the whole set validates, so a failed run leaves
+    # no dated directory a later reader could mistake for a complete snapshot.
+    assert not _archive_dir(workspace).exists()
+
+
+def test_job_fails_on_a_stale_output_rather_than_archiving_it(workspace, monkeypatch):
+    """A file left from an earlier run must not ride along into a dated snapshot.
+
+    This is the guard the op exists for: the parquet is regenerated upstream but
+    the report is written by this job, so a run that silently skipped the report
+    would otherwise archive last month's alongside this month's data.
+    """
+    from sbir_analytics.assets.jobs import phase_transition_archive as mod
+
+    stale = "reports/phase_transition/phase_transition_report.json"
+    stale_path = workspace / stale
+    stale_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_path.write_text("{}")
+    old = time.time() - 86_400
+    import os
+
+    os.utime(stale_path, (old, old))
+
+    fresh = [rel for rel in mod.ARCHIVED_OUTPUTS if rel != stale]
+    monkeypatch.setattr(
+        mod,
+        "generate_phase_transition_report",
+        lambda *args: _write_outputs(workspace, names=fresh),
+    )
+
+    result = mod.phase_transition_archive_job.execute_in_process(raise_on_error=False)
+
+    assert not result.success
+    message = result.failure_data_for_node(
+        "archive_phase_transition_outputs_op"
+    ).error.cause.message
+    assert "Refusing to archive an incomplete or stale phase-transition snapshot" in message
+    assert "Not written by this run" in message
+    assert stale in message

--- a/tests/unit/assets/jobs/test_source_download_execution.py
+++ b/tests/unit/assets/jobs/test_source_download_execution.py
@@ -1,0 +1,170 @@
+"""Layer-3 execution tests for the four host source-download jobs.
+
+The existing coverage is layers 1 and 2: `test_host_schedules.py` proves each
+schedule names a real job, and `test_source_download_jobs.py` exercises ops in
+isolation with `build_op_context`. That combination is exactly what
+`specs/actions-migration-followups/remaining-dagster-migrations.md` records as
+insufficient — `weekly_awards_report_job` held five passing tests at those two
+layers while being unable to run at all.
+
+These run each job *graph* through `execute_in_process` with the package API
+mocked, so they stay unit-fast. What they pin is the wiring the ops own rather
+than the downloaders' behaviour: that each op routes its destination through
+`_data_root()`, and that the guards which turn a "successful" fetch into a
+failure actually fire when the job runs.
+
+Destination routing is the specific thing worth a graph-level test. Promoting
+these downloaders out of `scripts/` changed what every op calls, and a
+regression that sent a fetch to a path outside the configured data root would
+leave every unit test passing and quietly write to the wrong volume on the
+server.
+"""
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+@pytest.fixture
+def data_root(tmp_path, monkeypatch):
+    """Point the jobs at an isolated data root."""
+    from sbir_analytics.assets.jobs import source_downloads as mod
+
+    monkeypatch.setenv(mod.DATA_ROOT_ENV, str(tmp_path))
+    return tmp_path
+
+
+def test_sbir_awards_job_routes_the_destination_through_the_data_root(data_root, monkeypatch):
+    from sbir_analytics.assets.jobs import source_downloads as mod
+
+    seen: dict[str, Path] = {}
+
+    def _fake(destination: Path) -> dict:
+        seen["destination"] = destination
+        return {"changed": True, "path": str(destination / "award_data.csv"), "sha256": "a" * 64}
+
+    monkeypatch.setattr(mod, "download_sbir_awards", _fake)
+
+    result = mod.sbir_awards_download_job.execute_in_process()
+
+    assert result.success
+    assert seen["destination"] == data_root / "raw" / "sbir"
+
+
+def test_usaspending_job_routes_the_destination_through_the_data_root(data_root, monkeypatch):
+    from sbir_analytics.assets.jobs import source_downloads as mod
+
+    seen: dict[str, Path] = {}
+
+    def _fake(destination: Path) -> dict:
+        seen["destination"] = destination
+        return {"status": "downloaded", "path": str(destination / "dump.zip"), "size": 1}
+
+    monkeypatch.setattr(mod, "download_local", _fake)
+
+    result = mod.usaspending_download_job.execute_in_process()
+
+    assert result.success
+    assert seen["destination"] == data_root / "usaspending"
+
+
+def test_sam_gov_job_counts_the_rows_it_actually_wrote(data_root, monkeypatch):
+    """The op reports `rows` by reading the parquet back, not by trusting a count."""
+    import pandas as pd
+
+    from sbir_analytics.assets.jobs import source_downloads as mod
+    from sbir_etl.extractors.source_downloads import sam_gov
+
+    seen: dict[str, Path] = {}
+
+    def _fake(destination: Path) -> Path:
+        seen["destination"] = destination
+        destination.mkdir(parents=True, exist_ok=True)
+        path = destination / "sam_public.parquet"
+        pd.DataFrame({"uei": ["A" * 12, "B" * 12, "C" * 12]}).to_parquet(path)
+        return path
+
+    monkeypatch.setattr(sam_gov, "download_sam_public_extract", _fake)
+
+    result = mod.sam_gov_download_job.execute_in_process()
+
+    assert result.success
+    assert seen["destination"] == data_root / "raw" / "sam_gov"
+    assert result.output_for_node("download_sam_gov_op")["rows"] == 3
+
+
+def test_uspto_job_fails_without_an_api_key(data_root, monkeypatch):
+    """The keyless path stopped working on 2026-06-18; the job must say so."""
+    from sbir_analytics.assets.jobs import source_downloads as mod
+
+    monkeypatch.delenv("USPTO_ODP_API_KEY", raising=False)
+
+    result = mod.uspto_download_job.execute_in_process(raise_on_error=False)
+
+    assert not result.success
+    failure = result.failure_data_for_node("download_uspto_op")
+    assert "USPTO_ODP_API_KEY" in failure.error.cause.message
+
+
+def test_uspto_job_fails_when_an_assignment_file_fails(data_root, monkeypatch):
+    """`download_assignments` records per-file errors instead of raising.
+
+    Without the op's own check the job would report success while holding a
+    partial assignment set, which is the failure mode the guard exists for.
+    """
+    from sbir_analytics.assets.jobs import source_downloads as mod
+    from sbir_etl.extractors.source_downloads import uspto, uspto_browser
+
+    monkeypatch.setenv("USPTO_ODP_API_KEY", "test-key")
+    monkeypatch.setattr(uspto, "create_session_with_retries", lambda: object())
+
+    def _write_plausible_file(*args, **kwargs):
+        destination = next(a for a in args if isinstance(a, Path))
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"0" * (mod.MIN_PLAUSIBLE_DOWNLOAD_BYTES + 1))
+        return {"status": "downloaded"}
+
+    monkeypatch.setattr(uspto, "download_odp_file", _write_plausible_file)
+    monkeypatch.setattr(uspto, "stream_download", _write_plausible_file)
+
+    async def _partial_failure(output_dir: Path):
+        return [{"file": "assignment", "error": "403 Forbidden"}]
+
+    monkeypatch.setattr(uspto_browser, "download_assignments", _partial_failure)
+
+    result = mod.uspto_download_job.execute_in_process(raise_on_error=False)
+
+    assert not result.success
+    failure = result.failure_data_for_node("download_uspto_op")
+    assert "403 Forbidden" in failure.error.cause.message
+
+
+def test_uspto_job_fails_when_no_assignment_file_is_produced(data_root, monkeypatch):
+    """An empty result set is a failed download, not an empty success."""
+    from sbir_analytics.assets.jobs import source_downloads as mod
+    from sbir_etl.extractors.source_downloads import uspto, uspto_browser
+
+    monkeypatch.setenv("USPTO_ODP_API_KEY", "test-key")
+    monkeypatch.setattr(uspto, "create_session_with_retries", lambda: object())
+
+    def _write_plausible_file(*args, **kwargs):
+        destination = next(a for a in args if isinstance(a, Path))
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"0" * (mod.MIN_PLAUSIBLE_DOWNLOAD_BYTES + 1))
+        return {"status": "downloaded"}
+
+    monkeypatch.setattr(uspto, "download_odp_file", _write_plausible_file)
+    monkeypatch.setattr(uspto, "stream_download", _write_plausible_file)
+
+    async def _no_files(output_dir: Path):
+        return []
+
+    monkeypatch.setattr(uspto_browser, "download_assignments", _no_files)
+
+    result = mod.uspto_download_job.execute_in_process(raise_on_error=False)
+
+    assert not result.success
+    failure = result.failure_data_for_node("download_uspto_op")
+    assert "no files" in failure.error.cause.message


### PR DESCRIPTION
## Description

Closes the layer-3 gap on the five host jobs that had none, and fixes a defect the new tests exposed.

`specs/actions-migration-followups/remaining-dagster-migrations.md` already says why layers 1 and 2 are not enough:

> `weekly_awards_report_job` had five passing tests covering layers 1 and 2 while being unable to run at all — executing it raised `FileNotFoundError: Could not resolve SBIR awards CSV`. Wiring tests cannot catch a job that is wired correctly to work it cannot do.

The four source-download jobs were in exactly that state — `test_host_schedules.py` for layer 1, `test_source_download_jobs.py` for layer 2, nothing above — and #542 changed what every one of their ops calls. `phase_transition_archive_job` had no test at any layer while its implementation was promoted out of `scripts/`.

Before this PR, `execute_in_process` appeared in four test files repo-wide, covering three jobs.

### What the tests pin

Downloader behaviour is not the target; the wiring the ops own is. Two things matter at the graph level:

**Destination routing.** Each op resolves its destination through `_data_root()`. A regression that sent a fetch to a CWD-relative path would leave every existing test green and quietly write to the wrong volume on the server, where the data root is a mounted disk.

**Guards that turn a "successful" fetch into a failure.** The missing `USPTO_ODP_API_KEY` (the keyless path stopped working 2026-06-18), a per-file assignment error (`download_assignments` records errors instead of raising, so the op would otherwise succeed holding a partial set), and an empty assignment result.

### The defect

`archive_phase_transition_outputs_op` documented this:

> Every expected output must exist and have been written by this run. A missing or stale file fails the op rather than producing an archive that silently mixes fresh parquet with an old report.

It did fail the run — but it copied while it validated and only raised at the end, so the files it had already reached stayed in the dated directory. That is the partial snapshot the docstring says it prevents, and a later reader cannot distinguish it from a complete one. The whole set is now validated before anything is copied.

I found this because an assertion I expected to hold did not. The op's stated contract and its behaviour disagreed, and the docstring was the one telling the truth.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Versioning Impact

- [x] No release impact (internal or unreleased work)

Tests plus an ordering change inside one op. No public surface, no output-format change.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

10 tests across two new files. Every one was checked against a mutated source rather than assumed to work:

| Mutation | Result |
|---|---|
| SBIR op destination → CWD-relative instead of `_data_root()` | 1 failed |
| Drop the `USPTO_ODP_API_KEY` guard | 1 failed |
| Drop the partial-assignment (`if failed:`) guard | 1 failed |
| Drop the empty-assignment-set guard | 1 failed |
| Drop the archive missing-file check | 1 failed |
| Drop the archive staleness check | 1 failed |
| `shutil.copy2` → `shutil.move` | 1 failed |

One of these earned its keep immediately. The first draft of the missing-file assertion **passed** under its mutant: it matched on the filename, and a plain `stat()` traceback names the same path, so it could not tell a deliberate guard from an incidental crash. It now asserts the op's own refusal message. That is the failure mode this whole PR is about, reproduced in miniature — a test that looks like coverage and verifies nothing.

Full CI unit selection: **5727 passed, 7 skipped**. Ruff, ruff-format, mypy, and all four guards clean; `Definitions.validate_loadable` OK.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

No documentation change: the four-layer pattern these follow is already written down in `specs/actions-migration-followups/remaining-dagster-migrations.md`, and this PR is that spec's testing table applied to the jobs it did not reach.

### Not covered here

`sbir_etl/extractors/source_downloads/uspto.py` and `uspto_browser.py` are still at 0% line coverage, and `tests/e2e/test_enrichment_job.py` is excluded from CI by its `requires_api` marker. Both are follow-ups, not this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smvpa16ur9YBVjVwbpgUhT)_