### PR TITLE
Reconcile epistemic-tier debt: retier four specs, archive ucc1, fix doc drift

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -945,7 +945,7 @@ the NVCA Yearbook [L25] — rather than NASEM and GAO.
   UCC-1 complements Form D's equity view. The CA-only pilot found equipment and
   community-bank patterns, and an absence of venture-debt lenders in the CA
   channel.
-  *Deps: ER, UCC-1 · Spec: [../specs/ucc1-financing-analysis/](../specs/ucc1-financing-analysis/) (PRs #303 / #305 merged)*
+  *Deps: ER, UCC-1 · Spec: [../specs/archive/completed-features/ucc1-financing-analysis/](../specs/archive/completed-features/ucc1-financing-analysis/) (PRs #303 / #305 merged)*
 
 - **Unified capital-event timeline**
   What does a single firm history look like when federal awards, private

--- a/docs/research/sbir-ucc1-pilot.md
+++ b/docs/research/sbir-ucc1-pilot.md
@@ -7,7 +7,7 @@ pilot run on the alphabetical-first 70 of 3,639 cohort firms produced a
 representative result; full coverage stopped by Imperva anti-bot
 operational limits (see "Pilot Results — Partial Run" section below).
 
-**Related:** [specs/ucc1-financing-analysis/](../../specs/ucc1-financing-analysis/),
+**Related:** [specs/archive/completed-features/ucc1-financing-analysis/](../../specs/archive/completed-features/ucc1-financing-analysis/),
 [sbir-form-d-fundraising-analysis.md](sbir-form-d-fundraising-analysis.md),
 [sbir-ma-exit-analysis.md](sbir-ma-exit-analysis.md)
 

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -105,12 +105,12 @@ the manifest schema, frozen-artifact hashes, and implementation references.
 
 ### Transitional Script Dependencies
 
-First-party packages may not add dependencies on `scripts/`. The architecture guard carries
-one exact temporary execution bridge from the tech-area report job to its script entry point.
-This is a migration bridge, not a
-fifth epistemic tier or an implicit promotion of those scripts. They are limited to named
-compatibility wrappers, must not be used by an evidence-tier artifact, and are removed when
-the implementations move behind package APIs. The CLI modules can then remain as entry points.
+First-party packages may not add dependencies on `scripts/`. All transitional bridges are
+retired: the architecture guard's import and execution allowlists are empty, and every
+formerly bridged script is now reached through a package API with the CLI retained as an
+entry point. Any future bridge must be named in the guard with a reason and a removal
+condition; it is a migration device, not a fifth epistemic tier and not an implicit
+promotion of the script, and an `evidence` artifact may never depend on one.
 
 The guard inspects both imports and literal Python-script targets passed to `subprocess`.
 Hiding a package-to-script dependency behind process execution does not change its direction.

--- a/specs/archive/completed-features/ucc1-financing-analysis/COMPLETION_RECORD.md
+++ b/specs/archive/completed-features/ucc1-financing-analysis/COMPLETION_RECORD.md
@@ -1,0 +1,28 @@
+# Completion Record — ucc1-financing-analysis
+
+**Status**: CA-only pilot complete; extension explicitly deferred by the
+research memo. Treated as a completed feature, not superseded work: the
+pilot answered its Phase 0 question and the stop was a deliberate scope
+decision, not a replacement by other machinery.
+**Archived**: 2026-08-07
+
+Evidence:
+
+- PRs #303 / #305 (merged) — Phase 0 probe and the CA-only pilot run.
+- [docs/research/sbir-ucc1-pilot.md](../../../../docs/research/sbir-ucc1-pilot.md)
+  — findings and the scope-narrowing decision. Phase 0 established that
+  Delaware has no free public UCC search, so the original DE+CA scope was
+  not achievable on free data; the pilot ran CA-only against the
+  CA-organized cohort subset. The partial run (alphabetical-first 70 of
+  3,639 cohort firms) produced a representative result before Imperva
+  anti-bot limits stopped full coverage.
+- `sbir_etl/ucc/` — the pilot's matcher and support code remain in-tree
+  (pipelines-tier package default; `ucc/matcher.py` labeled exploratory).
+
+Stop/defer rationale: full CA coverage is operationally blocked by
+anti-bot limits, Delaware requires paid authorized searchers, and the
+research memo defers any extension until UCC-1 financing evidence becomes
+a selected research priority. The spec's target tier was `evidence`; no
+study contract was ever created, and none is owed for an archived pilot —
+any revival starts from a fresh scope decision against
+docs/research-questions.md.

--- a/specs/archive/completed-features/ucc1-financing-analysis/design.md
+++ b/specs/archive/completed-features/ucc1-financing-analysis/design.md
@@ -9,7 +9,7 @@ a research memo answering (a) "what fraction of CA-organized cohort firms
 took secured debt and from whom" and (b) "do UCC-3 terminations
 corroborate known M&A events for those firms."
 
-See [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md)
+See [docs/research/sbir-ucc1-pilot.md](../../../../docs/research/sbir-ucc1-pilot.md)
 for the Phase 0 findings that drove the CA-only narrowing.
 
 ## Architecture

--- a/specs/archive/completed-features/ucc1-financing-analysis/requirements.md
+++ b/specs/archive/completed-features/ucc1-financing-analysis/requirements.md
@@ -5,9 +5,9 @@
 > **Status:** Pilot complete — PRs #303 / #305 merged. CA-only pilot found
 > equipment-finance and community-bank lender patterns and an absence of venture-debt
 > lenders in the CA-organized channel. See
-> [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md)
+> [docs/research/sbir-ucc1-pilot.md](../../../../docs/research/sbir-ucc1-pilot.md)
 > for findings. Anchors inventory question **F1** (UCC-1 sub-question) in
-> [docs/research-questions.md](../../docs/research-questions.md).
+> [docs/research-questions.md](../../../../docs/research-questions.md).
 
 **Research question anchor:** F1 — secured-debt composition of SBIR firms; A4 — foreign-lender signal
 **Answers for:** entrepreneurial finance researchers, defense industrial base analysts

--- a/specs/archive/completed-features/ucc1-financing-analysis/tasks.md
+++ b/specs/archive/completed-features/ucc1-financing-analysis/tasks.md
@@ -1,7 +1,7 @@
 # UCC-1 Financing Analysis — Tasks
 
 **Status:** Pilot complete through the partial-run epistemic checkpoint;
-extension deferred. See [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md)
+extension deferred. See [docs/research/sbir-ucc1-pilot.md](../../../../docs/research/sbir-ucc1-pilot.md)
 ("Recommendation: Stop here") for the rationale. Phases 4–6 and the
 remaining pieces of 7 / 8 are unimplemented by design — re-open this
 spec only if one of the Future-options paths (multi-state, paid DE bulk,
@@ -9,7 +9,7 @@ or BDC SoI pivot) is selected.
 
 ## Phase 0: Feasibility check — COMPLETE
 
-Recorded in [docs/research/sbir-ucc1-pilot.md](../../docs/research/sbir-ucc1-pilot.md).
+Recorded in [docs/research/sbir-ucc1-pilot.md](../../../../docs/research/sbir-ucc1-pilot.md).
 
 - [x] 0.1 ~~DE web search of 5 firms~~ → **DE has no free public UCC search.**
       All non-"Search to Reflect" searches require a paid Authorized

--- a/specs/company-categorization/requirements.md
+++ b/specs/company-categorization/requirements.md
@@ -1,8 +1,12 @@
 # Company Categorization — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `exploratory`
 
-> **Status:** 77% complete.
+> **Status:** 77% complete. Retiered from evidence on 2026-08-07: the
+> Product/Service/Mixed classifier is keyword heuristics, matching the
+> transformer's exploratory label; the Neo4j load path is separately
+> pipelines-tier. Citable categories would require a labeled-accuracy
+> study contract.
 > Anchors inventory question **B1** in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** B1 — product / service / mixed-mode firm classification

--- a/specs/modernbert_analysis_layer/requirements.md
+++ b/specs/modernbert_analysis_layer/requirements.md
@@ -1,8 +1,11 @@
 # Requirements — ModernBert Analysis Layer
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `exploratory`
 
-> **Status:** Partially implemented. Core ModernBert client, embedding assets,
+> **Status:** Partially implemented. Retiered from evidence on 2026-08-07:
+> embedding similarity is unvalidated model inference, matching the
+> modules' own exploratory labels; promotion returns via a study contract
+> if a question needs citable similarity results. Core ModernBert client, embedding assets,
 > similarity output, config, and client-level tests exist. Neo4j `SIMILAR_TO`
 > loading, quality/cohesion metrics, fuller asset checks, and Dagster integration
 > tests remain open. Requirements 5–7 (Bayesian MoE routing) are deferred pending

--- a/specs/phase3-transition-groundtruth/requirements.md
+++ b/specs/phase3-transition-groundtruth/requirements.md
@@ -17,6 +17,27 @@
 
 ---
 
+## Epistemic framing
+
+This spec spans two tiers, which is why its target is `pipelines` with the
+scoring evaluation held to `exploratory` (see
+[docs/steering/epistemic-tiers.md](../../docs/steering/epistemic-tiers.md)):
+
+- **Corpus construction is `pipelines`.** Cataloging sources, the frozen
+  extraction schema, identifier resolution, and retrieval-test assembly are
+  deterministic and reproducible from the declared inputs.
+- **Ranker scoring and the go/no-go decision are `exploratory`.** Precision@K,
+  MRR, the stratum/provenance splits, and the fusion-ordering recommendation
+  are analysis, not a validated finding; the reported figures are non-citable.
+- **Citing any of these numbers as validation requires a future `studies/`
+  contract** — frozen spec, SHA-pinned inputs, declared estimand, blocking
+  checks. Producing the numbers here does not make them citable; the corpus and
+  results stay provisional portfolio-linkage evidence until then. "Validation"
+  throughout this document means *this exploratory check*, not evidence-tier
+  validation.
+
+---
+
 ## Done when
 
 > ≥ **60** real Phase III transitions are collected from agency SBIR
@@ -27,7 +48,8 @@
 > scored against the recoverable subset; **precision@1/@3 and MRR are reported
 > split by stratum and by provenance, with 95% CIs**, and compared to the
 > proxy-label 0.68@1. The citation-independence and selection-bias caveats are
-> quantified, not hand-waved.
+> quantified, not hand-waved. These reported figures are exploratory-tier and
+> non-citable (see Epistemic framing).
 
 ---
 

--- a/specs/phase3-transition-groundtruth/requirements.md
+++ b/specs/phase3-transition-groundtruth/requirements.md
@@ -1,9 +1,14 @@
 # Independent Phase III Transition Ground-Truth Set — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `pipelines`
 
-> **Status:** Draft spec. No implementation. Validation deliverable for the
-> merged award-grain fusion ranker (#467).
+> **Status:** Implemented through T6/T7 — the independent corpus, scoring
+> results, and decision memo landed; results remain provisional
+> portfolio-linkage evidence. Retiered from evidence on 2026-08-07: the
+> deterministic corpus construction is pipelines work, the scoring
+> evaluation is exploratory, and citation requires a future study contract
+> per docs/steering/epistemic-tiers.md. Originally the validation
+> deliverable for the merged award-grain fusion ranker (#467).
 > Supports inventory questions **B2 / E1** in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** B2 (did SBIR research transition to a federal contract), E1 (Phase III identification)

--- a/specs/status.md
+++ b/specs/status.md
@@ -110,8 +110,9 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   reproduction, frozen coefficients, and packet integration landed. Reconcile
   the remaining documentation task and the explicitly missing second label channel.
 - **`phase3-transition-groundtruth` — Maintenance.** The independent corpus,
-  T6 results, and T7 decision memo landed, but the requirements header still
-  describes the work as unimplemented. Reconcile the spec before any extension.
+  T6 results, and T7 decision memo landed; the requirements header now says so
+  and the spec was retiered evidence → pipelines on 2026-08-07 (corpus
+  construction is deterministic; citation requires a future study contract).
 - **`phase3-undercount-extension` — Gated backlog.** Valid B3 follow-up, but it
   depends on reusable resolution/self-label components and must keep contract
   undercount separate from provisional non-contract vehicle counts.
@@ -128,24 +129,17 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`transition-coverage-expansion` — Active.** Initial access and coverage
   spikes are recorded. Credible grant/subaward attribution, OT resolution, and a
   channel-by-channel wire-in decision remain.
-- **`ucc1-financing-analysis` — Archive candidate.** CA-only pilot is complete
-  and extension is explicitly deferred by the research memo.
 - **`weekly-awards-report-refactor` — Maintenance.** Monolith is already split
   into weekly reporting modules. Remaining work is injection, coverage, and
   alias cleanup.
 
 ## Archive Candidates
 
-`ucc1-financing-analysis` is the only top-level archive candidate from this
-review. Before moving it:
-
-1. Update `docs/research-questions.md` and `docs/research/sbir-ucc1-pilot.md`
-   links to the archived path.
-2. Add a completion record summarizing PRs #303 / #305, the CA-only pilot result,
-   and the stop/defer rationale.
-3. Move the spec under `specs/archive/completed-features/` if treating the pilot
-   as complete, or `specs/archive/superseded/` if treating the extension plan as
-   dropped.
+`ucc1-financing-analysis` was archived on 2026-08-07 under
+`specs/archive/completed-features/` (treated as a completed pilot: it answered
+its Phase 0 question and the stop was a deliberate scope decision). All three
+archive steps were executed — live-doc links updated, completion record added,
+directory moved.
 
 No other top-level spec should be archived from this review because each still
 anchors a live research question or an active maintenance cleanup.

--- a/specs/tech-area-transition-report/requirements.md
+++ b/specs/tech-area-transition-report/requirements.md
@@ -1,14 +1,18 @@
 # Tech-Area Transition Report — Requirements
 
-**Target epistemic tier:** `evidence`
+**Target epistemic tier:** `exploratory`
 
-> **Status:** In progress (v1 cohort parameterization)
+> **Status:** In progress (v1 cohort parameterization). Retiered from
+> evidence on 2026-08-07 to match the deliberately exploratory,
+> citable-false implementation; when a headline channel earns evidence,
+> that promotion arrives as its own study contract per the tiers doctrine.
 > Anchors inventory questions **B** (commercialization / Phase II→III pathways) and
 > **C1** (cross-agency CET portfolio) in [docs/research-questions.md](../../docs/research-questions.md).
 > Coordinates with [dark-majority-resolution](../dark-majority-resolution/requirements.md)
 > (that spec owns deficiency *treatments*; this one owns parameterized *cohort → signal → report skeleton*).
-> Current implementation status: **exploratory / non-citable**. The named v1
-> admission profile has not yet earned this spec's evidence contract.
+> Current implementation status: **exploratory / non-citable**, now matching
+> the declared tier. A headline channel that earns evidence gets its own
+> study contract under `studies/`.
 
 **Research question anchor:** B — technology-area Phase II→III commercialization pathways;
 C1 — CET-area portfolio composition


### PR DESCRIPTION
## Description

Closes out the reconcile/retier debt surfaced in the original epistemic-tiers review. Retier decisions were made by the maintainer on 2026-08-07.

**Four over-declared evidence-target specs retiered to match their code's actual labels:**
- `phase3-transition-groundtruth`: evidence → **pipelines** (deterministic corpus construction; the scoring evaluation is exploratory; citation would need a future study contract). Requirements header also reconciled with the landed T6/T7 implementation it previously described as unbuilt.
- `modernbert_analysis_layer`: evidence → **exploratory** (embedding similarity is unvalidated model inference, matching the modules' own labels).
- `company-categorization`: evidence → **exploratory** (keyword-heuristic Product/Service/Mixed classifier; the Neo4j load path stays pipelines-tier).
- `tech-area-transition-report`: evidence → **exploratory** (implementation is deliberately citable-false; per-channel promotion arrives via study contracts).

Each retier carries a dated rationale note; promotion back to evidence is explicitly a future study-contract path in every case.

**Archived `ucc1-financing-analysis`** under `specs/archive/completed-features/` with a completion record (PRs #303/#305, CA-only pilot result, stop/defer rationale), executing all three archive steps from the registry: live-doc links updated (`research-questions.md`, the pilot memo), completion record added, directory moved. Registry entry removed and the Archive Candidates section closed out.

**Fixed `structure.md` drift**: it described a transitional script bridge that the architecture guard shows fully retired; the section now states the guard allowlists are empty and sets the conditions any future bridge must meet.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)

## Testing

- `uv run python scripts/ci/check_epistemic_tiers.py` — passed
- `make docs-check` — passed (link integrity across the archive move + registry coverage)
- `make lint-boundaries` — passed

- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_