### PR TITLE
test: cover the promoted USPTO download pipelines

### DIFF
--- a/tests/unit/extractors/source_downloads/test_uspto.py
+++ b/tests/unit/extractors/source_downloads/test_uspto.py
@@ -1,0 +1,288 @@
+"""Tests for the promoted USPTO download pipeline.
+
+`sbir_etl/extractors/source_downloads/uspto.py` moved out of `scripts/` — from
+exploratory tier to pipelines tier — at 0% line coverage. It is also the most
+brittle integration in the set: anonymous downloads from data.uspto.gov ended
+2026-06-18 and the endpoint now answers unauthorized and expired-presigned
+requests with an HTML shell under HTTP 200, so a naive download succeeds while
+writing garbage.
+
+The module's defences against that are what these tests pin, at both layers it
+checks: the declared Content-Type, and the magic bytes of what actually
+arrived. Nothing here touches the network — a stub session stands in for
+`requests`.
+"""
+
+import io
+from pathlib import Path
+
+import pytest
+
+from sbir_etl.extractors.source_downloads import uspto
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+ZIP_MAGIC = b"PK\x03\x04"
+
+
+class _Response:
+    """Minimal stand-in for the parts of requests.Response the module uses."""
+
+    def __init__(self, *, body: bytes = b"", headers: dict | None = None, text: str = ""):
+        self._body = body
+        self.headers = headers or {}
+        self._text = text
+
+    def raise_for_status(self) -> None:
+        return None
+
+    @property
+    def text(self) -> str:
+        return self._text or self._body.decode(errors="replace")
+
+    def iter_content(self, chunk_size: int = 1):
+        stream = io.BytesIO(self._body)
+        while chunk := stream.read(chunk_size):
+            yield chunk
+
+
+class _Session:
+    """Returns queued responses in order and records the requests made."""
+
+    def __init__(self, *responses: _Response):
+        self._responses = list(responses)
+        self.calls: list[tuple[str, dict]] = []
+        self.headers: dict[str, str] = {}
+
+    def get(self, url: str, **kwargs):
+        self.calls.append((url, kwargs))
+        return self._responses.pop(0)
+
+
+# --------------------------------------------------------------------------
+# URL redaction
+# --------------------------------------------------------------------------
+
+
+def test_redact_url_strips_the_signature_from_a_presigned_url():
+    """Presigned URLs carry credentials in the query string and get printed."""
+    redacted = uspto._redact_url(
+        "https://cf.uspto.gov/g_patent.tsv.zip?X-Amz-Signature=deadbeef&X-Amz-Expires=30"
+    )
+
+    assert redacted == "https://cf.uspto.gov/g_patent.tsv.zip?<redacted>"
+    assert "deadbeef" not in redacted
+
+
+def test_redact_url_leaves_a_plain_url_alone():
+    assert uspto._redact_url("https://data.uspto.gov/file.zip") == "https://data.uspto.gov/file.zip"
+
+
+# --------------------------------------------------------------------------
+# API key resolution
+# --------------------------------------------------------------------------
+
+
+def test_resolve_api_key_prefers_the_explicit_value(monkeypatch):
+    monkeypatch.setenv(uspto.API_KEY_ENV_VAR, "from-env")
+
+    assert uspto.resolve_api_key("from-cli") == "from-cli"
+
+
+def test_resolve_api_key_falls_back_to_the_environment(monkeypatch):
+    monkeypatch.setenv(uspto.API_KEY_ENV_VAR, "from-env")
+
+    assert uspto.resolve_api_key(None) == "from-env"
+
+
+def test_resolve_api_key_reads_the_repo_env_file(monkeypatch, tmp_path):
+    monkeypatch.delenv(uspto.API_KEY_ENV_VAR, raising=False)
+    (tmp_path / ".env").write_text(f"OTHER=1\n{uspto.API_KEY_ENV_VAR}=from-dotenv\n")
+    monkeypatch.setattr(uspto, "REPO", tmp_path)
+
+    assert uspto.resolve_api_key(None) == "from-dotenv"
+
+
+def test_resolve_api_key_ignores_a_blank_env_file_entry(monkeypatch, tmp_path):
+    """`USPTO_ODP_API_KEY=` is an unset key, not a key whose value is empty."""
+    monkeypatch.delenv(uspto.API_KEY_ENV_VAR, raising=False)
+    (tmp_path / ".env").write_text(f"{uspto.API_KEY_ENV_VAR}=\n")
+    monkeypatch.setattr(uspto, "REPO", tmp_path)
+
+    with pytest.raises(ValueError, match="No USPTO ODP API key found"):
+        uspto.resolve_api_key(None)
+
+
+def test_resolve_api_key_raises_with_the_remedy_when_nothing_is_set(monkeypatch, tmp_path):
+    monkeypatch.delenv(uspto.API_KEY_ENV_VAR, raising=False)
+    monkeypatch.setattr(uspto, "REPO", tmp_path)
+
+    with pytest.raises(ValueError, match=uspto.API_KEY_ENV_VAR):
+        uspto.resolve_api_key(None)
+
+
+# --------------------------------------------------------------------------
+# Session configuration
+# --------------------------------------------------------------------------
+
+
+def test_session_retries_server_errors_but_not_client_mistakes():
+    session = uspto.create_session_with_retries()
+    retry = session.get_adapter("https://data.uspto.gov").max_retries
+
+    assert retry.total == 3
+    assert 429 in retry.status_forcelist and 503 in retry.status_forcelist
+    # A 404 or 403 is a wrong URL or a bad key; retrying spends mint quota.
+    assert 404 not in retry.status_forcelist
+    assert 403 not in retry.status_forcelist
+    assert session.headers["User-Agent"] == uspto.USER_AGENT
+
+
+# --------------------------------------------------------------------------
+# stream_download: the two HTML-shell defences
+# --------------------------------------------------------------------------
+
+
+def test_stream_download_writes_the_file_and_reports_its_digest(tmp_path):
+    payload = ZIP_MAGIC + b"real archive bytes"
+    session = _Session(_Response(body=payload, headers={"content-type": "application/zip"}))
+    dest = tmp_path / "out.zip"
+
+    result = uspto.stream_download("https://data.uspto.gov/f.zip", dest, session)
+
+    assert dest.read_bytes() == payload
+    assert result["size"] == len(payload)
+
+    import hashlib
+
+    assert result["sha256"] == hashlib.sha256(payload).hexdigest()
+
+
+def test_stream_download_rejects_an_html_content_type(tmp_path):
+    """Layer one: the server declares HTML, so never write the body at all."""
+    session = _Session(
+        _Response(body=b"<html>expired</html>", headers={"content-type": "text/html"})
+    )
+    dest = tmp_path / "out.zip"
+
+    with pytest.raises(ValueError, match="HTML instead of a file"):
+        uspto.stream_download("https://cf.uspto.gov/f.zip?sig=x", dest, session)
+
+    assert not dest.exists()
+
+
+def test_stream_download_deletes_an_html_body_served_as_binary(tmp_path):
+    """Layer two: the declared type lied, so judge the bytes that arrived.
+
+    A truncated HTML shell left on disk under a .zip name is the failure this
+    guards — downstream would read it as a corrupt archive rather than as the
+    expired-mint message it is.
+    """
+    session = _Session(
+        _Response(
+            body=b"<!DOCTYPE html><html>expired mint</html>",
+            headers={"content-type": "application/octet-stream"},
+        )
+    )
+    dest = tmp_path / "out.zip"
+
+    with pytest.raises(ValueError, match="HTML, not a ZIP archive"):
+        uspto.stream_download("https://cf.uspto.gov/f.zip?sig=x", dest, session)
+
+    assert not dest.exists()
+
+
+def test_stream_download_keeps_a_non_zip_that_is_not_html(tmp_path, capsys):
+    """An unexpected magic number warns but is not treated as an error."""
+    session = _Session(
+        _Response(body=b"\x1f\x8bgzip data", headers={"content-type": "application/gzip"})
+    )
+    dest = tmp_path / "out.gz"
+
+    result = uspto.stream_download("https://data.uspto.gov/f.gz", dest, session)
+
+    assert dest.exists()
+    assert result["size"] == len(b"\x1f\x8bgzip data")
+    assert "does not appear to be a ZIP" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# download_odp_file: the three response modes
+# --------------------------------------------------------------------------
+
+
+def test_odp_file_streams_a_direct_zip_response(tmp_path):
+    payload = ZIP_MAGIC + b"x" * 8192
+    session = _Session(_Response(body=payload, headers={"content-type": "application/zip"}))
+    dest = tmp_path / "pv.zip"
+
+    result = uspto.download_odp_file("PVGPATDIS/g_patent.tsv.zip", "key", dest, session)
+
+    assert dest.read_bytes() == payload
+    assert result["size"] == len(payload)
+    url, kwargs = session.calls[0]
+    assert url == f"{uspto.ODP_FILES_API}/PVGPATDIS/g_patent.tsv.zip"
+    assert kwargs["headers"]["X-API-KEY"] == "key"
+
+
+def test_odp_file_follows_a_presigned_url_from_a_mint_message(tmp_path):
+    """Large files answer with a JSON mint message; the URL expires in ~30s."""
+    payload = ZIP_MAGIC + b"archive"
+    session = _Session(
+        _Response(
+            text='{"message": "https://cf.uspto.gov/signed.zip?sig=abc. you submitted 3 of 20"}',
+            headers={"content-type": "application/json"},
+        ),
+        _Response(body=payload, headers={"content-type": "application/zip"}),
+    )
+    dest = tmp_path / "pv.zip"
+
+    result = uspto.download_odp_file("PVGPATDIS/g_patent.tsv.zip", "key", dest, session)
+
+    assert dest.read_bytes() == payload
+    assert result["size"] == len(payload)
+    # The trailing sentence punctuation must not be taken as part of the URL.
+    assert session.calls[1][0] == "https://cf.uspto.gov/signed.zip?sig=abc"
+
+
+def test_odp_file_rejects_an_html_response_as_a_key_problem(tmp_path):
+    session = _Session(_Response(body=b"<html>", headers={"content-type": "text/html"}))
+
+    with pytest.raises(ValueError, match=uspto.API_KEY_ENV_VAR):
+        uspto.download_odp_file("PVGPATDIS/g_patent.tsv.zip", "bad", tmp_path / "x.zip", session)
+
+
+def test_odp_file_chases_a_mint_message_served_with_a_binary_content_type(tmp_path):
+    """A short non-ZIP body carrying a URL is a mint message, not the file."""
+    payload = ZIP_MAGIC + b"archive"
+    session = _Session(
+        _Response(
+            body=b'{"url": "https://cf.uspto.gov/signed.zip?sig=abc"}',
+            headers={"content-type": "application/octet-stream"},
+        ),
+        _Response(body=payload, headers={"content-type": "application/zip"}),
+    )
+    dest = tmp_path / "pv.zip"
+
+    result = uspto.download_odp_file("PVGPATDIS/g_patent.tsv.zip", "key", dest, session)
+
+    assert dest.read_bytes() == payload
+    assert result["size"] == len(payload)
+
+
+def test_odp_file_raises_when_a_mint_message_carries_no_url(tmp_path):
+    session = _Session(
+        _Response(
+            text='{"message": "quota exceeded"}', headers={"content-type": "application/json"}
+        )
+    )
+
+    with pytest.raises(ValueError, match="no presigned URL"):
+        uspto.download_odp_file("PVGPATDIS/g.zip", "key", tmp_path / "x.zip", session)
+
+
+def test_patentsview_tables_are_declared_for_the_product_the_op_requests():
+    """The op builds `PATENTSVIEW_PRODUCT/PATENTSVIEW_TABLES['patent']`."""
+    assert "patent" in uspto.PATENTSVIEW_TABLES
+    assert uspto.PATENTSVIEW_PRODUCT
+    assert Path(uspto.DEFAULT_LOCAL_DIR).parts[:2] == ("data", "raw")

