### PR TITLE
Remove self-fulfilling pipeline tests

### DIFF
--- a/tests/e2e/transition/test_detection_smoke.py
+++ b/tests/e2e/transition/test_detection_smoke.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-
 import pandas as pd
 import pytest
 
@@ -58,21 +56,3 @@ def test_transition_pipeline_summary(
     assert "award_transition_rate" in summary
     assert "company_transition_rate" in summary
     assert "cet_area_transition_rates" in summary
-
-
-def test_pipeline_output_files(tmp_path):
-    """Ensure downstream tasks write analytics + report artifacts."""
-    output_dir = tmp_path / "data" / "processed"
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    analytics_json = output_dir / "transition_analytics.json"
-    summary_md = output_dir / "transition_analytics_executive_summary.md"
-    checks_json = output_dir / "transition_analytics.checks.json"
-
-    analytics_json.write_text(json.dumps({"score_threshold": 0.6}))
-    summary_md.write_text("# Executive Summary")
-    checks_json.write_text(json.dumps({"ok": True}))
-
-    for path in (analytics_json, summary_md, checks_json):
-        assert path.exists()
-        assert path.stat().st_size > 0

--- a/tests/functional/test_pipelines.py
+++ b/tests/functional/test_pipelines.py
@@ -7,23 +7,11 @@ Tests each major pipeline function end-to-end:
 - ModernBert embeddings
 """
 
-import pytest
-import pandas as pd
-from pathlib import Path
-
-
-@pytest.fixture
-def output_dir(tmp_path):
-    """Create temporary output directory."""
-    output = tmp_path / "data" / "processed"
-    output.mkdir(parents=True)
-    return output
-
 
 class TestTransitionPipeline:
     """Functional tests for transition detection pipeline."""
 
-    def test_transition_run_produces_outputs(self, output_dir):
+    def test_transition_run_produces_outputs(self):
         """Test that transition pipeline produces expected outputs."""
         from dagster import materialize
         from sbir_analytics.assets.transition import validated_contracts_sample
@@ -83,73 +71,6 @@ class TestModernBertPipeline:
         assert len(result.asset_materializations_for_node("modernbert_embeddings_awards")) > 0
 
 
-@pytest.mark.parametrize(
-    "output_type,required_cols,validators",
-    [
-        (
-            "transitions",
-            ["award_id", "contract_id", "transition_score", "confidence"],
-            {
-                "transition_score": lambda df: (
-                    df["transition_score"].dtype in ["float64", "float32"]
-                ),
-                "confidence": lambda df: df["confidence"].dtype in ["float64", "float32"],
-            },
-        ),
-        (
-            "cet_classifications",
-            ["award_id", "cet_id", "score", "classification"],
-            {
-                "classification": lambda df: (
-                    df["classification"].isin(["High", "Medium", "Low"]).all()
-                ),
-            },
-        ),
-        (
-            "fiscal_returns",
-            ["award_id", "roi", "federal_tax_receipts", "economic_impact"],
-            {
-                "roi": lambda df: (
-                    df["roi"].dtype in ["float64", "float32"] and (df["roi"] >= 0).all()
-                ),
-            },
-        ),
-        (
-            "modernbert_award_patent_similarity",
-            ["award_id", "patent_id", "similarity_score"],
-            {
-                "similarity_score": lambda df: (
-                    df["similarity_score"].dtype in ["float64", "float32"]
-                    and (df["similarity_score"] >= 0).all()
-                    and (df["similarity_score"] <= 1).all()
-                ),
-            },
-        ),
-    ],
-)
-def test_pipeline_output_schema(
-    output_type: str, required_cols: list[str], validators: dict, repo_root: Path
-):
-    """Test that pipeline outputs have valid schema."""
-    output_path = repo_root / "data" / "processed" / f"{output_type}.parquet"
-    if not output_path.exists():
-        pytest.skip(f"{output_type} output not found")
-
-    df = pd.read_parquet(output_path)
-
-    # Validate schema
-    for col in required_cols:
-        assert col in df.columns, f"Missing column: {col}"
-
-    # Validate data quality
-    assert len(df) > 0, "Output is empty"
-    assert df[required_cols[0]].notna().all(), f"Null values in {required_cols[0]}"
-
-    # Run custom validators
-    for field, validator in validators.items():
-        assert validator(df), f"Validation failed for {field}"
-
-
 class TestPipelineIntegration:
     """Integration tests across multiple pipelines."""
 
@@ -166,17 +87,3 @@ class TestPipelineIntegration:
         # Run CET second
         result2 = materialize([enriched_cet_award_classifications])
         assert result2.success
-
-    def test_pipeline_outputs_dont_conflict(self):
-        """Test that pipeline outputs use separate files."""
-        outputs = [
-            "data/processed/transitions.parquet",
-            "data/processed/cet_classifications.parquet",
-            "data/processed/fiscal_returns.parquet",
-            "data/processed/modernbert_embeddings_awards.parquet",
-            "data/processed/modernbert_embeddings_patents.parquet",
-            "data/processed/modernbert_award_patent_similarity.parquet",
-        ]
-
-        # Check that outputs are distinct
-        assert len(outputs) == len(set(outputs))


### PR DESCRIPTION
## Summary

- remove an E2E test that created three files and immediately asserted they existed
- remove schema checks that skipped whenever developer-local outputs were absent
- remove a hard-coded filename-uniqueness assertion with no production behavior
- remove the now-unused temporary-output fixture

## Why

These tests increased the visible test count without exercising a production writer or a clean-checkout contract. The transition analytics writer and its JSON/checks payload remain covered by the integration chain, while real asset materializations remain in the functional suite.

## Impact

No production behavior changes. The suite now reports fewer but more meaningful tests.

## Verification

- transition E2E, functional pipeline, and analytics integration suites — 8 passed, 1 environment-dependent skip
- Ruff check and format check
- `git diff --check`