### PR TITLE
Improve portfolio-facing repository guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ position of any agency.
 The fastest end-to-end example is a deterministic Army procurement-transition
 packet built entirely from committed synthetic data:
 
+Run `make install` from the repository root first; `make install-core` omits the
+`sbir_ml` package used by this example.
+
 ```bash
 uv run python scripts/data/monthly_procurement_transition_report.py \
   --month 2026-06 \
@@ -45,8 +48,8 @@ The repository separates software capability from evidentiary maturity:
 
 | Capability | Current status | Evidence or boundary |
 | --- | --- | --- |
-| Procurement-transition reporting | Runnable synthetic demonstration | [Synthetic example and expected output](examples/README_ARMY_PROCUREMENT_TRANSITION.md) |
-| Award ingestion, entity resolution, and graph loading | Implemented; real-data setup required | [Getting-started guide](docs/getting-started/README.md) and [architecture](docs/architecture/detailed-overview.md) |
+| Procurement-transition reporting | Exploratory; runnable synthetic demonstration | [Synthetic example and expected output](examples/README_ARMY_PROCUREMENT_TRANSITION.md) |
+| Award ingestion, entity resolution, and graph loading | Implemented; real-data setup required | Operational capability, not an evidence claim; see the [getting-started guide](docs/getting-started/README.md) and [architecture](docs/architecture/detailed-overview.md) |
 | Phase III outcome analysis | Reproducible; not validated or approved for citation | [Phase III census study record](studies/phase-iii-census/study.yaml) |
 | Private-capital, M&A, and fiscal analyses | Exploratory and data-dependent | [Research output status index](docs/research/README.md) and the limitations below |
 
@@ -76,8 +79,9 @@ record to other public datasets. A few of the questions it explores:
   economic activity attributable to award spending, using BEA input-output tables
   where available and fallback assumptions when live BEA inputs are unavailable.
 
-The full, sourced inventory (organized by policy area and complexity) is
-in [docs/research-questions.md](docs/research-questions.md).
+The full, sourced inventory in
+[docs/research-questions.md](docs/research-questions.md) is the heart of the
+project: the code and studies exist to investigate and validate those questions.
 
 ## What it actually does
 
@@ -151,7 +155,7 @@ repository, start with these documents in order:
 
 ## Running it
 
-The project supports **Python 3.11 and 3.12** and uses
+The project targets **Python 3.11** and uses
 [`uv`](https://github.com/astral-sh/uv) for
 dependency management. There is intentionally no `requirements.txt` — the
 dependency set is defined by `pyproject.toml` and pinned in `uv.lock`. (If you
@@ -208,6 +212,9 @@ for compatibility boundaries, increment rules, and the release checklist.
 ## License
 
 MIT — see [LICENSE](LICENSE). Copyright (c) 2025 Conrad Hollomon.
+
+Contributions are welcome; see [CONTRIBUTING.md](CONTRIBUTING.md) for the local
+workflow and review expectations.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -5,21 +5,50 @@ downstream commercialization signals (federal contracts,
 patents, private financing, and acquisitions) to better
 understand what happens after a small business wins an SBIR award.
 
-## About this project (please read first)
+## My role and use of AI
 
-- I am a federal employee working in the SBIR/STTR domain, not a
-  trained data scientist or ML engineer. I'm hoping to contribute which
-  questions are worth asking, how they map to the policy and
-  academic literature, and what data could plausibly answer them.
-- This is built with substantial help from AI agents. Much of the
-  implementation was generated and iterated with Claude and Codex. I
-  directed the design and validated the analysis, but this code definitely
-  isn't professional-grade engineering. This is a **personal side project,
-  not production software.** PRs welcome!
-- Recommend newcomers read **[docs/research-questions.md](docs/research-questions.md)**, 
-  a structured inventory of the questions this project exists to answer, each
-  tied to the relevant GAO/NASEM/CRS reports and peer-reviewed studies. That
-  document is the heart of the project, and the code is the work to validate it.
+- Defined the research agenda and functional requirements, starting with the
+  policy questions in [docs/research-questions.md](docs/research-questions.md).
+- Selected public data sources and specified the entity-linkage, analytical,
+  and reporting methods used to investigate those questions.
+- Set evidence and validation boundaries, including what the outputs can and
+  cannot support.
+- Used Claude and Codex extensively to implement and iterate on the software,
+  then reviewed the work through tests, reproducibility checks, and documented
+  evidence limits.
+
+This is independent research software developed on personal time. It is not an
+agency product or a production service, and its findings do not represent the
+position of any agency.
+
+## See it work
+
+The fastest end-to-end example is a deterministic Army procurement-transition
+packet built entirely from committed synthetic data:
+
+```bash
+uv run python scripts/data/monthly_procurement_transition_report.py \
+  --month 2026-06 \
+  --awards examples/army_science_technology_awards.csv \
+  --candidates examples/army_science_technology_candidates.csv \
+  --opportunities examples/army_science_technology_opportunities.csv \
+  --output-root /tmp/procurement-transition-example
+```
+
+Read the [example walkthrough](examples/README_ARMY_PROCUREMENT_TRANSITION.md)
+and compare the result with the committed
+[expected report](examples/army_science_technology_report.md). Every company,
+award, opportunity, and judgment in this example is synthetic; it demonstrates
+the workflow and evidence trail, not live acquisition intelligence.
+
+The repository separates software capability from evidentiary maturity:
+
+| Capability | Current status | Evidence or boundary |
+| --- | --- | --- |
+| Procurement-transition reporting | Runnable synthetic demonstration | [Synthetic example and expected output](examples/README_ARMY_PROCUREMENT_TRANSITION.md) |
+| Award ingestion, entity resolution, and graph loading | Implemented; real-data setup required | [Getting-started guide](docs/getting-started/README.md) and [architecture](docs/architecture/detailed-overview.md) |
+| Phase III outcome analysis | Reproducible; not validated or approved for citation | [Phase III census study record](studies/phase-iii-census/study.yaml) |
+| Private-capital, M&A, and fiscal analyses | Exploratory and data-dependent | [Research output status index](docs/research/README.md) and the limitations below |
 
 ## Questions I'm trying to answer
 
@@ -106,19 +135,24 @@ repository, start with these documents in order:
 
 1. [Research questions](docs/research-questions.md): the core policy and
    evaluation questions the project is trying to answer.
-2. [SEC EDGAR SBIR learnings](docs/research/sec-edgar-sbir-learnings.md):
+2. [Army procurement-transition example](examples/README_ARMY_PROCUREMENT_TRANSITION.md):
+   a runnable vertical slice with synthetic inputs and a committed expected report.
+3. [Study contracts](studies/README.md): how the project distinguishes exploratory,
+   reproducible, validated, and citable work.
+4. [SEC EDGAR SBIR learnings](docs/research/sec-edgar-sbir-learnings.md):
    practical findings from using EDGAR to detect SBIR-related exits and
    financing signals.
-3. [SBIR Form D fundraising analysis](docs/research/sbir-form-d-fundraising-analysis.md):
+5. [SBIR Form D fundraising analysis](docs/research/sbir-form-d-fundraising-analysis.md):
    the private-capital lens on awardee commercialization.
-4. [Phase transition latency](docs/phase-transition-latency.md): how the repo
+6. [Phase transition latency](docs/phase-transition-latency.md): how the repo
    thinks about timing from SBIR awards to follow-on federal contracts.
-5. [SBIR identification methodology](docs/sbir-identification-methodology.md):
+7. [SBIR identification methodology](docs/sbir-identification-methodology.md):
    the methodology behind identifying and linking SBIR firms across datasets.
 
 ## Running it
 
-The project uses **Python 3.11** and [`uv`](https://github.com/astral-sh/uv) for
+The project supports **Python 3.11 and 3.12** and uses
+[`uv`](https://github.com/astral-sh/uv) for
 dependency management. There is intentionally no `requirements.txt` — the
 dependency set is defined by `pyproject.toml` and pinned in `uv.lock`. (If you
 need a flat list, run `uv export`.)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -38,11 +38,10 @@ Migrations are located in
 
 ### Manual CLI (Default)
 
-Install `sbir-graph` (or the full `sbir-analytics` package) before using the repository CLI
-wrapper:
+Install the full workspace from the repository root before using the repository CLI wrapper:
 
 ```bash
