### PR TITLE
Fix rotted e2e/functional tests and wire health check into server ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,17 +203,8 @@ jobs:
       # back to sample data, and the bulk corpora live on persistent server storage
       # where no runner can reach them.
       #
-      # Two exclusions, both for tests that no CI job has ever executed and
-      # that are broken today. They are pre-existing rot, not regressions, and
-      # deselecting them by name keeps that visible rather than hiding it
-      # behind a marker filter:
-      #   - requires_api needs live external APIs and credentials; it does not
-      #     belong in CI at all.
-      #   - test_detection_smoke.py raises "Cannot compare Timestamp with
-      #     datetime.date" (slow-marked, so tests/e2e never ran it).
-      #   - TestFiscalPipeline imports fiscal_returns_core, a name that no
-      #     longer exists in sbir_analytics.assets.fiscal_assets.
-      # Fix those and delete the matching line.
+      # One exclusion: requires_api needs live external APIs and credentials;
+      # it does not belong in CI at all.
       - name: Run full test suite
         env:
           NEO4J_URI: "bolt://localhost:7687"
@@ -223,8 +214,6 @@ jobs:
         run: |
           uv run pytest tests/ \
             -m "not requires_api" \
-            --deselect tests/e2e/transition/test_detection_smoke.py \
-            --deselect tests/functional/test_pipelines.py::TestFiscalPipeline::test_fiscal_run_produces_outputs \
             --cov=sbir_etl \
             --cov=packages/sbir-analytics/sbir_analytics \
             --cov=packages/sbir-ml/sbir_ml \

--- a/Makefile
+++ b/Makefile
@@ -654,6 +654,12 @@ server-status: server-env-check ## Show server stack status
 	@$(call info,Server stack status)
 	$(call run,$(SERVER_COMPOSE) --profile server ps)
 
+.PHONY: server-health
+server-health: server-env-check ## Run health checks (env, deps, Neo4j) inside the running stack
+	@$(call info,Checking server stack health)
+	$(call run,$(SERVER_COMPOSE) --profile server ps)
+	$(call run,$(SERVER_COMPOSE) --profile server exec -T dagster-code-server python /app/scripts/e2e_health_check.py --profile server)
+
 .PHONY: server-logs
 server-logs: server-env-check ## Tail server logs for SERVICE (default dagster-webserver)
 	@$(call info,Tailing server logs for service: $(SERVICE))

--- a/docs/deployment/self-hosted-server.md
+++ b/docs/deployment/self-hosted-server.md
@@ -41,7 +41,10 @@ Run every `make server-*` command and shell-driven live materialization from
 the clean deployment checkout. Use the documented Make targets; do not run
 `git clean`, destructive resets, or hand-written Compose teardown commands
 there. Treat materialization as a live-data mutation: confirm persistent
-storage is mounted and the stack is healthy first. Keep schedules disabled
+storage is mounted and the stack is healthy first — `make server-health` is
+the concrete check (compose status plus environment, dependency, and Neo4j
+connectivity checks run inside the code-server container). Run it before any
+live materialization and before enabling any schedule. Keep schedules disabled
 until their jobs have completed successfully by hand with the inputs available
 on this host.
 

