### PR TITLE
Align environment configuration contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,11 @@
 # -----------------------
 # Neo4j configuration
 # -----------------------
-# Neo4j authentication (username/password). Use a strong password for real deployments.
+# These four direct variables are read by the application configuration loader.
+# Use a strong password for real deployments.
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=test
+NEO4J_DATABASE=neo4j
 
 # Host-local processes connect through the published Docker port. Compose
 # overrides this with the internal service hostname for container processes.
@@ -22,8 +24,13 @@ NEO4J_server_memory_heap_max__size=1G
 # -----------------------
 # Application / runtime
 # -----------------------
-# Environment mode: dev | test | prod
+# Compose profile selector: dev | test | prod. Compose forwards this value to
+# the application under its canonical selector.
 ENVIRONMENT=dev
+
+# Direct host processes use this selector. Long aliases such as development
+# and production are also accepted.
+SBIR_ETL__PIPELINE__ENVIRONMENT=dev
 
 # Keep Python output unbuffered for container logs
 PYTHONUNBUFFERED=1
@@ -34,23 +41,8 @@ DOCKER_IMAGE_NAME=sbir-etl:latest
 # -----------------------
 # SBIR ETL application-specific variables
 # -----------------------
-# Canonical Neo4j Bolt URL used by host-local application processes
-SBIR_ETL__NEO4J__BOLT_URL=bolt://localhost:7687
-
-# Individual connection pieces (application may prefer either URL or these pieces)
-SBIR_ETL__NEO4J__HOST=localhost
-SBIR_ETL__NEO4J__PORT=7687
-SBIR_ETL__NEO4J__USERNAME=${NEO4J_USER}
-SBIR_ETL__NEO4J__PASSWORD=${NEO4J_PASSWORD}
-
 # DuckDB defaults (path inside container or host bind mount)
 SBIR_ETL__DUCKDB__DATABASE_PATH=data/processed/sbir.duckdb
-
-# Data directories (when using bind mounts in dev)
-SBIR_ETL__DATA_DIR=/app/data
-SBIR_ETL__CONFIG_DIR=/app/config
-SBIR_ETL__LOG_DIR=/app/logs
-SBIR_ETL__METRICS_DIR=/app/metrics
 
 # -----------------------
 # Optional service toggles / tuning

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,11 @@
 # -----------------------
 # Neo4j configuration
 # -----------------------
-# These four direct variables are read by the application configuration loader.
+# These direct variables are the documented application contract. Nested
+# SBIR_ETL__NEO4J__USERNAME/PASSWORD overrides are intentionally omitted: the
+# loader accepts them for compatibility, but they shadow these direct values,
+# and references such as ${NEO4J_USER} are not expanded inside Compose env_file
+# files. Unset stale nested overrides when migrating an existing environment.
 # Use a strong password for real deployments.
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=test
@@ -80,6 +84,10 @@ CPU_LIMIT=2.0
 # E2E Neo4j ports (to avoid conflicts with dev instance)
 NEO4J_E2E_HTTP_PORT=7475
 NEO4J_E2E_BOLT_PORT=7688
+
+# Direct host E2E scripts retain these compatibility names.
+NEO4J_USERNAME=neo4j
+SBIR_ETL__NEO4J__BOLT_URL=bolt://localhost:7687
 
 # -----------------------
 # Notes

--- a/.env.server.example
+++ b/.env.server.example
@@ -13,6 +13,8 @@
 # Runtime
 # -----------------------------------------------------------------------------
 ENVIRONMENT=prod
+# Compose forwards ENVIRONMENT to SBIR_ETL__PIPELINE__ENVIRONMENT in every
+# application container; keep a single deployment selector here.
 PYTHONUNBUFFERED=1
 SERVICE_STARTUP_TIMEOUT=120
 
@@ -40,6 +42,8 @@ DAGSTER_PORT=3000
 NEO4J_USER=neo4j
 # Required — the compose file fails fast if this is empty.
 NEO4J_PASSWORD=change_me