-pip install sbir-graph
+make install
 ```
 
 ```bash

--- a/packages/sbir-analytics/README.md
+++ b/packages/sbir-analytics/README.md
@@ -12,6 +12,8 @@ ETL library.
 These packages are currently installed from a repository checkout; they are not
 published to PyPI.
 
+From the repository root:
+
 ```bash
 make install       # full workspace; uv sync --extra stack-dev
 make install-core  # reusable sbir-etl library only; uv sync

--- a/packages/sbir-analytics/README.md
+++ b/packages/sbir-analytics/README.md
@@ -2,23 +2,15 @@
 
 Full SBIR analytics pipeline including Dagster orchestration, ML, and Neo4j.
 
-Installs [`sbir-etl`](../../) with all extras plus the `sbir_analytics` Python
-package containing Dagster orchestration and application tools that don't
-belong in the reusable ETL library.
+Installs the ETL integrations used by the pipeline plus the `sbir_ml` and
+`sbir_graph` workspace packages. The `sbir_analytics` Python package contains
+Dagster orchestration and application tools that do not belong in the reusable
+ETL library.
 
 ## Installation
 
-From a package index:
-
-```bash
-# Full pipeline (Dagster + ML + Neo4j)
-pip install sbir-analytics
-
-# ETL library only (no Dagster, ML, or Neo4j)
-pip install sbir-etl
-```
-
-From a repository checkout with development tools:
+These packages are currently installed from a repository checkout; they are not
+published to PyPI.
 
 ```bash
 make install       # full workspace; uv sync --extra stack-dev

