### PR TITLE
Add large-file guard: block oversized tracked files at 5 MiB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           uv run python scripts/ci/check_architecture_boundaries.py
           uv run python scripts/ci/check_epistemic_tiers.py
           uv run python scripts/ci/check_tier_boundaries.py
+          uv run python scripts/ci/check_file_sizes.py
           uv run python scripts/ci/check_removed_src_references.py
           uv run python scripts/ci/validate_study_manifests.py
           # Guards the company-identity primitive: a direct RapidFuzz scorer

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ lint-boundaries: ## Enforce package and archive dependency boundaries
 	@$(call info,Checking architecture boundaries)
 	$(call run,uv run python scripts/ci/check_architecture_boundaries.py)
 	$(call run,uv run python scripts/ci/check_tier_boundaries.py)
+	$(call run,uv run python scripts/ci/check_file_sizes.py)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
 

--- a/scripts/ci/check_file_sizes.py
+++ b/scripts/ci/check_file_sizes.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Fail when a git-tracked file exceeds the repository's size ceiling.
+
+`.gitignore` fences the known bulk formats (parquet, data/, reports/, db,
+duckdb, artifacts/), but it is pattern-based: a large file in an unforeseen
+format or path can still be committed. This guard is the size-based backstop —
+it inspects what git actually tracks (i.e. what reaches GitHub) and rejects
+anything over the ceiling, regardless of extension.
+
+Only tracked files are checked: a local, gitignored corpus under data/ never
+reaches GitHub and must not trip the guard, so a filesystem walk would be
+wrong. `git ls-files` is the authoritative "what is in the repo" list.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+MAX_FILE_BYTES = 5 * 1024 * 1024  # 5 MiB — far above any legitimate text/config
+                                  # file, far below any real data artifact.
+
+# Paths intentionally allowed to exceed the ceiling, each with a reason.
+# A tracked file over the ceiling that is NOT listed here fails the guard; an
+# entry here that is absent or no longer over the ceiling also fails, so the
+# list cannot silently rot (same discipline as the tier-boundary allowlist).
+SIZE_ALLOWLIST: dict[str, str] = {}
+
+
+@dataclass(frozen=True)
+class SizeViolation:
+    """One oversized tracked file or one stale allowlist entry."""
+
+    path: str
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}: {self.message}"
+
+
+def tracked_files(repository_root: Path = REPOSITORY_ROOT) -> list[str]:
+    """Return git-tracked paths (POSIX, repo-relative)."""
+
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=repository_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [entry for entry in result.stdout.split("\0") if entry]
+
+
+def scan(
+    *,
+    repository_root: Path = REPOSITORY_ROOT,
+    max_bytes: int = MAX_FILE_BYTES,
+    allowlist: dict[str, str] = SIZE_ALLOWLIST,
+) -> list[SizeViolation]:
+    """Flag tracked files over the ceiling and stale allowlist entries."""
+
+    violations: list[SizeViolation] = []
+    used_allowlist: set[str] = set()
+    limit_mib = max_bytes / (1024 * 1024)
+
+    for relative in tracked_files(repository_root):
+        path = repository_root / relative
+        if not path.is_file():  # symlink or deleted-but-staged edge case
+            continue
+        size = path.stat().st_size
+        if size <= max_bytes:
+            continue
+        if relative in allowlist:
+            used_allowlist.add(relative)
+            continue
+        violations.append(
+            SizeViolation(
+                relative,
+                f"{size / (1024 * 1024):.1f} MiB exceeds the {limit_mib:.0f} MiB "
+                "ceiling; keep large artifacts out of git (store bytes off-repo "
+                "and pin a hash), or add a justified SIZE_ALLOWLIST entry",
+            )
+        )
+
+    for allowed_path in sorted(allowlist):
+        if allowed_path not in used_allowlist:
+            violations.append(
+                SizeViolation(
+                    allowed_path,
+                    "stale SIZE_ALLOWLIST entry (file absent or no longer over the ceiling)",
+                )
+            )
+
+    return sorted(violations, key=lambda item: item.path)
+
+
+def main() -> int:
+    violations = scan()
+    if violations:
+        print("Oversized tracked files were found:")
+        print("\n".join(violation.format() for violation in violations))
+        return 1
+    print("File-size checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_file_sizes.py
+++ b/scripts/ci/check_file_sizes.py
@@ -68,9 +68,14 @@ def scan(
 
     for relative in tracked_files(repository_root):
         path = repository_root / relative
-        if not path.is_file():  # symlink or deleted-but-staged edge case
+        if path.is_symlink():
+            # Git stores the link target text, not the target's bytes. Use lstat
+            # so a tracked link cannot make the guard inspect outside the repo.
+            size = path.lstat().st_size
+        elif path.is_file():
+            size = path.stat().st_size
+        else:  # deleted-but-staged or other non-file edge case
             continue
-        size = path.stat().st_size
         if size <= max_bytes:
             continue
         if relative in allowlist:

--- a/tests/unit/scripts/test_file_sizes.py
+++ b/tests/unit/scripts/test_file_sizes.py
@@ -49,6 +49,16 @@ def test_gitignored_large_file_is_not_flagged(tmp_path):
     assert guard.scan(repository_root=root, max_bytes=1024 * 1024) == []
 
 
+def test_tracked_symlink_measures_link_not_target(tmp_path):
+    root = _repo(tmp_path)
+    target = tmp_path.parent / "large-target.bin"
+    target.write_bytes(b"x" * 2048)
+    (root / "large-target-link").symlink_to(target)
+    _git(root, "add", "large-target-link")
+
+    assert guard.scan(repository_root=root, max_bytes=512) == []
+
+
 def test_allowlisted_oversized_file_passes(tmp_path):
     root = _repo(tmp_path)
     _track(root, "big.bin", 2 * 1024 * 1024)

--- a/tests/unit/scripts/test_file_sizes.py
+++ b/tests/unit/scripts/test_file_sizes.py
@@ -1,0 +1,79 @@
+"""Tests for the large-file guard."""
+
+import subprocess
+from pathlib import Path
+
+from scripts.ci import check_file_sizes as guard
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=root, check=True, capture_output=True)
+
+
+def _repo(tmp_path: Path) -> Path:
+    _git(tmp_path, "init")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "t")
+    return tmp_path
+
+
+def _track(root: Path, relative: str, size: int) -> None:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"x" * size)
+    _git(root, "add", relative)
+
+
+def test_small_tracked_files_pass(tmp_path):
+    root = _repo(tmp_path)
+    _track(root, "a.txt", 10)
+    _track(root, "pkg/b.py", 2048)
+    assert guard.scan(repository_root=root, max_bytes=1024 * 1024) == []
+
+
+def test_oversized_tracked_file_fails(tmp_path):
+    root = _repo(tmp_path)
+    _track(root, "big.json", 2 * 1024 * 1024)
+    violations = guard.scan(repository_root=root, max_bytes=1024 * 1024)
+    assert len(violations) == 1
+    assert violations[0].path == "big.json"
+    assert "exceeds" in violations[0].message
+
+
+def test_gitignored_large_file_is_not_flagged(tmp_path):
+    root = _repo(tmp_path)
+    (root / ".gitignore").write_text("*.parquet\n")
+    _git(root, "add", ".gitignore")
+    # A large local parquet that git does not track must be invisible to the guard.
+    (root / "data.parquet").write_bytes(b"x" * (3 * 1024 * 1024))
+    assert guard.scan(repository_root=root, max_bytes=1024 * 1024) == []
+
+
+def test_allowlisted_oversized_file_passes(tmp_path):
+    root = _repo(tmp_path)
+    _track(root, "big.bin", 2 * 1024 * 1024)
+    allow = {"big.bin": "intentional fixture"}
+    assert guard.scan(repository_root=root, max_bytes=1024 * 1024, allowlist=allow) == []
+
+
+def test_stale_allowlist_entry_fails(tmp_path):
+    root = _repo(tmp_path)
+    _track(root, "small.txt", 10)
+    allow = {"gone.bin": "no longer present"}
+    violations = guard.scan(repository_root=root, max_bytes=1024 * 1024, allowlist=allow)
+    assert len(violations) == 1
+    assert "stale" in violations[0].message
+    assert violations[0].path == "gone.bin"
+
+
+def test_allowlisted_entry_now_under_ceiling_is_stale(tmp_path):
+    root = _repo(tmp_path)
+    _track(root, "shrunk.bin", 10)
+    allow = {"shrunk.bin": "used to be big"}
+    violations = guard.scan(repository_root=root, max_bytes=1024 * 1024, allowlist=allow)
+    assert len(violations) == 1
+    assert "stale" in violations[0].message
+
+
+def test_real_repository_passes():
+    assert guard.scan() == []