+NEO4J_URI=bolt://neo4j:7687
+NEO4J_DATABASE=neo4j
 NEO4J_server_memory_heap_max__size=1G
 NEO4J_server_memory_heap_initial__size=512M
 NEO4J_server_memory_pagecache_size=512M

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -38,6 +38,7 @@ x-server-environment: &server-environment
   NEO4J_URI: ${NEO4J_URI:-bolt://neo4j:7687}
   NEO4J_USER: ${NEO4J_USER:-neo4j}
   NEO4J_PASSWORD: ${NEO4J_PASSWORD:?NEO4J_PASSWORD is required for the server profile}
+  NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
   # Heavy assets (ML, fiscal, USPTO NLP) are loaded so they can be run by hand;
   # nothing schedules them. See .env.server.example for the capacity caveat.
   DAGSTER_LOAD_HEAVY_ASSETS: ${DAGSTER_LOAD_HEAVY_ASSETS:-true}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ x-common-environment: &common-environment
   NEO4J_URI: bolt://neo4j:7687
   NEO4J_USER: ${NEO4J_USER:-neo4j}
   NEO4J_PASSWORD: ${NEO4J_PASSWORD:-password}
+  NEO4J_DATABASE: ${NEO4J_DATABASE:-neo4j}
 
 x-dev-environment: &dev-environment
   <<: *common-environment
@@ -242,11 +243,11 @@ services:
       - SBIR_ETL__PIPELINE__ENVIRONMENT=test
       - PYTHONPATH=/app
       - NEO4J_URI=bolt://neo4j:7687
+      - NEO4J_USER=${NEO4J_USER}
       - NEO4J_USERNAME=${NEO4J_USER}
       - NEO4J_PASSWORD=${NEO4J_PASSWORD}
+      - NEO4J_DATABASE=${NEO4J_DATABASE:-neo4j}
       - SBIR_ETL__NEO4J__BOLT_URL=bolt://neo4j:7687
-      - SBIR_ETL__NEO4J__USERNAME=${NEO4J_USER}
-      - SBIR_ETL__NEO4J__PASSWORD=${NEO4J_PASSWORD}
       - SBIR_ETL__USPTO__RAW_DIR=/app/data/raw/uspto
       - PYTHONUNBUFFERED=1
       - COVERAGE_FILE=/tmp/.coverage

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -15,13 +15,14 @@
 #   ENTRYPOINT ["sh", "/app/scripts/docker/entrypoint.sh", "dagster-daemon"]
 #   ENTRYPOINT ["sh", "/app/scripts/docker/entrypoint.sh", "etl-runner", "python", "-m", "my.module"]
 #
-# Environment variables used (documented in .env.example):
-#   ENVIRONMENT                - dev|test|prod (affects behavior)
-#   SBIR_ETL__NEO4J__HOST      - Neo4j host (default: neo4j)
-#   SBIR_ETL__NEO4J__PORT      - Neo4j bolt port (default: 7687)
-#   SBIR_ETL__NEO4J__USERNAME  - Neo4j username
-#   SBIR_ETL__NEO4J__PASSWORD  - Neo4j password
-#   SERVICE_STARTUP_TIMEOUT    - seconds to wait for dependencies (default: 120)
+# Environment variables:
+#   ENVIRONMENT             - dev|test|prod (affects behavior)
+#   NEO4J_USER              - Neo4j username
+#   NEO4J_PASSWORD          - Neo4j password
+#   NEO4J_DATABASE          - Neo4j database name
+#   SERVICE_STARTUP_TIMEOUT - seconds to wait for dependencies (default: 120)
+# Compose supplies SBIR_ETL__NEO4J__HOST/PORT internally for dependency probes;
+# they are not host-facing .env.example settings.
 #
 # Notes:
 # - This script is intentionally POSIX-sh compatible for maximum portability.

--- a/scripts/server/backup.sh
+++ b/scripts/server/backup.sh
@@ -10,6 +10,7 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 . "$SCRIPT_DIR/env-file.sh"
 load_env_key SERVER_BACKUP_DIR
 load_env_key SERVER_NEO4J_DIR
+load_env_key NEO4J_DATABASE
 
 BACKUP_DIR="${SERVER_BACKUP_DIR:-./backups}"
 NEO4J_DIR="${SERVER_NEO4J_DIR:-./data/neo4j}"

--- a/tests/unit/config/test_env_example.py
+++ b/tests/unit/config/test_env_example.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ENV_EXAMPLE = Path(__file__).parents[3] / ".env.example"
+
+
+def _documented_keys() -> set[str]:
+    return {
+        line.partition("=")[0]
+        for raw_line in ENV_EXAMPLE.read_text(encoding="utf-8").splitlines()
+        if (line := raw_line.strip()) and not line.startswith("#") and "=" in line
+    }
+
+
+def test_env_example_documents_the_supported_runtime_selectors() -> None:
+    keys = _documented_keys()
+
+    assert {
+        "ENVIRONMENT",
+        "SBIR_ETL__PIPELINE__ENVIRONMENT",
+        "NEO4J_URI",
+        "NEO4J_USER",
+        "NEO4J_PASSWORD",
+        "NEO4J_DATABASE",
+    } <= keys
+
+    assert {
+        "SBIR_ETL__NEO4J__BOLT_URL",
+        "SBIR_ETL__NEO4J__HOST",
+        "SBIR_ETL__NEO4J__PORT",
+        "SBIR_ETL__DATA_DIR",
+        "SBIR_ETL__CONFIG_DIR",
+        "SBIR_ETL__LOG_DIR",
+        "SBIR_ETL__METRICS_DIR",
+    }.isdisjoint(keys)

--- a/tests/unit/config/test_env_example.py
+++ b/tests/unit/config/test_env_example.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 
 ENV_EXAMPLE = Path(__file__).parents[3] / ".env.example"
+COMPOSE_FILE = Path(__file__).parents[3] / "docker-compose.yml"
 
 
 def _documented_keys() -> set[str]:
@@ -22,14 +23,19 @@ def test_env_example_documents_the_supported_runtime_selectors() -> None:
         "NEO4J_USER",
         "NEO4J_PASSWORD",
         "NEO4J_DATABASE",
+        "NEO4J_USERNAME",
+        "SBIR_ETL__NEO4J__BOLT_URL",
     } <= keys
 