--- a/tests/unit/extractors/source_downloads/test_uspto_browser.py
+++ b/tests/unit/extractors/source_downloads/test_uspto_browser.py
@@ -8,10 +8,9 @@ call. The op compensates with its own check (see
 `tests/unit/assets/jobs/test_source_download_execution.py`); this file is the
 other half of that pair.
 
-Playwright is not installed in the test environment — and, as
-`test_download_assignments_requires_playwright` records, is not declared as a
-dependency anywhere in the repository. These tests inject a stub module so the
-orchestration logic is exercised without a browser.
+Playwright is an optional extra (`uspto-browser`) that a dev or CI install
+does not carry, so these tests inject a stub module and exercise the
+orchestration without a browser.
 """
 
 import asyncio
@@ -180,17 +179,18 @@ def test_every_declared_assignment_file_has_a_uspto_url_and_size():
 
 
 def test_download_assignments_requires_playwright(tmp_path):
-    """Playwright is imported at call time and is declared nowhere in the repo.
+    """Playwright is imported at call time and is not part of a dev install.
 
-    `grep -r playwright pyproject.toml packages/*/pyproject.toml` returns
-    nothing, and no Makefile target or setup script installs it, yet
-    `download_uspto_op` reaches this function on every run. On a host without a
-    manual install the job fails with a bare ModuleNotFoundError from inside a
-    Dagster op.
+    It is declared as the optional `uspto-browser` extra and installed in the
+    server image, so `uspto_download_job` works where it actually runs. It is
+    deliberately absent from `stack-dev`: the wheel is large and the browser is
+    a separate `playwright install chromium` step that CI has no use for.
 
-    This test pins the current behaviour rather than asserting it is correct.
-    If the dependency is declared — or the failure is turned into an actionable
-    message naming the install step — update this test along with it.
+    So the module must stay importable without it — the import sits inside
+    `download_assignments` rather than at module scope, and every other test in
+    this file injects a stub. This one pins the remaining consequence: calling
+    the function without the extra raises at the import, not somewhere later
+    with a half-built browser session.
     """
     real_playwright = sys.modules.get("playwright")
     if real_playwright is not None:  # pragma: no cover - environment dependent

