### PR TITLE
Correct precision-gate docs: fixture canary, not full-corpus CI automation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,11 @@ make lint-boundaries                   # Architecture, identity, and study guard
 make docs-check                        # Links, stale commands, and repository hygiene
 ```
 
-Transition scoring changes must maintain ≥85% precision benchmark.
+Transition scoring changes must maintain the ≥85% Phase III retrospective
+HIGH-precision benchmark. Enforcement today is a fixture-level canary
+(`tests/unit/scripts/test_phase_iii_precision_backtest.py`) that runs on every
+PR; the full benchmark against the S3 corpus is run manually via
+`scripts/phase_iii_precision_backtest.py` and is not yet automated in CI.
 
 ## Releases and versioning
 

--- a/specs/phase-3-solicitation-alerts/tasks.md
+++ b/specs/phase-3-solicitation-alerts/tasks.md
@@ -3,8 +3,10 @@
 > **Status (2026-07-15):** Phases 1–2 (S1 retrospective reclassification) implemented and merged
 > (PRs #394, #410, #412) — models in `sbir_etl/models/phase_iii_candidate.py`, asset package in
 > `packages/sbir-analytics/sbir_analytics/assets/phase_iii_candidates/` (`assets.py`, `pairing.py`,
-> `similarity.py`), precision gate `scripts/phase_iii_precision_backtest.py` wired into
-> `.github/workflows/ci.yml`. The public Opportunities model/extractor, S2/S3 pairing,
+> `similarity.py`), precision gate `scripts/phase_iii_precision_backtest.py` exercised
+> on every PR by the fixture canary `tests/unit/scripts/test_phase_iii_precision_backtest.py`
+> (the full S3-corpus benchmark is run manually, not automated in CI). The public
+> Opportunities model/extractor, S2/S3 pairing,
 > candidate assets, and monthly procurement-center report are now implemented. The Dagster
 > ingestion/config layer, production hand audits, and acceptance sign-off remain open.
 
@@ -52,8 +54,11 @@ ship independently.
       DoD-coded Phase III contracts as positives, runs the scorer, asserts
       `RETROSPECTIVE` HIGH precision ≥ 0.85, writes
       `reports/phase_iii/backtest.json`, exits non-zero on failure.
-- [x] 2.6 Wire the backtest script into the existing CI workflow that
-      already runs other release gates (reuse — do not add a new workflow).
+- [x] 2.6 Exercise the backtest on every PR via a fixture canary
+      (`tests/unit/scripts/test_phase_iii_precision_backtest.py`) that runs in
+      the Fast Tests shards — no new workflow. *(Shipped as a pytest canary on
+      a deterministic fixture, not a ci.yml step; the full ≥85% benchmark
+      against the S3 corpus is run manually and is not yet automated in CI.)*
 - [x] 2.7 Integration test: 100-row fixture with known positives and
       negatives; assert schema, evidence NDJSON structure, precision gate.
 

--- a/tests/unit/scripts/test_phase_iii_precision_backtest.py
+++ b/tests/unit/scripts/test_phase_iii_precision_backtest.py
@@ -1,10 +1,11 @@
 """PR-time precision canary for the Phase III retrospective backtest.
 
-The full ≥0.85 HIGH-precision benchmark runs against the S3 corpus in the
-``transition-mvp`` CI job (workflow_dispatch only). These tests keep the
-benchmark exercised on every PR with a small deterministic fixture: obvious
-true-positive pairs must clear the threshold, obvious non-transitions must
-not, and the data-missing sentinel must fail loudly in ``--strict`` mode.
+The full ≥0.85 HIGH-precision benchmark runs against the S3 corpus by invoking
+``scripts/phase_iii_precision_backtest.py`` manually; that full run is not yet
+automated in CI. These tests keep the benchmark exercised on every PR with a
+small deterministic fixture: obvious true-positive pairs must clear the
+threshold, obvious non-transitions must not, and the data-missing sentinel must
+fail loudly in ``--strict`` mode.
 """
 
 import sys


### PR DESCRIPTION
## Description

Three places in the repo claimed the ≥85% transition/Phase III precision benchmark was automated against the full corpus in CI. It isn't — none of that automation exists in either workflow. The real enforcement is a **PR-time fixture canary** (`tests/unit/scripts/test_phase_iii_precision_backtest.py`, which runs in the Fast Tests shards); the full ≥85% HIGH-precision benchmark against the S3 corpus is run **manually** and is not automated in CI.

Corrections:
- **`CLAUDE.md`** — names which precision is gated (Phase III retrospective HIGH precision), states the canary enforces it on every PR, and that the full benchmark is manual.
- **`specs/phase-3-solicitation-alerts/tasks.md`** — the status header and task 2.6 both claimed the backtest was *"wired into `.github/workflows/ci.yml`"*; it is not. Reworded to describe the pytest canary that actually shipped.
- **`tests/unit/scripts/test_phase_iii_precision_backtest.py`** — its docstring referenced a `transition-mvp` CI job (workflow_dispatch only) that does not exist in either workflow; corrected to say the full run is manual.

No behavior change. The canary test still passes (4 passed).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)

## Testing

- `uv run pytest tests/unit/scripts/test_phase_iii_precision_backtest.py` — 4 passed
- `uv run ruff check` on the touched test — clean
- `make docs-check` — passed

- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_