### PR TITLE
Add merge-attached e2e coverage: weekly report render and graph round-trip

### DIFF
--- a/tests/e2e/test_weekly_report_render.py
+++ b/tests/e2e/test_weekly_report_render.py
@@ -81,7 +81,7 @@ def test_pipe_in_title_keeps_tables_intact(awards):
     assert "Pipe" in md and "Widget" in md
 
 
-def test_empty_awards_keeps_banner(awards):
+def test_empty_awards_keeps_banner():
     md = generate_markdown([], days=7)
 
     assert "**Exploratory / non-citable.**" in md

--- a/tests/e2e/test_weekly_report_render.py
+++ b/tests/e2e/test_weekly_report_render.py
@@ -1,0 +1,100 @@
+"""End-to-end render of the weekly awards report from fixture awards.
+
+Hermetic full-document pass over models -> rendering (the unit tests cover the
+small helpers piecemeal). Asserts the output contract a reader relies on: the
+non-citable banner, the period header, summary and per-award sections, and the
+reference links — on populated, escaped, and empty inputs alike.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbir_etl.reporting.weekly.rendering import generate_markdown
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(60)]
+
+AGENCIES = ["DOD", "HHS", "NSF", "DOE"]
+
+
+def _award(i: int) -> dict:
+    return {
+        "Company": f"Fixture Co {i}",
+        "Award Title": f"Adaptive Widget Study {i}",
+        "Agency": AGENCIES[i % len(AGENCIES)],
+        "Phase": "I" if i % 2 == 0 else "II",
+        "Program": "SBIR",
+        "Award Amount": str(150000 + i * 10000),
+        "Proposal Award Date": f"2026-07-{(i % 28) + 1:02d}",
+        "State": "CA",
+        "PI Name": f"Casey Researcher {i}",
+        "Topic Code": f"T{i:02d}",
+        "Solicitation Number": f"SOL-26-{i:03d}",
+        "Contract": f"W91{i:04d}",
+    }
+
+
+@pytest.fixture(scope="module")
+def awards() -> list[dict]:
+    return [_award(i) for i in range(24)]
+
+
+def test_full_document_contract(awards):
+    md = generate_markdown(awards, days=7)
+
+    # Header and the label that must never fall off an exploratory artifact.
+    assert md.startswith("# SBIR Weekly Awards Report")
+    assert "**Exploratory / non-citable.**" in md
+    assert f"**Total new awards:** {len(awards)}" in md
+
+    # Summary and grouping sections.
+    assert "## Summary" in md
+    assert "## By Agency" in md
+    assert "## By Program & Phase" in md
+    for agency in AGENCIES:
+        assert f"| {agency} |" in md
+
+    # Every award appears with its company and reference links.
+    assert "## Awards" in md
+    for award in awards:
+        assert award["Company"] in md
+        assert f"https://www.sbir.gov/awards?keyword={award['Contract']}" in md
+    assert md.count("**References:**") == len(awards)
+    assert "https://www.usaspending.gov/search" in md
+
+
+def test_pipe_in_title_keeps_tables_intact(awards):
+    hostile = dict(awards[0])
+    hostile["Award Title"] = "Adaptive | Widget || Study"
+    hostile["Company"] = "Pipe | Co"
+
+    md = generate_markdown([hostile], days=7)
+
+    # Summary table rows must keep their column count; the escaped company
+    # renders without introducing new cell separators.
+    summary_start = md.index("## Summary")
+    summary_block = md[summary_start : md.index("## By Agency")]
+    for line in summary_block.splitlines():
+        if line.startswith("|") and "Metric" not in line and "---" not in line:
+            assert line.count("|") == 3, f"unexpected cell split: {line!r}"
+    assert "Pipe" in md and "Widget" in md
+
+
+def test_empty_awards_keeps_banner(awards):
+    md = generate_markdown([], days=7)
+
+    assert "**Exploratory / non-citable.**" in md
+    assert "**Total new awards:** 0" in md
+    assert "No new awards found for this period." in md
+
+
+def test_freshness_warnings_rendered(awards):
+    md = generate_markdown(
+        awards[:3],
+        days=7,
+        freshness_warnings=["SBIR.gov bulk file is 12 days old"],
+    )
+
+    assert "**Data Freshness Warning**" in md
+    assert "SBIR.gov bulk file is 12 days old" in md

--- a/tests/integration/neo4j/test_loader_roundtrip.py
+++ b/tests/integration/neo4j/test_loader_roundtrip.py
@@ -55,6 +55,9 @@ def _orgs(count: int = 6) -> list[dict]:
 
 
 def _node_count(client, label: str) -> int:
+    # Cypher cannot parameterize labels; constrain interpolation to this
+    # module's dedicated test labels.
+    assert label in {AWARD_LABEL, ORG_LABEL}
     with client.session() as session:
         return session.run(f"MATCH (n:{label}) RETURN count(n) AS c").single()["c"]
 

--- a/tests/integration/neo4j/test_loader_roundtrip.py
+++ b/tests/integration/neo4j/test_loader_roundtrip.py
@@ -1,0 +1,121 @@
+"""Round-trip contract for the standardized Neo4j loader path.
+
+Loads fixture awards and organizations through BaseNeo4jLoader's batch APIs,
+reads them back with Cypher, and re-runs the identical batch to prove MERGE
+idempotency — the property the loaders' pipelines-tier claim rests on. Uses
+dedicated RoundTrip* labels so it cannot interfere with real schema data.
+
+Requires a running Neo4j; skips otherwise, like the sibling integration tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sbir_graph.loaders.neo4j.base import BaseNeo4jLoader
+
+
+pytestmark = [
+    pytest.mark.integration,
+    # Resolve Neo4j when a test executes, not while pytest imports this module.
+    pytest.mark.usefixtures("neo4j_driver"),
+    # Shares one xdist worker with the other Neo4j integration tests so they
+    # never race each other against the shared container.
+    pytest.mark.xdist_group("neo4j_integration"),
+    pytest.mark.timeout(120),
+]
+
+AWARD_LABEL = "RoundTripAward"
+ORG_LABEL = "RoundTripOrganization"
+REL_TYPE = "RT_AWARDED_TO"
+
+
+class RoundTripLoader(BaseNeo4jLoader):
+    """Minimal concrete loader exercising the shared batch APIs."""
+
+
+@pytest.fixture
+def loader(neo4j_client):
+    loader = RoundTripLoader(neo4j_client)
+    yield loader
+    with neo4j_client.session() as session:
+        session.run(f"MATCH (n:{AWARD_LABEL}) DETACH DELETE n")
+        session.run(f"MATCH (n:{ORG_LABEL}) DETACH DELETE n")
+
+
+def _awards(count: int = 12) -> list[dict]:
+    return [
+        {"award_id": f"RT-AWD-{i:03d}", "title": f"Round trip {i}", "amount": 100000 + i}
+        for i in range(count)
+    ]
+
+
+def _orgs(count: int = 6) -> list[dict]:
+    return [{"org_key": f"RT-ORG-{i:03d}", "name": f"Round Trip Org {i}"} for i in range(count)]
+
+
+def _node_count(client, label: str) -> int:
+    with client.session() as session:
+        return session.run(f"MATCH (n:{label}) RETURN count(n) AS c").single()["c"]
+
+
+def _rel_count(client) -> int:
+    with client.session() as session:
+        query = f"MATCH (:{AWARD_LABEL})-[r:{REL_TYPE}]->(:{ORG_LABEL}) RETURN count(r) AS c"
+        return session.run(query).single()["c"]
+
+
+def test_load_query_reload_is_idempotent(neo4j_client, loader):
+    awards, orgs = _awards(), _orgs()
+    relationships = [
+        (award["award_id"], orgs[i % len(orgs)]["org_key"], {"amount": award["amount"]})
+        for i, award in enumerate(awards)
+    ]
+
+    def load_once():
+        loader.batch_upsert_nodes(AWARD_LABEL, "award_id", awards)
+        loader.batch_upsert_nodes(ORG_LABEL, "org_key", orgs)
+        loader.batch_create_relationships(
+            source_label=AWARD_LABEL,
+            source_key="award_id",
+            target_label=ORG_LABEL,
+            target_key="org_key",
+            rel_type=REL_TYPE,
+            relationships=relationships,
+        )
+
+    load_once()
+    assert _node_count(neo4j_client, AWARD_LABEL) == len(awards)
+    assert _node_count(neo4j_client, ORG_LABEL) == len(orgs)
+    assert _rel_count(neo4j_client) == len(awards)
+
+    # The identical batch again: MERGE semantics mean nothing multiplies.
+    load_once()
+    assert _node_count(neo4j_client, AWARD_LABEL) == len(awards)
+    assert _node_count(neo4j_client, ORG_LABEL) == len(orgs)
+    assert _rel_count(neo4j_client) == len(awards)
+
+    # Every loaded row is readable back with its properties intact.
+    with neo4j_client.session() as session:
+        rows = session.run(
+            f"MATCH (a:{AWARD_LABEL}) RETURN a.award_id AS id, a.amount AS amount ORDER BY id"
+        ).data()
+    assert [row["id"] for row in rows] == [award["award_id"] for award in awards]
+    assert rows[0]["amount"] == awards[0]["amount"]
+
+
+def test_reupsert_updates_properties_in_place(neo4j_client, loader):
+    award = {"award_id": "RT-AWD-UPD", "title": "Before", "amount": 1}
+    loader.batch_upsert_nodes(AWARD_LABEL, "award_id", [award])
+
+    updated = dict(award, title="After", amount=2)
+    loader.batch_upsert_nodes(AWARD_LABEL, "award_id", [updated])
+
+    assert _node_count(neo4j_client, AWARD_LABEL) == 1
+    with neo4j_client.session() as session:
+        row = session.run(
+            f"MATCH (a:{AWARD_LABEL} {{award_id: 'RT-AWD-UPD'}}) "
+            "RETURN a.title AS title, a.amount AS amount"
+        ).single()
+    assert row["title"] == "After"
+    assert row["amount"] == 2


