### PR TITLE
Declare sbir_etl config, models, and company_names as primitives tier

### DIFF
--- a/sbir_etl/config/__init__.py
+++ b/sbir_etl/config/__init__.py
@@ -1,1 +1,8 @@
-"""Configuration loading utilities."""
+"""Configuration loading utilities.
+
+Epistemic tier: primitives. All configuration access goes through this
+package's loader and schemas; behavior that changes loaded values is a
+versioned change, never an edit in place.
+"""
+
+EPISTEMIC_TIER = "primitives"

--- a/sbir_etl/identity/company_names.py
+++ b/sbir_etl/identity/company_names.py
@@ -1,5 +1,9 @@
 """Versioned company-name policies with a single 0..1 similarity contract.
 
+Epistemic tier: primitives. Profiles are frozen policies; normalization or
+similarity behavior that changes output requires a new named profile
+version, never an edit in place.
+
 The profiles preserve current analytical behavior while making differences
 explicit and reviewable. They are compatibility policies, not a claim that all
 name-matching use cases should have identical recall. New consumers must select
@@ -21,6 +25,9 @@ try:
 except ImportError:  # pragma: no cover - supported dependency-light fallback
     fuzz = None  # type: ignore[assignment]
     JaroWinkler = None  # type: ignore[assignment, misc]
+
+
+EPISTEMIC_TIER = "primitives"
 
 
 class CompanyNameProfile(StrEnum):

--- a/sbir_etl/models/__init__.py
+++ b/sbir_etl/models/__init__.py
@@ -1,7 +1,15 @@
-"""Data models for the SBIR ETL pipeline — lazily imported to avoid heavy optional-dependency load at package import time."""
+"""Data models for the SBIR ETL pipeline — lazily imported to avoid heavy optional-dependency load at package import time.
+
+Epistemic tier: primitives. Every downstream package depends on these
+schemas; a change that alters field shape or validation is a new versioned
+behavior, never an edit in place.
+"""
 
 from importlib import import_module
 from typing import Any
+
+
+EPISTEMIC_TIER = "primitives"
 
 
 _LAZY_BY_MODULE: dict[str, tuple[str, ...]] = {


### PR DESCRIPTION
## Description

Label-only promotion of `sbir_etl/config/`, `sbir_etl/models/`, and `sbir_etl/identity/company_names.py` to the `primitives` epistemic tier, per the contracts in `docs/steering/epistemic-tiers.md`.

These modules already meet the primitives contract — single implementation per concept, comprehensive unit tests, versioned behavior — but carried no declaration, so under the "unstated means exploratory" rule they were formally exploratory while everything in the repository depends on them. `company_names.py` was also the one undeclared implementation file among its identity siblings (`sbir_awards.py`, `geography.py`, `exact_awards.py` all declare `primitives`).

Each file gains the standard docstring tier paragraph and module-level `EPISTEMIC_TIER = "primitives"` constant, matching the existing pattern in `sbir_etl/identity/geography.py`. No behavior change.

Companion PRs: sbir-graph loader declarations (separate PR), and a broader categorization sweep + doc-drift fixes on `claude/epistemic-tier-categorization-xltqmb`.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

- `uv run ruff check sbir_etl/config sbir_etl/models sbir_etl/identity` — all checks passed
- `uv run pytest tests/unit/config tests/unit/models tests/unit/identity -q` — 715 passed
- `make lint-boundaries` — architecture, identity, and study-manifest guards passed

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_