### PR TITLE
build: declare playwright as the uspto-browser extra

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,11 @@ RUN pip install \
 # USPTO patent assignments are only reachable through browser automation since
 # data.uspto.gov stopped serving them to plain HTTP clients (2026-06-18), so
 # uspto_download_job needs a real Chromium on the server image.
+#
+# The playwright pin above duplicates the `uspto-browser` extra in pyproject.toml,
+# which is the source of truth. This image installs packages directly rather than
+# installing this project (it copies source and sets PYTHONPATH), so it cannot
+# resolve the extra; keep the two constraints in step by hand.
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers
 RUN playwright install --with-deps chromium && \
     chmod -R a+rX /opt/pw-browsers

--- a/docs/deployment/self-hosted-server.md
+++ b/docs/deployment/self-hosted-server.md
@@ -454,6 +454,18 @@ Before enabling, note:
   HTML shell with HTTP 200, so the job fetches PatentsView and AI patents
   through the ODP mint flow and assignments through browser automation. A
   size/HTML guard fails the run rather than saving an error page as data.
+  The container image already carries both. Running the job outside the image
+  needs the `uspto-browser` extra plus the browser itself, which pip does not
+  install:
+
+  ```bash
+  uv sync --extra uspto-browser
+  uv run playwright install chromium
+  ```
+
+  Without them `download_assignments` raises `ModuleNotFoundError: playwright`
+  from inside the op. The extra is deliberately absent from `stack-dev`, so a
+  normal dev or CI environment does not carry it.
 - Downloads land under `SBIR_ETL__PATHS__DATA_ROOT`, which the server profile
   points at persistent host storage.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,14 @@ refresh-state-rates = "sbir_etl.transformers.fiscal.refresh_state_rates:main"
 ucc1-pilot = ["curl_cffi>=0.7.0,<1.0.0"]
 # USPTO SPSS/SAS file extraction
 uspto = ["pyreadstat>=1.1.4,<2.0.0"]