-    assert {
-        "SBIR_ETL__NEO4J__BOLT_URL",
-        "SBIR_ETL__NEO4J__HOST",
-        "SBIR_ETL__NEO4J__PORT",
-        "SBIR_ETL__DATA_DIR",
-        "SBIR_ETL__CONFIG_DIR",
-        "SBIR_ETL__LOG_DIR",
-        "SBIR_ETL__METRICS_DIR",
-    }.isdisjoint(keys)
+    nested_neo4j_keys = {key for key in keys if key.startswith("SBIR_ETL__NEO4J__")}
+    assert nested_neo4j_keys == {"SBIR_ETL__NEO4J__BOLT_URL"}
+
+
+def test_compose_forwards_every_documented_direct_neo4j_setting() -> None:
+    compose = COMPOSE_FILE.read_text(encoding="utf-8")
+    common_environment = compose.split("x-common-environment:", 1)[1].split(
+        "x-dev-environment:", 1
+    )[0]
+
+    for key in ("NEO4J_URI", "NEO4J_USER", "NEO4J_PASSWORD", "NEO4J_DATABASE"):
+        assert f"  {key}:" in common_environment

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -584,7 +584,7 @@ class TestGetConfig:
                 "NEO4J_PASSWORD": "custom-password",
                 "NEO4J_DATABASE": "analytics",
             }
-            with patch.dict(os.environ, neo4j_environment):
+            with patch.dict(os.environ, neo4j_environment, clear=True):
                 reload_config()  # Clear cache
                 config = get_config(environment="development", config_dir=config_dir)
 