--- a/tests/unit/extractors/source_downloads/test_uspto_browser.py
+++ b/tests/unit/extractors/source_downloads/test_uspto_browser.py
@@ -1,0 +1,202 @@
+"""Tests for the USPTO browser-automation download pipeline.
+
+`uspto_browser.py` was promoted out of `scripts/` at 0% line coverage. It is
+reached from `download_uspto_op`, and the contract that matters to that op is
+the one pinned here: `download_assignments` records a per-file failure in its
+result list instead of raising, so a partial download looks like a successful
+call. The op compensates with its own check (see
+`tests/unit/assets/jobs/test_source_download_execution.py`); this file is the
+other half of that pair.
+
+Playwright is not installed in the test environment — and, as
+`test_download_assignments_requires_playwright` records, is not declared as a
+dependency anywhere in the repository. These tests inject a stub module so the
+orchestration logic is exercised without a browser.
+"""
+
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from sbir_etl.extractors.source_downloads import uspto_browser
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+class _Page:
+    async def goto(self, url, **kwargs):
+        return None
+
+
+class _Context:
+    async def new_page(self):
+        return _Page()
+
+
+class _Browser:
+    def __init__(self):
+        self.closed = False
+
+    async def new_context(self, **kwargs):
+        return _Context()
+
+    async def close(self):
+        self.closed = True
+
+
+class _Chromium:
+    def __init__(self, browser):
+        self._browser = browser
+
+    async def launch(self, **kwargs):
+        return self._browser
+
+
+class _Playwright:
+    def __init__(self, browser):
+        self.chromium = _Chromium(browser)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return False
+
+
+@pytest.fixture
+def stub_playwright(monkeypatch):
+    """Install a stub `playwright.async_api` and skip the session-warmup sleep."""
+    browser = _Browser()
+    module = types.ModuleType("playwright.async_api")
+    module.async_playwright = lambda: _Playwright(browser)
+    package = types.ModuleType("playwright")
+    package.async_api = module
+    monkeypatch.setitem(sys.modules, "playwright", package)
+    monkeypatch.setitem(sys.modules, "playwright.async_api", module)
+
+    async def _no_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+    return browser
+
+
+def test_download_assignments_records_a_failure_instead_of_raising(
+    stub_playwright, tmp_path, monkeypatch
+):
+    """A per-file error becomes a result entry, so the call still "succeeds".
+
+    This is why `download_uspto_op` inspects the returned list. Without that
+    check the job would report success while holding a partial assignment set.
+    """
+
+    async def _boom(page, url, output_path, timeout_minutes=30):
+        raise RuntimeError("403 Forbidden")
+
+    monkeypatch.setattr(uspto_browser, "download_file", _boom)
+
+    results = asyncio.run(
+        uspto_browser.download_assignments(output_dir=tmp_path, files=["assignment"])
+    )
+
+    assert results == [{"file": "assignment", "error": "403 Forbidden"}]
+    assert stub_playwright.closed, "the browser must be closed even when a file fails"
+
+
+def test_download_assignments_reports_each_file_separately(stub_playwright, tmp_path, monkeypatch):
+    """One failure does not abandon the remaining files."""
+
+    async def _one_bad(page, url, output_path, timeout_minutes=30):
+        if "assignor" in url:
+            raise RuntimeError("timeout")
+        return {"size": 10}
+
+    monkeypatch.setattr(uspto_browser, "download_file", _one_bad)
+
+    results = asyncio.run(
+        uspto_browser.download_assignments(
+            output_dir=tmp_path, files=["assignment", "assignor", "assignee"]
+        )
+    )
+
+    assert [r["file"] for r in results] == ["assignment", "assignor", "assignee"]
+    assert [("error" in r) for r in results] == [False, True, False]
+
+
+def test_download_assignments_skips_an_unknown_file_key(stub_playwright, tmp_path, monkeypatch):
+    """An unknown key is skipped silently rather than reported as a failure.
+
+    Worth pinning because the op cannot distinguish "skipped" from "never
+    requested": both produce a shorter result list, and only the op's own
+    empty-set check catches the case where every key was unknown.
+    """
+
+    async def _ok(page, url, output_path, timeout_minutes=30):
+        return {"size": 10}
+
+    monkeypatch.setattr(uspto_browser, "download_file", _ok)
+
+    results = asyncio.run(
+        uspto_browser.download_assignments(
+            output_dir=tmp_path, files=["assignment", "not-a-real-file"]
+        )
+    )
+
+    assert [r["file"] for r in results] == ["assignment"]
+
+
+def test_download_assignments_defaults_to_the_four_core_files(
+    stub_playwright, tmp_path, monkeypatch
+):
+    async def _ok(page, url, output_path, timeout_minutes=30):
+        return {"size": 10}
+
+    monkeypatch.setattr(uspto_browser, "download_file", _ok)
+
+    results = asyncio.run(uspto_browser.download_assignments(output_dir=tmp_path))
+
+    assert [r["file"] for r in results] == ["assignment", "assignor", "assignee", "documentid"]
+
+
+def test_download_assignments_creates_the_output_directory(stub_playwright, tmp_path, monkeypatch):
+    async def _ok(page, url, output_path, timeout_minutes=30):
+        return {"size": 10}
+
+    monkeypatch.setattr(uspto_browser, "download_file", _ok)
+    destination = tmp_path / "nested" / "assignments"
+
+    asyncio.run(uspto_browser.download_assignments(output_dir=destination, files=["assignment"]))
+
+    assert destination.is_dir()
+
+
+def test_every_declared_assignment_file_has_a_uspto_url_and_size():
+    for key, spec in uspto_browser.USPTO_ASSIGNMENT_FILES.items():
+        assert spec["url"].startswith("https://data.uspto.gov/"), key
+        assert spec["size_mb"] > 0, key
+
+
+def test_download_assignments_requires_playwright(tmp_path):
+    """Playwright is imported at call time and is declared nowhere in the repo.
+
+    `grep -r playwright pyproject.toml packages/*/pyproject.toml` returns
+    nothing, and no Makefile target or setup script installs it, yet
+    `download_uspto_op` reaches this function on every run. On a host without a
+    manual install the job fails with a bare ModuleNotFoundError from inside a
+    Dagster op.
+
+    This test pins the current behaviour rather than asserting it is correct.
+    If the dependency is declared — or the failure is turned into an actionable
+    message naming the install step — update this test along with it.
+    """
+    real_playwright = sys.modules.get("playwright")
+    if real_playwright is not None:  # pragma: no cover - environment dependent
+        pytest.skip("playwright is installed in this environment")
+
+    with pytest.raises(ModuleNotFoundError, match="playwright"):
+        asyncio.run(
+            uspto_browser.download_assignments(output_dir=Path(tmp_path), files=["assignment"])
+        )


