### PR TITLE
Label tech census outputs non-citable

### DIFF
--- a/docs/research/massachusetts_unmanned_systems_sbir_readout.md
+++ b/docs/research/massachusetts_unmanned_systems_sbir_readout.md
@@ -1,5 +1,10 @@
 # Massachusetts Physical Unmanned-Systems SBIR/STTR Readout
 
+> **Exploratory / non-citable.** Use this readout for discovery, not as
+> evidence-tier support or an externally cited result. The 238-award reviewed
+> total cannot be regenerated until the original award-level review decisions
+> are reconstructed as a retained, auditable ledger.
+
 - **Data source:** SBIR.gov bulk `award_data.csv` local snapshot
 - **Source timestamp:** 2026-04-01T00:00:06.904233+00:00
 - **Source SHA-256:** `73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd`

--- a/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
+++ b/packages/sbir-analytics/sbir_analytics/tools/tech_census/compute_tech_census.py
@@ -66,7 +66,7 @@ class ComputeTechCensusTool(BaseTool):
     """Classify awards into a versioned technology profile and aggregate them."""
 
     name = "compute_tech_census"
-    version = "2.1.0"
+    version = "2.2.0"
 
     def execute(
         self,
@@ -181,6 +181,7 @@ class ComputeTechCensusTool(BaseTool):
         results_df = pd.DataFrame(result["classified_awards"])
 
         summary = {
+            "_epistemic": result["_epistemic"],
             "area_id": result["area_id"],
             "display_name": result["display_name"],
             "config_version": result["config_version"],
@@ -235,11 +236,14 @@ class ComputeTechCensusTool(BaseTool):
 
     @staticmethod
     def _empty_result(area_id: str) -> dict[str, Any]:
+        from sbir_etl.utils.tech_census import census_epistemic_metadata
+
         return {
             "award_count": 0,
             "award_dollars": 0.0,
             "results": pd.DataFrame(),
             "summary": {
+                "_epistemic": census_epistemic_metadata(),
                 "area_id": area_id,
                 "grand_total": {"n": 0, "usd": 0.0},
                 "fy_totals": {},

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -31,6 +31,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 CONFIG_DIR = REPO_ROOT / "config" / "tech_census"
 
 
+def census_epistemic_metadata() -> dict[str, Any]:
+    """Return the non-citable status that every census output must preserve."""
+
+    return {
+        "tier": EPISTEMIC_TIER,
+        "citable": False,
+        "notice": (
+            "Profile-driven technology classification is exploratory; "
+            "do not cite as an evidence-tier result."
+        ),
+    }
+
+
 class CensusAward(TypedDict, total=False):
     """Canonical award shape used by the census engine."""
 
@@ -536,6 +549,7 @@ def run_census(
             totals["usd"] = round(totals["usd"], 2)
 
     return {
+        "_epistemic": census_epistemic_metadata(),
         "area_id": compiled.area_id,
         "display_name": compiled.display_name,
         "config_version": compiled.version,

--- a/scripts/data/build_tech_census.py
+++ b/scripts/data/build_tech_census.py
@@ -121,6 +121,9 @@ def main() -> int:
             if normalize_state_code(award.get("state")) in selected_states
         ]
     result = run_census(reporting_awards, compiled, programs=args.programs)
+    epistemic = result["_epistemic"]
+    print("\nStatus: EXPLORATORY / NON-CITABLE")
+    print(f"  {epistemic['notice']}")
     grand = result["grand_total"]
     print(f"\nIn-scope awards: {grand['n']:,}  (${grand['usd'] / 1e6:,.1f}M)")
     if result["exclusion_counts"]:
@@ -220,6 +223,7 @@ def main() -> int:
     summary_path = out_dir / "summary.json"
     source_timestamp = _source_timestamp(awards_csv)
     json_safe = {
+        "_epistemic": result["_epistemic"],
         "area_id": result["area_id"],
         "display_name": result["display_name"],
         "grand_total": result["grand_total"],

--- a/tests/unit/scripts/test_build_tech_census.py
+++ b/tests/unit/scripts/test_build_tech_census.py
@@ -1,0 +1,57 @@
+import json
+import sys
+from pathlib import Path
+
+from scripts.data import build_tech_census as census_cli
+
+
+def test_cli_labels_console_and_summary_non_citable(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    awards_csv = tmp_path / "award_data.csv"
+    awards_csv.write_text("fixture\n", encoding="utf-8")
+    monkeypatch.setattr(census_cli, "DATA", tmp_path)
+    monkeypatch.setattr(
+        census_cli,
+        "load_award_data_csv",
+        lambda _path: [
+            {
+                "title": "Drone airframe prototype",
+                "abstract": "We will design and fabricate the airframe.",
+                "company": "Example Robotics",
+                "state": "MA",
+                "program": "SBIR",
+                "phase": "Phase II",
+                "award_year": 2025,
+                "award_amount": 500_000.0,
+                "agency_tracking_number": "TRACK-1",
+                "contract": "CONTRACT-1",
+                "source_row": 2,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build_tech_census.py",
+            "--area",
+            "drone_manufacturing",
+            "--awards",
+            str(awards_csv),
+        ],
+    )
+
+    assert census_cli.main() == 0
+
+    output = capsys.readouterr().out
+    assert "Status: EXPLORATORY / NON-CITABLE" in output
+    summary = json.loads(
+        (tmp_path / "tech_census" / "drone_manufacturing" / "summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert summary["_epistemic"]["tier"] == "exploratory"
+    assert summary["_epistemic"]["citable"] is False

--- a/tests/unit/tools/test_tech_census.py
+++ b/tests/unit/tools/test_tech_census.py
@@ -42,6 +42,7 @@ class TestComputeTechCensusTool:
     def test_empty_dataframe(self):
         tool = ComputeTechCensusTool()
         result = tool.run(awards_df=pd.DataFrame(), area_id="drone_manufacturing")
+        assert result.data["summary"]["_epistemic"]["citable"] is False
         assert result.data["summary"]["grand_total"] == {"n": 0, "usd": 0.0}
         assert "No awards data provided" in result.metadata.warnings
 
@@ -75,6 +76,8 @@ class TestComputeTechCensusTool:
         )
         result = tool.run(awards_df=df, area_id="drone_manufacturing")
         summary = result.data["summary"]
+        assert summary["_epistemic"]["tier"] == "exploratory"
+        assert summary["_epistemic"]["citable"] is False
         assert summary["grand_total"] == {"n": 2, "usd": 1_500_000.0}
         assert result.data["award_count"] == 2
         assert result.data["award_dollars"] == 1_500_000.0

--- a/tests/unit/utils/test_tech_census.py
+++ b/tests/unit/utils/test_tech_census.py
@@ -180,6 +180,14 @@ def test_run_census_aggregates_without_double_counting() -> None:
         ],
         _compiled(),
     )
+    assert result["_epistemic"] == {
+        "tier": "exploratory",
+        "citable": False,
+        "notice": (
+            "Profile-driven technology classification is exploratory; "
+            "do not cite as an evidence-tier result."
+        ),
+    }
     assert result["grand_total"] == {"n": 3, "usd": 350_000.0}
     assert result["subset_totals"]["Propulsion"] == {"n": 2, "usd": 300_000.0}
     assert result["fy_totals"][2025] == {"n": 1, "usd": 50_000.0}


### PR DESCRIPTION
## What changed

- adds a prominent exploratory/non-citable banner to the Massachusetts unmanned-systems readout
- emits canonical `_epistemic` metadata from the shared census engine
- preserves that metadata through successful and empty API results
- prints the status in the CLI and writes it into `summary.json`
- bumps the tech-census tool from 2.1.0 to 2.2.0 for the additive output contract

## Why

The census implementation was labeled exploratory in module prose, but generated results and the published Massachusetts readout did not reliably carry that status. The reviewed 238-award figure cannot currently be regenerated because its award-level review ledger was not retained.

## Impact

People reading or consuming a tech-census result now see `tier: exploratory` and `citable: false` at the output boundary, including zero-row/error results. This prevents a deterministic-but-contestable classifier result from being mistaken for evidence-tier output.

## Validation

- 57 focused tech-census core, API, and CLI tests passed
- Ruff check and format check passed
- repository-hygiene, epistemic-declaration, and tier-boundary guards passed
- `git diff --check` passed