@@ -592,6 +592,22 @@ class TestGetConfig:
             assert config.neo4j.username == "custom-user"
             assert config.neo4j.password == "custom-password"
             assert config.neo4j.database == "analytics"
+
+    def test_nested_neo4j_environment_overrides_direct_compatibility_values(self):
+        """Nested compatibility values retain their documented precedence."""
+        environment = {
+            "NEO4J_USER": "direct-user",
+            "NEO4J_PASSWORD": "direct-password",
+            "SBIR_ETL__NEO4J__USERNAME": "nested-user",
+            "SBIR_ETL__NEO4J__PASSWORD": "nested-password",
+        }
+
+        with patch.dict(os.environ, environment, clear=True):
+            reload_config()
+            config = get_config(environment="development")
+
+        assert config.neo4j.username == "nested-user"
+        assert config.neo4j.password == "nested-password"
 
     def test_get_config_handles_legacy_loading_neo4j(self):
         """Test get_config handles legacy 'loading.neo4j' structure."""

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -567,8 +567,8 @@ class TestGetConfig:
             # Production uses prod-neo4j by default (can be overridden via env vars)
             assert config.neo4j.uri == "bolt://prod-neo4j:7687"
 
-    def test_get_config_respects_explicit_neo4j_uri_env(self):
-        """Test get_config respects explicit NEO4J_URI environment variable."""
+    def test_get_config_respects_direct_neo4j_environment(self):
+        """Direct Neo4j variables populate every connection field in the schema."""
         base_content = {}
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -578,11 +578,20 @@ class TestGetConfig:
             with open(base_file, "w") as f:
                 yaml.dump(base_content, f)
 
-            with patch.dict(os.environ, {"NEO4J_URI": "bolt://custom:7687"}):
+            neo4j_environment = {
+                "NEO4J_URI": "bolt://custom:7687",
+                "NEO4J_USER": "custom-user",
+                "NEO4J_PASSWORD": "custom-password",
+                "NEO4J_DATABASE": "analytics",
+            }
+            with patch.dict(os.environ, neo4j_environment):
                 reload_config()  # Clear cache
                 config = get_config(environment="development", config_dir=config_dir)
 
             assert config.neo4j.uri == "bolt://custom:7687"
+            assert config.neo4j.username == "custom-user"
+            assert config.neo4j.password == "custom-password"
+            assert config.neo4j.database == "analytics"
 
     def test_get_config_handles_legacy_loading_neo4j(self):
         """Test get_config handles legacy 'loading.neo4j' structure."""


### PR DESCRIPTION
## Summary

- document the direct Neo4j variables used by host and Compose workflows, including the database selector
- distinguish the Compose `ENVIRONMENT` selector from the canonical loader environment variable
- omit nested `SBIR_ETL__NEO4J__USERNAME/PASSWORD` compatibility overrides because they shadow the direct credentials and `env_file` does not expand their old ${...} values
- retain the legacy Bolt URL only where the host E2E scripts still consume it
- forward every documented direct Neo4j setting through both Compose environments
- add contract tests for the public template, Compose mapping, and override precedence

## Why

The public environment template mixed three different contracts: direct loader settings, nested compatibility overrides, and script-only E2E names. In particular, the nested username/password settings are accepted by the loader and take precedence over the direct values, while their old ${NEO4J_USER} syntax remained literal when read through Compose `env_file`.

This PR makes those boundaries explicit without changing the loader's compatibility behavior. It intentionally does not enable global rejection of extra configuration keys because environment profiles still contain component-owned top-level sections.

## Verification

- `uv run pytest -q tests/unit/config/test_loader.py tests/unit/config/test_env_example.py tests/unit/test_server_runtime_contract.py tests/unit/test_server_ops.py` — 99 passed
- `uv run ruff check tests/unit/config/test_loader.py tests/unit/config/test_env_example.py`
- development and server Compose configurations parse with their example environment files
- `git diff --check`