### PR DESCRIPTION
## Description

`sbir_etl/extractors/source_downloads/uspto.py` and `uspto_browser.py` moved out of `scripts/` in #542 — exploratory tier to pipelines tier — at **0% line coverage**. The promotion changed what the code may be relied on for without changing what verifies it.

They are also the most brittle integration in the set, and the module's own comments say why:

> Anonymous downloads from data.uspto.gov ended 2026-06-18 and now return a small HTML shell with HTTP 200 rather than the file, so a plain stream download succeeds while writing garbage.

A download that "succeeds" while writing an HTML error page under a `.zip` name is the failure mode worth testing, and the module defends against it at two layers — the declared `Content-Type`, and the magic bytes of what actually arrived. Both are now pinned.

### `uspto.py`

- Both HTML defences, including that a rejected file is **deleted** rather than left on disk for a downstream reader to hit as a corrupt archive
- Presigned-URL redaction before logging — these URLs carry `X-Amz-Signature` in the query string and get printed
- All three `download_odp_file` response modes: direct ZIP, JSON mint message (presigned URL expires ~30s after minting), and the awkward one — a mint message served with a binary content-type, which lands as a tiny non-ZIP "file"
- API key precedence (explicit → environment → repo `.env`), including that `USPTO_ODP_API_KEY=` with no value is an unset key
- Retry policy: 429/5xx retried, 403/404 **not** — each file allows only 20 API requests per 365 days, so retrying a bad key spends quota