### PR DESCRIPTION
## Description

Makes "no huge artifacts on GitHub" a structural guarantee rather than a convention. `.gitignore` fences the known bulk formats (`*.parquet`, `/data/*`, `reports/`, `*.db`, `*.duckdb`, `artifacts/`) but it's pattern-based — a large file in an unforeseen format or path can still slip through. This adds the size-based backstop.

- **`scripts/ci/check_file_sizes.py`** — inspects **git-tracked files only** (`git ls-files`, since a gitignored local corpus never reaches GitHub and must not trip the guard) and fails any file over **5 MiB**. Ceiling chosen to sit far above any legitimate text/config file (the repo's largest tracked file today is `.test_durations` at 704 KiB) and far below any real data artifact. A reason-annotated `SIZE_ALLOWLIST` handles deliberate exceptions and **fails on stale entries** — same discipline as the tier-boundary guard, so it can't quietly rot.
- Wired into `make lint-boundaries` and the CI quality job, alongside the other `scripts/ci` guards.
- 8 unit tests on throwaway git repos: small files pass, oversized fails, a gitignored large file is correctly ignored, allowlist passes, stale/absent and now-under-ceiling allowlist entries fail.

Passes on the current tree with an empty allowlist. Directly serves the concern behind the corpus-pinning design (#562): keeps large artifacts out of git by construction, catching the mistake at PR time instead of after it's in history.

## Type of Change

- [ ] Bug fix
- [x] New feature (repository-hygiene guard)
- [ ] Breaking change
- [ ] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)

## Testing

- `uv run python scripts/ci/check_file_sizes.py` — "File-size checks passed." on the real tree
- `uv run pytest tests/unit/scripts/test_file_sizes.py` — 8 passed
- `uv run ruff check` on both files — clean
- ci.yml parses

- [x] Unit tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA

---
_Generated by [Claude Code](https://claude.ai/code/session_011kXraQ1EnmEyyDCwk46PuA)_