### PR TITLE
Consolidate YAML configuration loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
           uv run python scripts/ci/check_epistemic_tiers.py
           uv run python scripts/ci/check_tier_boundaries.py
           uv run python scripts/ci/check_file_sizes.py
+          uv run python scripts/ci/check_config_boundaries.py
           uv run python scripts/ci/check_removed_src_references.py
           uv run python scripts/ci/validate_study_manifests.py
           # Guards the company-identity primitive: a direct RapidFuzz scorer

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ lint-boundaries: ## Enforce package and archive dependency boundaries
 	$(call run,uv run python scripts/ci/check_architecture_boundaries.py)
 	$(call run,uv run python scripts/ci/check_tier_boundaries.py)
 	$(call run,uv run python scripts/ci/check_file_sizes.py)
+	$(call run,uv run python scripts/ci/check_config_boundaries.py)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
 

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -202,12 +202,13 @@ What already holds:
   build outright (`specs/epistemic-tier-enforcement/`).
 - The Phase III census implements the evidence-tier mechanisms: frozen
   artifacts, SHA enforcement, a declared estimand, and a blocking asset check.
+- Production YAML mapping reads route through the configuration loader or the
+  shared strict-mapping reader. `scripts/ci/check_config_boundaries.py` makes
+  that single-reader contract executable while preserving explicit
+  `allow_empty=True` policy at permissive call sites.
 
 What does not:
 
-- Seven direct `yaml.safe_load` call sites remain outside the configuration
-  loader and the shared strict-mapping reader; several intentionally use
-  permissive empty-file behavior.
 - `scripts/phase3_groundtruth/` and `scripts/validation/` now carry explicit
   `exploratory` labels, but their analytical weight — T6/T7 groundtruth
   results feeding the evidence-target `phase3-transition-groundtruth` spec —

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/baselines.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/baselines.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 
-import yaml
+from sbir_etl.config.yaml_io import read_yaml_mapping
 
 
 DEFAULT_REGISTRY_PATH = Path("config/agency_private_capital/published_baselines.yaml")
@@ -53,8 +53,11 @@ class PublishedBaselineRegistry:
 
     @classmethod
     def load(cls, path: str | Path = DEFAULT_REGISTRY_PATH) -> PublishedBaselineRegistry:
-        text = Path(path).read_text(encoding="utf-8")
-        data = yaml.safe_load(text) or {}
+        data = read_yaml_mapping(
+            Path(path),
+            description="published baseline registry",
+            allow_empty=True,
+        )
         raw = data.get("baselines") or []
         records = tuple(_to_baseline(entry) for entry in raw)
         return cls(baselines=records)

--- a/packages/sbir-ml/sbir_ml/ml/features/patent_features.py
+++ b/packages/sbir-ml/sbir_ml/ml/features/patent_features.py
@@ -557,7 +557,7 @@ def load_keywords_map(path: object | None = None) -> Mapping[str, Sequence[str]]
         # Local imports for import-safety
         from pathlib import Path
 
-        import yaml
+        from sbir_etl.config.yaml_io import read_yaml_mapping
     except Exception:
         return {}
 
@@ -576,9 +576,11 @@ def load_keywords_map(path: object | None = None) -> Mapping[str, Sequence[str]]
         return {}
 
     try:
-        data = yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
-        if not isinstance(data, dict):
-            return {}
+        data = read_yaml_mapping(
+            candidate,
+            description="CET patent keyword map",
+            allow_empty=True,
+        )
         # Allow both nested and flat schemas
         if "cet_keywords" in data and isinstance(data["cet_keywords"], dict):
             kw_map = data["cet_keywords"]

--- a/sbir_etl/config/yaml_io.py
+++ b/sbir_etl/config/yaml_io.py
@@ -12,8 +12,10 @@ validate a schema. Pipeline configuration resolution belongs in
 ``loader.get_config``; per-file schema validation stays with the caller that
 owns the schema.
 