--- a/packages/sbir-graph/README.md
+++ b/packages/sbir-graph/README.md
@@ -10,11 +10,11 @@ documented in [`docs/schemas/neo4j.md`](../../docs/schemas/neo4j.md) and
 
 ## Installation
 
-Install the graph package directly, or install the full analytics pipeline that depends on it:
+The workspace packages are currently installed from a repository checkout; they
+are not published to PyPI. From the repository root:
 
 ```bash
-pip install sbir-graph       # graph loaders, Neo4j client, and packaged migrations
-pip install sbir-analytics   # full pipeline; installs sbir-graph as a dependency
+make install  # full workspace, including sbir-graph
 ```
 
 Depends on `neo4j>=5.20`, `pydantic`, `pandas`, `loguru`.

--- a/packages/sbir-graph/sbir_graph/loaders/__init__.py
+++ b/packages/sbir-graph/sbir_graph/loaders/__init__.py
@@ -4,9 +4,9 @@ Epistemic tier: pipelines. Loaders move validated records into Neo4j with
 deterministic MERGE semantics; correctness is faithfulness to the input
 records, and no loader performs inference or scoring.
 
-Neo4j loaders are available when the ``neo4j`` extra is installed::
+Neo4j loaders are available after installing the repository workspace::
 
-    pip install sbir-graph
+    make install
 """
 
 from __future__ import annotations

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/__init__.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/__init__.py
@@ -5,9 +5,9 @@ Epistemic tier: pipelines. Every loader writes upstream records with
 deterministic MERGE semantics; correctness is faithfulness to the input
 records, and no loader performs inference or scoring.
 
-This package requires the ``neo4j`` optional dependency.  Install it with::
+This package requires the ``neo4j`` dependency from the repository workspace::
 
-    pip install sbir-graph
+    make install
 
 All public symbols are lazily imported so that the rest of the ``sbir_etl``
 package can be imported without neo4j being installed.
@@ -89,7 +89,7 @@ def __getattr__(name: str) -> Any:
         except ImportError as exc:
             raise ImportError(
                 f"The neo4j package is required to use {name}. "
-                "Install it with: pip install sbir-graph"
+                "Install this repository's full workspace with: make install"
             ) from exc
         value = getattr(mod, attr)
         globals()[name] = value

--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/client.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/client.py
@@ -14,7 +14,8 @@ try:
     from neo4j import Driver, GraphDatabase, Session, Transaction  # type: ignore[attr-defined]
 except ImportError as _neo4j_err:
     raise ImportError(
-        "The neo4j package is required for Neo4j loaders. Install it with: pip install sbir-graph"
+        "The neo4j package is required for Neo4j loaders. "
+        "Install this repository's full workspace with: make install"
     ) from _neo4j_err
 
 

--- a/packages/sbir-ml/README.md
+++ b/packages/sbir-ml/README.md
@@ -11,11 +11,11 @@ is documented under [`docs/ml/`](../../docs/ml/) and
 
 ## Installation
 
-Installed automatically with the ML extra or the full pipeline:
+The workspace packages are currently installed from a repository checkout; they
+are not published to PyPI. From the repository root:
 
 ```bash
-pip install "sbir-etl[ml]"   # ETL library + this package
-pip install sbir-analytics    # full pipeline (includes [ml])
+make install  # full workspace, including sbir-ml[nlp]
 ```
 
 Core deps: `sbir-etl`, `scikit-learn`, `tqdm`. Optional extras:


### PR DESCRIPTION
## Summary

- replace self-disqualifying authorship language with a factual account of project direction, evidence design, and AI-assisted implementation
- promote the runnable synthetic Army procurement-transition example and its committed expected output
- add a compact capability/status table that distinguishes implementation from evidentiary maturity
- replace invalid package-index installation commands with the verified workspace install path

## Why

The repository already contains strong technical and research artifacts, but the front page buries them and asks reviewers to discount the work before seeing the evidence. The package READMEs also advertise packages that are not published to PyPI, including an ML extra that does not exist.

This is a deliberately narrow first portfolio-readiness change. Runtime reliability, CI truthfulness, stale architecture material, and broader packaging metadata are deferred to focused follow-up PRs.

## Verification

- `make install`
- `make install-core`
- `make docs-check`
- `git diff --check`
- generated the documented Army packet and byte-compared it with `examples/army_science_technology_report.md`