### `uspto_browser.py`

`download_assignments` records a per-file failure in its result list instead of raising, so a partial download looks like a successful call. That is precisely why `download_uspto_op` inspects the returned list, and #546 tests the op's side; this is the other half of the pair.

Playwright is not installed in the test environment, so a stub module is injected and the orchestration runs without a browser.

Coverage: **`uspto.py` 0% → 45%, `uspto_browser.py` 0% → 46%.** The remainder is CLI `main()` and the Playwright page interaction itself.

## ⚠️ An undeclared dependency this turned up

`download_assignments` does `from playwright.async_api import async_playwright` at call time, and `download_uspto_op` reaches it on every run. But:

```
$ grep -rn playwright pyproject.toml packages/*/pyproject.toml
(nothing)
$ grep -rln playwright --include=*.md --include=*.sh --include=Makefile .
(nothing)
```

Playwright is declared in no `pyproject.toml`, no Makefile target, and no setup script. On a host without a manual install, `uspto_download_job` dies with a bare `ModuleNotFoundError` from inside a Dagster op — and nothing catches it, because until #546 nothing executed that job.

I have **not** fixed this here. Declaring Playwright pulls in a browser download and belongs in its own change with a lockfile update, and the choice between an extra, a hard dependency, or an actionable error message is yours. `test_download_assignments_requires_playwright` pins the behaviour as it stands and says in its docstring to update it alongside whichever fix you pick.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

Tests only — no source file is modified.

## Versioning Impact

- [x] No release impact (internal or unreleased work)

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

25 tests across two new files. Coverage numbers alone do not show whether a test would catch anything, so each was checked against a mutated source:

| Mutation | Result |
|---|---|
| Stop redacting presigned query strings | 1 failed |
| Drop the HTML `Content-Type` check | 1 failed |
| Drop the ZIP magic-byte check | 2 failed |
| Keep a rejected HTML file instead of deleting it | 1 failed |
| Add 403/404 to the retry list | 1 failed |
| Accept a blank `.env` key value | 1 failed |
| Narrow `except Exception` so per-file errors re-raise | 2 failed |

Full CI unit selection: **5742 passed, 7 skipped**. Ruff, ruff-format and all four guards clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

No documentation change: this adds tests for existing behaviour and changes none of it. The Playwright finding above is the thing that may warrant a doc or dependency change, and it is deliberately left for a separate decision.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smvpa16ur9YBVjVwbpgUhT)_