### PR TITLE
Label epistemic tiers across sbir_etl, packages, and analysis scripts

### DIFF
--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -161,23 +161,29 @@ What already holds:
 - `sbir_etl/` is a clean foundation layer — 141 imports inbound from
   `packages/`, zero outbound.
 - `sbir_etl/identity/` meets the `primitives` contract, with a boundary checker
-  at `scripts/ci/check_identity_boundaries.py`.
+  at `scripts/ci/check_identity_boundaries.py` enforced by the CI quality job.
+- Active specs declare a target tier in `requirements.md`;
+  `scripts/ci/check_epistemic_tiers.py` rejects missing, duplicate, and
+  invalid declarations in CI.
 - The Phase III census implements the evidence-tier mechanisms: frozen
   artifacts, SHA enforcement, a declared estimand, and a blocking asset check.
 
 What does not:
 
-- The identity boundary checker is enforced by the CI quality job.
-- Active specs declare a target tier in `requirements.md`; CI rejects missing,
-  duplicate, and invalid declarations.
-- Nine direct `yaml.safe_load` call sites remain outside the configuration
+- Seven direct `yaml.safe_load` call sites remain outside the configuration
   loader and the shared strict-mapping reader; several intentionally use
   permissive empty-file behavior.
-- `scripts/` carries analytical weight from `phase3_groundtruth/` and
-  `validation/` with no contract at all.
-- Existing modules are not yet universally declared. An undeclared module is
-  therefore still exploratory until an explicit promotion satisfies its target
-  contract.
+- `scripts/phase3_groundtruth/` and `scripts/validation/` now carry explicit
+  `exploratory` labels, but their analytical weight — T6/T7 groundtruth
+  results feeding the evidence-target `phase3-transition-groundtruth` spec —
+  still exceeds their tier. The remaining issue is that tension, not missing
+  labels.
+- Module-level declaration is now the standard — subpackages carry package
+  defaults and divergent modules carry per-file `EPISTEMIC_TIER` constants —
+  but coverage is not yet universal. The remaining gaps are whatever
+  `rg --files-without-match '^EPISTEMIC_TIER'` reports, not a fixed list, and
+  an undeclared module is still exploratory until an explicit promotion
+  satisfies its target contract.
 
 The first useful step is labeling, not moving directories. Directory
 reorganization is the last step, and optional.

--- a/packages/sbir-analytics/sbir_analytics/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/__init__.py
@@ -1,5 +1,12 @@
 """SBIR Analytics application package.
 
+Epistemic tier: pipelines. Package default for deterministic orchestration
+and materialization; asset modules that rank, score, or infer declare
+exploratory per-file, and evidence-tier census machinery is governed by its
+study contract under ``studies/``.
+
 This package contains Dagster orchestration and application tools that should
 not be part of the reusable sbir-etl library.
 """
+
+EPISTEMIC_TIER = "pipelines"

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/__init__.py
@@ -17,6 +17,10 @@ Phase 2 outputs:
     - ``agency_vs_form_d_matched_pairs.parquet``
     - ``agency_vs_form_d_comparison.md``
     - ``threats_to_validity.json``
+
+Epistemic tier: exploratory. Cohort matching and outcome comparisons against
+published external baselines are contestable analysis, so comparison
+artifacts are non-citable.
 """
 
 from .asset import AgencyPrivateCapitalConfig, agency_private_capital_baseline_comparison
@@ -36,6 +40,9 @@ from .outcomes import OutcomeMetricsCalculator, wilson_interval
 from .phase2_outcomes import MatchedCohortOutcomes
 from .reconcile import ReconciliationNarrative, ReconciliationRecord
 from .threats import ThreatsToValidity
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 __all__ = [

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/__init__.py
@@ -1,5 +1,9 @@
 """CET (Critical & Emerging Technologies) assets package.
 
+Epistemic tier: exploratory. Award and patent CET classification and
+classifier training are unvalidated model inference, so technology labels
+are non-citable.
+
 This package contains modularized Dagster assets for CET taxonomy processing,
 classification, training, analytics, validation, company profiling, and Neo4j loading.
 
@@ -83,6 +87,8 @@ from .validation import (
     validated_cet_iaa_report,
 )
 
+
+EPISTEMIC_TIER = "exploratory"
 
 # Backward compatibility aliases
 neo4j_cetarea_nodes = loaded_cet_areas

--- a/packages/sbir-analytics/sbir_analytics/assets/company_categorization.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/company_categorization.py
@@ -3,6 +3,9 @@
 This module implements the company categorization system that classifies SBIR
 companies as Product, Service, or Mixed based on their federal contract portfolios
 from USAspending.
