### PR TITLE
Make fiscal runtime claims truthful

### DIFF
--- a/docs/architecture/dagster-pipelines.md
+++ b/docs/architecture/dagster-pipelines.md
@@ -52,7 +52,7 @@ import, its job is replaced by an empty **placeholder** job (name suffixed
 | Job (`name`) | Selection | Notes |
 |---|---|---|
 | `cet_full_pipeline_job` | 8 CET keys (classifications, profiles, Neo4j CET nodes/edges) | Ships run config (parquet/json paths, `batch_size: 1000`, create constraints/indexes) |
-| `fiscal_returns_mvp_job` | 9 fiscal keys (NAICS→BEA, inflation, economic/tax) | Exploratory Python/BEA model; needs at least 8 GB RAM |
+| `fiscal_returns_mvp_job` | 9 fiscal keys (NAICS→BEA, inflation, economic/tax) | Exploratory Python/BEA model; memory requirement is not yet measured |
 | `fiscal_returns_full_job` | asset groups `fiscal_data_prep`, `economic_modeling`, `tax_calculation`, `sensitivity_analysis` | Full fiscal run incl. sensitivity sweep |
 | `modernbert_job` | ModernBERT award/patent embeddings + similarity | Requires ML extras |
 | `uspto_ai_extraction_job` | USPTO AI extract + dedup + human sample | — |

--- a/docs/architecture/dagster-pipelines.md
+++ b/docs/architecture/dagster-pipelines.md
@@ -52,7 +52,7 @@ import, its job is replaced by an empty **placeholder** job (name suffixed
 | Job (`name`) | Selection | Notes |
 |---|---|---|
 | `cet_full_pipeline_job` | 8 CET keys (classifications, profiles, Neo4j CET nodes/edges) | Ships run config (parquet/json paths, `batch_size: 1000`, create constraints/indexes) |
-| `fiscal_returns_mvp_job` | 9 fiscal keys (NAICS→BEA, inflation, economic/tax) | R/StateIO; needs at least 8 GB RAM |
+| `fiscal_returns_mvp_job` | 9 fiscal keys (NAICS→BEA, inflation, economic/tax) | Exploratory Python/BEA model; needs at least 8 GB RAM |
 | `fiscal_returns_full_job` | asset groups `fiscal_data_prep`, `economic_modeling`, `tax_calculation`, `sensitivity_analysis` | Full fiscal run incl. sensitivity sweep |
 | `modernbert_job` | ModernBERT award/patent embeddings + similarity | Requires ML extras |
 | `uspto_ai_extraction_job` | USPTO AI extract + dedup + human sample | — |

--- a/docs/fiscal/sbir-fiscal-pipeline-guide.md
+++ b/docs/fiscal/sbir-fiscal-pipeline-guide.md
@@ -70,7 +70,7 @@ impacts = calculator.calculate_impacts_from_sbir_awards(awards_df)
 # - award_total (sum of SBIR awards)
 # - production_impact (economic multiplier)
 # - wage_impact, tax_impact, jobs_created
-# - model_version, confidence, quality_flags
+# - model_version, quality_flags
 ```
 
 ### Summary Statistics
@@ -103,7 +103,6 @@ sector_summary = calculator.calculate_summary_by_sector(impacts)
 | consumption_impact | Consumption effects | Dollars |
 | jobs_created | Employment created | Count |
 | model_version | Economic model version | String |
-| confidence | Confidence score (0-1) | Float |
 | quality_flags | Data quality indicators | String |
 
 ### Quality Flags
@@ -302,8 +301,10 @@ high_quality = impacts[
     impacts["quality_flags"].str.contains("stateio_ratios")
 ]
 
-# Check confidence scores
-reliable = impacts[impacts["confidence"] > 0.7]
+# Keep only rows backed by a successful BEA computation
+bea_backed = impacts[
+    impacts["quality_flags"].isin(["bea_api_with_ratios", "bea_api_default_ratios"])
+]
 ```
 
 ## Troubleshooting
@@ -329,23 +330,26 @@ Warning: No BEA mapping found for NAICS 999999
 
 **Solution**: Check NAICS code validity or provide custom concordance
 
-### Low Confidence Scores
+### Placeholder Computation
 
 ```console
-Average Confidence Score: 0.40
+Warning: BEA_API_KEY not set. Adapter will use placeholder computation.
 ```
 
-**Causes**:
+`confidence` is not emitted: the prior fixed values were not calibrated quality
+scores. Use `quality_flags` to distinguish BEA-backed rows from placeholders.
 
-- BEA data unavailable for requested year
-- Fallback to default ratios
+**Causes of placeholder output**:
+
+- BEA data unavailable for the requested year
+- BEA request failure
 - BEA API key not configured
 
 **Solutions**:
 
 - Set BEA_API_KEY environment variable
 - Use a year with available BEA I-O tables (2017-2022 typically available)
-- Accept lower precision or exclude low-confidence records
+- Exclude `placeholder_computation` rows from analytical use
 
 ## References
 

--- a/examples/README_FISCAL_EXAMPLE.md
+++ b/examples/README_FISCAL_EXAMPLE.md
@@ -43,13 +43,24 @@ input-output tables. Its tax and employment estimates remain exploratory and
 non-citable; see the epistemic-tier declaration in
 `sbir_etl/transformers/sbir_fiscal_pipeline.py`.
 
-Both examples expect awards with these columns:
+When `BEA_API_KEY` is absent, or a BEA request fails, this path falls back to
+hard-coded placeholder multipliers. Check `quality_flags`: only
+`bea_api_with_ratios` and `bea_api_default_ratios` identify BEA-backed rows;
+`placeholder_computation` is illustrative fallback output.
 
-- `award_id`
+The Python and mock calculator examples require these award columns:
+
 - `award_amount`
 - `state`
 - `naics_code`
 - `fiscal_year`
 
+The district example additionally requires `company_address`, `company_city`,
+`company_state`, and `company_zip` for geographic resolution. Its sample also
+includes `award_id` and `company_name` for readability, but neither calculator
+requires them.
+
 For the project-wide evidence boundaries, see the
 [research output status index](../docs/research/README.md).
+For the fiscal pipeline schema and quality flags, see the
+[fiscal pipeline guide](../docs/fiscal/sbir-fiscal-pipeline-guide.md).

--- a/examples/README_FISCAL_EXAMPLE.md
+++ b/examples/README_FISCAL_EXAMPLE.md
@@ -1,218 +1,55 @@
-# SBIR Fiscal Impact Example
+# SBIR Fiscal Impact Examples
 
-This directory contains examples demonstrating the SBIR fiscal impact analysis pipeline.
+These examples demonstrate the shape of the exploratory fiscal-impact pipeline.
+They are integration aids, not validated economic findings.
 
-## Files
+## Examples
 
-- **`sbir_fiscal_impact_example.py`** - Full example requiring R and StateIO packages
-- **`sbir_fiscal_impact_example_mock.py`** - Demo version using mock economic multipliers (no R required)
+- `sbir_fiscal_impact_example.py` exercises the current Python implementation,
+  which uses BEA input-output data when `BEA_API_KEY` is configured.
+- `sbir_fiscal_impact_example_mock.py` uses hand-authored multipliers so the data
+  flow can be inspected without network access. Its numerical outputs are
+  illustrative and must not be cited.
+- `sbir_fiscal_impact_by_district_example.py` demonstrates how the mock output
+  can be grouped geographically. It carries the same evidence limitation.
 
-## Quick Start (Mock Version - No R Required)
+The repository no longer ships an R, StateIO, or USEEIOR runtime. Docker Compose
+does not install those tools, and there is no `r` dependency extra.
 
-The mock version provides a demonstration of the pipeline without requiring R installation:
+## Run the deterministic demonstration
+
+From a development checkout:
 
 ```bash
-# Ensure dependencies are installed
-uv sync
-
-# Run the mock example
+make install
 .venv/bin/python examples/sbir_fiscal_impact_example_mock.py
 ```
 
-The mock version uses simplified economic multipliers to demonstrate the pipeline flow. It's perfect for:
+The mock implementation uses simplified sector multipliers and emits
+`quality_flags=mock_data`. It is useful for inspecting schemas, aggregation,
+and reporting behavior only.
 
-- Understanding how the pipeline works
-- Testing integration with your SBIR data
-- Development and debugging without R setup
+## Run the current BEA-backed implementation
 
-## Running with Real Economic Models (Docker)
-
-For actual fiscal impact calculations using EPA's USEEIOR and StateIO packages, use Docker:
-
-### Prerequisites
-
-- Docker and Docker Compose installed
-- 4GB+ available RAM
-
-### Steps
-
-1. **Build the Docker image** (includes R and all required packages):
+Register for a BEA API key, export it, and run:
 
 ```bash
-docker compose --profile dev build
-```
-
-1. **Start the services**:
-
-```bash
-docker compose --profile dev up -d
-```
-
-1. **Run the real example inside the container**:
-
-```bash
-docker compose exec dagster-webserver python examples/sbir_fiscal_impact_example.py
-```
-
-The Docker image includes:
-
-- R runtime
-- EPA StateIO package (`USEPA/stateior`)
-- EPA USEEIOR package (`USEPA/useeior`)
-- rpy2 Python-R bridge
-- All required R dependencies
-
-## Running with Local R Installation
-
-If you prefer running outside Docker, you need to install R and the required packages:
-
-### 1. Install R
-
-**Ubuntu/Debian:**
-
-```bash
-sudo apt-get install r-base r-base-dev
-```
-
-**macOS:**
-
-```bash
-brew install r
-```
-
-**Windows:**
-Download from <https://www.r-project.org/>
-
-### 2. Install R Packages
-
-Open R and run:
-
-```r
-install.packages('remotes')
-remotes::install_github('USEPA/stateior')
-remotes::install_github('USEPA/useeior')
-```
-
-### 3. Install Python Dependencies
-
-```bash
-uv sync --extra r
-```
-
-### 4. Run the Example
-
-```bash
+export BEA_API_KEY=replace-with-your-key
 .venv/bin/python examples/sbir_fiscal_impact_example.py
 ```
 
-## Understanding the Output
+The current calculator maps NAICS codes to BEA sectors and applies national
+input-output tables. Its tax and employment estimates remain exploratory and
+non-citable; see the epistemic-tier declaration in
+`sbir_etl/transformers/sbir_fiscal_pipeline.py`.
 
-Both examples produce the following outputs:
+Both examples expect awards with these columns:
 
-### Detailed Impacts
+- `award_id`
+- `award_amount`
+- `state`
+- `naics_code`
+- `fiscal_year`
 
-Shows economic impacts by state and BEA sector:
-
-- **award_total**: Total SBIR funding for state/sector
-- **production_impact**: Total economic output (GDP contribution)
-- **wage_impact**: Labor income generated
-- **tax_impact**: Tax revenue (federal + state)
-- **jobs_created**: Employment created (full-time equivalents)
-
-### State-Level Summary
-
-Aggregates impacts by state to show regional economic effects.
-
-### Sector-Level Summary
-
-Aggregates impacts by industry sector (BEA classification).
-
-### Key Metrics
-
-- **Production Multiplier**: Total economic output per dollar of SBIR investment
-  - Typical range: 1.5x - 3.0x depending on sector
-- **Tax Revenue Multiplier**: Tax revenue per dollar invested
-  - Typical range: $0.10 - $0.30 per dollar
-- **Jobs per $1M**: Employment created per million dollars invested
-  - Typical range: 5-15 jobs per $1M
-
-## Differences Between Mock and Real Versions
-
-| Feature | Mock Version | Real Version (R + StateIO) |
-|---------|-------------|---------------------------|
-| R Installation | Not required | Required |
-| Economic Model | Simplified multipliers | EPA USEEIOR/StateIO |
-| Accuracy | Demonstration only | Research-grade |
-| Speed | Fast (~1 second) | Slower (10-60 seconds) |
-| Sector-specific | Basic variation | Detailed 71-sector I-O tables |
-| Regional variation | None | State-specific models |
-| Use case | Development, testing | Production, research |
-
-## Customizing for Your Data
-
-To use with your own SBIR data:
-
-1. **Load your awards data** into a DataFrame with these required columns:
-   - `award_id`: Unique identifier
-   - `award_amount`: Dollar amount
-   - `state`: Two-letter state code (e.g., "CA")
-   - `naics_code`: NAICS industry code (2-6 digits)
-   - `fiscal_year`: Year of award
-
-2. **Replace the sample data** in the example:
-
-```python
-# Instead of:
-awards = create_sample_sbir_awards()
-
-# Use your data:
-awards = pd.read_csv("your_sbir_data.csv")
-```
-
-1. **Run the calculator**:
-
-```python
-calculator = SBIRFiscalImpactCalculator()
-impacts = calculator.calculate_impacts_from_sbir_awards(awards)
-```
-
-## Troubleshooting
-
-### "rpy2 is not installed" Error
-
-- **Solution 1** (Recommended): Use Docker (see above)
-- **Solution 2**: Install R and run `uv sync --extra r`
-- **Solution 3**: Use the mock version for development
-
-### R Package Installation Fails
-
-If StateIO/USEEIOR installation fails in R:
-
-```r
-# Try installing dependencies first
-install.packages(c('arrow', 'dplyr', 'tidyr', 'data.table'))
-
-# Then try again
-remotes::install_github('USEPA/stateior')
-```
-
-### Memory Issues
-
-StateIO can use significant RAM for state models. If you encounter memory errors:
-
-- Increase Docker memory limit to 4GB+
-- Process states in smaller batches
-- Use the mock version for development
-
-## Additional Resources
-
-- [EPA USEEIOR Documentation](https://github.com/USEPA/useeior)
-- [EPA StateIO Documentation](https://github.com/USEPA/stateior)
-- [Project Dockerfile](../Dockerfile) - See how R packages are installed
-- [Fiscal Analysis Documentation](../docs/fiscal/) - Technical details
-
-## Questions or Issues?
-
-- Check the [main project README](../README.md)
-- Review the [Dockerfile](../Dockerfile) for R setup details
-- See `src/transformers/sbir_fiscal_pipeline.py` for implementation details
+For the project-wide evidence boundaries, see the
+[research output status index](../docs/research/README.md).

--- a/examples/sbir_fiscal_impact_example.py
+++ b/examples/sbir_fiscal_impact_example.py
@@ -89,7 +89,7 @@ def main():
     calculator = SBIRFiscalImpactCalculator()
     print("  ✓ Calculator initialized")
     print("  ✓ NAICS→BEA mapper loaded")
-    print("  ✓ BEA I-O economic models ready")
+    print("  ✓ BEA I-O adapter initialized; inspect quality_flags for fallback use")
     print()
 
     # Step 3: Calculate impacts
@@ -193,10 +193,6 @@ def main():
         print("Quality Flags Distribution:")
         for flag, count in quality_counts.items():
             print(f"  {flag}: {count} records")
-        print()
-
-        avg_confidence = float(impacts["confidence"].mean())
-        print(f"Average Confidence Score: {avg_confidence:.2%}")
         print()
 
     except Exception as e:

--- a/examples/sbir_fiscal_impact_example_mock.py
+++ b/examples/sbir_fiscal_impact_example_mock.py
@@ -86,7 +86,6 @@ class MockBEAIOAdapter:
 
         # Add metadata
         result_df["model_version"] = self.model_version
-        result_df["confidence"] = 0.85  # Mock confidence score
         result_df["quality_flags"] = "mock_data"
 
         # Clean up temporary columns
@@ -267,8 +266,7 @@ def main():
     print("=" * 80)
     print()
     print("NOTE: This is a demonstration using mock economic multipliers.")
-    print("      For real calculations, set BEA_API_KEY environment variable.")
-    print("      See Dockerfile and docker-compose.yml for setup.")
+    print("      Its numerical outputs are illustrative and non-citable.")
     print()
 
     # Step 1: Create/load SBIR awards
@@ -387,19 +385,13 @@ def main():
         print(f"  {flag}: {count} records")
     print()
 
-    avg_confidence = float(impacts["confidence"].mean())
-    print(f"Average Confidence Score: {avg_confidence:.2%}")
-    print()
-
     print("=" * 80)
     print("Analysis Complete!")
     print("=" * 80)
     print()
     print("Next steps:")
-    print("  - For real calculations: docker compose --profile dev up --build")
-    print(
-        "  - Then run: docker compose exec dagster-webserver python examples/sbir_fiscal_impact_example.py"
-    )
+    print("  - To exercise the BEA-backed path, set BEA_API_KEY and run")
+    print("    examples/sbir_fiscal_impact_example.py")
     print("  - Export results to CSV/database")
     print("  - Create visualizations")
     print("  - Compare across fiscal years")

--- a/examples/sbir_fiscal_impact_example_mock.py
+++ b/examples/sbir_fiscal_impact_example_mock.py
@@ -3,8 +3,8 @@
 This example demonstrates the complete pipeline from SBIR awards to
 tax and job impact analysis by state and industry using mock data.
 
-This version works WITHOUT R and provides realistic demo outputs.
-For real calculations, set BEA_API_KEY (register at https://apps.bea.gov/API/signup/).
+This version uses hand-authored multipliers and produces illustrative,
+non-citable demo outputs without network access.
 
 Usage:
     python examples/sbir_fiscal_impact_example_mock.py
@@ -25,14 +25,14 @@ from sbir_etl.enrichers.fiscal_bea_mapper import NAICSToBEAMapper as NAICSBEAMap
 
 
 class MockBEAIOAdapter:
-    """Mock BEA I-O adapter that provides realistic outputs for examples."""
+    """Mock BEA I-O adapter that provides illustrative outputs for examples."""
 
     def __init__(self):
         """Initialize mock adapter."""
         self.model_version = "v2.1-mock"
 
     def compute_impacts(self, shocks_df: pd.DataFrame) -> pd.DataFrame:
-        """Compute mock impacts using simple but realistic multipliers.
+        """Compute mock impacts using simple illustrative multipliers.
 
         Args:
             shocks_df: DataFrame with state, bea_sector, fiscal_year, shock_amount
@@ -282,7 +282,7 @@ def main():
     calculator = MockSBIRFiscalImpactCalculator()
     print("  ✓ Mock calculator initialized")
     print("  ✓ NAICS→BEA mapper loaded")
-    print("  ✓ Using simplified economic multipliers (BEA_API_KEY not set)")
+    print("  ✓ Using hand-authored illustrative economic multipliers")
     print()
 
     # Step 3: Calculate impacts

--- a/packages/sbir-analytics/README.md
+++ b/packages/sbir-analytics/README.md
@@ -30,7 +30,7 @@ make install-core  # reusable sbir-etl library only; uv sync
 | Package | What You Get |
 |---------|-------------|
 | `sbir-etl` | ETL library — extractors, enrichers, transformers, models, config |
-| `sbir-etl[cloud,uspto,monitoring]` | ETL integrations used by the pipeline |
+| `sbir-etl[uspto,monitoring]` | ETL integrations used by the pipeline |
 | `sbir-ml[nlp]` | ML/NLP models and enrichment |
 | `sbir-graph` | Neo4j loaders, queries, and packaged migrations |
 | **`sbir-analytics`** | **All of the above** + orchestration and analysis tools |

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.11,<3.13"
 
 # sbir-analytics is the full pipeline: ETL library + ML + orchestration + CLI + storage.
 dependencies = [
-    "sbir-etl[cloud,uspto,monitoring]",
+    "sbir-etl[uspto,monitoring]",
     "sbir-ml[nlp]",
     "sbir-graph",
     # Dagster orchestration
@@ -17,7 +17,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-r = ["sbir-etl[r]"]
 modernbert-local = ["sbir-ml[modernbert-local]"]
 dev = ["sbir-etl[dev]"]
 

--- a/packages/sbir-analytics/sbir_analytics/assets/fiscal_assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/fiscal_assets.py
@@ -453,7 +453,7 @@ _IMPACT_COLS = (
 @asset(
     description="Economic impacts computed from shocks using BEA I-O model",
     group_name="economic_modeling",
-    compute_kind="r",
+    compute_kind="python_bea_io",
 )
 def economic_impacts(
     context: AssetExecutionContext,
@@ -555,7 +555,9 @@ def economic_impacts_quality_check(economic_impacts: pd.DataFrame) -> AssetCheck
         return AssetCheckResult(
             passed=False,
             severity=AssetCheckSeverity.ERROR,
-            description="✗ Economic impacts FAILED: Using placeholder model (R adapter unavailable)",
+            description=(
+                "✗ Economic impacts FAILED: Using placeholder model (BEA I-O adapter unavailable)"
+            ),
             metadata={"model_version": "placeholder"},
         )
 

--- a/packages/sbir-analytics/sbir_analytics/assets/fiscal_assets.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/fiscal_assets.py
@@ -527,7 +527,6 @@ def _create_placeholder_impacts(
     for col in _IMPACT_COLS:
         df[col] = 0.0
     df["model_version"] = "placeholder"
-    df["confidence"] = 0.0
     df["quality_flags"] = "bea_adapter_unavailable"
     return Output(
         value=df,

--- a/packages/sbir-analytics/sbir_analytics/assets/sbir_fiscal_impacts.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/sbir_fiscal_impacts.py
@@ -28,7 +28,7 @@ EPISTEMIC_TIER = "exploratory"
 @asset(
     description="SBIR fiscal impacts: tax revenue and jobs by state and industry",
     group_name="fiscal_analysis",
-    compute_kind="r_economic_model",
+    compute_kind="python_bea_io",
 )
 def sbir_fiscal_impacts(
     context: AssetExecutionContext,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ uspto = ["pyreadstat>=1.1.4,<2.0.0"]
 # pins the same constraint in the Dockerfile, which installs packages directly
 # rather than installing this project.
 uspto-browser = ["playwright>=1.47.0,<2.0.0"]
-# AWS S3 cloud storage (for extractors that pull from S3)
-cloud = [
-]
 # Stream a single member out of a remote USAspending database .zip over HTTP range,
 # avoiding the full ~217GB download (contract_extractor.stream_remote_zip_member).
 streaming = ["remotezip>=0.12.0,<1.0.0"]

--- a/sbir_etl/transformers/bea_io_adapter.py
+++ b/sbir_etl/transformers/bea_io_adapter.py
@@ -371,7 +371,6 @@ class BEAIOAdapter:
                             "production_impact": production_impact,
                             "employment_impact": employment_impact,
                             "model_version": model_version,
-                            "confidence": Decimal("0.85"),
                             "quality_flags": quality_flags,
                         }
                     )
@@ -394,7 +393,6 @@ class BEAIOAdapter:
                             "production_impact": Decimal("0"),
                             "employment_impact": 0.0,
                             "model_version": model_version,
-                            "confidence": Decimal("0.0"),
                             "quality_flags": f"bea_api_failed:{str(e)[:50]}",
                         }
                     )
@@ -440,8 +438,6 @@ class BEAIOAdapter:
                 )
 
         result_df["model_version"] = model_version
-        if "confidence" not in result_df.columns:
-            result_df["confidence"] = 0.85
         if "quality_flags" not in result_df.columns:
             result_df["quality_flags"] = "bea_api_computation"
 
@@ -470,7 +466,6 @@ class BEAIOAdapter:
         result_df["production_impact"] = result_df["shock_amount"] * multiplier
         result_df["employment_impact"] = result_df["wage_impact"].astype(float) / 100_000
         result_df["model_version"] = model_version
-        result_df["confidence"] = Decimal("0.75")
         result_df["quality_flags"] = "placeholder_computation"
 
         return result_df

--- a/sbir_etl/transformers/sbir_fiscal_pipeline.py
+++ b/sbir_etl/transformers/sbir_fiscal_pipeline.py
@@ -84,7 +84,6 @@ class SBIRFiscalImpactCalculator:
                 - consumption_impact: Consumption effects
                 - jobs_created: Employment created (if include_employment=True)
                 - model_version: Economic model version used
-                - confidence: Confidence score (0-1)
                 - quality_flags: Data quality indicators
 
         Raises:

--- a/sbir_etl/transformers/sbir_fiscal_pipeline.py
+++ b/sbir_etl/transformers/sbir_fiscal_pipeline.py
@@ -211,7 +211,7 @@ class SBIRFiscalImpactCalculator:
         integrate with BEA employment data.
 
         Args:
-            impacts: Impacts DataFrame from R adapter
+            impacts: Impacts DataFrame from the BEA I-O adapter
 
         Returns:
             Impacts DataFrame with added jobs_created column

--- a/tests/integration/test_fiscal_pipeline_integration.py
+++ b/tests/integration/test_fiscal_pipeline_integration.py
@@ -196,7 +196,7 @@ class TestFiscalPipelineIntegration:
         context = build_asset_context()
 
         # Set up mocks
-        # Mock R adapter availability
+        # Mock BEA I-O adapter availability
         mock_is_available.return_value = True
 
         # Mock geographic resolution

--- a/tests/unit/assets/test_fiscal_assets.py
+++ b/tests/unit/assets/test_fiscal_assets.py
@@ -574,7 +574,6 @@ class TestEdgeCases:
             "tax_impact",
             "production_impact",
             "model_version",
-            "confidence",
             "quality_flags",
         ]
 

--- a/tests/unit/transformers/test_bea_io_adapter.py
+++ b/tests/unit/transformers/test_bea_io_adapter.py
@@ -148,6 +148,7 @@ class TestBEAIOAdapterImpactComputation:
         assert len(result) == 3
         assert "wage_impact" in result.columns
         assert result["quality_flags"].iloc[0] == "placeholder_computation"
+        assert "confidence" not in result.columns
 
     @patch("sbir_etl.transformers.bea_io_adapter.BEAApiClient")
     @patch("sbir_etl.transformers.bea_io_adapter.fetch_use_table")
@@ -184,6 +185,7 @@ class TestBEAIOAdapterImpactComputation:
         assert "wage_impact" in result.columns
         assert "production_impact" in result.columns
         assert result["model_version"].iloc[0] == "v2.1"
+        assert "confidence" not in result.columns
 
     @patch("sbir_etl.transformers.bea_io_adapter.BEAApiClient")
     def test_ensure_impact_columns(self, mock_client_cls, mock_config, sample_shocks):

--- a/tests/unit/transformers/test_sbir_fiscal_pipeline.py
+++ b/tests/unit/transformers/test_sbir_fiscal_pipeline.py
@@ -193,7 +193,7 @@ class TestSBIRFiscalImpactCalculator:
         )
         mock_aggregate.return_value = mock_shocks
 
-        # Mock R adapter compute_impacts
+        # Mock BEA I-O adapter compute_impacts
         calculator.io_adapter.compute_impacts.return_value = sample_impacts.copy()
 
         # Run pipeline

--- a/uv.lock
+++ b/uv.lock
@@ -2594,14 +2594,13 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "dagster", specifier = ">=1.7.0,<2.0.0" },
-    { name = "sbir-etl", extras = ["cloud", "uspto", "monitoring"] },
     { name = "sbir-etl", extras = ["dev"], marker = "extra == 'dev'" },
-    { name = "sbir-etl", extras = ["r"], marker = "extra == 'r'" },
+    { name = "sbir-etl", extras = ["uspto", "monitoring"] },
     { name = "sbir-graph" },
     { name = "sbir-ml", extras = ["modernbert-local"], marker = "extra == 'modernbert-local'" },
     { name = "sbir-ml", extras = ["nlp"] },
 ]
-provides-extras = ["r", "modernbert-local", "dev"]
+provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
@@ -2733,7 +2732,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0,<7.0.0" },
     { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.67.3.20260408,<5.0.0" },
 ]
-provides-extras = ["ucc1-pilot", "uspto", "uspto-browser", "cloud", "streaming", "phonetic", "monitoring", "viz", "dev", "stack-dev"]
+provides-extras = ["ucc1-pilot", "uspto", "uspto-browser", "streaming", "phonetic", "monitoring", "viz", "dev", "stack-dev"]
 
 [package.metadata.requires-dev]
 notebooks = [


### PR DESCRIPTION
## Summary

- replace obsolete R/StateIO/USEEIOR instructions with the current Python BEA workflow
- label mock fiscal outputs as illustrative and non-citable
- remove the fabricated mock confidence score
- remove the empty `cloud` extra and nonexistent `r` extra
- synchronize `uv.lock` with the supported dependency contract

## Why

The repository currently advertises an R runtime, Docker packages, and dependency extras that do not exist. It also describes exploratory fiscal estimates as research-grade production output. These claims make the public setup surface unreliable and conflict with the project's evidence-tier policy.

## Impact

The supported fiscal path is now explicit: the deterministic mock demonstrates data flow, while the BEA-backed Python example requires `BEA_API_KEY` and remains exploratory. The heavier Docker image is intentionally retained until the default locked image covers its valid ML dependencies.

## Verification

- `uv lock --check`
- 41 focused fiscal/tool tests passed
- mock fiscal example executed end to end
- Ruff check and format check
- `make docs-check`
- `git diff --check`