+# USPTO patent-assignment downloads. data.uspto.gov stopped serving assignments
+# to plain HTTP clients on 2026-06-18, so uspto_download_job drives a real
+# browser (sbir_etl/extractors/source_downloads/uspto_browser.py). Kept out of
+# stack-dev: the wheel is large and needs a separate `playwright install
+# chromium` for the browser itself, which CI has no use for. The server image
+# pins the same constraint in the Dockerfile, which installs packages directly
+# rather than installing this project.
+uspto-browser = ["playwright>=1.47.0,<2.0.0"]
 # AWS S3 cloud storage (for extractors that pull from S3)
 cloud = [
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -761,6 +761,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/de/f28ced0a67749cac23fecb02b694f6473f47686dff6afaa211d186e2ef9c/greenlet-3.2.4-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:96378df1de302bc38e99c3a9aa311967b7dc80ced1dcc6f171e99842987882a2", size = 272305, upload-time = "2025-08-07T13:15:41.288Z" },
     { url = "https://files.pythonhosted.org/packages/09/16/2c3792cba130000bf2a31c5272999113f4764fd9d874fb257ff588ac779a/greenlet-3.2.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1ee8fae0519a337f2329cb78bd7a8e128ec0f881073d43f023c7b8d4831d5246", size = 632472, upload-time = "2025-08-07T13:42:55.044Z" },
     { url = "https://files.pythonhosted.org/packages/ae/8f/95d48d7e3d433e6dae5b1682e4292242a53f22df82e6d3dda81b1701a960/greenlet-3.2.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:94abf90142c2a18151632371140b3dba4dee031633fe614cb592dbb6c9e17bc3", size = 644646, upload-time = "2025-08-07T13:45:26.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5e/405965351aef8c76b8ef7ad370e5da58d57ef6068df197548b015464001a/greenlet-3.2.4-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:4d1378601b85e2e5171b99be8d2dc85f594c79967599328f95c1dc1a40f1c633", size = 640519, upload-time = "2025-08-07T13:53:13.928Z" },
     { url = "https://files.pythonhosted.org/packages/25/5d/382753b52006ce0218297ec1b628e048c4e64b155379331f25a7316eb749/greenlet-3.2.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0db5594dce18db94f7d1650d7489909b57afde4c580806b8d9203b6e79cdc079", size = 639707, upload-time = "2025-08-07T13:18:27.146Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8e/abdd3f14d735b2929290a018ecf133c901be4874b858dd1c604b9319f064/greenlet-3.2.4-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2523e5246274f54fdadbce8494458a2ebdcdbc7b802318466ac5606d3cded1f8", size = 587684, upload-time = "2025-08-07T13:18:25.164Z" },
     { url = "https://files.pythonhosted.org/packages/5d/65/deb2a69c3e5996439b0176f6651e0052542bb6c8f8ec2e3fba97c9768805/greenlet-3.2.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1987de92fec508535687fb807a5cea1560f6196285a4cde35c100b8cd632cc52", size = 1116647, upload-time = "2025-08-07T13:42:38.655Z" },
@@ -771,6 +772,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1835,6 +1837,25 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "plotly"
 version = "6.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2069,6 +2090,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -2643,6 +2676,9 @@ ucc1-pilot = [
 uspto = [
     { name = "pyreadstat" },
 ]
+uspto-browser = [
+    { name = "playwright" },
+]
 viz = [
     { name = "plotly" },
 ]
@@ -2669,6 +2705,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0,<3" },
     { name = "pandas", specifier = ">=3.0.2,<4.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.2.0,<4.0.0" },
+    { name = "playwright", marker = "extra == 'uspto-browser'", specifier = ">=1.47.0,<2.0.0" },
     { name = "plotly", marker = "extra == 'viz'", specifier = ">=5.18.0,<7.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.5.0,<5.0.0" },
     { name = "psutil", marker = "extra == 'monitoring'", specifier = ">=5.9.0,<8.0.0" },
@@ -2696,7 +2733,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
     { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.67.3.20260408,<5.0.0" },
 ]
-provides-extras = ["ucc1-pilot", "uspto", "cloud", "streaming", "phonetic", "monitoring", "viz", "dev", "stack-dev"]
+provides-extras = ["ucc1-pilot", "uspto", "uspto-browser", "cloud", "streaming", "phonetic", "monitoring", "viz", "dev", "stack-dev"]
 
 [package.metadata.requires-dev]
 notebooks = [


### PR DESCRIPTION
## Description

Declares Playwright in project metadata as an optional `uspto-browser` extra, locks it, and documents the non-Docker install path.

### Correcting the premise

I previously reported this as an undeclared dependency that would kill `uspto_download_job` on any host. **That was overstated.** The dependency is real and deliberately installed — just not in project metadata:

- `Dockerfile:20` pins `playwright>=1.47.0,<2.0.0`, and lines 25–27 install Chromium into `/opt/pw-browsers`, with a comment naming `uspto_download_job` and the 2026-06-18 endpoint change
- `docs/deployment/self-hosted-server.md:452` already tells operators USPTO needs "a working Playwright/Chromium install"

The grep behind my claim covered `pyproject.toml`, `*.md`, `*.sh` and `Makefile` and excluded the `Dockerfile`, which is where the answer was. **Production was never broken.**

### What actually needed fixing

The pin lived in a Dockerfile `pip install` line and nowhere else, which means:

- `uv sync` never provides it, so the job cannot be run or exercised from a normal checkout
- it never reached `uv.lock`, so it is invisible to dependency resolution and tooling
- nothing connects `Dockerfile:20` to the single import that needs it — `uspto_browser.py:127`, reached only by `download_uspto_op`

### Where Playwright is used

One import site in executing code, and that is the whole of it:

| Location | What it is |
|---|---|
| `sbir_etl/extractors/source_downloads/uspto_browser.py:127` | `from playwright.async_api import async_playwright`, inside `download_assignments()`. The only import in the repo. |
| `Dockerfile:20,25-27` | Pin + `playwright install --with-deps chromium` for the server image |
| `docs/deployment/self-hosted-server.md:452` | Operator requirement |
| `specs/ucc1-financing-analysis/tasks.md:69` | Names "real Playwright" as scaling work the UCC1 pilot **deemed not warranted**. Not a use — that pilot runs on `curl_cffi` (the `ucc1-pilot` extra). |
| `.gitignore:229` | Playwright MCP debugging traces. Unrelated. |

### Choices

**A separate extra, not folded into `uspto`.** That one is `pyreadstat` for SPSS/SAS file extraction — a different concern that happens to share a vendor.

**Deliberately not in `stack-dev`.** The wheel is large and the browser is a further `playwright install chromium` that pip does not perform. CI has no use for either: the tests for this module inject a stub rather than driving a browser. Confirmed `uv sync --extra stack-dev` still resolves zero Playwright packages, and that the default dev environment still cannot import it — which keeps the stub approach in #547 honest rather than incidental.

**The Dockerfile pin stays.** That image installs packages directly rather than installing this project — it copies source and sets `PYTHONPATH=/app` — so it cannot resolve an extra. The pin now carries a comment naming pyproject as the source of truth. Two constraints kept in step by hand is a real cost; a CI check asserting they match would remove it, and I have not built one because it is beyond what was asked. Say the word.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Versioning Impact

- [x] MINOR: new capability, deprecation, or breaking change during `0.x`

A new installable extra is a user-visible packaging capability. Nothing existing changes: no current install grows a dependency, and `stack-dev` resolves identically. `check_versioning.py` passes at the current `0.3.0`; the increment applies whenever the next release PR is cut.

## Testing

- [ ] Unit tests added/updated
- [x] All tests pass locally

No new tests — this adds no behaviour. Verified instead:

- `uv lock` → resolves `playwright==1.62.0` (+ `pyee`), 3 lockfile entries
- `uv sync --extra uspto-browser --dry-run` → `+ playwright==1.62.0`
- `uv sync --extra stack-dev --dry-run` → **zero** Playwright mentions
- after a real `uv sync --extra stack-dev`, `import playwright` still raises `ModuleNotFoundError`
- `scripts/ci/check_versioning.py` → passed for 0.3.0
- all four guards, `make docs-check`, `docker compose config -q`, ruff → clean
- full CI unit selection: **5717 passed, 7 skipped**

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

The runbook now records the two commands a non-Docker host needs (`uv sync --extra uspto-browser` and `uv run playwright install chromium`) and says why a dev environment does not carry them.

### Related

#547 asserted in a test docstring that the dependency was "declared nowhere in the repo". That branch has been updated with the correction and now describes this arrangement. Merge order does not matter.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Smvpa16ur9YBVjVwbpgUhT)_