### PR TITLE
Address remaining epistemic-tier review gaps

### DIFF
--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -160,6 +160,31 @@ Two rules make this stick:
   new contract satisfied in that change. Nothing gets promoted by being useful,
   by being imported, or by accumulating callers.
 
+### Assigning spec targets
+
+A spec's declaration is the contract for its next authorized implementation
+slice. It is neither a claim that current code already satisfies that contract
+nor an aspirational label for every possible future phase. Review
+[`specs/status.md`](../../specs/status.md) first, then apply these rules:
+
+- Target `primitives` only when the deliverable is the single shared,
+  versioned implementation of a repository-wide concept.
+- Target `pipelines` when the authorized work is deterministic extraction,
+  materialization, or operational plumbing. A gated or deferred spec may use
+  this target to permit data preparation, but it does not authorize any
+  contestable analysis in that spec; that phase requires an explicit retier.
+- Target `evidence` only when a selected active or maintenance deliverable is
+  an externally reportable finding, benchmark, or validation and the
+  implementation must satisfy all four evidence-contract items.
+- Target `exploratory` for open-ended prototypes and contestable work without
+  an approved evidence contract.
+
+The initial declaration sweep therefore capped gated and deferred analytical
+specs at their deterministic preparation stage and retained `evidence` only
+where the requirements already named the reportable result or validation as a
+selected deliverable. Determinism alone never turns classification, imputation,
+ranking, or another contestable decision into a pipeline.
+
 ## Relationship to the research questions
 
 [research-questions.md](../research-questions.md) is the inventory of what the

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -113,7 +113,7 @@ removal condition: move the implementation behind a package API while retaining
 the CLI as an entry point. No new bridge may be added without those conditions,
 and an `evidence` artifact may not depend on one. See
 [structure.md](structure.md#transitional-script-dependencies) for the current
-bridge.
+bridge policy; no transitional bridges are currently active.
 
 #### Two populations: workbench and operated
 

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -105,9 +105,9 @@ the manifest schema, frozen-artifact hashes, and implementation references.
 
 ### Transitional Script Dependencies
 
-First-party packages may not add dependencies on `scripts/`. All transitional bridges are
-retired: the architecture guard's import and execution allowlists are empty, and every
-formerly bridged script is now reached through a package API with the CLI retained as an
+First-party packages may not add dependencies on `scripts/`. All three transitional execution
+bridges are retired: the architecture guard's import and execution allowlists are empty, and
+every formerly bridged script is now reached through a package API with the CLI retained as an
 entry point. Any future bridge must be named in the guard with a reason and a removal
 condition; it is a migration device, not a fifth epistemic tier and not an implicit
 promotion of the script, and an `evidence` artifact may never depend on one.

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -112,8 +112,10 @@ entry point. Any future bridge must be named in the guard with a reason and a re
 condition; it is a migration device, not a fifth epistemic tier and not an implicit
 promotion of the script, and an `evidence` artifact may never depend on one.
 
-The guard inspects both imports and literal Python-script targets passed to `subprocess`.
-Hiding a package-to-script dependency behind process execution does not change its direction.
+The guard inspects both imports and literal Python-script targets in `subprocess` command
+arguments, following simple local assignments. It is an architecture lint, not a runtime
+sandbox, so dynamically constructed paths remain outside its static view. Hiding a
+package-to-script dependency behind process execution does not change its direction.
 
 ### Separation of Concerns
 

--- a/scripts/ci/check_architecture_boundaries.py
+++ b/scripts/ci/check_architecture_boundaries.py
@@ -4,6 +4,10 @@
 The package layout is intentionally layered.  This check makes that direction
 an executable contract so a convenient local import cannot quietly turn into a
 new architectural back-edge.
+
+Subprocess inspection follows literal command arguments and simple local
+assignments. It is an architecture lint, not a runtime sandbox, and cannot see
+dynamically constructed targets.
 """
 
 from __future__ import annotations
@@ -40,7 +44,7 @@ TRANSITIONAL_SCRIPT_EXECUTIONS: dict[str, frozenset[str]] = {}
 
 @dataclass(frozen=True)
 class BoundaryViolation:
-    """One forbidden first-party import."""
+    """One forbidden first-party dependency."""
 
     path: str
     line_number: int

--- a/scripts/ci/check_epistemic_tiers.py
+++ b/scripts/ci/check_epistemic_tiers.py
@@ -13,6 +13,7 @@ TIER_DECLARATION = re.compile(
     r"^\*\*Target epistemic tier:\*\*\s*`?([A-Za-z]+)`?\s*$",
     flags=re.MULTILINE,
 )
+FENCE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
 EXCLUDED_SPEC_DIRECTORIES = frozenset({"archive"})
 
 
@@ -25,6 +26,25 @@ class TierDeclarationViolation:
 
     def format(self) -> str:
         return f"{self.path}: {self.message}"
+
+
+def _outside_fenced_code(markdown: str) -> str:
+    """Return Markdown content outside fenced code blocks."""
+
+    retained: list[str] = []
+    marker: tuple[str, int] | None = None
+    for line in markdown.splitlines():
+        match = FENCE.match(line)
+        if marker is None:
+            if match:
+                fence = match.group(1)
+                marker = fence[0], len(fence)
+            else:
+                retained.append(line)
+            continue
+        if match and match.group(1)[0] == marker[0] and len(match.group(1)) >= marker[1]:
+            marker = None
+    return "\n".join(retained)
 
 
 def validate_spec_directory(
@@ -44,7 +64,8 @@ def validate_spec_directory(
             )
         ]
 
-    declarations = TIER_DECLARATION.findall(requirements.read_text(encoding="utf-8"))
+    markdown = _outside_fenced_code(requirements.read_text(encoding="utf-8"))
+    declarations = TIER_DECLARATION.findall(markdown)
     if not declarations:
         return [
             TierDeclarationViolation(

--- a/scripts/ci/check_epistemic_tiers.py
+++ b/scripts/ci/check_epistemic_tiers.py
@@ -13,7 +13,7 @@ TIER_DECLARATION = re.compile(
     r"^\*\*Target epistemic tier:\*\*\s*`?([A-Za-z]+)`?\s*$",
     flags=re.MULTILINE,
 )
-FENCE = re.compile(r"^[ \t]{0,3}(`{3,}|~{3,})")
+FENCE = re.compile(r"^[ \t]*(?P<fence>`{3,}|~{3,})(?P<suffix>.*)$")
 EXCLUDED_SPEC_DIRECTORIES = frozenset({"archive"})
 
 
@@ -29,21 +29,37 @@ class TierDeclarationViolation:
 
 
 def _outside_fenced_code(markdown: str) -> str:
-    """Return Markdown content outside fenced code blocks."""
+    """Return Markdown content outside complete fenced code blocks.
+
+    Unterminated candidate fences are retained. A malformed example must not
+    hide a real declaration later in the specification.
+    """
 
     retained: list[str] = []
+    pending: list[str] = []
     marker: tuple[str, int] | None = None
     for line in markdown.splitlines():
         match = FENCE.match(line)
         if marker is None:
-            if match:
-                fence = match.group(1)
+            if match and not (
+                match.group("fence").startswith("`") and "`" in match.group("suffix")
+            ):
+                fence = match.group("fence")
                 marker = fence[0], len(fence)
+                pending = [line]
             else:
                 retained.append(line)
             continue
-        if match and match.group(1)[0] == marker[0] and len(match.group(1)) >= marker[1]:
+        pending.append(line)
+        if (
+            match
+            and match.group("fence")[0] == marker[0]
+            and len(match.group("fence")) >= marker[1]
+            and not match.group("suffix").strip()
+        ):
             marker = None
+            pending = []
+    retained.extend(pending)
     return "\n".join(retained)
 
 

--- a/tests/unit/scripts/test_epistemic_tiers.py
+++ b/tests/unit/scripts/test_epistemic_tiers.py
@@ -86,3 +86,18 @@ def test_capitalized_tier_is_reported_as_invalid_not_missing(tmp_path: Path) -> 
 
     assert len(violations) == 1
     assert "invalid target tier 'Evidence'" in violations[0].message
+
+
+def test_declaration_inside_fenced_code_is_ignored(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "# Example\n\n"
+        "**Target epistemic tier:** pipelines\n\n"
+        "```markdown\n"
+        "**Target epistemic tier:** evidence\n"
+        "```\n",
+    )
+
+    assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)

--- a/tests/unit/scripts/test_epistemic_tiers.py
+++ b/tests/unit/scripts/test_epistemic_tiers.py
@@ -101,3 +101,89 @@ def test_declaration_inside_fenced_code_is_ignored(tmp_path: Path) -> None:
     )
 
     assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+
+def test_unterminated_fence_does_not_swallow_a_real_declaration(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "# Example\n\n```markdown\nunterminated example\n\n"
+        "**Target epistemic tier:** pipelines\n",
+    )
+
+    assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+
+def test_unterminated_fence_still_reports_a_genuine_duplicate(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "**Target epistemic tier:** pipelines\n\n```markdown\nunterminated example\n\n"
+        "**Target epistemic tier:** evidence\n",
+    )
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "multiple target tier" in violations[0].message
+
+
+def test_indented_fence_inside_list_hides_example_declaration(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "**Target epistemic tier:** pipelines\n\n"
+        "- Example:\n"
+        "    ```markdown\n"
+        "    **Target epistemic tier:** evidence\n"
+        "    ```\n",
+    )
+
+    assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+
+def test_closing_fence_with_info_string_does_not_close(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "**Target epistemic tier:** pipelines\n\n"
+        "```markdown\n"
+        "```python\n"
+        "**Target epistemic tier:** evidence\n"
+        "```\n",
+    )
+
+    assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+
+def test_inline_code_span_at_line_start_is_not_a_fence(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "```markdown``` is inline code\n\n**Target epistemic tier:** pipelines\n",
+    )
+
+    assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+
+def test_supported_fence_variants_hide_example_declarations(tmp_path: Path) -> None:
+    for name, opener, closer in (
+        ("tilde", "~~~markdown", "~~~"),
+        ("long", "````markdown", "````"),
+        ("tab", "\t```markdown", "\t```"),
+        ("spaces", "   ```markdown", "   ```"),
+    ):
+        spec = tmp_path / "specs" / name
+        _write(
+            tmp_path,
+            f"specs/{name}/requirements.md",
+            "**Target epistemic tier:** pipelines\n\n"
+            f"{opener}\n**Target epistemic tier:** evidence\n{closer}\n",
+        )
+
+        assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)

--- a/tests/unit/scripts/test_epistemic_tiers.py
+++ b/tests/unit/scripts/test_epistemic_tiers.py
@@ -108,8 +108,7 @@ def test_unterminated_fence_does_not_swallow_a_real_declaration(tmp_path: Path) 
     _write(
         tmp_path,
         "specs/example/requirements.md",
-        "# Example\n\n```markdown\nunterminated example\n\n"
-        "**Target epistemic tier:** pipelines\n",
+        "# Example\n\n```markdown\nunterminated example\n\n**Target epistemic tier:** pipelines\n",
     )
 
     assert not tiers.validate_spec_directory(spec, repository_root=tmp_path)


### PR DESCRIPTION
## What changed

- ignore tier declarations inside fenced Markdown code blocks so quoted examples cannot create false duplicate declarations
- document the rule used to assign specification target tiers, including the lifecycle gate between deterministic preparation and contestable analysis
- document the subprocess guard's literal/static limits and synchronize the architecture guide with the now-empty migration allowlists

## Why

This is the follow-up to #538, which merged before its review thread was resolved. Later merges already fixed the subprocess false-positive bug, local-command resolution, capitalized-tier diagnostics, the gated/deferred tier assignments, and the #531 compatibility file. This PR closes the remaining review gaps without replaying those already-landed changes.

The fenced-block issue came from applying the tier-declaration regular expression to raw Markdown, so a declaration quoted in a code example counted as a real header.

## Impact

No production runtime behavior changes. Spec validation becomes more precise, and future implementers get an explicit rule for the maintenance cost implied by a target-tier declaration.

## Validation

- `pytest -q tests/unit/scripts/test_architecture_boundaries.py tests/unit/scripts/test_epistemic_tiers.py` — 18 passed
- Ruff check and format check on changed Python files
- `scripts/ci/check_architecture_boundaries.py`
- `scripts/ci/check_epistemic_tiers.py`
- `scripts/ci/check_tier_boundaries.py`
- `scripts/ci/check_removed_src_references.py`
- `git diff --check`
