### PR TITLE
Remove private residue from public documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: docs@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/_template.md
+++ b/docs/_template.md
@@ -1,6 +1,6 @@
 ---
 Type: <Tutorial|How-to|Explanation|Reference|Overview>
-Owner: <owner-email>
+Maintainer: <maintainer-name>
 Last-Reviewed: <YYYY-MM-DD>
 Status: <active|draft|deprecated|archived>
 

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -1,6 +1,6 @@
 ---
 Type: Architecture
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/archive/design/2026-07-29-awardee-first-procurement-packet-design.md
+++ b/docs/archive/design/2026-07-29-awardee-first-procurement-packet-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-29
 **Status:** Implemented; retained as the design record
-**Original branch:** `feat/awardee-first-procurement-packet` (merged through PR #466 follow-ups)
+**Implementation history:** PR #466 and follow-up PRs
 
 ## Problem
 
@@ -212,7 +212,6 @@ reproduces it (golden test) so future drift is caught.
 
 ## Consolidation
 
-This branch is built on `codex/pr450-address-comments` (PR #464), which already contains
-all of `agent/monthly-procurement-transition-report` (PR #450). A single PR against `main`
-will therefore carry all three bodies of work. PRs #450 and #464 will be closed with a
-pointer to the consolidated PR.
+This work was built on PR #464, which already contained the work from PR #450. A
+single PR against `main` therefore carried all three bodies of work. PRs #450 and
+#464 were superseded by the consolidated PR.

--- a/docs/archive/design/2026-07-30-why-it-connects-explanation-design.md
+++ b/docs/archive/design/2026-07-30-why-it-connects-explanation-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-30
 **Status:** Implemented; retained as the Phase 1/2 design record
-**Original branch:** `feat/awardee-first-procurement-packet` (PR #466 and follow-up phases)
+**Implementation history:** PR #466 and follow-up PRs
 
 ## Problem
 

--- a/docs/archive/development/cleanup-inventory.md
+++ b/docs/archive/development/cleanup-inventory.md
@@ -1,6 +1,6 @@
 ---
 Type: Reference
-Owner: devops@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-07-07
 Status: archived
 ---

--- a/docs/archive/enrichment/base-client-migration.md
+++ b/docs/archive/enrichment/base-client-migration.md
@@ -1,6 +1,6 @@
 # Enricher consolidation: BaseAsyncAPIClient migration
 
-Status as of 2026-04-13 · see branch `claude/repo-analysis-AYGBQ`
+Status as of 2026-04-13
 
 Short version: **8 of 10 enricher clients** now inherit from
 `sbir_etl.enrichers.base_client.BaseAsyncAPIClient`, sharing a single

--- a/docs/archive/research/capital-events-v1.md
+++ b/docs/archive/research/capital-events-v1.md
@@ -1,7 +1,6 @@
 # Capital-Event Timeline v1 — Results
 
 **Date:** 2026-05-17
-**Branch:** `claude/capital-events-timeline`
 **Cohort:** Form D high-confidence SBIR cohort (3,639 firms; produced by
 `sbir_etl/ucc/export_cohort.py` from PR #303)
 **Source code:** `scripts/data/build_capital_events.py` +

--- a/docs/commercialization-benchmark-methodology.md
+++ b/docs/commercialization-benchmark-methodology.md
@@ -6,11 +6,17 @@ It also documents where our methodology diverges from the authoritative SBA proc
 
 ## Implementation status — read this first
 
-The audit harness this doc describes (`run_commercialization_benchmark.py`, `audit_one_firm.py`, the FY2026 audited CSV at `reports/validation/commercialization_benchmark_eval_fy2026.csv`) is **local-only / not committed to this repo**. It exists on the author's machine and was used to produce the FY2026 figures cited below (143 cohort firms, 28 Tier-1/2 firms, 2 dual-penalty firms).
+The audit harness and FY2026 cohort used for the numerical results below are not
+committed. Those results cannot be independently reproduced from this
+repository and must not be treated as validated or citable outputs.
 
 The shippable counterpart on `main` is `scripts/run_benchmark.py` + `sbir_etl/models/benchmark_models.py`, which implements the same statutory framework (§638(qq) tier thresholds, 10-FY window, cohort selection) via a different CLI shape (`evaluate` / `sensitivity` / `company` subcommands). It does not currently produce per-firm audit JSON files or do the USAspending + Form D proxy substitution the harness does.
 
-This doc is committed as the **methodology record** so the audit-harness logic is auditable and reproducible, even before the harness itself ships. **Future work**: migrate the harness into `scripts/run_benchmark.py` (or alongside it under `packages/sbir-analytics/`) so the cited file paths resolve and the run is reproducible from `main`. See research-questions.md "Output products" section for the broader status.
+This document is retained as a **historical methodology record**. The described
+audit-harness logic is not auditable from the repository until it is migrated
+into `scripts/run_benchmark.py` (or alongside it under
+`packages/sbir-analytics/`) with committed fixtures and verification. See
+research-questions.md "Output products" for the broader status.
 
 ## Authoritative sources
 

--- a/docs/commercialization-benchmark-methodology.md
+++ b/docs/commercialization-benchmark-methodology.md
@@ -6,15 +6,19 @@ It also documents where our methodology diverges from the authoritative SBA proc
 
 ## Implementation status — read this first
 
-The audit harness and FY2026 cohort used for the numerical results below are not
-committed. Those results cannot be independently reproduced from this
-repository and must not be treated as validated or citable outputs.
+The audit harness is committed
+(`scripts/archive/data/run_commercialization_benchmark.py` and
+`scripts/data/audit_one_firm.py`), but the FY2026 cohort and the evaluation
+output it produced are not. The numerical results below therefore cannot be
+independently reproduced from this repository and must not be treated as
+validated or citable outputs.
 
 The shippable counterpart on `main` is `scripts/run_benchmark.py` + `sbir_etl/models/benchmark_models.py`, which implements the same statutory framework (§638(qq) tier thresholds, 10-FY window, cohort selection) via a different CLI shape (`evaluate` / `sensitivity` / `company` subcommands). It does not currently produce per-firm audit JSON files or do the USAspending + Form D proxy substitution the harness does.
 
-This document is retained as a **historical methodology record**. The described
-audit-harness logic is not auditable from the repository until it is migrated
-into `scripts/run_benchmark.py` (or alongside it under
+This document is retained as a **historical methodology record**. The committed
+harness makes its statutory and proxy logic auditable, but reproducing the
+FY2026 figures requires the missing cohort and evaluation output. Future work
+may migrate the harness into `scripts/run_benchmark.py` (or alongside it under
 `packages/sbir-analytics/`) with committed fixtures and verification. See
 research-questions.md "Output products" for the broader status.
 
@@ -121,7 +125,7 @@ Firms in the `increased_*` cohort (P2 ≥ 51) that also FAIL their `standard_net
 - §638(mm)(2): ineligible for Phase I awards for 1 year
 - §638(qq): capped at 20 SBIR/STTR awards per agency
 
-In our FY2026 run, 2 firms hit this dual-penalty state under net broad: **NanoSonic** (VA, tier 1, 69 P2) and **Nanohmics** (TX, tier 1, 54 P2). Both have ~95% of their federal revenue derived from their own SBIR P1+P2 awards and zero Form D capital. Under strict CCR the dual-penalty count expands materially.
+The historical FY2026 run reported 2 firms in this dual-penalty state under net broad: **NanoSonic** (VA, tier 1, 69 P2) and **Nanohmics** (TX, tier 1, 54 P2). At the time of that run, both had ~95% of their observed federal revenue derived from their own SBIR P1+P2 awards and zero matched Form D capital. Under the strict CCR calculation, the reported dual-penalty count expanded materially.
 
 ## Sales proxy: USAspending
 
@@ -146,13 +150,13 @@ Each cohort firm is matched on `UPPER(TRIM(company_name)) = UPPER(TRIM(firm))`. 
 - The filing's state matches the SBIR firm's USPS state code, **OR**
 - The Form D enricher tagged it `match_confidence.tier = "high"`
 
-This filter dropped 14 false-positive matches representing $421M of "investment" from an earlier unfiltered run. Final cohort match rate: **6 of 143 firms (4%)** have any Form D credit. All 6 are Standard tier; **zero Tier 1/2 firms have Form D credit**.
+This filter dropped 14 false-positive matches representing $421M of "investment" from an earlier unfiltered run. The historical final cohort match rate was **6 of 143 firms (4%)** with any Form D credit. All 6 were Standard tier; **zero Tier 1/2 firms had Form D credit**.
 
 **Known structural undercount**: Form D covers Reg D securities offerings only. Misses bank loans, convertible notes outside Reg D, M&A proceeds, foreign rounds, and companies that file 10-K instead (Luna Innovations is publicly traded). The CCR captures these via self-report; we cannot.
 
 ## Patents path: not implemented
 
-CCR Standard tier allows passing via ≥15% patents per P2 as an alternative to the dollar threshold. The script does not test this path because USPTO data on this branch is fixture-only — ingestion has not been run. None of our 115 Standard-tier passes need the patent path under our dollar calculation, but a firm we report as Standard FAIL could potentially be a patent-path PASS.
+CCR Standard tier allows passing via ≥15% patents per P2 as an alternative to the dollar threshold. The script does not test this path. At the time of the historical run, USPTO ingestion had not been run and only fixture data was available. None of the 115 reported Standard-tier passes needed the patent path under the historical dollar calculation, but a firm reported as Standard FAIL could potentially have been a patent-path PASS.
 
 ## Known divergences from the authoritative SBA process
 
@@ -166,7 +170,7 @@ CCR Standard tier allows passing via ≥15% patents per P2 as an alternative to 
 | `recipient_search_text` is full-text search, not strict UEI equality | Pre-UEI awards (with DUNS only) may be missed | DUNS→UEI mapping wasn't fully back-applied to USAspending; conservative undercount of older obligations |
 | No subaward inclusion | Misses subcontract revenue | `subawards=false` explicit in API call |
 | Other Transaction Authority (OTA) agreements not in FPDS/FABS | Misses DARPA OTA work | Acknowledged structural blind spot |
-| Two sequential USAspending queries on the same firm can return marginally different totals if the index updates between calls | Caused 1 of 143 firms (Lambda Science) to show `contracts_rd_usd` $826 higher than `contracts_fpds_usd` in our FY2026 run — a USAspending-side inconsistency | Script clamps `contracts_non_rd_val = max(contracts − contracts_rd, 0)`; effect on the affected firm's verdict was $0 (strict avg/P2 would have been $52 vs $100K threshold either way). Audit JSON files in `data/audit/fy2026/usaspending/<UEI>_*.json` preserve the source-of-truth API responses |
+| Two sequential USAspending queries on the same firm can return marginally different totals if the index updates between calls | Caused 1 of 143 firms (Lambda Science) to show `contracts_rd_usd` $826 higher than `contracts_fpds_usd` in the historical FY2026 run — a USAspending-side inconsistency | Script clamps `contracts_non_rd_val = max(contracts − contracts_rd, 0)`; effect on the affected firm's verdict was $0 (strict avg/P2 would have been $52 vs $100K threshold either way). Audit JSON files in `data/audit/fy2026/usaspending/<UEI>_*.json` preserve the source-of-truth API responses |
 
 ## Reproducibility
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 **Type**: Reference
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/data/README.md
+++ b/docs/data/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: docs@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/data/uspto-data-refresh.md
+++ b/docs/data/uspto-data-refresh.md
@@ -1,6 +1,6 @@
 ---
 Type: Operator Guide
-Owner: data-team
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/decisions/ADR-003-api-before-mcp.md
+++ b/docs/decisions/ADR-003-api-before-mcp.md
@@ -1,7 +1,7 @@
 ---
 
 Type: Decision
-Owner: data@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-07-12
 Status: superseded
 

--- a/docs/decisions/ADR-004-retire-private-analytics-api.md
+++ b/docs/decisions/ADR-004-retire-private-analytics-api.md
@@ -1,6 +1,6 @@
 ---
 Type: Decision
-Owner: data@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-04
 Status: accepted
 ---

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: docs@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-07-16
 Status: active
 

--- a/docs/decisions/_template.md
+++ b/docs/decisions/_template.md
@@ -1,7 +1,7 @@
 ---
 
 Type: Decision
-Owner: <owner-email>
+Maintainer: <maintainer-name>
 Last-Reviewed: <YYYY-MM-DD>
 Status: draft
 

--- a/docs/decisions/dspy-evaluation.md
+++ b/docs/decisions/dspy-evaluation.md
@@ -1,6 +1,6 @@
 ---
 Type: Evaluation
-Owner: data@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-07-16
 Status: prototype-recommended
 ---

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: docs@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-04
 Status: active
 ---

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: devops@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-04
 Status: active
 ---

--- a/docs/development/exception-handling.md
+++ b/docs/development/exception-handling.md
@@ -1,7 +1,7 @@
 # Exception Handling Guide
 
 **Type**: Reference
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 **Last-Reviewed**: 2025-01-04
 **Status**: Active
 

--- a/docs/development/logging-standards.md
+++ b/docs/development/logging-standards.md
@@ -1,7 +1,7 @@
 # Logging Standards
 
 **Type**: Reference
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 **Last-Updated**: 2025-11-05
 **Status**: Active
 

--- a/docs/development/spec-workflow-guide.md
+++ b/docs/development/spec-workflow-guide.md
@@ -1,6 +1,6 @@
 ---
 Type: Development Guide
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/enrichment/sam-gov-integration.md
+++ b/docs/enrichment/sam-gov-integration.md
@@ -2,7 +2,7 @@
 
 **Type**: Operator and Architecture Guide
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/guides/statistical-reporting.md
+++ b/docs/guides/statistical-reporting.md
@@ -1,6 +1,6 @@
 ---
 Type: Guide
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -1,6 +1,6 @@
 ---
 Type: Reference
-Owner: docs@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-01
 Status: active
 

--- a/docs/ml/cet-integration.md
+++ b/docs/ml/cet-integration.md
@@ -1,6 +1,6 @@
 ---
 Type: Subsystem Overview
-Owner: ml@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,6 +1,6 @@
 ---
 Type: Runbook
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -595,8 +595,8 @@ statutory goal is Phase III commercialization.*
   company-level CLI) backed by `sbir_etl/models/benchmark_models.py`, with tests
   in `tests/unit/test_benchmark_evaluator.py`.
   *Caveat:* the fuller methodology is committed, but its additional per-firm audit
-  infrastructure and FY2026 audited cohort remain local-only — see
-  [Output products](#commercialization-benchmark-methodology-committed-audit-harness-remains-local).
+  infrastructure and FY2026 cohort are not reproducible from this repository — see
+  [Output products](#commercialization-benchmark-methodology-historical-not-reproducible).
   *Deps: ER, ID, transitions, SEC EDGAR · Spec: [../specs/archive/completed-features/commercialization-benchmark/](../specs/archive/completed-features/commercialization-benchmark/)*
 
 ### B4. Predictive (Tier 4)
@@ -1037,9 +1037,9 @@ political-safety vetting. Vetting depth covers press review, SEC Form D filings,
 M&A history, and political-sensitivity factors (foreign ownership, classified
 work exposure, recent acquisition).
 
-**Districts covered to date** (in conversation; not yet committed as repo
-artifacts): KY-3 (McGarvey), NJ-10 (McIver), NY-16 (Latimer), NH-2 (Goodlander),
-MT-2 (Downing), TX-6 (Ellzey), plus a CNMI null finding for King-Hinds.
+No district briefing artifacts are committed. Until a reproducible briefing
+workflow and its evidence packet are present, this remains a proposed output
+rather than a repository capability.
 
 **Supporting code:** `sbir_etl/enrichers/congressional_district_resolver.py`
 (UEI → district resolver), `scripts/setup_congressional_districts.py` (district
@@ -1069,7 +1069,7 @@ program-wide private-capital leverage.
 **Pulls from:** F1 (Form D profile), F3 (private-to-SBIR leverage), A1/A4
 (DoD-specific firm-health and acquisition decomposition).
 
-### Commercialization-benchmark methodology (committed; audit harness remains local)
+### Commercialization-benchmark methodology (historical, not reproducible)
 
 **Audience:** SBA program oversight, statutory compliance reviewers, GAO.
 
@@ -1078,17 +1078,15 @@ is committed and documents the §638(qq)(3) statutory framework, FY2026 evaluati
 method, data-source provenance (FPDS/USAspending contracts, SEC Form D investment,
 and SBIR.gov FABS grants), and per-firm audit protocol.
 
-The methodology doc pairs with a per-firm audit harness
-(`scripts/archive/data/run_commercialization_benchmark.py` and
-`scripts/data/audit_one_firm.py`) and an FY2026 audited cohort CSV — all of which
-are **local-only / uncommitted** on the author's machine. The shippable
-counterpart on `main` is `scripts/run_benchmark.py` plus
+The methodology document refers to an audit harness and FY2026 cohort that are
+not committed and therefore cannot be independently reviewed or reproduced.
+Its numerical results are historical context, not citable repository outputs.
+The maintained counterpart is `scripts/run_benchmark.py` plus
 `sbir_etl/models/benchmark_models.py`, which implements the same statutory
 framework through a different CLI shape.
 
-The methodology is reviewable, but the local audit harness and FY2026 audited
-cohort are still not reproducible from `main`. Migrating that harness into the
-maintained CLI remains the coverage gap.
+Migrating the missing audit behavior into the maintained CLI, with committed
+synthetic fixtures and validation checks, remains the coverage gap.
 
 **Pulls from:** B3 (transition effectiveness and the §638(qq) benchmark
 question), F1 (Form D investment signal), F2 (NVCA-baseline comparison).

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: research@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/research/sbir-ma-exit-analysis.md
+++ b/docs/research/sbir-ma-exit-analysis.md
@@ -1,7 +1,6 @@
 # SBIR Company M&A Exit Analysis
 
 **Date:** 2026-04-23
-**Branch:** `claude/sbir-ma-exit-analysis`
 **Research question:** A4 (M&A activity detection)
 
 ## Summary

--- a/docs/research/sec-edgar-sbir-learnings.md
+++ b/docs/research/sec-edgar-sbir-learnings.md
@@ -1,7 +1,6 @@
 # SEC EDGAR Enrichment for SBIR Companies — Learnings
 
 **Date:** 2026-04-19/22
-**Branch:** `claude/integrate-sec-edgar-sbir-6Krd1`
 **PR:** #227
 
 ## What We Built

--- a/docs/schemas/neo4j.md
+++ b/docs/schemas/neo4j.md
@@ -1,7 +1,7 @@
 ---
 
 Type: Reference
-Owner: data@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-06-26
 Status: active
 

--- a/docs/steering/data-quality.md
+++ b/docs/steering/data-quality.md
@@ -1,6 +1,6 @@
 ---
 Type: Steering
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/steering/enrichment-patterns.md
+++ b/docs/steering/enrichment-patterns.md
@@ -1,6 +1,6 @@
 ---
 Type: Steering
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/steering/product.md
+++ b/docs/steering/product.md
@@ -1,6 +1,6 @@
 ---
 Type: Steering
-Owner: research@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/steering/structure.md
+++ b/docs/steering/structure.md
@@ -1,6 +1,6 @@
 ---
 Type: Steering
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -1,6 +1,6 @@
 ---
 Type: Steering
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -1,6 +1,6 @@
 ---
 Type: Overview
-Owner: docs@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/docs/testing/categorization-testing.md
+++ b/docs/testing/categorization-testing.md
@@ -2,7 +2,7 @@
 
 **Type**: Testing Guide
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -2,7 +2,7 @@
 
 **Type**: Testing Guide
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/testing/test-scheduling.md
+++ b/docs/testing/test-scheduling.md
@@ -2,7 +2,7 @@
 
 **Type**: Testing Guide
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/testing/test-suite-inventory.md
+++ b/docs/testing/test-suite-inventory.md
@@ -2,7 +2,7 @@
 
 **Type**: Reference
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/testing/validation-testing.md
+++ b/docs/testing/validation-testing.md
@@ -2,7 +2,7 @@
 
 **Type**: Operator Guide
 
-**Owner**: Engineering Team
+**Maintainer**: Conrad Hollomon
 
 **Last-Reviewed**: 2026-08-03
 

--- a/docs/transition/cet-integration.md
+++ b/docs/transition/cet-integration.md
@@ -1,6 +1,6 @@
 ---
 Type: Integration Note
-Owner: ml@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: limited
 ---

--- a/docs/transition/overview.md
+++ b/docs/transition/overview.md
@@ -1,6 +1,6 @@
 ---
 Type: Subsystem Overview
-Owner: engineering@project
+Maintainer: Conrad Hollomon
 Last-Reviewed: 2026-08-03
 Status: active
 ---

--- a/scripts/phase3_groundtruth/score_t6.py
+++ b/scripts/phase3_groundtruth/score_t6.py
@@ -53,7 +53,7 @@ from sbir_ml.transition.detection.fusion_scoring import (  # noqa: E402
 
 EPISTEMIC_TIER = "exploratory"
 
-DATA_ROOT = Path(os.getenv("SBIR_ETL__PATHS__DATA_ROOT", _WORKTREE_ROOT / "data"))
+DATA_ROOT = Path(os.getenv("SBIR_ETL__PATHS__DATA_ROOT", "data"))
 DEFAULT_AWARD_DATA = DATA_ROOT / "raw" / "sbir" / "award_data.csv"
 DEFAULT_UNIVERSE = DATA_ROOT / "processed" / "sbir_phase3" / "phase3_universe.jsonl"
 DEFAULT_CORPUS = DATA_ROOT / "derived" / "phase3_notice_corpus.parquet"

--- a/scripts/phase3_groundtruth/score_t6.py
+++ b/scripts/phase3_groundtruth/score_t6.py
@@ -22,6 +22,7 @@ through the evidence-tier contract of specs/phase3-transition-groundtruth.
 import argparse
 import csv
 import json
+import os
 import random
 import re
 import sys
@@ -52,13 +53,10 @@ from sbir_ml.transition.detection.fusion_scoring import (  # noqa: E402
 
 EPISTEMIC_TIER = "exploratory"
 
-REPO_MAIN = Path("/Users/hollomancer/projects/sbir-analytics")
-DEFAULT_AWARD_DATA = REPO_MAIN / "data" / "raw" / "sbir" / "award_data.csv"
-DEFAULT_UNIVERSE = REPO_MAIN / "data" / "processed" / "sbir_phase3" / "phase3_universe.jsonl"
-DEFAULT_CORPUS = Path(
-    "/Users/hollomancer/projects/sbir-analytics/.claude/worktrees/"
-    "notice-corpus-fusion-spec/data/derived/phase3_notice_corpus.parquet"
-)
+DATA_ROOT = Path(os.getenv("SBIR_ETL__PATHS__DATA_ROOT", _WORKTREE_ROOT / "data"))
+DEFAULT_AWARD_DATA = DATA_ROOT / "raw" / "sbir" / "award_data.csv"
+DEFAULT_UNIVERSE = DATA_ROOT / "processed" / "sbir_phase3" / "phase3_universe.jsonl"
+DEFAULT_CORPUS = DATA_ROOT / "derived" / "phase3_notice_corpus.parquet"
 SPEC_DIR = _WORKTREE_ROOT / "specs" / "phase3-transition-groundtruth"
 COLLECTED_DIR = SPEC_DIR / "collected"
 

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -59,7 +59,7 @@ not "what would seed VCs alone do."
 
 This spec was originally drafted under the assumption that EDGAR ingest, Form
 D parsing, CIK resolution, and M&A signal extraction were all greenfield work.
-That assumption was wrong. **PR #286 (`claude/sbir-ma-exit-analysis`) builds
+That assumption was wrong. **PR #286 builds
 all of that infrastructure** and was discovered mid-spec:
 
 - `sbir_etl/enrichers/sec_edgar/{client,enricher,form_d_scoring}.py` — full

--- a/specs/archive/completed-features/unify-company-into-organization/design.md
+++ b/specs/archive/completed-features/unify-company-into-organization/design.md
@@ -88,7 +88,7 @@ One Cypher check: `count(:Company)` == orphan count (ideally 0); a sampled
 | Orphan `:Company` deleted | Med | Log + leave unmatched `:Company` (no blind delete) |
 | Property name collision on merge | Low | Inventory in task 1; distinct namespaces; exclude `__`-prefixed |
 | Coverage drop (categorization for a firm not yet an `:Organization`) | Low | Same as Phase 1 award reasoning — categorization is keyed on SBIR-recipient UEIs, which the SBIR loader writes as `:Organization`; orphans logged |
-| Depends on PR #379 (Phase 1 primitive) | — | Stack on `claude/unify-graph-node-labels`; rebase onto main once #379 merges |
+| Depends on PR #379 (Phase 1 primitive) | — | Stack on PR #379; rebase onto main once it merges |
 
 ## Deferred
 

--- a/specs/dark-majority-resolution/tasks.md
+++ b/specs/dark-majority-resolution/tasks.md
@@ -76,7 +76,7 @@ Sequencing rationale in `requirements.md`. Effort tags: S (<half day), M (1–2 
   enriched_sbir_ma_events.jsonl, and the Finding 2 prime registry — invisible to all
   three). Six conclusions total (was five).
 
-- [x] **T21 (S, addendum, 2026-07-12, branch claude/nanotech-maintenance-fee-lapses):**
+- [x] **T21 (S, addendum, 2026-07-12):**
   Patent maintenance-fee lapse check — the first weak-negative instrument in the plan
   (every prior WS3/5/6 channel is a positive detector that can only raise the floor).
   → `scripts/data/nano_dark_firm_maintenance_lapses.py`, USPTO PTMNFEE2 (single latest
@@ -92,7 +92,7 @@ Sequencing rationale in `requirements.md`. Effort tags: S (<half day), M (1–2 
   use is ranking the T11 survey's priority stratum, not moving the headline percentages.
   Report: new Finding 3 paragraph, methodological note, and a sentence in the "measurement
   lesson" closing paragraph. Opened as an isolated branch/PR per user request, based on
-  the tip of claude/nanotech-sbir-analysis (PR #428) so the shared liveness/alias
+  PR #428 so the shared liveness/alias
   infrastructure is available without re-deriving it.
 
 - [ ] **T7 (M, WS3.3) — DEFERRED (2026-07-12):** State corporate registry status for dark

--- a/specs/ma-discovery-integration/design.md
+++ b/specs/ma-discovery-integration/design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft for review.
 **Date:** 2026-06-26.
-**Relates to:** [`specs/archive/completed-features/merger_acquisition_detection/`](../archive/completed-features/merger_acquisition_detection/design.md) (existing Form D + EFTS detection), [`sbir_etl/capital_events/sources/ma_events.py`](../../sbir_etl/capital_events/sources/ma_events.py) (downstream consumer), local branch `chore/ma-discovery-toolkit` (scaffolded toolkit, never merged) preserved in draft PR [#371](https://github.com/hollomancer/sbir-analytics/pull/371).
+**Relates to:** [`specs/archive/completed-features/merger_acquisition_detection/`](../archive/completed-features/merger_acquisition_detection/design.md) (existing Form D + EFTS detection), [`sbir_etl/capital_events/sources/ma_events.py`](../../sbir_etl/capital_events/sources/ma_events.py) (downstream consumer), and the unmerged toolkit scaffold preserved in draft PR [#371](https://github.com/hollomancer/sbir-analytics/pull/371).
 
 ## Why
 
@@ -14,7 +14,7 @@ A web-search-based discovery path can recover some of those, but only if the row
 
 The capital-events builder at `sbir_etl/capital_events/sources/ma_events.py:13-55` reads `data/enriched_sbir_ma_events.jsonl` and filters on `confidence in {"high", "medium"}` (string tier, not a numeric score). The pipeline shape is fixed; discovery must conform to it.
 
-Note: `detect_sbir_ma_events.py` writes `data/sbir_ma_events.jsonl`; the builder reads `data/enriched_sbir_ma_events.jsonl`. **No script in this branch produces the enriched file** — the press-wire enrichment step (`SyncPressWireClient` in `sbir_etl/enrichers/press_wire.py`) exists as a library but is not wired into a standalone CLI. The diagram below treats `enrich_ma_with_press.py` as a **to-be-added** component; discovery integration assumes this enrichment glue lands as part of (or before) the discovery implementation PR.
+Note: `detect_sbir_ma_events.py` writes `data/sbir_ma_events.jsonl`; the builder reads `data/enriched_sbir_ma_events.jsonl`. **No committed script produces the enriched file** — the press-wire enrichment step (`SyncPressWireClient` in `sbir_etl/enrichers/press_wire.py`) exists as a library but is not wired into a standalone CLI. The diagram below treats `enrich_ma_with_press.py` as a **to-be-added** component; discovery integration assumes this enrichment glue lands as part of (or before) the discovery implementation PR.
 
 **Adopted: option C with collision rule C3.**
 
@@ -57,7 +57,7 @@ Rows that fail company-name match outright are not written. The LLM extractor's 
 
 ## MAEvent model — fix the `confidence` field
 
-The toolkit's `MAEvent.confidence: str` field on the `chore/ma-discovery-toolkit` branch has no derivation logic (description says "derived from the score" but every caller has to set it manually). Replace with a Pydantic `@computed_field` over `confidence_score`:
+The toolkit's `MAEvent.confidence: str` field in draft PR #371 has no derivation logic (description says "derived from the score" but every caller has to set it manually). Replace with a Pydantic `@computed_field` over `confidence_score`:
 
 ```python
 class MAEvent(BaseModel):
@@ -76,7 +76,7 @@ class MAEvent(BaseModel):
 
 **File-contract requirement.** The capital-events builder filters on the string-typed `confidence` tier (`_KEEP_CONFIDENCES = {"high", "medium"}`); it does not read a numeric score. Discovery must emit the string `confidence` tier in each row of `enriched_sbir_ma_events.jsonl` — internally derived from `confidence_score` via the `@computed_field` above, but the on-disk contract is the tier, not the score. The `≥ 0.45` threshold above is therefore an *internal* starting point; the builder-level inclusion bar is `confidence in {"high", "medium"}`.
 
-**Threshold alignment requirement.** The preserved toolkit branch in PR #371 currently maps `confidence_score` to tiers at different cutoffs (`high >= 0.8`, `medium >= 0.5`) via a model validator. Do not land the confidence-field cleanup until the implementation branch either adopts the provisional `0.75 / 0.45` cutoffs in this design or explicitly replaces them with empirically calibrated thresholds. The important invariant is that every producer writes the same string tier for the same numeric score before rows reach `capital_events.parquet`.
+**Threshold alignment requirement.** The toolkit preserved in PR #371 currently maps `confidence_score` to tiers at different cutoffs (`high >= 0.8`, `medium >= 0.5`) via a model validator. Do not land the confidence-field cleanup until the implementation either adopts the provisional `0.75 / 0.45` cutoffs in this design or explicitly replaces them with empirically calibrated thresholds. The important invariant is that every producer writes the same string tier for the same numeric score before rows reach `capital_events.parquet`.
 
 ## Triggering & cost
 

--- a/specs/phase3-match-benchmark/inputs/vehicle_mse_result.json
+++ b/specs/phase3-match-benchmark/inputs/vehicle_mse_result.json
@@ -1,7 +1,7 @@
 {
   "inputs": {
-    "/Users/hollomancer/projects/sbir-analytics/data/derived/m0a_coded_dod.parquet": "42207a95a341e4b3256c3223514b56a5071341a0e2050d4078000564f8ce3120",
-    "/Users/hollomancer/projects/sbir-analytics/data/derived/m0a_desc_phase3_dod.parquet": "e803b5fd083072f489f65ead8bcc22e5744117b1f6ac05989d26674f3ea26175",
+    "data/derived/m0a_coded_dod.parquet": "42207a95a341e4b3256c3223514b56a5071341a0e2050d4078000564f8ce3120",
+    "data/derived/m0a_desc_phase3_dod.parquet": "e803b5fd083072f489f65ead8bcc22e5744117b1f6ac05989d26674f3ea26175",
     "specs/phase3-match-benchmark/inputs/vehicle149_children.json": "7b8cfa0a128612dc2d86bd796c4ef9831a276bc7a332656c124a192f98094ffc"
   },
   "n_units_observed": 6712,

--- a/specs/phase3-match-benchmark/mse-dark-phase3.md
+++ b/specs/phase3-match-benchmark/mse-dark-phase3.md
@@ -86,8 +86,8 @@ code and the description text** — the property MSE needs.
 
 ## Validation — the gold-standard tie-in
 
-The blind hand-adjudication (`~/Documents/phase3_adjudication_*`) is the external check: (a) it measures each
-list's **precision** (are flagged contracts really Phase III?), and (b) adjudicating a random sample of
+The external `phase3_adjudication_*` hand-adjudication artifacts are the independent check: (a) they measure
+each list's **precision** (are flagged contracts really Phase III?), and (b) adjudicating a random sample of
 **un-flagged** DoD contracts directly estimates the false-negative rate → an *independent* read on the dark
 cell to cross-check the MSE extrapolation. If the direct sample and the MSE disagree, the model assumptions
 are wrong and we learn which.

--- a/specs/phase3-notice-corpus-fusion/requirements.md
+++ b/specs/phase3-notice-corpus-fusion/requirements.md
@@ -2,7 +2,7 @@
 
 **Target epistemic tier:** `evidence`
 
-> **Status:** Implemented (T1–T7 done — see `tasks.md`). This branch ships a production
+> **Status:** Implemented (T1–T7 done — see `tasks.md`). The implementation ships a production
 > scoring path: coefficients are frozen at
 > `packages/sbir-ml/sbir_ml/transition/detection/fusion_coefficients.json` and the monthly
 > procurement packet consumes them, which **changes packet ordering** (strongest match
@@ -52,8 +52,7 @@ here rather than quietly dropped:
 ## Background
 
 The transition-ranker study (commit `2bc346a6`; findings in
-`specs/phase3-match-benchmark/transition-ranker.md` on branch
-`codex/phase3-methodology-hardening`, not yet on `main`) produced the strongest
+`specs/phase3-match-benchmark/transition-ranker.md`) produced the strongest
 candidate-selection result in the repo: award-level retrieval
 **AUC 0.844** (95% CI [0.800, 0.886]) from sparse word TF-IDF fused with orthogonal
 structural features (char-n-gram, temporal soft-gap, identifier cross-ref, NAICS,
@@ -66,8 +65,8 @@ because its **training substrate is not in the repo**:
   July 2026 benchmark sessions from GSA's `falextracts` Contract-Opportunities
   archive (`aws s3 cp`) and linked firm↔notice via FPDS `VENDOR_UEI` and
   Sol#+PIID joins (33/849 solicitations recovered over a 10-year window).
-- Only derived outputs were committed (the scoring core and findings on the
-  hardening branch; local benchmark parquets under `data/derived/` are gitignored
+- Only derived outputs were committed (the scoring core and findings; local
+  benchmark parquets under `data/derived/` are gitignored
   per `/data/*`, so no notice text is in version control). The corpus and recovery
   scripts were not committed to `main`.
 - The ranker findings parked productionization under **#442** ("external evidence


### PR DESCRIPTION
## Summary

- replace synthetic team aliases with accountable maintainer metadata
- remove transient AI branch names and personal absolute paths from public artifacts
- relabel uncommitted commercialization results as historical and non-citable
- make the Phase III T6 scorer resolve inputs from the repository's existing data-root environment contract

## Why

Public documentation should describe artifacts an outside reviewer can inspect and reproduce. Branch names, workstation paths, and uncommitted local analyses make canonical docs look like an internal scratchpad and overstate the evidence available in the repository.

## Impact

No analytical behavior changes. The T6 script's defaults are now portable; callers can override the data root with `SBIR_ETL__PATHS__DATA_ROOT`.

## Verification

- `make docs-check`
- `pytest tests/unit/phase3_groundtruth/test_score_t6.py -q` — 5 passed
- Ruff check and format check for `score_t6.py`
- `git diff --check`