-Callers that treat an empty file as a valid empty mapping want ``or {}`` at the
-call site instead — that is a different policy, not a bug this helper fixes.
+Callers that intentionally treat an empty file as an empty mapping must opt in
+with ``allow_empty=True``. Keeping that policy in this primitive prevents each
+caller from growing its own ``safe_load(...) or {}`` implementation while the
+default stays fail-closed.
 """
 
 from pathlib import Path
@@ -27,20 +29,28 @@ from ..exceptions import ConfigurationError
 __all__ = ["read_yaml_mapping"]
 
 
-def read_yaml_mapping(path: Path, *, description: str = "YAML file") -> dict[str, Any]:
+def read_yaml_mapping(
+    path: Path,
+    *,
+    description: str = "YAML file",
+    allow_empty: bool = False,
+) -> dict[str, Any]:
     """Read ``path`` and return its top-level mapping.
 
     Args:
         path: File to read.
         description: What the file is, used in error messages (e.g. "CET
             taxonomy"). Keep it a noun phrase — it is interpolated directly.
+        allow_empty: Return an empty mapping when the document is empty or
+            comment-only. Invalid YAML and non-mapping documents still fail.
 
     Returns:
         The parsed top-level mapping.
 
     Raises:
         ConfigurationError: The file is missing, unreadable, not valid YAML,
-            empty, or does not hold a mapping at the top level.
+            empty when ``allow_empty`` is false, or does not hold a mapping at
+            the top level.
     """
     try:
         text = path.read_text(encoding="utf-8")
@@ -53,6 +63,8 @@ def read_yaml_mapping(path: Path, *, description: str = "YAML file") -> dict[str
         raise ConfigurationError(f"{description} is not valid YAML: {path} ({exc})") from exc
 
     if payload is None:
+        if allow_empty:
+            return {}
         raise ConfigurationError(f"{description} is empty: {path}")
     if not isinstance(payload, dict):
         raise ConfigurationError(

--- a/sbir_etl/enrichers/fiscal_bea_mapper.py
+++ b/sbir_etl/enrichers/fiscal_bea_mapper.py
@@ -18,10 +18,10 @@ from types import MappingProxyType
 from typing import Any
 
 import pandas as pd
-import yaml
 from loguru import logger
 
 from ..config.loader import get_config
+from ..config.yaml_io import read_yaml_mapping
 
 
 EPISTEMIC_TIER = "exploratory"
@@ -167,8 +167,11 @@ class NAICSToBEAMapper:
         # Load fallback configuration
         if self.fallback_config_path.exists():
             try:
-                with self.fallback_config_path.open() as f:
-                    self.fallback_config = yaml.safe_load(f) or {}
+                self.fallback_config = read_yaml_mapping(
+                    self.fallback_config_path,
+                    description="NAICS-to-BEA fallback config",
+                    allow_empty=True,
+                )
                 logger.info(f"Loaded fallback mappings from {self.fallback_config_path}")
             except Exception as e:
                 logger.warning(

--- a/sbir_etl/reporting/procurement_transition/cet_vocabulary.py
+++ b/sbir_etl/reporting/procurement_transition/cet_vocabulary.py
@@ -6,8 +6,8 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
-import yaml
-
+from sbir_etl.config.yaml_io import read_yaml_mapping
+from sbir_etl.exceptions import ConfigurationError
 from sbir_etl.utils.procurement_text import find_lineage_phrases
 
 
@@ -24,11 +24,15 @@ def load_cet_vocabulary(path: str | None = None) -> dict[str, tuple[str, ...]]:
 
     taxonomy_path = Path(path) if path is not None else DEFAULT_TAXONOMY_PATH
     try:
-        data = yaml.safe_load(taxonomy_path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
+        data = read_yaml_mapping(
+            taxonomy_path,
+            description="CET taxonomy",
+            allow_empty=True,
+        )
+    except ConfigurationError:
         return {}
     vocabulary: dict[str, tuple[str, ...]] = {}
-    for area in (data or {}).get("cet_areas", []):
+    for area in data.get("cet_areas", []):
         name = str(area.get("name", "")).strip()
         keywords = tuple(str(keyword).strip() for keyword in area.get("keywords", []) if keyword)
         if name and keywords:

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -19,8 +19,7 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, TypedDict
 
-import yaml
-
+from sbir_etl.config.yaml_io import read_yaml_mapping
 from sbir_etl.extractors.sbir_public_awards import load_sbir_awards_csv
 from sbir_etl.identity.geography import normalize_us_jurisdiction
 
@@ -80,7 +79,11 @@ def load_census_config(area_id: str, config_dir: Path | None = None) -> dict[str
         raise FileNotFoundError(
             f"No tech-census config at {path}. Add config/tech_census/{area_id}.yaml"
         )
-    cfg = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    cfg = read_yaml_mapping(
+        path,
+        description=f"{area_id} tech-census profile",
+        allow_empty=True,
+    )
     if cfg.get("area_id") and cfg["area_id"] != area_id:
         raise ValueError(f"area_id in {path} is {cfg['area_id']!r}, expected {area_id!r}")
     cfg["area_id"] = area_id
@@ -106,7 +109,11 @@ def load_census_config(area_id: str, config_dir: Path | None = None) -> dict[str
             raise ValueError(f"{path}: overrides_file must remain under {directory}") from exc
         if not override_path.exists():
             raise FileNotFoundError(f"Override ledger not found: {override_path}")
-        ledger = yaml.safe_load(override_path.read_text(encoding="utf-8")) or {}
+        ledger = read_yaml_mapping(
+            override_path,
+            description=f"{area_id} tech-census override ledger",
+            allow_empty=True,
+        )
         cfg["_overrides"] = ledger.get("overrides", []) or []
         cfg["_override_version"] = str(ledger.get("version", "unversioned"))
     return cfg

--- a/sbir_etl/utils/transition_report_paths.py
+++ b/sbir_etl/utils/transition_report_paths.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-import yaml
+from sbir_etl.config.yaml_io import read_yaml_mapping
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA = REPO_ROOT / "data"
@@ -128,7 +128,11 @@ class ReportPaths:
                 f"No area config at {self.config_path}. "
                 f"Add config/transition_reports/{self.area_id}.yaml"
             )
-        cfg = yaml.safe_load(self.config_path.read_text(encoding="utf-8")) or {}
+        cfg = read_yaml_mapping(
+            self.config_path,
+            description=f"{self.area_id} transition-report profile",
+            allow_empty=True,
+        )
         cfg.setdefault("area_id", self.area_id)
         return cfg
 

--- a/scripts/ci/check_config_boundaries.py
+++ b/scripts/ci/check_config_boundaries.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Prevent production code from bypassing the shared YAML configuration reader."""
+
+from __future__ import annotations
+
+import ast
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CANONICAL_YAML_READERS = frozenset(
+    {
+        "sbir_etl/config/loader.py",
+        "sbir_etl/config/yaml_io.py",
+    }
+)
+IGNORED_PREFIXES = ("scripts/archive/", "tests/")
+
+
+@dataclass(frozen=True)
+class ConfigBoundaryViolation:
+    """One direct PyYAML read outside the configuration primitive."""
+
+    path: str
+    line_number: int
+
+    def format(self) -> str:
+        return (
+            f"{self.path}:{self.line_number}: direct yaml.safe_load bypasses the "
+            "configuration primitive; use sbir_etl.config.yaml_io.read_yaml_mapping "
+            "or sbir_etl.config.get_config"
+        )
+
+
+def _safe_load_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
+    """Return aliases for the yaml module and directly imported safe_load function."""
+
+    module_aliases: set[str] = set()
+    function_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "yaml":
+                    module_aliases.add(alias.asname or alias.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "yaml":
+            for alias in node.names:
+                if alias.name == "safe_load":
+                    function_aliases.add(alias.asname or alias.name)
+    return module_aliases, function_aliases
+
+
+def _is_safe_load_call(
+    node: ast.Call,
+    *,
+    module_aliases: set[str],
+    function_aliases: set[str],
+) -> bool:
+    function = node.func
+    if isinstance(function, ast.Name):
+        return function.id in function_aliases
+    return (
+        isinstance(function, ast.Attribute)
+        and function.attr == "safe_load"
+        and isinstance(function.value, ast.Name)
+        and function.value.id in module_aliases
+    )
+
+
+def scan_file(
+    path: Path, *, repository_root: Path = REPOSITORY_ROOT
+) -> list[ConfigBoundaryViolation]:
+    """Find direct ``yaml.safe_load`` calls in one production Python file."""
+
+    relative = path.resolve().relative_to(repository_root.resolve()).as_posix()
+    if relative in CANONICAL_YAML_READERS or relative.startswith(IGNORED_PREFIXES):
+        return []
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    module_aliases, function_aliases = _safe_load_aliases(tree)
+    return [
+        ConfigBoundaryViolation(relative, node.lineno)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and _is_safe_load_call(
+            node,
+            module_aliases=module_aliases,
+            function_aliases=function_aliases,
+        )
+    ]
+
+
+def tracked_python_files(*, repository_root: Path = REPOSITORY_ROOT) -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        cwd=repository_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [repository_root / relative for relative in result.stdout.splitlines()]
+
+
+def scan_repository(*, repository_root: Path = REPOSITORY_ROOT) -> list[ConfigBoundaryViolation]:
+    violations: list[ConfigBoundaryViolation] = []
+    for path in tracked_python_files(repository_root=repository_root):
+        violations.extend(scan_file(path, repository_root=repository_root))
+    return sorted(violations, key=lambda violation: (violation.path, violation.line_number))
+
+
+def main() -> int:
+    violations = scan_repository()
+    if violations:
+        print("Configuration boundary violations were found:")
+        print("\n".join(violation.format() for violation in violations))
+        return 1
+    print("Configuration boundary checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -19,6 +19,7 @@ AGENT_DOCUMENTATION_FILES = {"AGENTS.md", "CLAUDE.md"}
 AGENT_DOCUMENTATION_PREFIXES = (".claude/", ".agents/")
 EXCLUDED_HISTORICAL_DOCUMENTS = {"docs/decisions/ADR-002-etl-library-extraction.md"}
 EXCLUDED_SCAN_FILES = {
+    "scripts/ci/check_config_boundaries.py",
     "scripts/ci/check_identity_boundaries.py",
     "tests/unit/scripts/test_repository_hygiene.py",
 }

--- a/tests/unit/config/test_yaml_io.py
+++ b/tests/unit/config/test_yaml_io.py
@@ -42,6 +42,14 @@ def test_comment_only_file_is_rejected(tmp_path: Path) -> None:
         read_yaml_mapping(path)
 
 
+@pytest.mark.parametrize("content", ["", "# intentionally empty\n"])
+def test_empty_file_can_explicitly_mean_empty_mapping(tmp_path: Path, content: str) -> None:
+    path = tmp_path / "empty.yaml"
+    path.write_text(content, encoding="utf-8")
+
+    assert read_yaml_mapping(path, allow_empty=True) == {}
+
+
 @pytest.mark.parametrize(
     ("content", "type_name"),
     [("- one\n- two\n", "list"), ("just a string\n", "str"), ("42\n", "int")],

--- a/tests/unit/scripts/test_config_boundaries.py
+++ b/tests/unit/scripts/test_config_boundaries.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+
+from scripts.ci import check_config_boundaries as boundaries
+
+
+def _write(root: Path, relative: str, text: str) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_module_safe_load_call_is_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "import yaml as y\npayload = y.safe_load('key: value')\n",
+    )
+
+    violations = boundaries.scan_file(path, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert violations[0].path == "sbir_etl/example.py"
+
+
+def test_direct_safe_load_import_is_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "scripts/data/example.py",
+        "from yaml import safe_load as load\npayload = load('key: value')\n",
+    )
+
+    assert len(boundaries.scan_file(path, repository_root=tmp_path)) == 1
+
+
+def test_shared_reader_and_yaml_writes_are_allowed(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        "sbir_etl/example.py",
+        "import yaml\n"
+        "from sbir_etl.config.yaml_io import read_yaml_mapping\n"
+        "text = yaml.safe_dump({'key': 'value'})\n",
+    )
+
+    assert boundaries.scan_file(path, repository_root=tmp_path) == []
+
+
+def test_canonical_readers_and_tests_are_outside_the_guard(tmp_path: Path) -> None:
+    canonical = _write(
+        tmp_path,
+        "sbir_etl/config/yaml_io.py",
+        "import yaml\npayload = yaml.safe_load('key: value')\n",
+    )
+    test_file = _write(
+        tmp_path,
+        "tests/unit/test_fixture.py",
+        "import yaml\npayload = yaml.safe_load('key: value')\n",
+    )
+
+    assert boundaries.scan_file(canonical, repository_root=tmp_path) == []
+    assert boundaries.scan_file(test_file, repository_root=tmp_path) == []
+
+
+def test_current_repository_obeys_config_boundaries() -> None:
+    assert boundaries.scan_repository() == []


### PR DESCRIPTION
## What changed

- routes the seven production `yaml.safe_load` call sites through `read_yaml_mapping`
- adds an explicit `allow_empty=True` policy for callers that intentionally accept empty documents
- adds an AST boundary guard that rejects new direct production `yaml.safe_load` calls
- wires the guard into CI and `make lint-boundaries`
- updates the epistemic-tier steering readout to reflect the enforced contract

## Why

Configuration parsing had seven local implementations with subtly different failure and empty-file behavior. That was invisible divergence outside the existing configuration primitive.

## Impact

Production YAML mapping reads now share one error and type-validation boundary. Existing permissive callers retain their behavior through an explicit option, and future bypasses fail CI.

## Validation

- 99 focused unit tests passed
- baseline-registry and patent-keyword smoke checks passed
- Ruff check and format check passed
- configuration, repository-hygiene, identity, epistemic declaration, architecture, and tier boundary guards passed
- study manifest validation passed