+
+Epistemic tier: exploratory. These assets materialize the Product/Service/Mixed
+heuristic classification — a contestable inference — so results are non-citable.
 """
 
 import pandas as pd
@@ -21,6 +24,9 @@ from sbir_etl.config.loader import get_config
 from sbir_etl.enrichers.company_categorization import retrieve_company_contracts
 from sbir_etl.extractors.usaspending import DuckDBUSAspendingExtractor
 from sbir_etl.transformers.company_categorization import aggregate_company_classification
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 @asset(

--- a/packages/sbir-analytics/sbir_analytics/assets/fiscal_assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/fiscal_assets.py
@@ -1,4 +1,8 @@
-"""Dagster assets for fiscal analysis pipeline."""
+"""Dagster assets for fiscal analysis pipeline.
+
+Epistemic tier: exploratory. Fiscal materializations are BEA I-O model
+estimates with contestable modeling choices, so outputs are non-citable.
+"""
 
 from decimal import Decimal
 from typing import Any
@@ -29,6 +33,9 @@ from sbir_etl.transformers.fiscal import (
     FiscalUncertaintyQuantifier,
 )
 from sbir_etl.utils.monitoring import performance_monitor
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/sbir-analytics/sbir_analytics/assets/follow_on_multiplier/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/follow_on_multiplier/__init__.py
@@ -1,5 +1,9 @@
 """Pure follow-on funding multiplier analysis and production-input adapters.
 
+Epistemic tier: exploratory. The calculator is deterministic, but which
+obligations count as follow-on is a contestable attribution policy, so
+multiplier readouts are non-citable.
+
 Dagster wiring lives in :mod:`sbir_analytics.assets.follow_on_multiplier.asset` so importing the
 pure calculator does not require orchestration dependencies.
 """
@@ -11,6 +15,9 @@ from .analysis import (
 )
 from .integration import build_canonical_obligations
 from .reconcile import NASEM_DOD_BENCHMARK, reconcile_nasem, reconciliation_markdown
+
+
+EPISTEMIC_TIER = "exploratory"
 
 __all__ = [
     "FollowOnMultiplierPolicy",

--- a/packages/sbir-analytics/sbir_analytics/assets/modernbert/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/modernbert/__init__.py
@@ -1,10 +1,17 @@
-"""Dagster assets for ModernBert embedding generation and similarity computation."""
+"""Dagster assets for ModernBert embedding generation and similarity computation.
+
+Epistemic tier: exploratory. Neural embedding similarity used as transition
+evidence has no validated contract, so similarity outputs are non-citable.
+"""
 
 from .embeddings import (
     modernbert_award_patent_similarity,
     modernbert_embeddings_awards,
     modernbert_embeddings_patents,
 )
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 __all__ = [

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/__init__.py
@@ -1,9 +1,17 @@
 """Phase III candidate-surfacing assets.
 
+Epistemic tier: exploratory. Candidate surfacing ranks pairs with
+hand-weighted similarity and thresholds (an experimental lift per
+``specs/phase3-candidate-enrichment``, not production), so candidates are
+non-citable; deterministic pair construction in ``pairing`` declares
+pipelines per-file.
+
 See ``specs/phase-3-solicitation-alerts/`` for the surfacing pipeline that
 emits ``data/processed/phase_iii_candidates.parquet``. v1 ships the
 RETROSPECTIVE, DIRECTED, and competitive FOLLOWON signal classes.
 """
+
+EPISTEMIC_TIER = "exploratory"
 
 __all__ = [
     "CANDIDATES_OUTPUT_PATH",

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/pairing.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/pairing.py
@@ -1,4 +1,9 @@
-"""Shared UEI pair construction and Phase III candidate filters."""
+"""Shared UEI pair construction and Phase III candidate filters.
+
+Epistemic tier: pipelines. Pair construction and coded-status filters are
+deterministic data movement with no scoring — the evidence-tier census
+imports this boundary, so it must never gain inference.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +13,9 @@ import pandas as pd
 
 from sbir_etl.utils.award_identity import award_key_series
 from sbir_etl.utils.procurement_text import DIRECTED_LINEAGE_TERMS
+
+
+EPISTEMIC_TIER = "pipelines"
 
 # FPDS Element 10Q codes that mark a contract as already-coded Phase III.
 # Duplicated intentionally — avoids cross-package import for a five-element set.

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_fiscal_impacts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_fiscal_impacts.py
@@ -2,6 +2,9 @@
 
 Calculates tax revenue and job creation impacts from SBIR awards using
 BEA I-O economic models.
+
+Epistemic tier: exploratory. Tax and job impacts are model estimates a reader
+could mistake for findings, so outputs are non-citable.
 """
 
 import pandas as pd
@@ -17,6 +20,9 @@ from dagster import (
 from sbir_etl.config.loader import get_config
 from sbir_etl.transformers.sbir_fiscal_pipeline import SBIRFiscalImpactCalculator
 from sbir_etl.utils.monitoring import performance_monitor
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 @asset(

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/__init__.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/__init__.py
@@ -1,5 +1,9 @@
 """Transition Detection assets package.
 
+Epistemic tier: exploratory. Vendor resolution and transition scoring rest on
+fuzzy matching and model-weighted similarity, so detections are non-citable
+without evidence-tier validation.
+
 This package contains modularized Dagster assets for the Transition Detection MVP,
 which identifies SBIR award recipients who transition to federal contracts.
 