### PR DESCRIPTION
## Description

Adds the two highest-value missing end-to-end paths, attached to the merge-triggered lanes so pull requests pay nothing (the PR lane runs `tests/unit` only):

- **`tests/e2e/test_weekly_report_render.py`** — full-document weekly report generation from fixture awards, asserting the reader-facing contract: the *Exploratory / non-citable* banner (including on the empty-report path, where the label must never fall off), period header, summary/grouping sections, per-award content and reference links, and table integrity under pipe-bearing input. Hermetic — no network, no data files. Runs in Full Tests on every push to main.
- **`tests/integration/neo4j/test_loader_roundtrip.py`** — loads fixture awards and organizations through `BaseNeo4jLoader`'s shared batch APIs against a **real Neo4j**, reads them back with Cypher, re-runs the identical batch to prove MERGE idempotency (nodes and relationships both), and verifies in-place property updates. Uses dedicated `RoundTrip*` labels so it cannot touch real schema data, cleans up after itself, and follows the sibling pattern exactly: `integration` marker, `neo4j_driver` skip resolution at execution time, `xdist_group("neo4j_integration")` to avoid container races.

Both carry `pytest-timeout` caps so a hang cannot consume a job.

Where they run: the round-trip joins the conditional **Neo4j Integration** lane on graph-touching PRs (including this one, since `tests/integration/**` is in the paths filter — so the live path is exercised on this very PR) and Full Tests after merge; the render e2e runs in Full Tests. Nothing new runs in the fast PR shards.

This is the "attach comprehensive tests to merges, not calendars" piece of the e2e plan — no scheduled workflows are introduced.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

- `uv run pytest tests/e2e/test_weekly_report_render.py` — 4 passed (hermetic, ~2s)
- `uv run pytest tests/integration/neo4j/test_loader_roundtrip.py` — 2 skipped locally with no Neo4j instance, by design; the live path runs in this PR's Neo4j Integration lane
- Collection check across `tests/e2e` + `tests/integration/neo4j` — 59 tests collected, no import errors
- `uv run ruff check` on both files — clean

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_