--- a/packages/sbir-ml/sbir_ml/transition/detection/detector.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/detector.py
@@ -140,6 +140,11 @@ class TransitionDetector:
         Returns:
             List of contracts within timing window
         """
+        # DataFrame-sourced awards and contracts carry pandas Timestamps
+        # (datetime subclasses), which plain date cannot compare against;
+        # the window is day-granular either way, so compare as dates.
+        if isinstance(award_completion_date, datetime):
+            award_completion_date = award_completion_date.date()
         min_date = award_completion_date + timedelta(days=self.min_days_after)
         max_date = award_completion_date + timedelta(days=self.max_days_after)
 
@@ -150,6 +155,9 @@ class TransitionDetector:
             contract_date = contract.action_date or contract.start_date
             if not contract_date:
                 continue
+
+            if isinstance(contract_date, datetime):
+                contract_date = contract_date.date()
 
             if min_date <= contract_date <= max_date:
                 filtered.append(contract)

--- a/packages/sbir-ml/sbir_ml/transition/detection/scoring.py
+++ b/packages/sbir-ml/sbir_ml/transition/detection/scoring.py
@@ -16,6 +16,7 @@ to produce a composite likelihood score (0.0-1.0) and confidence classification.
 from __future__ import annotations
 
 import re
+from datetime import datetime
 from typing import Any
 
 from loguru import logger
@@ -198,6 +199,14 @@ class TransitionScorer:
 
         if not award_completion_date or not contract_date:
             return TimingSignal(timing_score=0.0)
+
+        # DataFrame-sourced values arrive as pandas Timestamps (datetime
+        # subclasses), which plain date cannot mix with in arithmetic; the
+        # signal is day-granular either way, so subtract as dates.
+        if isinstance(award_completion_date, datetime):
+            award_completion_date = award_completion_date.date()
+        if isinstance(contract_date, datetime):
+            contract_date = contract_date.date()
 
         # Calculate days between
         days_between = (contract_date - award_completion_date).days

--- a/scripts/e2e_health_check.py
+++ b/scripts/e2e_health_check.py
@@ -126,15 +126,35 @@ def check_resource_constraints() -> tuple[bool, str]:
     return True, f"Resource constraints OK (Memory: {memory_limit_gb}GB, CPU: {cpu_limit})"
 
 
-def run_health_checks() -> dict[str, tuple[bool, str]]:
-    """Run all health checks and return results."""
-    checks = {
+# The server profile drops the two e2e-container-specific checks: test-data
+# fixtures do not exist on the live stack, and the MacBook Air resource guard
+# fails precisely when a host has more resources than a laptop.
+CHECK_PROFILES = {
+    "e2e": [
+        "Environment Variables",
+        "Python Dependencies",
+        "Test Data",
+        "Resource Constraints",
+        "Neo4j Connection",
+    ],
+    "server": [
+        "Environment Variables",
+        "Python Dependencies",
+        "Neo4j Connection",
+    ],
+}
+
+
+def run_health_checks(profile: str = "e2e") -> dict[str, tuple[bool, str]]:
+    """Run the profile's health checks and return results."""
+    all_checks = {
         "Environment Variables": check_environment_variables,
         "Python Dependencies": check_python_dependencies,
         "Test Data": check_test_data_availability,
         "Resource Constraints": check_resource_constraints,
         "Neo4j Connection": check_neo4j_connection,
     }
+    checks = {name: all_checks[name] for name in CHECK_PROFILES[profile]}
 
     results = {}
     for check_name, check_func in checks.items():
@@ -157,10 +177,22 @@ def run_health_checks() -> dict[str, tuple[bool, str]]:
 
 def main():
     """Main entry point for health check."""
-    print("🏥 E2E Environment Health Check")
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Environment health check")
+    parser.add_argument(
+        "--profile",
+        choices=sorted(CHECK_PROFILES),
+        default="e2e",
+        help="Which check set to run: 'e2e' for the test containers, "
+        "'server' for the live stack (default: e2e)",
+    )
+    args = parser.parse_args()
+
+    print(f"🏥 Environment Health Check ({args.profile} profile)")
     print("=" * 50)
 
-    results = run_health_checks()
+    results = run_health_checks(args.profile)
 
     print("\n" + "=" * 50)
     print("📋 Health Check Summary")

--- a/tests/e2e/transition/conftest.py
+++ b/tests/e2e/transition/conftest.py
@@ -83,6 +83,9 @@ def transition_detection_dataframe(
             award=award.to_dict(),
             candidate_contracts=contracts,
         )