@@ -88,6 +92,9 @@ from .utils import (
 
 # Vendor resolution module
 from .vendor_resolution import enriched_vendor_resolution
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 __all__ = [

--- a/packages/sbir-graph/sbir_graph/__init__.py
+++ b/packages/sbir-graph/sbir_graph/__init__.py
@@ -1,6 +1,12 @@
 """SBIR Graph — Neo4j graph database loading and query modules.
 
+Epistemic tier: pipelines. Package default: loading, schema migrations, and
+queries move validated ETL outputs deterministically without producing new
+inference.
+
 This package contains Neo4j-specific code: loaders for writing ETL
 outputs to the graph database, and query modules for traversing
 transition pathways.
 """
+
+EPISTEMIC_TIER = "pipelines"

--- a/packages/sbir-graph/sbir_graph/migrations/__init__.py
+++ b/packages/sbir-graph/sbir_graph/migrations/__init__.py
@@ -1,1 +1,7 @@
-"""Neo4j schema migrations for the SBIR graph package."""
+"""Neo4j schema migrations for the SBIR graph package.
+
+Epistemic tier: pipelines. Migrations are deterministic, versioned schema
+changes applied in order; they decide nothing contestable.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/packages/sbir-graph/sbir_graph/queries/pathway_queries.py
+++ b/packages/sbir-graph/sbir_graph/queries/pathway_queries.py
@@ -7,12 +7,18 @@ Implements sophisticated queries to traverse transition detection pathways:
 - Award → CET → Transition (technology-focused)
 - Company → Transition Metrics (company success)
 - Aggregations by CET area and confidence levels
+
+Epistemic tier: pipelines. Queries traverse persisted graph relationships
+deterministically and report stored scores without producing new inference.
 """
 
 from dataclasses import dataclass
 from typing import Any
 
 from neo4j import Driver  # type: ignore[attr-defined]
+
+
+EPISTEMIC_TIER = "pipelines"
 
 
 @dataclass

--- a/packages/sbir-ml/sbir_ml/__init__.py
+++ b/packages/sbir-ml/sbir_ml/__init__.py
@@ -1,5 +1,12 @@
 """SBIR ML/data science package — classification, transition detection, and analysis tools.
 
+Epistemic tier: exploratory. Package default for model training, scoring,
+classification, and transition detection — unvalidated model output is
+non-citable; deterministic feature-extraction and config-loading subpackages
+declare pipelines.
+
 This package contains ML models, transition detection scoring, and analytics
 tools that consume sbir-etl outputs. Requires scikit-learn, spacy, etc.
 """
+
+EPISTEMIC_TIER = "exploratory"

--- a/packages/sbir-ml/sbir_ml/ml/config/__init__.py
+++ b/packages/sbir-ml/sbir_ml/ml/config/__init__.py
@@ -1,8 +1,15 @@
-"""Configuration loaders for CET taxonomy, hyperparameters, and ModernBert client."""
+"""Configuration loaders for CET taxonomy, hyperparameters, and ModernBert client.
+
+Epistemic tier: pipelines. Taxonomy and client configuration loading is
+deterministic, validated data movement; it decides nothing contestable.
+"""
 
 from pydantic import BaseModel, Field
 
 from .taxonomy_loader import ClassificationConfig, TaxonomyConfig, TaxonomyLoader
+
+
+EPISTEMIC_TIER = "pipelines"
 
 
 class ModernBertClientConfig(BaseModel):

--- a/packages/sbir-ml/sbir_ml/ml/features/__init__.py
+++ b/packages/sbir-ml/sbir_ml/ml/features/__init__.py
@@ -1,3 +1,10 @@
-"""Feature extraction and evidence generation for CET classification."""
+"""Feature extraction and evidence generation for CET classification.
+
+Epistemic tier: pipelines. Feature extraction is deterministic text and
+metadata processing; scoring and classification live in the exploratory
+model modules.
+"""
+
+EPISTEMIC_TIER = "pipelines"
 
 __all__ = []

--- a/sbir_etl/capital_events/__init__.py
+++ b/sbir_etl/capital_events/__init__.py
@@ -1,0 +1,8 @@
+"""Capital-event timeline construction over cohort firms.
+
+Epistemic tier: pipelines. Source builders project already-matched records
+into a common schema and aggregate deterministically; match confidence is
+consumed here, never produced.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/sbir_etl/enrichers/__init__.py
+++ b/sbir_etl/enrichers/__init__.py
@@ -1,1 +1,8 @@
-"""Data enrichment modules for external API integration."""
+"""Data enrichment modules for external API integration.
+
+Epistemic tier: pipelines. Package default for deterministic retrieval and
+enrichment clients; modules that score, classify, or infer declare
+exploratory per-file.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/sbir_etl/enrichers/company_fuzzy_matcher.py
+++ b/sbir_etl/enrichers/company_fuzzy_matcher.py
@@ -31,6 +31,10 @@ Notes:
 - The module is intentionally dependency-light besides pandas + rapidfuzz.
 - Keep audit fields (score and method) so downstream logic can decide how to
   treat lower-confidence matches.
+
+Epistemic tier: exploratory. Threshold-based fuzzy match acceptance is
+contestable identity inference, not deterministic data movement, so its match
+decisions are non-citable.
 """
 
 from __future__ import annotations
@@ -44,6 +48,9 @@ import pandas as pd
 from ..exceptions import ValidationError
 from ..utils.text_normalization import normalize_name
 from sbir_etl.identity import rapidfuzz_jaro_winkler_100, rapidfuzz_token_set_100
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 def _set_award_match(

--- a/sbir_etl/enrichers/fiscal_bea_mapper.py
+++ b/sbir_etl/enrichers/fiscal_bea_mapper.py
@@ -3,6 +3,10 @@ NAICS-to-BEA Sector Mapper for fiscal returns analysis.
 
 This module implements the core mapping logic to convert NAICS codes to BEA Input-Output
 sectors using official crosswalks and hierarchical fallback strategies.
+
+Epistemic tier: exploratory. Fallback selection and allocation weights are
+modeling choices that shape fiscal impact estimates, so mapped sectors are
+non-citable analysis inputs.
 """
 
 from __future__ import annotations
@@ -18,6 +22,9 @@ import yaml
 from loguru import logger
 
 from ..config.loader import get_config
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 @dataclass

--- a/sbir_etl/enrichers/naics/fiscal/strategies/text_inference.py
+++ b/sbir_etl/enrichers/naics/fiscal/strategies/text_inference.py
@@ -1,4 +1,9 @@
-"""Strategy for NAICS enrichment from text inference."""
+"""Strategy for NAICS enrichment from text inference.
+
+Epistemic tier: exploratory. Keyword-based NAICS imputation from award text
+is contestable classification, not extraction, so inferred codes are
+non-citable.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +13,9 @@ import pandas as pd
 
 from ..utils import normalize_naics_code
 from .base import EnrichmentStrategy, NAICSEnrichmentResult
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 class TextInferenceStrategy(EnrichmentStrategy):

--- a/sbir_etl/extractors/__init__.py
+++ b/sbir_etl/extractors/__init__.py
@@ -1,1 +1,7 @@
-"""Data extraction modules for different sources."""
+"""Data extraction modules for different sources.
+
+Epistemic tier: pipelines. Extractors fetch and faithfully materialize
+declared sources; they do not classify, score, or infer findings.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/sbir_etl/identity/__init__.py
+++ b/sbir_etl/identity/__init__.py
@@ -1,4 +1,9 @@
-"""Shared company-identity normalization and similarity contracts."""
+"""Shared company-identity normalization and similarity contracts.
+
+Epistemic tier: primitives. Every member module is a versioned identity
+contract; output-changing behavior requires a new named profile version,
+never an edit in place.
+"""
 
 from .company_names import (
     ENHANCED_ABBREVIATIONS,
@@ -36,6 +41,9 @@ from .sbir_awards import (
     sbir_award_public_id,
     stable_sbir_award_id,
 )
+
+
+EPISTEMIC_TIER = "primitives"
 
 
 __all__ = [

--- a/sbir_etl/ot_consortium/__init__.py
+++ b/sbir_etl/ot_consortium/__init__.py
@@ -11,6 +11,10 @@ defeat that opacity — it measures it. T2/T3/T4 are first-class results, not
 failures, and their union is reported as a first-class "unverifiable share".
 
 See ``docs/ot-consortium/tiers.md`` for the full tier logic and assumptions.
+
+Epistemic tier: pipelines. Verification-tier assignment is a deterministic,
+auditable function of federal-record fields — name similarity is never
+sufficient — so it measures record opacity rather than inferring transitions.
 """
 
 from __future__ import annotations
@@ -28,6 +32,9 @@ from .models import (
     VerificationTier,
 )
 from .registry import CMFRecord, CMFRegistry
+
+
+EPISTEMIC_TIER = "pipelines"
 
 __all__ = [
     "UNVERIFIABLE_TIERS",

--- a/sbir_etl/quality/__init__.py
+++ b/sbir_etl/quality/__init__.py
@@ -1,9 +1,15 @@
 """Quality utilities for SBIR ETL.
 
+Epistemic tier: pipelines. Quality checks, baselines, and study-manifest
+handling are deterministic gates over declared inputs; they infer nothing.
+
 Submodules: uspto_validators, baseline, dashboard, checks.
 """
 
 from .uspto_validators import USPTODataQualityValidator, USPTOValidationConfig
+
+
+EPISTEMIC_TIER = "pipelines"
 
 
 __all__ = ["USPTODataQualityValidator", "USPTOValidationConfig"]

--- a/sbir_etl/reporting/__init__.py
+++ b/sbir_etl/reporting/__init__.py
@@ -1,1 +1,7 @@
-"""Report generation built on the sbir_etl library."""
+"""Report generation built on the sbir_etl library.
+
+Epistemic tier: exploratory. Report generation selects contestable analytical
+framings and its declared members are exploratory, so outputs are non-citable.
+"""
+
+EPISTEMIC_TIER = "exploratory"

--- a/sbir_etl/supply_chain/__init__.py
+++ b/sbir_etl/supply_chain/__init__.py
@@ -1,4 +1,9 @@
-"""Observable supply-network relationships involving SBIR awardees."""
+"""Observable supply-network relationships involving SBIR awardees.
+
+Epistemic tier: pipelines. Modules normalize observed funding relationships
+and build reproducible releases without asserting criticality; the CET
+screen declares exploratory per-file.
+"""
 
 from sbir_etl.supply_chain.defense_funding import (
     build_defense_funding_summary,
@@ -30,6 +35,9 @@ from sbir_etl.supply_chain.subaward_network import (
     build_supplier_customer_exposure,
     build_subaward_facts,
 )
+
+
+EPISTEMIC_TIER = "pipelines"
 
 __all__ = [
     "NSFReconciliationResult",

--- a/sbir_etl/supply_chain/nsf_screen.py
+++ b/sbir_etl/supply_chain/nsf_screen.py
@@ -1,4 +1,8 @@
-"""Screen NSF SBIR supplier candidates against existing CET policy mappings."""
+"""Screen NSF SBIR supplier candidates against existing CET policy mappings.
+
+Epistemic tier: exploratory. Rule-based CET screening decides contestable
+technology relevance, so emitted review candidates are non-citable.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +18,9 @@ from sbir_etl.reporting.local_cet_classifier import (
     LocalCETRuleClassifier,
     load_local_cet_rule_classifier,
 )
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 def screen_direct_nsf_awards(

--- a/sbir_etl/transformers/__init__.py
+++ b/sbir_etl/transformers/__init__.py
@@ -1,4 +1,11 @@
-"""Data transformation modules for business logic and normalization."""
+"""Data transformation modules for business logic and normalization.
+
+Epistemic tier: pipelines. Package default for deterministic reshaping and
+normalization; modules that classify or estimate declare exploratory
+per-file.
+"""
+
+EPISTEMIC_TIER = "pipelines"
 
 # Placeholder for future transformer implementations
 __all__: list[str] = []

--- a/sbir_etl/transformers/bea_io_adapter.py
+++ b/sbir_etl/transformers/bea_io_adapter.py
@@ -1,5 +1,8 @@
 """BEA I-O adapter for economic impact computation.
 
+Epistemic tier: exploratory. Multiplier impacts computed from spending shocks
+are model estimates, not observed data, so computed impacts are non-citable.
+
 Fetches national Input-Output tables from the BEA REST API and computes
 Leontief-based economic multiplier impacts from SBIR spending shocks.
 """
@@ -30,6 +33,9 @@ from .bea_io_functions import (
     fetch_value_added,
 )
 from .economic_model_interface import validate_shocks_input
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 class BEAIOAdapter:

--- a/sbir_etl/transformers/bea_io_functions.py
+++ b/sbir_etl/transformers/bea_io_functions.py
@@ -1,5 +1,9 @@
 """BEA I-O table functions for economic impact computation.
 
+Epistemic tier: exploratory. Leontief input-output analysis produces modeled
+economic impact estimates a reader could mistake for findings, so outputs are
+non-citable.
+
 Fetches national Use tables and Value-Added data from the BEA API, then
 performs Leontief input-output analysis in NumPy/Pandas.
 """
@@ -11,6 +15,9 @@ import pandas as pd
 from loguru import logger
 
 from .bea_api_client import BEAApiClient
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 # ---------------------------------------------------------------------------

--- a/sbir_etl/transformers/company_categorization.py
+++ b/sbir_etl/transformers/company_categorization.py
@@ -12,11 +12,18 @@ The classification system operates at two levels:
 Key Functions:
     - classify_contract: Classify a single contract/award
     - aggregate_company_classification: Aggregate contract classifications to company level
+
+Epistemic tier: exploratory. Keyword and contract-type heuristics classify
+firms as Product/Service/Mixed — a contestable inference a reader could
+mistake for a finding — so classifications are non-citable.
 """
 
 from loguru import logger
 
 from sbir_etl.models.categorization import CompanyClassification, ContractClassification
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 def classify_contract(contract: dict) -> ContractClassification:

--- a/sbir_etl/transformers/company_cet_aggregator.py
+++ b/sbir_etl/transformers/company_cet_aggregator.py
@@ -14,6 +14,10 @@ Key behaviors:
 
 The implementation is defensive about optional dependencies: if `pandas` is not available,
 the class will raise an informative ImportError when used.
+
+Epistemic tier: exploratory. Dominant-CET selection and specialization scoring
+aggregate unvalidated ML classifications, so company CET profiles are
+non-citable.
 """
 
 from __future__ import annotations
@@ -29,6 +33,9 @@ try:
 except Exception:  # pragma: no cover - defensive import
     pd = None  # type: ignore[assignment]
     np = None  # type: ignore[assignment]
+
+
+EPISTEMIC_TIER = "exploratory"
 
 __all__ = ["CompanyCETAggregator"]
 

--- a/sbir_etl/transformers/fiscal/__init__.py
+++ b/sbir_etl/transformers/fiscal/__init__.py
@@ -28,6 +28,10 @@ Exported Classes:
 
 Exported Functions:
 - calculate_fiscal_year: Convert award date to government fiscal year
+
+Epistemic tier: exploratory. Tax estimation, ROI, and sensitivity analysis
+are model-based estimation with no evidence-tier contract, so outputs are
+non-citable.
 """
 
 from __future__ import annotations
@@ -52,6 +56,9 @@ from .shocks import FiscalShockAggregator, ShockAggregationStats, calculate_fisc
 
 # Taxes module
 from .taxes import FiscalTaxEstimator, TaxEstimationStats
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 __all__ = [

--- a/sbir_etl/transformers/sbir_fiscal_pipeline.py
+++ b/sbir_etl/transformers/sbir_fiscal_pipeline.py
@@ -6,6 +6,10 @@ BEA I-O economic models.
 Pipeline flow:
     SBIR Awards (with NAICS) → Map to BEA Sectors → Aggregate → BEA I-O
     → Tax & Wage Impacts → Employment Calculation → Final Results
+
+Epistemic tier: exploratory. Tax and employment impacts are BEA I-O model
+estimates a reader could mistake for findings, so pipeline outputs are
+non-citable.
 """
 
 from __future__ import annotations
@@ -22,6 +26,9 @@ from .bea_io_adapter import BEAIOAdapter
 
 if TYPE_CHECKING:
     from ..config import Config  # type: ignore[attr-defined]
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 class SBIRFiscalImpactCalculator:

--- a/sbir_etl/ucc/__init__.py
+++ b/sbir_etl/ucc/__init__.py
@@ -1,0 +1,8 @@
+"""UCC-1 filing extraction and cohort tooling (California pilot).
+
+Epistemic tier: pipelines. Extraction, filtering, and cohort export are
+deterministic reproductions of declared definitions; the fuzzy debtor
+matcher declares exploratory per-file.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/sbir_etl/ucc/matcher.py
+++ b/sbir_etl/ucc/matcher.py
@@ -19,6 +19,10 @@ most of these because the spurious matches are in different cities than
 the cohort firm.
 
 Reuses sbir_etl.enrichers.matching for name normalization + similarity.
+
+Epistemic tier: exploratory. Debtor matching combines name-similarity
+thresholds with address heuristics — contestable identity inference — so
+match sets are non-citable.
 """
 
 import argparse
@@ -36,6 +40,9 @@ from sbir_etl.identity import (  # noqa: E402
 )
 
 from sbir_etl.ucc._common import data_path
+
+
+EPISTEMIC_TIER = "exploratory"
 
 # Name-tier thresholds (Jaro-Winkler 0..1)
 TIER_MEDIUM_THRESHOLD = 0.92

--- a/sbir_etl/utils/__init__.py
+++ b/sbir_etl/utils/__init__.py
@@ -1,1 +1,8 @@
-"""Shared utilities for the SBIR ETL pipeline."""
+"""Shared utilities for the SBIR ETL pipeline.
+
+Epistemic tier: pipelines. Package default for deterministic shared helpers;
+modules that back identity primitives or encode contestable analytical policy
+declare their own tier per-file.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/sbir_etl/utils/coercion.py
+++ b/sbir_etl/utils/coercion.py
@@ -1,10 +1,18 @@
-"""Generic type-coercion helpers shared across ETL modules."""
+"""Generic type-coercion helpers shared across ETL modules.
+
+Epistemic tier: primitives. Identity primitives depend on these coercion
+helpers, so output-changing edits move identity results and carry the
+primitives contract, not the utils package default.
+"""
 
 from __future__ import annotations
 
 from typing import Any
 
 import pandas as pd
+
+
+EPISTEMIC_TIER = "primitives"
 
 # Explicit pandas NA singleton types — avoids pd.isna() on arrays/lists
 # which returns an ambiguous boolean array and triggers DeprecationWarning.

--- a/sbir_etl/utils/company_canonicalizer.py
+++ b/sbir_etl/utils/company_canonicalizer.py
@@ -1,4 +1,9 @@
-"""Company canonicalization utilities for pre-loading deduplication."""
+"""Company canonicalization utilities for pre-loading deduplication.
+
+Epistemic tier: exploratory. Canonical-company grouping rides on threshold
+fuzzy matching — contestable identity inference — so its groupings are
+non-citable.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +14,9 @@ import pandas as pd
 
 from ..enrichers.company_fuzzy_matcher import enrich_awards_with_companies
 from ..utils.text_normalization import normalize_company_name
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 def canonicalize_companies_from_awards(

--- a/sbir_etl/utils/identifiers.py
+++ b/sbir_etl/utils/identifiers.py
@@ -1,4 +1,9 @@
-"""Canonical domain identifier normalizers."""
+"""Canonical domain identifier normalizers.
+
+Epistemic tier: primitives. Identity primitives depend on these UEI/DUNS/CAGE
+normalizers, so output-changing behavior requires a versioned change under the
+primitives contract, not the utils package default.
+"""
 
 from __future__ import annotations
 
@@ -6,6 +11,9 @@ import re
 from typing import Any
 
 from sbir_etl.utils.coercion import _blank
+
+
+EPISTEMIC_TIER = "primitives"
 
 
 def normalize_uspto_identifier(value: Any) -> str | None:

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -4,6 +4,10 @@ Profiles answer two separate questions: broad technology relevance and a
 stricter physical-product/manufacturing census.  The engine keeps the
 classification rules in versioned YAML and emits enough evidence and source
 identifiers to audit every included award.
+
+Epistemic tier: exploratory. The engine is deterministic, but profile-driven
+award admission is a contestable analytical policy, so census outputs are
+non-citable.
 """
 
 from __future__ import annotations
@@ -19,6 +23,9 @@ import yaml
 
 from sbir_etl.extractors.sbir_public_awards import load_sbir_awards_csv
 from sbir_etl.identity.geography import normalize_us_jurisdiction
+
+
+EPISTEMIC_TIER = "exploratory"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONFIG_DIR = REPO_ROOT / "config" / "tech_census"

--- a/sbir_etl/utils/transition_signals.py
+++ b/sbir_etl/utils/transition_signals.py
@@ -6,6 +6,10 @@ FPDS / M&A / Form D channels and ``deficiency_class`` without importing the
 nanotech script (which pulls in matplotlib).
 
 Dark-majority WS1/WS2/liveness **require** ``deficiency_class`` on the cohort.
+
+Epistemic tier: exploratory. Channel enrichment and deficiency classification
+encode contestable analytical policy for exploratory cohort studies, so
+outputs are non-citable.
 """
 
 from __future__ import annotations
@@ -14,6 +18,9 @@ import csv
 import json
 from datetime import date
 from pathlib import Path
+
+
+EPISTEMIC_TIER = "exploratory"
 
 # Awards younger than this are censored observations, not transition failures.
 INSUFFICIENT_TIME_YEAR = date.today().year - 3

--- a/sbir_etl/validators/__init__.py
+++ b/sbir_etl/validators/__init__.py
@@ -1,1 +1,7 @@
-"""Data validation and quality checking module."""
+"""Data validation and quality checking module.
+
+Epistemic tier: pipelines. Validation is deterministic conformance checking
+against declared schemas; it decides nothing contestable.
+"""
+
+EPISTEMIC_TIER = "pipelines"

--- a/scripts/phase3_groundtruth/resolve_firm_awards.py
+++ b/scripts/phase3_groundtruth/resolve_firm_awards.py
@@ -11,6 +11,10 @@ Matching is exact-on-normalized-name first, then token-set fuzzy (rapidfuzz)
 above a threshold, so "Acme Photonics" resolves to "ACME PHOTONICS INC" without
 also grabbing "Acme Robotics". Every match reports its score and method so a
 human can spot-check the fuzzy ones.
+
+Epistemic tier: exploratory. Fuzzy firm-name resolution for groundtruth
+assembly is non-citable; its results reach the evidence-target
+phase3-transition-groundtruth spec only through that spec's own contract.
 """
 
 from __future__ import annotations
@@ -28,6 +32,9 @@ from sbir_etl.identity import (
     normalize_company_name,
     rapidfuzz_token_set_100,
 )
+
+
+EPISTEMIC_TIER = "exploratory"
 
 FUZZY_THRESHOLD = 88.0
 

--- a/scripts/phase3_groundtruth/score_t6.py
+++ b/scripts/phase3_groundtruth/score_t6.py
@@ -14,6 +14,9 @@ Two paths (design: ``specs/phase3-transition-groundtruth/T6_DESIGN.md``):
 
 The A<->B gap is the contract->notice transfer caveat, measured. Neither path
 validates forward / open-solicitation use — both score a *retrospective* ranking.
+
+Epistemic tier: exploratory. T6 scoring results are non-citable until promoted
+through the evidence-tier contract of specs/phase3-transition-groundtruth.
 """
 
 import argparse
@@ -45,6 +48,9 @@ from sbir_ml.transition.detection.fusion_model import (  # noqa: E402
 from sbir_ml.transition.detection.fusion_scoring import (  # noqa: E402
     score_pairs_with_fusion,
 )
+
+
+EPISTEMIC_TIER = "exploratory"
 
 REPO_MAIN = Path("/Users/hollomancer/projects/sbir-analytics")
 DEFAULT_AWARD_DATA = REPO_MAIN / "data" / "raw" / "sbir" / "award_data.csv"

--- a/scripts/validation/__init__.py
+++ b/scripts/validation/__init__.py
@@ -1,5 +1,10 @@
 """SBIR ETL validation scripts.
 
+Epistemic tier: exploratory. These are one-off diagnostics with no contract;
+their numbers are non-citable.
+
 This package contains scripts for validating various aspects of the SBIR ETL pipeline,
 including data quality checks, enrichment validation, and pipeline health checks.
 """
+
+EPISTEMIC_TIER = "exploratory"

--- a/scripts/validation/categorization_validation.py
+++ b/scripts/validation/categorization_validation.py
@@ -31,6 +31,9 @@ Usage:
 
     # Load to Neo4j after categorization
     uv run python scripts/validation/categorization_validation.py --load-neo4j
+
+Epistemic tier: exploratory. This validates the heuristic categorization
+against a hand-assembled dataset; its results are diagnostics and non-citable.
 """
 
 import argparse
@@ -58,6 +61,9 @@ from sbir_etl.transformers.company_categorization import (
     is_cost_based_contract,
     is_service_based_contract,
 )
+
+
+EPISTEMIC_TIER = "exploratory"
 
 
 def _extract_year_from_date(date_str: str | None) -> int | None:

--- a/specs/status.md
+++ b/specs/status.md
@@ -81,9 +81,12 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`phase-3-solicitation-alerts` — Maintenance.** Retrospective S1 work is
   implemented. SAM.gov Opportunities S2/S3 paths remain backlog.
 - **`phase-iii-census` — Active.** Phase 1 is implemented and materialized under
-  a reproducible study contract, and the control-identity eligibility gate passed.
-  Control construction/matching, placebo tests, and labeled validation remain
-  required before any undercount or statutory Phase III claim.
+  a reproducible study contract; the control-identity eligibility gate, the
+  exact-matching balance gate, and the preregistered fixed-seed placebo
+  falsification have all passed (2026-08-03 audits). Matched negative-control
+  outcomes are descriptive only — a 2.10x clearing ratio with 0.853 overlap, so
+  the frozen criteria do not cleanly discriminate. Hand-labeled validation
+  remains required before any undercount or statutory Phase III claim.
 - **`phase-iii-source-materialization` — Maintenance.** The schema-verified
   USAspending and SBIR.gov source layer is implemented. Keep it aligned with the
   census and other transition consumers rather than extending it with scoring policy.


### PR DESCRIPTION
## Description

Completes the epistemic-tier categorization sweep per `docs/steering/epistemic-tiers.md`: 49 modules gain the standard docstring tier paragraph and `EPISTEMIC_TIER` constant (51 files, +379/−32), plus fixes for known drift in the tier doc and spec status registry. Labeling only — no behavior change, no refactoring.

**primitives**
- `sbir_etl/identity/__init__.py`; per-file `utils/coercion.py` and `utils/identifiers.py` — both are imported by declared identity primitives, and the exploratory contract forbids a higher tier depending on unlabeled modules.

**pipelines (package-level defaults)**
- `sbir_etl/`: `utils`, `enrichers`, `transformers`, `validators`, `quality`, `capital_events`, `ot_consortium`, `supply_chain`, `ucc`, `extractors`
- `packages/sbir-analytics/sbir_analytics/__init__.py`; `packages/sbir-graph`: package root, `migrations/`, `queries/pathway_queries.py`; `packages/sbir-ml`: `ml/config/`, `ml/features/` (deterministic loading/feature extraction)
- Per-file: `assets/phase_iii_candidates/pairing.py` — the evidence-tier census imports `build_uei_pairs` from it, inside an otherwise exploratory package

**exploratory (modules whose output a reader could mistake for a finding)**
- Fuzzy identity inference: `company_fuzzy_matcher`, `ucc/matcher`, `company_canonicalizer`
- Classification heuristics: `transformers/company_categorization` (+ asset + validation script), `naics .../text_inference`, `nsf_screen`
- Model estimation: the BEA/fiscal Leontief cluster (`bea_io_functions`/`adapter`, `sbir_fiscal_pipeline`, `transformers/fiscal/`, `fiscal_bea_mapper`, fiscal asset modules)
- Scoring/ML: `company_cet_aggregator`, `cet/`, `modernbert/`, `transition/`, `sbir-ml` package root
- Contestable analysis policy: `follow_on_multiplier/`, `agency_private_capital/`, `utils/tech_census`, `utils/transition_signals`, `sbir_etl/reporting/__init__.py`
- `scripts/phase3_groundtruth/` and `scripts/validation/` — the two directories the tier doc names as carrying analytical weight with no contract, now explicitly labeled

**Doc drift fixed**
- `docs/steering/epistemic-tiers.md` "Current status": the two now-true bullets (identity checker CI enforcement, spec tier declarations enforced by `check_epistemic_tiers.py`) moved into "What already holds"; `yaml.safe_load` count corrected nine → seven; scripts bullet rewritten around the remaining labeled-but-overweight groundtruth tension; module-declaration bullet reworded to stay true regardless of companion-PR merge order.
- `specs/status.md` census entry reconciled with the 2026-08-03 audits: eligibility gate and exact-matching balance gate passed, preregistered placebo falsification passed, negative-control outcomes descriptive only (2.10x clearing ratio, 0.853 overlap), hand-labeled validation the sole remaining requirement before undercount/statutory claims.

**Known residual tensions, labeled but deliberately not resolved here**: `sbir_neo4j_loading.py` (pipelines) imports now-exploratory `company_canonicalizer`; `defense_release.py` imports now-exploratory `nsf_screen`. The labels make these tier violations visible for follow-up.

Deliberately untouched: `assets/phase_iii_census/` and `assets/phase_iii_negative_controls/` (evidence machinery governed by `studies/phase-iii-census/study.yaml`), the 27 files already declaring a tier, the rest of `scripts/` (unstated-means-exploratory is the design working), and everything covered by companion PRs #550 (config/models/company_names → primitives) and #551 (sbir-graph loaders → pipelines). No file overlap with either companion PR; all three merge independently.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

- `uv run ruff check` across all touched paths — all checks passed
- `uv run pytest tests/unit/{identity,scripts,enrichers,transformers}` — 1686 passed
- Remaining touched areas: `tests/unit/{utils,supply_chain,ucc,quality,capital_events,ot_consortium,validators,extractors,reporting}` — 1533 passed, 4 skipped; `tests/unit/{assets,phase_iii_candidates,phase_iii_census,phase_iii_negative_controls,transition,agency_private_capital,follow_on_multiplier,ml,loaders,phase_transition,phase3_groundtruth}` — 1392 passed, 1 skipped; migration/query/fiscal-asset tests — 27 passed
- `make lint-boundaries` — architecture, identity, and study-manifest guards passed; `scripts/ci/check_epistemic_tiers.py` passed
- `make docs-check` — passed (covers the two doc edits)
- Runtime smoke test importing every labeled package and reading its tier constant, including the `phase_iii_candidates` lazy `__getattr__` path

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_