+        # Column names are TransitionAnalytics.summarize's documented
+        # transitions_df contract (award_id/score/contract_id), mapped here
+        # from the Transition model's attributes.
         detections.extend(
             {
                 "award_id": r.award_id,

--- a/tests/e2e/transition/conftest.py
+++ b/tests/e2e/transition/conftest.py
@@ -83,7 +83,14 @@ def transition_detection_dataframe(
             award=award.to_dict(),
             candidate_contracts=contracts,
         )
-        detections.extend([r.to_dict() for r in records])
+        detections.extend(
+            {
+                "award_id": r.award_id,
+                "contract_id": r.primary_contract.contract_id if r.primary_contract else None,
+                "score": r.likelihood_score,
+            }
+            for r in records
+        )
 
     return pd.DataFrame(detections or [{"award_id": None, "contract_id": None, "score": 0.0}])
 

--- a/tests/e2e/transition/test_detection_smoke.py
+++ b/tests/e2e/transition/test_detection_smoke.py
@@ -38,8 +38,8 @@ def test_transition_detector_smoke(
     if detections:
         detection = detections[0]
         assert hasattr(detection, "award_id")
-        assert hasattr(detection, "contract_id")
-        assert hasattr(detection, "score")
+        assert hasattr(detection, "primary_contract")
+        assert hasattr(detection, "likelihood_score")
 
 
 def test_transition_pipeline_summary(

--- a/tests/functional/test_pipelines.py
+++ b/tests/functional/test_pipelines.py
@@ -61,7 +61,8 @@ class TestFiscalPipeline:
         from dagster import materialize
         from sbir_analytics.assets.fiscal_assets import sensitivity_scenarios
 
-        # Only materialize the asset without upstream dependencies
+        # sensitivity_scenarios has no upstream dependencies, so it can be
+        # materialized on its own.
         result = materialize([sensitivity_scenarios])
 
         assert result.success

--- a/tests/functional/test_pipelines.py
+++ b/tests/functional/test_pipelines.py
@@ -59,12 +59,13 @@ class TestFiscalPipeline:
     def test_fiscal_run_produces_outputs(self):
         """Test that fiscal pipeline produces expected outputs."""
         from dagster import materialize
-        from sbir_analytics.assets.fiscal_assets import fiscal_returns_core
+        from sbir_analytics.assets.fiscal_assets import sensitivity_scenarios
 
-        result = materialize([fiscal_returns_core])
+        # Only materialize the asset without upstream dependencies
+        result = materialize([sensitivity_scenarios])
 
         assert result.success
-        assert len(result.asset_materializations_for_node("fiscal_returns_core")) > 0
+        assert len(result.asset_materializations_for_node("sensitivity_scenarios")) > 0
 
 
 class TestModernBertPipeline:


### PR DESCRIPTION
## Description

Fixes the two tests `ci.yml` deselected by name (its own comment said "fix those and delete the matching line" — both lines are now removed), and wires `scripts/e2e_health_check.py` into server operations.

**Test fixes**

- **Transition detection date-type crashes.** DataFrame-sourced awards and contracts carry pandas `Timestamp`s (datetime subclasses), which plain `date` cannot compare or subtract against. Normalized to day-granular dates at the two failure sites: the timing-window filter (`detector.py`) and the timing-proximity signal (`scoring.py`). Only previously-crashing inputs change behavior — date-vs-date paths and scoring semantics are untouched, so the ≥85% transition precision benchmark is unaffected by construction.
- **Schema drift in the smoke test.** `test_detection_smoke.py` asserted stale `contract_id`/`score` attributes and its conftest called `.to_dict()` on the now-pydantic `Transition` model. Assertions updated to `award_id`/`primary_contract`/`likelihood_score`, and the analytics fixture now builds the documented `award_id`/`contract_id`/`score` frame that `TransitionAnalytics.summarize` expects.
- **`TestFiscalPipeline` materialized `fiscal_returns_core`**, an asset that no longer exists. It now materializes `sensitivity_scenarios` — the current fiscal asset with no upstream dependencies, matching the sibling smoke-test pattern in `tests/functional/test_pipelines.py`.

**Health check wiring**

- `scripts/e2e_health_check.py` gains a `--profile {e2e,server}` switch. The default `e2e` profile is unchanged (the docker-compose ci caller is unaffected). The `server` profile runs environment, dependency, and Neo4j connectivity checks, dropping the two e2e-container-specific checks: test-data fixtures, and the MacBook Air resource guard — which fails precisely when a host has *more* resources than a laptop.
- New `make server-health` target: compose status plus the in-container check via `dagster-code-server` (the script already ships in the image at `/app/scripts/`).
- The runbook's "confirm the stack is healthy" requirement now names `make server-health` as the concrete command, to run before live materializations and before enabling any schedule.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

- Both formerly-deselected tests pass: `tests/e2e/transition/test_detection_smoke.py` (3 tests) and `tests/functional/test_pipelines.py::TestFiscalPipeline::test_fiscal_run_produces_outputs`
- Affected suites: `tests/unit/ml`, `tests/unit/phase_transition`, `tests/e2e/transition` (excluding the Neo4j-required graph queries, which need a running instance), `tests/functional` — 216 passed, 6 pre-existing skips
- Both health-check profiles exercised: `--profile server` runs exactly its 3 checks; the default runs all 5
- `make help` lists `server-health`; `uv run ruff check` clean on all touched paths; `make docs-check` passes

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_