### PR TITLE
Repair and materialize NSF private-capital Phase 1 gate

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -998,7 +998,12 @@ The relevant literature is Lerner [L10], Howell [L11], and Kortum & Lerner
   For Phase II awardees of any agency, do follow-on funding and exit outcomes
   match published small-business and peer-reviewed entrepreneurial-finance
   baselines?
-  *Deps: ER, SEC EDGAR · Refs: [L10], [L11], [L24] · Spec: (PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, with terminology changed from "VC" to "private capital")*
+  **Status:** Partial and non-citable. The Phase 1 NSF review validates the
+  Phase I→II cohort component: 672 of 1,502 firms in the 2015–2019 vintage
+  (44.7%, 95% Wilson interval 42.2%–47.3%). It does not yet answer this
+  question because transition, survival, M&A, and patent channels were
+  unavailable in that run.
+  *Deps: ER, SEC EDGAR · Refs: [L10], [L11], [L24] · Report: [NSF Phase I baseline review](research/agency-private-capital-phase1-nsf.md) · Spec: [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/) (PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, with terminology changed from "VC" to "private capital")*
 
 - **Crowd-in vs. crowd-out**
   Does SBIR funding crowd in or crowd out subsequent private capital?

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -23,6 +23,7 @@ and [study requirements](../../studies/README.md) for the review rules.
 | [Form D fundraising analysis](sbir-form-d-fundraising-analysis.md) | F1, F3 | Dated analysis; not approved for citation | Form D and SBIR spending, 2009–2024; method revised 2026-04-23 |
 | [DoD Form D leverage](dod-form-d-leverage.md) | A3, A4, F3 | Dated breakdown and follow-up analysis | Combined 2026-06-21 |
 | [Form D data dictionary](form-d-data-dictionary.md) | F1, F3 | Reference for fields and confidence levels | Form D files currently produced by the pipeline |
+| [NSF Phase I to Phase II baseline comparison](agency-private-capital-phase1-nsf.md) | B2, B3, F3 | Exploratory Phase 1 review; non-citable with incomplete outcomes | Pinned SBIR.gov snapshot (219,500 rows); NSF Phase I firms, 2015–2019 |
 | [Agency private-capital Phase 2 method](agency-private-capital-phase2-form-d.md) | B2, B3, F3 | Compares matched groups; does not prove cause and effect | No fixed published run |
 | [M&A exit analysis](sbir-ma-exit-analysis.md) | A4, F1, F2 | Dated analysis; likely understates exits because it uses public filings | Run documented 2026-04-23 |
 | [Capital-pathway cohorts](sbir-pathway-cohorts.md) | F1, F2 | Dated group analysis | 3,639 firms with high-confidence matches; 2026-06-23 |

--- a/docs/research/agency-private-capital-phase1-nsf.manifest.json
+++ b/docs/research/agency-private-capital-phase1-nsf.manifest.json
@@ -5,6 +5,8 @@
     "awards_csv": {
       "available": true,
       "path": "award_data.csv",
+      "retrieved_at": "2026-03-31",
+      "retrieved_at_basis": "provided",
       "row_count": 219500,
       "schema": {
         "columns": [
@@ -55,11 +57,14 @@
       },
       "sha256": "73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd",
       "size_bytes": 394456822,
-      "source": "sbir_gov_bulk_awards"
+      "source": "sbir_gov_bulk_awards",
+      "source_url": "https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv"
     },
     "ma_events_jsonl": {
       "available": false,
       "path": "sbir_ma_events.jsonl",
+      "retrieved_at": null,
+      "retrieved_at_basis": null,
       "row_count": null,
       "schema": {
         "company_key": "company_name",
@@ -67,11 +72,14 @@
       },
       "sha256": null,
       "size_bytes": null,
-      "source": "sbir_ma_events"
+      "source": "sbir_ma_events",
+      "source_url": null
     },
     "published_baselines_yaml": {
       "available": true,
       "path": "published_baselines.yaml",
+      "retrieved_at": null,
+      "retrieved_at_basis": null,
       "row_count": 4,
       "schema": {
         "collection": "baselines",
@@ -79,7 +87,8 @@
       },
       "sha256": "5bfa088e1a86c2290d08befae1e3d35ca46c6f3aaf28bbdb684279d69c4405f7",
       "size_bytes": 3578,
-      "source": "published_baseline_registry"
+      "source": "published_baseline_registry",
+      "source_url": null
     }
   },
   "limitations": [
@@ -109,6 +118,23 @@
       "reason": "Transition-score enrichment is not read by this standalone runner."
     }
   },
+  "outputs": {
+    "agency_baseline_comparison_json": {
+      "path": "agency_baseline_comparison.json",
+      "sha256": "0e40db8a993c5830a2c600f0432b0519363b91f01e5a6667a512adfcbaf21ca5",
+      "size_bytes": 6639
+    },
+    "agency_cohort_outcomes_parquet": {
+      "path": "agency_cohort_outcomes.parquet",
+      "sha256": "e09cb80c92c65e6ff569e2ac658c665e6786f1551fff8d52f577fcf6fe3a2b11",
+      "size_bytes": 6991
+    },
+    "agency_vs_published_baselines_markdown": {
+      "path": "agency_vs_published_baselines.md",
+      "sha256": "78f9f83807efacfc32bf9255314540e72b71c17b9a7ce854dae5296a6b6feb68",
+      "size_bytes": 5937
+    }
+  },
   "parameters": {
     "agency_code": "NSF",
     "graduation_horizon_years": 5,
@@ -117,5 +143,73 @@
     "transition_score_threshold": 0.65,
     "vintage_bucket_size": 5
   },
-  "schema_version": 1
+  "review_artifact": {
+    "path": "docs/research/agency-private-capital-phase1-nsf.md",
+    "sha256": "6d377238318f30985504a66829f0af47de8b5b948b7a3aca0dbf1b2a86c0417b",
+    "size_bytes": 6717
+  },
+  "results": {
+    "graduation_horizon_sensitivity": [
+      {
+        "available": true,
+        "ci_high": 0.430500094008737,
+        "ci_low": 0.3809010343528,
+        "denominator": 1502,
+        "horizon_years": 2,
+        "numerator": 609,
+        "rate": 0.4054593874833555
+      },
+      {
+        "available": true,
+        "ci_high": 0.4653051187281718,
+        "ci_low": 0.4151603851629432,
+        "denominator": 1502,
+        "horizon_years": 3,
+        "numerator": 661,
+        "rate": 0.4400798934753662
+      },
+      {
+        "available": true,
+        "ci_high": 0.4726517838014854,
+        "ci_low": 0.42242349183627115,
+        "denominator": 1502,
+        "horizon_years": 5,
+        "numerator": 672,
+        "rate": 0.4474034620505992
+      },
+      {
+        "available": true,
+        "ci_high": 0.47732407161179863,
+        "ci_low": 0.4270483315010934,
+        "denominator": 1502,
+        "horizon_years": null,
+        "numerator": 679,
+        "rate": 0.45206391478029295
+      }
+    ],
+    "headline_graduation": {
+      "available": true,
+      "ci_high": 0.4726517838014854,
+      "ci_low": 0.42242349183627115,
+      "denominator": 1502,
+      "horizon_years": 5,
+      "numerator": 672,
+      "rate": 0.4474034620505992,
+      "vintage_bucket": "2015-2019"
+    },
+    "identity_coverage": {
+      "company_basis_counts": {
+        "duns": 326,
+        "name": 16,
+        "uei": 1160
+      },
+      "company_count": 1502,
+      "resolved_row_count": 1546,
+      "resolved_row_rate": 1.0,
+      "row_count": 1546,
+      "uei_duns_bridge_company_count": 1143
+    }
+  },
+  "run_date": "2026-08-11",
+  "schema_version": 2
 }

--- a/docs/research/agency-private-capital-phase1-nsf.manifest.json
+++ b/docs/research/agency-private-capital-phase1-nsf.manifest.json
@@ -121,8 +121,8 @@
   "outputs": {
     "agency_baseline_comparison_json": {
       "path": "agency_baseline_comparison.json",
-      "sha256": "0e40db8a993c5830a2c600f0432b0519363b91f01e5a6667a512adfcbaf21ca5",
-      "size_bytes": 6639
+      "sha256": "9cab800604316ccc0c94993781d215b53e0800102eecee23104d846fd2fc479a",
+      "size_bytes": 5262
     },
     "agency_cohort_outcomes_parquet": {
       "path": "agency_cohort_outcomes.parquet",
@@ -131,8 +131,8 @@
     },
     "agency_vs_published_baselines_markdown": {
       "path": "agency_vs_published_baselines.md",
-      "sha256": "78f9f83807efacfc32bf9255314540e72b71c17b9a7ce854dae5296a6b6feb68",
-      "size_bytes": 5937
+      "sha256": "7c28f05feb5f9f3513e45f36b686b5fae2ccaa9a4703e47d31fc09253a303da8",
+      "size_bytes": 5060
     }
   },
   "parameters": {
@@ -145,8 +145,8 @@
   },
   "review_artifact": {
     "path": "docs/research/agency-private-capital-phase1-nsf.md",
-    "sha256": "6d377238318f30985504a66829f0af47de8b5b948b7a3aca0dbf1b2a86c0417b",
-    "size_bytes": 6717
+    "sha256": "8a8ae9eb3d5a2dda6fc870301ce274740ec27543d156d80d6fc734e34dde7a53",
+    "size_bytes": 6198
   },
   "results": {
     "graduation_horizon_sensitivity": [
@@ -210,6 +210,6 @@
       "uei_duns_bridge_company_count": 1143
     }
   },
-  "run_date": "2026-08-11",
+  "run_date": "2026-08-12",
   "schema_version": 2
 }

--- a/docs/research/agency-private-capital-phase1-nsf.manifest.json
+++ b/docs/research/agency-private-capital-phase1-nsf.manifest.json
@@ -1,0 +1,121 @@
+{
+  "citable": false,
+  "epistemic_tier": "exploratory",
+  "inputs": {
+    "awards_csv": {
+      "available": true,
+      "path": "award_data.csv",
+      "row_count": 219500,
+      "schema": {
+        "columns": [
+          "Company",
+          "Award Title",
+          "Agency",
+          "Branch",
+          "Phase",
+          "Program",
+          "Agency Tracking Number",
+          "Contract",
+          "Proposal Award Date",
+          "Contract End Date",
+          "Solicitation Number",
+          "Solicitation Year",
+          "Solicitation Close Date",
+          "Proposal Receipt Date",
+          "Date of Notification",
+          "Topic Code",
+          "Award Year",
+          "Award Amount",
+          "UEI",
+          "Duns",
+          "HUBZone Owned",
+          "Socially and Economically Disadvantaged",
+          "Woman Owned",
+          "Number Employees",
+          "Company Website",
+          "Address1",
+          "Address2",
+          "City",
+          "State",
+          "Zip",
+          "Abstract",
+          "Contact Name",
+          "Contact Title",
+          "Contact Phone",
+          "Contact Email",
+          "PI Name",
+          "PI Title",
+          "PI Phone",
+          "PI Email",
+          "RI Name",
+          "RI POC Name",
+          "RI POC Phone"
+        ],
+        "format": "csv"
+      },
+      "sha256": "73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd",
+      "size_bytes": 394456822,
+      "source": "sbir_gov_bulk_awards"
+    },
+    "ma_events_jsonl": {
+      "available": false,
+      "path": "sbir_ma_events.jsonl",
+      "row_count": null,
+      "schema": {
+        "company_key": "company_name",
+        "format": "jsonl"
+      },
+      "sha256": null,
+      "size_bytes": null,
+      "source": "sbir_ma_events"
+    },
+    "published_baselines_yaml": {
+      "available": true,
+      "path": "published_baselines.yaml",
+      "row_count": 4,
+      "schema": {
+        "collection": "baselines",
+        "format": "yaml"
+      },
+      "sha256": "5bfa088e1a86c2290d08befae1e3d35ca46c6f3aaf28bbdb684279d69c4405f7",
+      "size_bytes": 3578,
+      "source": "published_baseline_registry"
+    }
+  },
+  "limitations": [
+    "Standalone runner omits transition-score and federal-activity enrichment inputs.",
+    "Patent rate is deferred to Phase 2.",
+    "Results are exploratory and non-citable."
+  ],
+  "metric_availability": {
+    "five_year_survival_proxy": {
+      "available": false,
+      "reason": "Federal recipient/vendor activity is not read by this standalone runner."
+    },
+    "ma_exit_rate": {
+      "available": false,
+      "reason": "The M&A events input was not found."
+    },
+    "patent_rate": {
+      "available": false,
+      "reason": "PATLINK is deferred to Phase 2 and is not read by this runner."
+    },
+    "phase_i_to_ii_graduation": {
+      "available": true,
+      "reason": null
+    },
+    "phase_ii_to_federal_contract_transition": {
+      "available": false,
+      "reason": "Transition-score enrichment is not read by this standalone runner."
+    }
+  },
+  "parameters": {
+    "agency_code": "NSF",
+    "graduation_horizon_years": 5,
+    "headline_vintage": "2015-2019",
+    "survival_horizon_years": 5,
+    "transition_score_threshold": 0.65,
+    "vintage_bucket_size": 5
+  },
+  "schema_version": 1
+}

--- a/docs/research/agency-private-capital-phase1-nsf.md
+++ b/docs/research/agency-private-capital-phase1-nsf.md
@@ -1,0 +1,101 @@
+---
+Type: Research Report
+Owner: research@project
+Last-Reviewed: 2026-08-09
+Status: draft
+---
+
+# NSF Phase I to Phase II baseline comparison
+
+> **Exploratory and non-citable.** This is the Phase 1 review artifact, not a
+> validated program-performance finding. No external private-capital comparator
+> is applied, and four requested outcome channels were unavailable in this run.
+
+## Review result
+
+On the pinned SBIR.gov award snapshot, **672 of 1,502 uniquely identified NSF
+firms with a Phase I award in 2015–2019 had a Phase II award no earlier than the
+Phase I and within five calendar years**. The exploratory rate is **44.7%** with
+a 95% Wilson interval of **42.2%–47.3%**.
+
+| Measure | Value |
+| --- | ---: |
+| NSF Phase I firms, 2015–2019 | 1,502 |
+| Firms with a qualifying Phase II within five years | 672 |
+| Graduation rate | 44.7% |
+| 95% Wilson interval | 42.2%–47.3% |
+
+This artifact reports an internal SBIR phase-graduation measure. It does not
+apply an external private-capital comparator, and the result must not be used to
+claim relative program performance.
+
+## Cohort and estimand
+
+- **Input:** SBIR.gov bulk awards, 219,500 rows, award years 1983–2026.
+- **Agency:** `National Science Foundation`, resolved by the shared agency
+  cohort builder from canonical raw `Agency` values.
+- **Vintage:** firms with at least one Phase I award in calendar years
+  2015–2019.
+- **Firm key:** UEI when present, then DUNS, then lower-cased company name.
+- **Numerator:** a firm with at least one Phase II award in `[Phase I year,
+  Phase I year + 5]` for any of its Phase I awards in the vintage.
+- **Denominator:** unique recoverable firm keys with a Phase I award in the
+  vintage.
+- **Interval:** two-sided 95% Wilson score interval.
+
+This definition fixes two problems in the prior implementation: Phase II awards
+that predated Phase I could count as graduation, and there was no follow-up
+horizon. Entity changes that are not bridged by UEI or DUNS can still undercount
+graduation; this run does not claim that the fallback name key fully resolves
+firm lineage.
+
+## Outcome availability
+
+| Metric | Available? | Reason |
+| --- | --- | --- |
+| Phase I to Phase II graduation | Yes | Computed from the pinned awards file |
+| Phase II to federal-contract transition | No | Transition-score enrichment was not supplied to the standalone runner |
+| Five-year survival proxy | No | Federal recipient/vendor activity was not supplied |
+| M&A exit rate | No | `sbir_ma_events.jsonl` was not available on the host |
+| Patent rate | No | PATLINK remains deferred to Phase 2 |
+
+Unavailable means **not measured**, never zero.
+
+## Provenance
+
+The machine-readable manifest is
+[agency-private-capital-phase1-nsf.manifest.json](agency-private-capital-phase1-nsf.manifest.json).
+
+| Input | SHA-256 | Size / rows |
+| --- | --- | --- |
+| `award_data.csv` | `73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd` | 394,456,822 bytes / 219,500 rows |
+| `published_baselines.yaml` | `5bfa088e1a86c2290d08befae1e3d35ca46c6f3aaf28bbdb684279d69c4405f7` | 3,578 bytes / 4 entries |
+| `sbir_ma_events.jsonl` | unavailable | M&A metric suppressed |
+
+Reproduce from a checkout with the awards snapshot available:
+
+```bash
+uv run --extra stack-dev python \
+  scripts/archive/data/run_agency_private_capital_phase1.py \
+  --agency NSF \
+  --awards-csv data/raw/sbir/award_data.csv \
+  --headline-vintage 2015-2019 \
+  --graduation-horizon-years 5 \
+  --skip-download
+```
+
+The command emits the comparison Markdown, structured JSON, outcome Parquet,
+and deterministic `run_manifest.json` under
+`data/processed/agency_private_capital/nsf/`.
+
+## Gate decision
+
+Phase 1 is **materialized but not signed off**. Review must resolve the following
+before Phase 2 begins:
+
+1. accept or revise the five-year graduation estimand and entity-key fallback;
+2. decide whether the missing transition, survival, M&A, and patent channels
+   must be populated before Phase 1 is considered complete.
+
+Phase 2 control construction, multi-agency publication, the FY M&A trend, and a
+filer/non-filer or crowd-in/crowd-out design remain separate gated work.

--- a/docs/research/agency-private-capital-phase1-nsf.md
+++ b/docs/research/agency-private-capital-phase1-nsf.md
@@ -1,7 +1,7 @@
 ---
 Type: Research Report
 Owner: research@project
-Last-Reviewed: 2026-08-11
+Last-Reviewed: 2026-08-12
 Status: draft
 ---
 
@@ -104,7 +104,7 @@ The machine-readable manifest is
 
 The SBIR.gov snapshot was retrieved on **2026-03-31** from the
 [bulk awards CSV](https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv);
-this repaired run was executed on **2026-08-11**. The manifest records the
+this repaired run was executed on **2026-08-12**. The manifest records the
 headline result, the four horizon-sensitivity rows, identity coverage, and
 SHA-256 hashes for every generated output so the prose can be checked against
 the machine-readable run.
@@ -118,7 +118,7 @@ uv run --extra stack-dev python \
   --awards-csv data/raw/sbir/award_data.csv \
   --headline-vintage 2015-2019 \
   --graduation-horizon-years 5 \
-  --run-date 2026-08-11 \
+  --run-date 2026-08-12 \
   --awards-retrieved-at 2026-03-31 \
   --skip-download
 ```

--- a/docs/research/agency-private-capital-phase1-nsf.md
+++ b/docs/research/agency-private-capital-phase1-nsf.md
@@ -1,7 +1,7 @@
 ---
 Type: Research Report
 Owner: research@project
-Last-Reviewed: 2026-08-09
+Last-Reviewed: 2026-08-11
 Status: draft
 ---
 
@@ -36,7 +36,11 @@ claim relative program performance.
   cohort builder from canonical raw `Agency` values.
 - **Vintage:** firms with at least one Phase I award in calendar years
   2015–2019.
-- **Firm key:** UEI when present, then DUNS, then lower-cased company name.
+- **Program scope:** SBIR and STTR are pooled. A cross-program STTR Phase I to
+  SBIR Phase II (or the reverse) counts when the firm and timing rules match.
+- **Firm key:** connected components across every UEI, DUNS, and exact
+  `ORGANIZATION_KEY_V1` normalized-name alias present on each firm's rows;
+  canonical labels prefer UEI, then DUNS, then name.
 - **Numerator:** a firm with at least one Phase II award in `[Phase I year,
   Phase I year + 5]` for any of its Phase I awards in the vintage.
 - **Denominator:** unique recoverable firm keys with a Phase I award in the
@@ -45,9 +49,35 @@ claim relative program performance.
 
 This definition fixes two problems in the prior implementation: Phase II awards
 that predated Phase I could count as graduation, and there was no follow-up
-horizon. Entity changes that are not bridged by UEI or DUNS can still undercount
-graduation; this run does not claim that the fallback name key fully resolves
-firm lineage.
+horizon. It also fixes mixed-identifier undercount: a DUNS-only Phase I row now
+joins a UEI+DUNS or UEI-only Phase II row through the exact alias graph.
+
+This is a **firm-level**, not project-level, graduation estimand. A qualifying
+Phase II need not descend from the particular in-vintage Phase I project, so the
+rate is not comparable to NSF's project-level conversion statistic. Corporate
+renames or restructurings with no shared UEI, DUNS, or exact normalized name can
+still undercount graduation; the crosswalk does not use fuzzy matching.
+
+## Horizon sensitivity
+
+| Maximum follow-up from Phase I | Graduated firms | Phase I firms | Rate |
+| --- | ---: | ---: | ---: |
+| 2 years | 609 | 1,502 | 40.5% |
+| 3 years | 661 | 1,502 | 44.0% |
+| 5 years | 672 | 1,502 | 44.7% |
+| Unbounded | 679 | 1,502 | 45.2% |
+
+The five-year cutoff is the current review setting, not a validated optimum.
+The sensitivity table makes the consequence of revising that estimand explicit.
+
+## Entity-resolution coverage
+
+The 1,502 firms in the headline Phase I denominator comprise 1,160 UEI-backed
+components, 326 DUNS-backed components with no UEI, and 16 normalized-name-only
+components. Of these, 1,143 components bridge both UEI and DUNS. All 1,546 Phase
+I award rows in the 2015–2019 vintage have at least one recoverable identity
+alias. These are coverage diagnostics, not a recall estimate against an
+independently labeled firm-lineage set.
 
 ## Outcome availability
 
@@ -72,6 +102,13 @@ The machine-readable manifest is
 | `published_baselines.yaml` | `5bfa088e1a86c2290d08befae1e3d35ca46c6f3aaf28bbdb684279d69c4405f7` | 3,578 bytes / 4 entries |
 | `sbir_ma_events.jsonl` | unavailable | M&A metric suppressed |
 
+The SBIR.gov snapshot was retrieved on **2026-03-31** from the
+[bulk awards CSV](https://data.www.sbir.gov/mod_awarddatapublic/award_data.csv);
+this repaired run was executed on **2026-08-11**. The manifest records the
+headline result, the four horizon-sensitivity rows, identity coverage, and
+SHA-256 hashes for every generated output so the prose can be checked against
+the machine-readable run.
+
 Reproduce from a checkout with the awards snapshot available:
 
 ```bash
@@ -81,6 +118,8 @@ uv run --extra stack-dev python \
   --awards-csv data/raw/sbir/award_data.csv \
   --headline-vintage 2015-2019 \
   --graduation-horizon-years 5 \
+  --run-date 2026-08-11 \
+  --awards-retrieved-at 2026-03-31 \
   --skip-download
 ```
 
@@ -93,7 +132,8 @@ and deterministic `run_manifest.json` under
 Phase 1 is **materialized but not signed off**. Review must resolve the following
 before Phase 2 begins:
 
-1. accept or revise the five-year graduation estimand and entity-key fallback;
+1. accept or revise the five-year, firm-level, pooled SBIR/STTR graduation
+   estimand and the exact-alias crosswalk assumptions;
 2. decide whether the missing transition, survival, M&A, and patent channels
    must be populated before Phase 1 is considered complete.
 

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/asset.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/asset.py
@@ -10,6 +10,9 @@ events, then emits three artifacts under
 - ``agency_vs_published_baselines.md`` — human-readable reconciliation report.
 - ``agency_baseline_comparison.json`` — structured comparison records.
 
+The graduation horizon is explicit run configuration and is recorded in the
+JSON artifact and Dagster metadata. Outputs remain exploratory and non-citable.
+
 Per project convention: ``from __future__ import annotations`` is NOT used
 here because Dagster's runtime context type-validation requires concrete
 type names.
@@ -21,6 +24,7 @@ from typing import Any
 
 import pandas as pd
 from dagster import AssetExecutionContext, Config, MetadataValue, Output, asset
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 from .baselines import DEFAULT_REGISTRY_PATH, PublishedBaselineRegistry
 from .cohort import AgencyCohortBuilder
@@ -38,9 +42,13 @@ class AgencyPrivateCapitalConfig(Config):
     Attributes:
         agency_code: The funding agency to filter to. Default ``"NSF"``
             preserves existing behavior.
+        graduation_horizon_years: Maximum inclusive years from Phase I to a
+            qualifying Phase II. ``None`` restores the historical unbounded
+            estimand. Default 5 is the current Phase 1 review setting.
     """
 
     agency_code: str = "NSF"
+    graduation_horizon_years: int | None = 5
 
 
 @asset(
@@ -85,6 +93,7 @@ def agency_private_capital_baseline_comparison(
         context.log.info("Loaded M&A event company set", extra={"n": len(ma_event_companies)})
 
     calc = OutcomeMetricsCalculator(
+        graduation_horizon_years=config.graduation_horizon_years,
         transition_scores=(
             transformed_transition_scores
             if transformed_transition_scores is not None and not transformed_transition_scores.empty
@@ -103,9 +112,29 @@ def agency_private_capital_baseline_comparison(
         headline_vintage=DEFAULT_HEADLINE_VINTAGE,
         agency_code=config.agency_code,
     )
+    horizon_label = (
+        "unbounded"
+        if config.graduation_horizon_years is None
+        else f"{config.graduation_horizon_years} years"
+    )
+    md_text = (
+        "> **Exploratory / non-citable.** This comparison is a review artifact, not a "
+        "validated program-performance finding.\n>\n"
+        f"> **Phase I -> Phase II graduation horizon:** {horizon_label}.\n\n"
+        f"{md_text}"
+    )
     md_path.write_text(md_text, encoding="utf-8")
+    comparison_records = []
+    for record in records:
+        payload = record.to_json()
+        payload["analysis_parameters"] = {
+            "graduation_horizon_years": config.graduation_horizon_years,
+            "headline_vintage": DEFAULT_HEADLINE_VINTAGE,
+        }
+        payload["citable"] = False
+        comparison_records.append(payload)
     json_path.write_text(
-        json.dumps([r.to_json() for r in records], indent=2, default=str),
+        json.dumps(comparison_records, indent=2, default=str),
         encoding="utf-8",
     )
 
@@ -117,8 +146,18 @@ def agency_private_capital_baseline_comparison(
         "cohort_rows": int(len(cohort)),
         "stratum_counts": MetadataValue.json(counts.to_dict("records")),
         "headline_vintage": DEFAULT_HEADLINE_VINTAGE,
+        "graduation_horizon_years": config.graduation_horizon_years,
         "baseline_count": int(len(registry)),
         "ma_events_loaded": ma_event_companies is not None,
+        "epistemic_tier": "exploratory",
+        "citable": False,
+        "identity_coverage": MetadataValue.json(
+            OutcomeMetricsCalculator.identity_coverage(
+                cohort,
+                vintage_bucket=DEFAULT_HEADLINE_VINTAGE,
+                phase_label="I",
+            )
+        ),
     }
     return Output(str(md_path), metadata=metadata)
 
@@ -126,9 +165,8 @@ def agency_private_capital_baseline_comparison(
 def _load_ma_event_companies(path: Path) -> set[str] | None:
     """Read PR #286's M&A events JSONL and return a set of company name keys.
 
-    Each event has a ``company_name`` field; we normalize to ``name:<lower>``
-    so it can join against the cohort's ``_name_key`` (the name-based key
-    computed on every cohort row regardless of whether UEI/DUNS are present).
+    Each event has a ``company_name`` field; we normalize it with the same
+    versioned organization-key policy used by the cohort alias graph.
     Returns ``None`` if the file is missing so the calculator can render the
     metric as unavailable.
     """
@@ -147,5 +185,10 @@ def _load_ma_event_companies(path: Path) -> set[str] | None:
                 continue
             name = event.get("company_name")
             if name and str(name).strip():
-                keys.add(f"name:{str(name).strip().lower()}")
+                normalized = normalize_company_name(
+                    name,
+                    profile=CompanyNameProfile.ORGANIZATION_KEY_V1,
+                )
+                if normalized:
+                    keys.add(f"name:{normalized.lower()}")
     return keys

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/cohort.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/cohort.py
@@ -150,8 +150,10 @@ class AgencyCohortBuilder:
     """Filter to a funding agency's SBIR/STTR awards and stratify by vintage + phase.
 
     ``build`` returns a copy of the input frame restricted to rows matching
-    ``agency_code`` with two new columns: ``vintage_bucket`` (5-year label)
-    and ``phase_label`` (``"I"`` | ``"II"`` | ``"III"``).
+    ``agency_code`` with three new columns: ``award_year_resolved`` (nullable
+    integer), ``vintage_bucket`` (5-year label), and ``phase_label``
+    (``"I"`` | ``"II"`` | ``"III"``). Rows with no parseable award year are
+    retained with a null year and vintage instead of aborting the full run.
 
     Args:
         agency_code: The agency to filter to. Default ``"NSF"`` preserves
@@ -166,17 +168,22 @@ class AgencyCohortBuilder:
     def build(self, awards: pd.DataFrame) -> pd.DataFrame:
         if awards.empty:
             return awards.assign(
-                vintage_bucket=pd.Series(dtype="object"), phase_label=pd.Series(dtype="object")
+                award_year_resolved=pd.Series(dtype="Int64"),
+                vintage_bucket=pd.Series(dtype="object"),
+                phase_label=pd.Series(dtype="object"),
             )
         mask = awards.apply(_is_agency_row, axis=1, agency_code=self.agency_code)  # type: ignore[call-overload]
         cohort = awards[mask].copy()
         if cohort.empty:
+            cohort["award_year_resolved"] = pd.Series(dtype="Int64")
             cohort["vintage_bucket"] = pd.Series(dtype="object")
             cohort["phase_label"] = pd.Series(dtype="object")
             return cohort
-        years = cohort.apply(_award_year, axis=1)  # type: ignore[call-overload]
+        years = cohort.apply(_award_year, axis=1).astype("Int64")  # type: ignore[call-overload]
+        cohort["award_year_resolved"] = years
         cohort["vintage_bucket"] = years.map(
-            lambda y: vintage_bucket(y, size=self.vintage_size) if y is not None else None
+            lambda y: vintage_bucket(y, size=self.vintage_size) if pd.notna(y) else None,
+            na_action="ignore",
         )
         phase_src = cohort.get("phase", cohort.get("Phase"))
         cohort["phase_label"] = phase_src.map(_normalize_phase) if phase_src is not None else None

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/cohort.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/cohort.py
@@ -7,7 +7,9 @@ agency match uses normalized substring comparison so variants like
 ``"National Science Foundation (NSF)"`` all resolve to the ``"NSF"`` agency
 code. When an explicit ALN/CFDA column is present it is checked first
 against the agency's known ALN set; the agency-name column acts as a
-fallback when ALN is absent.
+fallback when ALN is absent. Both normalized column names and the canonical
+SBIR.gov bulk-file casing (for example, ``Agency`` and ``Award Year``) are
+accepted.
 """
 
 from __future__ import annotations
@@ -71,13 +73,26 @@ def _normalize_phase(value: object) -> str | None:
     return None
 
 
+def _first_nonempty(row: pd.Series, *keys: str) -> object | None:
+    """Return the first non-empty value among column-name aliases."""
+
+    for key in keys:
+        value = row.get(key)
+        if value is None or pd.isna(value) or not str(value).strip():
+            continue
+        return value
+    return None
+
+
 def _is_agency_row(row: pd.Series, agency_code: str = "NSF") -> bool:
     """Return True if ``row`` belongs to the given agency.
 
     Matching strategy (in priority order):
     1. If the row has an explicit ALN/CFDA number and that number is in the
-       agency's known ALN set, accept it.
-    2. Normalize the row's ``agency`` column value (lowercase + strip), then
+       agency's known ALN set, accept it. Normalized and title-cased aliases
+       are accepted.
+    2. Normalize the row's ``agency`` or raw ``Agency`` column value
+       (lowercase + strip), then
        check whether any of the agency's known name tokens is a substring of
        that value. Tokens include both the abbreviation (e.g. ``"nsf"``) and
        the full name (e.g. ``"national science foundation"``), so all of
@@ -91,12 +106,20 @@ def _is_agency_row(row: pd.Series, agency_code: str = "NSF") -> bool:
     code_upper = agency_code.strip().upper()
     alns = AGENCY_ALN_MAP.get(code_upper, frozenset())
 
-    cfda = row.get("cfda_number") or row.get("aln") or row.get("assistance_listing_number")
-    if cfda and str(cfda).strip() in alns:
+    cfda = _first_nonempty(
+        row,
+        "cfda_number",
+        "CFDA Number",
+        "aln",
+        "ALN",
+        "assistance_listing_number",
+        "Assistance Listing Number",
+    )
+    if cfda is not None and str(cfda).strip() in alns:
         return True
 
-    agency = row.get("agency")
-    if agency is None or (isinstance(agency, float) and pd.isna(agency)):
+    agency = _first_nonempty(row, "agency", "Agency")
+    if agency is None:
         return False
 
     agency_lower = str(agency).strip().lower()

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py
@@ -7,7 +7,8 @@ all numeric fields are ``None`` so the downstream report can still render.
 
 Metrics:
     - phase_i_to_ii_graduation: any company with a Phase I award in stratum
-      that has a Phase II award (any year) in the cohort.
+      that has a Phase II award in the cohort no earlier than that Phase I
+      and within the configured graduation horizon (default: 5 years).
     - phase_ii_to_federal_contract_transition: Phase II awards with at least
       one upstream transition score >= the configured threshold (consumes
       ``transformed_transition_scores`` produced by the existing detector;
@@ -28,6 +29,8 @@ from dataclasses import dataclass, field
 from typing import Any
 
 import pandas as pd
+
+from .cohort import _award_year
 
 
 WILSON_Z_95 = 1.959963984540054
@@ -107,6 +110,9 @@ class OutcomeMetricsCalculator:
     """Compute per-stratum SBIR cohort outcome rates with Wilson CIs.
 
     Args:
+        graduation_horizon_years: maximum inclusive number of calendar years
+            from a Phase I award to a qualifying Phase II award. Default 5
+            matches the published-baseline cohort window.
         transition_score_threshold: minimum upstream transition-score for a
             Phase II award to count as transitioned. Default 0.65 matches
             the ``likely`` confidence threshold in
@@ -115,6 +121,7 @@ class OutcomeMetricsCalculator:
             recipient/vendor activity. Default 5.
     """
 
+    graduation_horizon_years: int = 5
     transition_score_threshold: float = 0.65
     survival_horizon_years: int = 5
     z: float = WILSON_Z_95
@@ -146,15 +153,32 @@ class OutcomeMetricsCalculator:
         cohort["_company_key"] = cohort.apply(_company_key, axis=1)
         cohort["_name_key"] = cohort.apply(_normalized_name_key, axis=1)
 
-        # Phase I->II graduation: per-vintage
+        # Phase I->II graduation: per-vintage. A Phase II that predates its
+        # company's Phase I is not a graduation, nor is one outside the
+        # configured cohort window.
         phase_i = cohort[cohort["phase_label"] == "I"]
-        phase_ii_companies = {
-            ck for ck in cohort.loc[cohort["phase_label"] == "II", "_company_key"] if ck
-        }
+        phase_ii = cohort[cohort["phase_label"] == "II"].copy()
+        phase_ii_years: dict[str, set[int]] = {}
+        for _, row in phase_ii.iterrows():
+            company_key = row["_company_key"]
+            year = _award_year(row)
+            if company_key and year is not None:
+                phase_ii_years.setdefault(company_key, set()).add(year)
+
         for vintage, group in phase_i.groupby("vintage_bucket", dropna=False):
             keys = [k for k in group["_company_key"].tolist() if k]
             unique_keys = set(keys)
-            graduated = unique_keys & phase_ii_companies
+            graduated: set[str] = set()
+            for _, row in group.iterrows():
+                company_key = row["_company_key"]
+                phase_i_year = _award_year(row)
+                if not company_key or phase_i_year is None:
+                    continue
+                if any(
+                    phase_i_year <= phase_ii_year <= phase_i_year + self.graduation_horizon_years
+                    for phase_ii_year in phase_ii_years.get(company_key, set())
+                ):
+                    graduated.add(company_key)
             records.append(
                 self._make_row(
                     vintage,
@@ -167,7 +191,6 @@ class OutcomeMetricsCalculator:
             )
 
         # Phase II -> federal-contract transition
-        phase_ii = cohort[cohort["phase_label"] == "II"].copy()
         transition_award_ids = self._transitioned_award_ids()
         for vintage, group in phase_ii.groupby("vintage_bucket", dropna=False):
             denom = len(group)

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py
@@ -6,9 +6,11 @@ is missing the corresponding metric is reported as ``available=False`` and
 all numeric fields are ``None`` so the downstream report can still render.
 
 Metrics:
-    - phase_i_to_ii_graduation: any company with a Phase I award in stratum
-      that has a Phase II award in the cohort no earlier than that Phase I
-      and within the configured graduation horizon (default: 5 years).
+    - phase_i_to_ii_graduation: any canonically resolved company with a Phase I
+      award in stratum that has a Phase II award in the cohort no earlier than
+      that Phase I and within the configured graduation horizon (default:
+      5 years). Every UEI, DUNS, and normalized-name alias present on a row is
+      connected before this firm-level calculation.
     - phase_ii_to_federal_contract_transition: Phase II awards with at least
       one upstream transition score >= the configured threshold (consumes
       ``transformed_transition_scores`` produced by the existing detector;
@@ -18,8 +20,7 @@ Metrics:
       vendor in any federal dataset >=5 years after Phase II award year.
       Denominator is unique companies (not award rows) per stratum.
     - ma_exit_rate: SBIR awardee appears in the M&A events JSONL (post-#286).
-      Join is UEI/DUNS-first; falls back to normalized company name when
-      UEI/DUNS are absent from the cohort row.
+      The join checks every alias attached to the resolved company component.
 """
 
 from __future__ import annotations
@@ -30,7 +31,7 @@ from typing import Any
 
 import pandas as pd
 
-from .cohort import _award_year
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 
 WILSON_Z_95 = 1.959963984540054
@@ -73,36 +74,119 @@ def wilson_interval(
     }
 
 
-def _company_key(row: pd.Series) -> str | None:
-    for key in ("uei", "UEI"):
-        v = row.get(key)
-        if v is not None and not (isinstance(v, float) and pd.isna(v)) and str(v).strip():
-            return f"uei:{str(v).strip().upper()}"
-    for key in ("duns", "Duns"):
-        v = row.get(key)
-        if v is not None and not (isinstance(v, float) and pd.isna(v)) and str(v).strip():
-            return f"duns:{str(v).strip()}"
-    for key in ("company_name", "Company"):
-        v = row.get(key)
-        if v is not None and not (isinstance(v, float) and pd.isna(v)) and str(v).strip():
-            return f"name:{str(v).strip().lower()}"
+_IDENTITY_PREFIX_ORDER = {"uei": 0, "duns": 1, "name": 2}
+
+
+def _nonempty_value(row: pd.Series, *keys: str) -> object | None:
+    for key in keys:
+        value = row.get(key)
+        if value is None:
+            continue
+        try:
+            if bool(pd.isna(value)):
+                continue
+        except (TypeError, ValueError):  # pragma: no cover - non-scalar cell
+            continue
+        if str(value).strip():
+            return value
     return None
 
 
-def _normalized_name_key(row: pd.Series) -> str | None:
-    """Return a ``name:`` key regardless of whether UEI/DUNS are present.
+def _normalized_duns(value: object) -> str:
+    text = str(value).strip()
+    if text.endswith(".0") and text[:-2].isdigit():
+        text = text[:-2]
+    digits = "".join(character for character in text if character.isdigit())
+    return digits or text.upper()
 
-    Used for the M&A exit-rate join: ``sbir_ma_events.jsonl`` is keyed by
-    company name, so a cohort row that has a UEI (and therefore resolves
-    to ``uei:XXX`` via ``_company_key``) still needs a name-based fallback
-    for the join. When both keys are available we join on both; any match
-    counts.
+
+def _identity_aliases(row: pd.Series) -> frozenset[str]:
+    """Return every exact identity alias present on an award row.
+
+    Names use the repository's versioned organization-key policy. This is an
+    exact alias graph, not a fuzzy match: rows are joined only when they share
+    a normalized UEI, DUNS, or organization name, including through a
+    transitive chain of co-occurring identifiers.
     """
-    for key in ("company_name", "Company"):
-        v = row.get(key)
-        if v is not None and not (isinstance(v, float) and pd.isna(v)) and str(v).strip():
-            return f"name:{str(v).strip().lower()}"
-    return None
+
+    aliases: set[str] = set()
+    uei = _nonempty_value(row, "uei", "UEI")
+    if uei is not None:
+        aliases.add(f"uei:{str(uei).strip().upper()}")
+    duns = _nonempty_value(row, "duns", "Duns")
+    if duns is not None:
+        aliases.add(f"duns:{_normalized_duns(duns)}")
+    name = _nonempty_value(row, "company_name", "Company")
+    if name is not None:
+        normalized_name = normalize_company_name(
+            name,
+            profile=CompanyNameProfile.ORGANIZATION_KEY_V1,
+        )
+        if normalized_name:
+            aliases.add(f"name:{normalized_name.lower()}")
+    return frozenset(aliases)
+
+
+def _alias_sort_key(alias: str) -> tuple[int, str]:
+    prefix = alias.partition(":")[0]
+    return (_IDENTITY_PREFIX_ORDER.get(prefix, 99), alias)
+
+
+def _resolve_company_identities(
+    cohort: pd.DataFrame,
+) -> tuple[list[str | None], list[frozenset[str]]]:
+    """Resolve rows to deterministic connected components of exact aliases."""
+
+    row_aliases = [_identity_aliases(row) for _, row in cohort.iterrows()]
+    parent: dict[str, str] = {}
+
+    def find(alias: str) -> str:
+        parent.setdefault(alias, alias)
+        root = alias
+        while parent[root] != root:
+            root = parent[root]
+        while parent[alias] != alias:
+            next_alias = parent[alias]
+            parent[alias] = root
+            alias = next_alias
+        return root
+
+    def union(left: str, right: str) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root == right_root:
+            return
+        if _alias_sort_key(left_root) <= _alias_sort_key(right_root):
+            parent[right_root] = left_root
+        else:
+            parent[left_root] = right_root
+
+    for aliases in row_aliases:
+        ordered = sorted(aliases, key=_alias_sort_key)
+        if not ordered:
+            continue
+        find(ordered[0])
+        for alias in ordered[1:]:
+            union(ordered[0], alias)
+
+    component_aliases: dict[str, set[str]] = {}
+    for alias in parent:
+        component_aliases.setdefault(find(alias), set()).add(alias)
+    canonical_by_root = {
+        root: min(aliases, key=_alias_sort_key) for root, aliases in component_aliases.items()
+    }
+    company_keys = [
+        canonical_by_root[find(min(aliases, key=_alias_sort_key))] if aliases else None
+        for aliases in row_aliases
+    ]
+    return company_keys, row_aliases
+
+
+def _resolved_award_year(row: pd.Series) -> int | None:
+    value = row.get("award_year_resolved")
+    if value is None or pd.isna(value):
+        return None
+    return int(value)
 
 
 @dataclass
@@ -111,8 +195,9 @@ class OutcomeMetricsCalculator:
 
     Args:
         graduation_horizon_years: maximum inclusive number of calendar years
-            from a Phase I award to a qualifying Phase II award. Default 5
-            matches the published-baseline cohort window.
+            from a Phase I award to a qualifying Phase II award. ``None``
+            means unbounded follow-up. Default 5 is the current Phase 1 review
+            estimand and is configurable rather than implicit.
         transition_score_threshold: minimum upstream transition-score for a
             Phase II award to count as transitioned. Default 0.65 matches
             the ``likely`` confidence threshold in
@@ -121,7 +206,7 @@ class OutcomeMetricsCalculator:
             recipient/vendor activity. Default 5.
     """
 
-    graduation_horizon_years: int = 5
+    graduation_horizon_years: int | None = 5
     transition_score_threshold: float = 0.65
     survival_horizon_years: int = 5
     z: float = WILSON_Z_95
@@ -129,6 +214,73 @@ class OutcomeMetricsCalculator:
     transition_scores: pd.DataFrame | None = field(default=None)
     federal_activity_companies: set[str] | None = field(default=None)
     ma_event_companies: set[str] | None = field(default=None)
+
+    def __post_init__(self) -> None:
+        if self.graduation_horizon_years is not None and self.graduation_horizon_years < 0:
+            raise ValueError("graduation_horizon_years must be non-negative or None")
+
+    @staticmethod
+    def identity_coverage(
+        cohort: pd.DataFrame,
+        *,
+        vintage_bucket: str | None = None,
+        phase_label: str | None = None,
+    ) -> dict[str, object]:
+        """Summarize coverage after resolving aliases across the full cohort.
+
+        Optional vintage and phase filters select the rows whose firms form the
+        reported denominator, while retaining aliases learned from every row.
+        """
+
+        if cohort.empty:
+            return {
+                "row_count": 0,
+                "resolved_row_count": 0,
+                "resolved_row_rate": None,
+                "company_count": 0,
+                "company_basis_counts": {"uei": 0, "duns": 0, "name": 0},
+                "uei_duns_bridge_company_count": 0,
+            }
+        company_keys, row_aliases = _resolve_company_identities(cohort)
+        selected = pd.Series(True, index=cohort.index)
+        if vintage_bucket is not None:
+            selected &= cohort["vintage_bucket"] == vintage_bucket
+        if phase_label is not None:
+            selected &= cohort["phase_label"] == phase_label
+        selected_positions = [
+            position for position, keep in enumerate(selected.tolist()) if bool(keep)
+        ]
+        selected_company_keys: set[str] = set()
+        for position in selected_positions:
+            company_key = company_keys[position]
+            if company_key is not None:
+                selected_company_keys.add(company_key)
+        aliases_by_company: dict[str, set[str]] = {}
+        for company_key, aliases in zip(company_keys, row_aliases, strict=True):
+            if company_key is not None and company_key in selected_company_keys:
+                aliases_by_company.setdefault(company_key, set()).update(aliases)
+        basis_counts = {"uei": 0, "duns": 0, "name": 0}
+        bridge_count = 0
+        for component_aliases in aliases_by_company.values():
+            prefixes = {alias.partition(":")[0] for alias in component_aliases}
+            if "uei" in prefixes:
+                basis_counts["uei"] += 1
+            elif "duns" in prefixes:
+                basis_counts["duns"] += 1
+            else:
+                basis_counts["name"] += 1
+            if {"uei", "duns"}.issubset(prefixes):
+                bridge_count += 1
+        resolved_rows = sum(company_keys[position] is not None for position in selected_positions)
+        row_count = len(selected_positions)
+        return {
+            "row_count": row_count,
+            "resolved_row_count": resolved_rows,
+            "resolved_row_rate": resolved_rows / row_count if row_count else None,
+            "company_count": len(aliases_by_company),
+            "company_basis_counts": basis_counts,
+            "uei_duns_bridge_company_count": bridge_count,
+        }
 
     def compute(self, cohort: pd.DataFrame) -> pd.DataFrame:
         """Emit one row per (vintage_bucket, phase_label, metric) stratum."""
@@ -150,8 +302,9 @@ class OutcomeMetricsCalculator:
 
         records: list[dict[str, Any]] = []
         cohort = cohort.copy()
-        cohort["_company_key"] = cohort.apply(_company_key, axis=1)
-        cohort["_name_key"] = cohort.apply(_normalized_name_key, axis=1)
+        company_keys, row_aliases = _resolve_company_identities(cohort)
+        cohort["_company_key"] = company_keys
+        cohort["_identity_aliases"] = row_aliases
 
         # Phase I->II graduation: per-vintage. A Phase II that predates its
         # company's Phase I is not a graduation, nor is one outside the
@@ -161,7 +314,7 @@ class OutcomeMetricsCalculator:
         phase_ii_years: dict[str, set[int]] = {}
         for _, row in phase_ii.iterrows():
             company_key = row["_company_key"]
-            year = _award_year(row)
+            year = _resolved_award_year(row)
             if company_key and year is not None:
                 phase_ii_years.setdefault(company_key, set()).add(year)
 
@@ -171,11 +324,15 @@ class OutcomeMetricsCalculator:
             graduated: set[str] = set()
             for _, row in group.iterrows():
                 company_key = row["_company_key"]
-                phase_i_year = _award_year(row)
+                phase_i_year = _resolved_award_year(row)
                 if not company_key or phase_i_year is None:
                     continue
                 if any(
-                    phase_i_year <= phase_ii_year <= phase_i_year + self.graduation_horizon_years
+                    phase_i_year <= phase_ii_year
+                    and (
+                        self.graduation_horizon_years is None
+                        or phase_ii_year <= phase_i_year + self.graduation_horizon_years
+                    )
                     for phase_ii_year in phase_ii_years.get(company_key, set())
                 ):
                     graduated.add(company_key)
@@ -200,7 +357,7 @@ class OutcomeMetricsCalculator:
                         vintage,
                         "II",
                         "phase_ii_to_federal_contract_transition",
-                        numerator=0,
+                        numerator=None,
                         denominator=denom,
                         available=False,
                     )
@@ -230,14 +387,14 @@ class OutcomeMetricsCalculator:
                         vintage,
                         "II",
                         "five_year_survival_proxy",
-                        numerator=0,
+                        numerator=None,
                         denominator=denom,
                         available=False,
                     )
                 )
                 continue
-            company_keys = {k for k in group["_company_key"].tolist() if k}
-            survived = company_keys & self.federal_activity_companies
+            active_company_keys = {k for k in group["_company_key"].tolist() if k}
+            survived = active_company_keys & self.federal_activity_companies
             records.append(
                 self._make_row(
                     vintage,
@@ -250,9 +407,8 @@ class OutcomeMetricsCalculator:
             )
 
         # M&A exit rate (per stratum, all phases).
-        # Bug fix: join on UEI/DUNS key first; also check name key as fallback so
-        # that sbir_ma_events.jsonl (keyed by company_name) matches cohort rows
-        # that have a UEI/DUNS in addition to rows that only have a name.
+        # Match every alias on a resolved company component. The current M&A
+        # artifact is name-keyed, while future inputs may carry UEI or DUNS.
         for (vintage, phase), group in cohort.groupby(
             ["vintage_bucket", "phase_label"], dropna=False
         ):
@@ -264,31 +420,18 @@ class OutcomeMetricsCalculator:
                         vintage,
                         phase,
                         "ma_exit_rate",
-                        numerator=0,
+                        numerator=None,
                         denominator=denom,
                         available=False,
                     )
                 )
                 continue
-            # Primary join: UEI/DUNS company keys
-            exited = denom_keys & self.ma_event_companies
-            # Fallback join: normalized name keys for rows where UEI/DUNS matched
-            # to a different key format than what the M&A JSONL uses. Only count
-            # each unique company once.
-            name_keys = {k for k in group["_name_key"].tolist() if k}
-            exited_by_name = name_keys & self.ma_event_companies
-            # A company that has a UEI key may not appear in exited yet; add any
-            # that match by name, de-duplicated by tracking which names already
-            # contributed a counted company.
-            already_counted_ueis = {
-                row["_company_key"] for _, row in group.iterrows() if row["_company_key"] in exited
-            }
+            exited: set[str] = set()
             for _, row in group.iterrows():
-                name_k = row.get("_name_key")
                 company_k = row.get("_company_key")
-                if name_k and name_k in exited_by_name and company_k not in already_counted_ueis:
-                    exited.add(company_k or name_k)
-                    already_counted_ueis.add(company_k)
+                aliases = row.get("_identity_aliases") or frozenset()
+                if company_k and any(alias in self.ma_event_companies for alias in aliases):
+                    exited.add(company_k)
             records.append(
                 self._make_row(
                     vintage,
@@ -318,11 +461,12 @@ class OutcomeMetricsCalculator:
         phase: object,
         metric: str,
         *,
-        numerator: int,
+        numerator: int | None,
         denominator: int,
         available: bool,
     ) -> dict[str, Any]:
-        if available and denominator > 0:
+        wi: dict[str, Any]
+        if available and numerator is not None and denominator > 0:
             wi = wilson_interval(numerator, denominator, z=self.z)
         else:
             wi = {
@@ -336,7 +480,7 @@ class OutcomeMetricsCalculator:
             "vintage_bucket": vintage,
             "phase_label": phase,
             "metric": metric,
-            "numerator": int(wi["numerator"]),
+            "numerator": int(wi["numerator"]) if wi["numerator"] is not None else None,
             "denominator": int(wi["denominator"]),
             "rate": wi["rate"],
             "ci_low": wi["ci_low"],

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py
@@ -306,6 +306,15 @@ class OutcomeMetricsCalculator:
         cohort["_company_key"] = company_keys
         cohort["_identity_aliases"] = row_aliases
 
+        # Union every alias onto its resolved component, cohort-wide. Identity is a
+        # property of the company, not of the row it happened to appear on: a
+        # UEI-only row must still match a name-keyed outcome event that reached the
+        # component through some other row.
+        aliases_by_company: dict[str, set[str]] = {}
+        for company_key, aliases in zip(company_keys, row_aliases, strict=True):
+            if company_key is not None:
+                aliases_by_company.setdefault(company_key, set()).update(aliases)
+
         # Phase I->II graduation: per-vintage. A Phase II that predates its
         # company's Phase I is not a graduation, nor is one outside the
         # configured cohort window.
@@ -426,12 +435,11 @@ class OutcomeMetricsCalculator:
                     )
                 )
                 continue
-            exited: set[str] = set()
-            for _, row in group.iterrows():
-                company_k = row.get("_company_key")
-                aliases = row.get("_identity_aliases") or frozenset()
-                if company_k and any(alias in self.ma_event_companies for alias in aliases):
-                    exited.add(company_k)
+            exited = {
+                company_k
+                for company_k in denom_keys
+                if aliases_by_company.get(company_k, set()) & self.ma_event_companies
+            }
             records.append(
                 self._make_row(
                     vintage,

--- a/scripts/archive/data/run_agency_private_capital_phase1.py
+++ b/scripts/archive/data/run_agency_private_capital_phase1.py
@@ -33,6 +33,7 @@ import argparse
 import hashlib
 import json
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pandas as pd
@@ -48,12 +49,14 @@ from sbir_analytics.assets.agency_private_capital.cohort import AgencyCohortBuil
 from sbir_analytics.assets.agency_private_capital.outcomes import OutcomeMetricsCalculator
 from sbir_analytics.assets.agency_private_capital.reconcile import ReconciliationNarrative
 from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
 
 DEFAULT_AWARDS_CSV = Path("/tmp/sbir_awards_full.csv")
 DEFAULT_MA_EVENTS = Path("data/sbir_ma_events.jsonl")
 DEFAULT_HEADLINE_VINTAGE = "2015-2019"
 DEFAULT_GRADUATION_HORIZON_YEARS = 5
+DEFAULT_SENSITIVITY_HORIZONS: tuple[int | None, ...] = (2, 3, 5, None)
 
 _METRICS = (
     "phase_i_to_ii_graduation",
@@ -108,7 +111,12 @@ def _load_ma_event_companies(path: Path) -> set[str] | None:
                 continue
             name = event.get("company_name")
             if name and str(name).strip():
-                keys.add(f"name:{str(name).strip().lower()}")
+                normalized = normalize_company_name(
+                    name,
+                    profile=CompanyNameProfile.ORGANIZATION_KEY_V1,
+                )
+                if normalized:
+                    keys.add(f"name:{normalized.lower()}")
     return keys
 
 
@@ -131,6 +139,9 @@ def _file_provenance(
     source: str,
     row_count: int | None,
     schema: dict[str, object],
+    source_url: str | None = None,
+    retrieved_at: str | None = None,
+    retrieved_at_basis: str | None = None,
 ) -> dict[str, object]:
     """Describe an input without persisting a machine-specific absolute path."""
 
@@ -143,6 +154,21 @@ def _file_provenance(
         "sha256": _sha256_file(path) if available else None,
         "size_bytes": path.stat().st_size if available else None,
         "source": source,
+        "source_url": source_url,
+        "retrieved_at": retrieved_at if available else None,
+        "retrieved_at_basis": retrieved_at_basis if available else None,
+    }
+
+
+def _file_modified_date(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC).date().isoformat()
+
+
+def _output_provenance(path: Path) -> dict[str, object]:
+    return {
+        "path": path.name,
+        "sha256": _sha256_file(path),
+        "size_bytes": path.stat().st_size,
     }
 
 
@@ -177,11 +203,106 @@ def _metric_availability(
     return availability
 
 
+def _graduation_result(outcomes: pd.DataFrame, *, vintage: str) -> dict[str, object]:
+    rows = outcomes[
+        (outcomes["metric"] == "phase_i_to_ii_graduation") & (outcomes["vintage_bucket"] == vintage)
+    ]
+    if rows.empty:
+        return {
+            "available": False,
+            "numerator": None,
+            "denominator": None,
+            "rate": None,
+            "ci_low": None,
+            "ci_high": None,
+        }
+    row = rows.iloc[0]
+    return {
+        "available": bool(row["available"]),
+        "numerator": int(row["numerator"]) if pd.notna(row["numerator"]) else None,
+        "denominator": int(row["denominator"]) if pd.notna(row["denominator"]) else None,
+        "rate": float(row["rate"]) if pd.notna(row["rate"]) else None,
+        "ci_low": float(row["ci_low"]) if pd.notna(row["ci_low"]) else None,
+        "ci_high": float(row["ci_high"]) if pd.notna(row["ci_high"]) else None,
+    }
+
+
+def _graduation_sensitivity(
+    cohort: pd.DataFrame,
+    *,
+    headline_vintage: str,
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for horizon in DEFAULT_SENSITIVITY_HORIZONS:
+        outcomes = OutcomeMetricsCalculator(graduation_horizon_years=horizon).compute(cohort)
+        rows.append(
+            {
+                "horizon_years": horizon,
+                **_graduation_result(outcomes, vintage=headline_vintage),
+            }
+        )
+    return rows
+
+
+def _format_rate(value: object) -> str:
+    return "not available" if value is None else f"{float(str(value)):.1%}"
+
+
+def _diagnostics_markdown(
+    *,
+    horizon_sensitivity: list[dict[str, object]],
+    identity_coverage: dict[str, object],
+) -> str:
+    lines = [
+        "## Graduation-horizon sensitivity",
+        "",
+        "| Maximum follow-up | Graduated firms | Phase I firms | Rate |",
+        "| --- | ---: | ---: | ---: |",
+    ]
+    for result in horizon_sensitivity:
+        horizon = result["horizon_years"]
+        horizon_label = "Unbounded" if horizon is None else f"{horizon} years"
+        lines.append(
+            f"| {horizon_label} | {result['numerator']} | {result['denominator']} | "
+            f"{_format_rate(result['rate'])} |"
+        )
+    basis = identity_coverage["company_basis_counts"]
+    assert isinstance(basis, dict)
+    resolved_rate = identity_coverage["resolved_row_rate"]
+    lines.extend(
+        [
+            "",
+            "## Entity-resolution coverage",
+            "",
+            (
+                f"The headline Phase I denominator resolves to "
+                f"**{identity_coverage['company_count']:,} firms**: "
+                f"{basis['uei']:,} with a UEI-backed component, "
+                f"{basis['duns']:,} with DUNS but no UEI, and "
+                f"{basis['name']:,} by normalized name only. "
+                f"{identity_coverage['uei_duns_bridge_company_count']:,} components bridge both "
+                "UEI and DUNS."
+            ),
+            "",
+            (
+                f"Resolved award rows in the headline denominator: "
+                f"{identity_coverage['resolved_row_count']:,}/"
+                f"{identity_coverage['row_count']:,} ({float(str(resolved_rate)):.1%})."
+                if resolved_rate is not None
+                else "No headline award rows were available for identity coverage."
+            ),
+        ]
+    )
+    return "\n".join(lines)
+
+
 def _annotate_report(
     markdown: str,
     *,
     metric_availability: dict[str, dict[str, object]],
     graduation_horizon_years: int,
+    horizon_sensitivity: list[dict[str, object]],
+    identity_coverage: dict[str, object],
 ) -> str:
     unavailable = [
         f"`{metric}` ({details['reason']})"
@@ -198,7 +319,11 @@ def _annotate_report(
     )
     if not separator:
         return f"{title}\n\n{banner}\n"
-    return f"{title}\n\n{banner}\n{remainder}"
+    diagnostics = _diagnostics_markdown(
+        horizon_sensitivity=horizon_sensitivity,
+        identity_coverage=identity_coverage,
+    )
+    return f"{title}\n\n{banner}\n{remainder}\n{diagnostics}\n"
 
 
 def _build_run_manifest(
@@ -210,8 +335,13 @@ def _build_run_manifest(
     ma_events_row_count: int | None,
     registry_path: Path,
     registry_row_count: int,
+    run_date: str,
+    awards_retrieved_at: str,
+    awards_retrieved_at_basis: str,
     parameters: dict[str, object],
     metric_availability: dict[str, dict[str, object]],
+    results: dict[str, object],
+    output_paths: dict[str, Path],
 ) -> dict[str, object]:
     """Build deterministic provenance for a standalone exploratory run."""
 
@@ -222,6 +352,9 @@ def _build_run_manifest(
             "awards_csv": _file_provenance(
                 awards_path,
                 source="sbir_gov_bulk_awards",
+                source_url=SBIR_AWARDS_CSV_URL,
+                retrieved_at=awards_retrieved_at,
+                retrieved_at_basis=awards_retrieved_at_basis,
                 row_count=awards_row_count,
                 schema={"columns": awards_columns, "format": "csv"},
             ),
@@ -244,8 +377,11 @@ def _build_run_manifest(
             "Results are exploratory and non-citable.",
         ],
         "metric_availability": metric_availability,
+        "outputs": {name: _output_provenance(path) for name, path in sorted(output_paths.items())},
         "parameters": parameters,
-        "schema_version": 1,
+        "results": results,
+        "run_date": run_date,
+        "schema_version": 2,
     }
 
 
@@ -277,6 +413,19 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--run-date",
+        default=datetime.now(UTC).date().isoformat(),
+        help="Manifest run date in YYYY-MM-DD format (default: current UTC date)",
+    )
+    parser.add_argument(
+        "--awards-retrieved-at",
+        default=None,
+        help=(
+            "SBIR.gov snapshot retrieval date in YYYY-MM-DD format. Defaults to the input "
+            "file's modification date and records that basis explicitly."
+        ),
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         default=None,
@@ -293,6 +442,16 @@ def main() -> int:
     args = parser.parse_args()
     if args.graduation_horizon_years < 0:
         parser.error("--graduation-horizon-years must be non-negative")
+    for option, value in (
+        ("--run-date", args.run_date),
+        ("--awards-retrieved-at", args.awards_retrieved_at),
+    ):
+        if value is None:
+            continue
+        try:
+            datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            parser.error(f"{option} must use YYYY-MM-DD format")
 
     agency_code: str = args.agency.strip().upper()
     output_dir: Path = args.output_dir or (
@@ -303,6 +462,8 @@ def main() -> int:
         print(f"awards CSV not found at {args.awards_csv}", file=sys.stderr)
         return 2
     awards_path = _ensure_awards_csv(args.awards_csv)
+    awards_retrieved_at = args.awards_retrieved_at or _file_modified_date(awards_path)
+    awards_retrieved_at_basis = "provided" if args.awards_retrieved_at else "file_mtime"
 
     print(f"Loading awards from {awards_path}")
     awards = pd.read_csv(awards_path, dtype=str, low_memory=False, encoding_errors="replace")
@@ -327,6 +488,15 @@ def main() -> int:
         ma_event_companies=ma_companies,
     )
     outcomes = calc.compute(cohort)
+    horizon_sensitivity = _graduation_sensitivity(
+        cohort,
+        headline_vintage=args.headline_vintage,
+    )
+    identity_coverage = OutcomeMetricsCalculator.identity_coverage(
+        cohort,
+        vintage_bucket=args.headline_vintage,
+        phase_label="I",
+    )
     metric_availability = _metric_availability(
         outcomes,
         ma_events_loaded=ma_companies is not None,
@@ -349,15 +519,24 @@ def main() -> int:
         ),
         metric_availability=metric_availability,
         graduation_horizon_years=args.graduation_horizon_years,
+        horizon_sensitivity=horizon_sensitivity,
+        identity_coverage=identity_coverage,
     )
     md_path.write_text(
         md_text,
         encoding="utf-8",
     )
-    json_path.write_text(
-        json.dumps([r.to_json() for r in records], indent=2, default=str),
-        encoding="utf-8",
-    )
+    comparison_records = []
+    for record in records:
+        payload = record.to_json()
+        payload["analysis_parameters"] = {
+            "graduation_horizon_years": args.graduation_horizon_years,
+            "headline_vintage": args.headline_vintage,
+        }
+        payload["citable"] = False
+        comparison_records.append(payload)
+    json_path.write_text(json.dumps(comparison_records, indent=2, default=str), encoding="utf-8")
+    headline_result = _graduation_result(outcomes, vintage=args.headline_vintage)
     manifest = _build_run_manifest(
         awards_path=awards_path,
         awards_row_count=len(awards),
@@ -366,6 +545,9 @@ def main() -> int:
         ma_events_row_count=ma_event_row_count,
         registry_path=args.registry,
         registry_row_count=len(registry),
+        run_date=args.run_date,
+        awards_retrieved_at=awards_retrieved_at,
+        awards_retrieved_at_basis=awards_retrieved_at_basis,
         parameters={
             "agency_code": agency_code,
             "graduation_horizon_years": args.graduation_horizon_years,
@@ -375,6 +557,20 @@ def main() -> int:
             "vintage_bucket_size": builder.vintage_size,
         },
         metric_availability=metric_availability,
+        results={
+            "headline_graduation": {
+                "vintage_bucket": args.headline_vintage,
+                "horizon_years": args.graduation_horizon_years,
+                **headline_result,
+            },
+            "graduation_horizon_sensitivity": horizon_sensitivity,
+            "identity_coverage": identity_coverage,
+        },
+        output_paths={
+            "agency_baseline_comparison_json": json_path,
+            "agency_cohort_outcomes_parquet": parquet_path,
+            "agency_vs_published_baselines_markdown": md_path,
+        },
     )
     manifest_path = _write_run_manifest(output_dir, manifest)
 

--- a/scripts/archive/data/run_agency_private_capital_phase1.py
+++ b/scripts/archive/data/run_agency_private_capital_phase1.py
@@ -13,20 +13,24 @@ Defaults mirror PR #286's pipeline conventions: the awards CSV defaults to
 the M&A events JSONL defaults to ``data/sbir_ma_events.jsonl`` (produced by
 ``scripts/archive/data/detect_sbir_ma_events.py``).
 
-Outputs three artifacts to ``data/processed/agency_private_capital/<agency_lower>/``:
+Outputs four artifacts to ``data/processed/agency_private_capital/<agency_lower>/``:
 - agency_cohort_outcomes.parquet
 - agency_vs_published_baselines.md
 - agency_baseline_comparison.json
+- run_manifest.json
 
 This script reproduces the Dagster asset's logic in-process so we can
 materialize Phase 1 against real data without wiring the full
 ``enriched_sbir_awards`` upstream chain. Survival, patent, and transition
 metrics will render as ``available=False`` (those signals require
-enrichment outputs that aren't read here); graduation and M&A exit rates
-will populate.
+enrichment outputs that aren't read here). Graduation will populate; M&A
+exit rates populate only when the optional events file is present. The report
+and manifest explicitly retain the package's exploratory, non-citable
+epistemic label.
 """
 
 import argparse
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -35,6 +39,7 @@ import pandas as pd
 import requests
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from sbir_analytics.assets.agency_private_capital import EPISTEMIC_TIER
 from sbir_analytics.assets.agency_private_capital.baselines import (
     DEFAULT_REGISTRY_PATH,
     PublishedBaselineRegistry,
@@ -48,6 +53,15 @@ from sbir_etl.extractors.sbir_gov_api import SBIR_AWARDS_CSV_URL
 DEFAULT_AWARDS_CSV = Path("/tmp/sbir_awards_full.csv")
 DEFAULT_MA_EVENTS = Path("data/sbir_ma_events.jsonl")
 DEFAULT_HEADLINE_VINTAGE = "2015-2019"
+DEFAULT_GRADUATION_HORIZON_YEARS = 5
+
+_METRICS = (
+    "phase_i_to_ii_graduation",
+    "phase_ii_to_federal_contract_transition",
+    "five_year_survival_proxy",
+    "ma_exit_rate",
+    "patent_rate",
+)
 
 
 @retry(
@@ -98,6 +112,149 @@ def _load_ma_event_companies(path: Path) -> set[str] | None:
     return keys
 
 
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _nonempty_line_count(path: Path) -> int:
+    with path.open(encoding="utf-8") as fh:
+        return sum(1 for line in fh if line.strip())
+
+
+def _file_provenance(
+    path: Path,
+    *,
+    source: str,
+    row_count: int | None,
+    schema: dict[str, object],
+) -> dict[str, object]:
+    """Describe an input without persisting a machine-specific absolute path."""
+
+    available = path.is_file()
+    return {
+        "available": available,
+        "path": path.name,
+        "row_count": row_count if available else None,
+        "schema": schema,
+        "sha256": _sha256_file(path) if available else None,
+        "size_bytes": path.stat().st_size if available else None,
+        "source": source,
+    }
+
+
+def _metric_availability(
+    outcomes: pd.DataFrame,
+    *,
+    ma_events_loaded: bool,
+) -> dict[str, dict[str, object]]:
+    unavailable_reasons = {
+        "phase_i_to_ii_graduation": "No qualifying Phase I cohort rows were available.",
+        "phase_ii_to_federal_contract_transition": (
+            "Transition-score enrichment is not read by this standalone runner."
+        ),
+        "five_year_survival_proxy": (
+            "Federal recipient/vendor activity is not read by this standalone runner."
+        ),
+        "ma_exit_rate": (
+            "The M&A events input was not found."
+            if not ma_events_loaded
+            else "No qualifying cohort rows were available."
+        ),
+        "patent_rate": "PATLINK is deferred to Phase 2 and is not read by this runner.",
+    }
+    availability: dict[str, dict[str, object]] = {}
+    for metric in _METRICS:
+        rows = outcomes[outcomes["metric"] == metric] if not outcomes.empty else outcomes
+        available = bool(not rows.empty and rows["available"].fillna(False).any())
+        availability[metric] = {
+            "available": available,
+            "reason": None if available else unavailable_reasons[metric],
+        }
+    return availability
+
+
+def _annotate_report(
+    markdown: str,
+    *,
+    metric_availability: dict[str, dict[str, object]],
+    graduation_horizon_years: int,
+) -> str:
+    unavailable = [
+        f"`{metric}` ({details['reason']})"
+        for metric, details in metric_availability.items()
+        if not details["available"]
+    ]
+    unavailable_text = "; ".join(unavailable) if unavailable else "None."
+    title, separator, remainder = markdown.partition("\n")
+    banner = (
+        "> **Exploratory / non-citable.** This standalone analysis has not earned "
+        "publication-quality validation.\n>\n"
+        f"> **Phase I -> Phase II graduation horizon:** {graduation_horizon_years} years.\n>\n"
+        f"> **Unavailable metrics in this run:** {unavailable_text}"
+    )
+    if not separator:
+        return f"{title}\n\n{banner}\n"
+    return f"{title}\n\n{banner}\n{remainder}"
+
+
+def _build_run_manifest(
+    *,
+    awards_path: Path,
+    awards_row_count: int,
+    awards_columns: list[str],
+    ma_events_path: Path,
+    ma_events_row_count: int | None,
+    registry_path: Path,
+    registry_row_count: int,
+    parameters: dict[str, object],
+    metric_availability: dict[str, dict[str, object]],
+) -> dict[str, object]:
+    """Build deterministic provenance for a standalone exploratory run."""
+
+    return {
+        "citable": False,
+        "epistemic_tier": EPISTEMIC_TIER,
+        "inputs": {
+            "awards_csv": _file_provenance(
+                awards_path,
+                source="sbir_gov_bulk_awards",
+                row_count=awards_row_count,
+                schema={"columns": awards_columns, "format": "csv"},
+            ),
+            "ma_events_jsonl": _file_provenance(
+                ma_events_path,
+                source="sbir_ma_events",
+                row_count=ma_events_row_count,
+                schema={"company_key": "company_name", "format": "jsonl"},
+            ),
+            "published_baselines_yaml": _file_provenance(
+                registry_path,
+                source="published_baseline_registry",
+                row_count=registry_row_count,
+                schema={"collection": "baselines", "format": "yaml"},
+            ),
+        },
+        "limitations": [
+            "Standalone runner omits transition-score and federal-activity enrichment inputs.",
+            "Patent rate is deferred to Phase 2.",
+            "Results are exploratory and non-citable.",
+        ],
+        "metric_availability": metric_availability,
+        "parameters": parameters,
+        "schema_version": 1,
+    }
+
+
+def _write_run_manifest(output_dir: Path, manifest: dict[str, object]) -> Path:
+    path = output_dir / "run_manifest.json"
+    path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -110,6 +267,15 @@ def main() -> int:
     parser.add_argument("--ma-events", type=Path, default=DEFAULT_MA_EVENTS)
     parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY_PATH)
     parser.add_argument("--headline-vintage", default=DEFAULT_HEADLINE_VINTAGE)
+    parser.add_argument(
+        "--graduation-horizon-years",
+        type=int,
+        default=DEFAULT_GRADUATION_HORIZON_YEARS,
+        help=(
+            "Maximum inclusive years from Phase I to a qualifying Phase II "
+            f"(default: {DEFAULT_GRADUATION_HORIZON_YEARS})"
+        ),
+    )
     parser.add_argument(
         "--output-dir",
         type=Path,
@@ -125,6 +291,8 @@ def main() -> int:
         help="Fail rather than download the awards CSV if missing.",
     )
     args = parser.parse_args()
+    if args.graduation_horizon_years < 0:
+        parser.error("--graduation-horizon-years must be non-negative")
 
     agency_code: str = args.agency.strip().upper()
     output_dir: Path = args.output_dir or (
@@ -148,13 +316,21 @@ def main() -> int:
     print(counts.to_string(index=False))
 
     ma_companies = _load_ma_event_companies(args.ma_events)
+    ma_event_row_count = _nonempty_line_count(args.ma_events) if args.ma_events.is_file() else None
     if ma_companies is None:
         print(f"M&A events not found at {args.ma_events} — metric will render as unavailable")
     else:
         print(f"Loaded M&A event company set: n={len(ma_companies):,}")
 
-    calc = OutcomeMetricsCalculator(ma_event_companies=ma_companies)
+    calc = OutcomeMetricsCalculator(
+        graduation_horizon_years=args.graduation_horizon_years,
+        ma_event_companies=ma_companies,
+    )
     outcomes = calc.compute(cohort)
+    metric_availability = _metric_availability(
+        outcomes,
+        ma_events_loaded=ma_companies is not None,
+    )
 
     output_dir.mkdir(parents=True, exist_ok=True)
     parquet_path = output_dir / "agency_cohort_outcomes.parquet"
@@ -165,22 +341,53 @@ def main() -> int:
     registry = PublishedBaselineRegistry.load(args.registry)
     narrative = ReconciliationNarrative(registry=registry)
     records = narrative.reconcile(outcomes, headline_vintage=args.headline_vintage)
-    md_path.write_text(
+    md_text = _annotate_report(
         narrative.to_markdown(
             records,
             headline_vintage=args.headline_vintage,
             agency_code=args.agency,
         ),
+        metric_availability=metric_availability,
+        graduation_horizon_years=args.graduation_horizon_years,
+    )
+    md_path.write_text(
+        md_text,
         encoding="utf-8",
     )
     json_path.write_text(
         json.dumps([r.to_json() for r in records], indent=2, default=str),
         encoding="utf-8",
     )
+    manifest = _build_run_manifest(
+        awards_path=awards_path,
+        awards_row_count=len(awards),
+        awards_columns=[str(column) for column in awards.columns],
+        ma_events_path=args.ma_events,
+        ma_events_row_count=ma_event_row_count,
+        registry_path=args.registry,
+        registry_row_count=len(registry),
+        parameters={
+            "agency_code": agency_code,
+            "graduation_horizon_years": args.graduation_horizon_years,
+            "headline_vintage": args.headline_vintage,
+            "survival_horizon_years": calc.survival_horizon_years,
+            "transition_score_threshold": calc.transition_score_threshold,
+            "vintage_bucket_size": builder.vintage_size,
+        },
+        metric_availability=metric_availability,
+    )
+    manifest_path = _write_run_manifest(output_dir, manifest)
 
+    unavailable_metrics = [
+        metric for metric, details in metric_availability.items() if not details["available"]
+    ]
+    print("\nEpistemic status: exploratory / non-citable")
+    print(f"Graduation horizon: {args.graduation_horizon_years} years")
+    print(f"Unavailable metrics: {', '.join(unavailable_metrics) or 'none'}")
     print(f"\nWrote {parquet_path}")
     print(f"Wrote {md_path}")
     print(f"Wrote {json_path}")
+    print(f"Wrote {manifest_path}")
     return 0
 
 

--- a/specs/agency-private-capital-comparison/design.md
+++ b/specs/agency-private-capital-comparison/design.md
@@ -39,9 +39,13 @@ SBIR.gov awards → filter by agency_code (default NSF: ALN ∈ {47.041, 47.084}
    `agency_code` parameter.
 2. **`OutcomeMetricsCalculator`** — Reuses existing transition detector and
    #286's `sbir_ma_events.jsonl` for the M&A-exit metric. Emits per-cohort
-   rates with Wilson confidence intervals and sample sizes. Five-year survival
-   denominator is unique companies (not award rows). M&A join is UEI/DUNS-
-   first with a normalized-name fallback.
+   rates with Wilson confidence intervals and sample sizes. The firm-level
+   graduation identity is an exact connected component across every UEI, DUNS,
+   and `ORGANIZATION_KEY_V1` name alias on the award rows. Its inclusive
+   follow-up horizon is run configuration (default 5 years; `None` restores
+   unbounded behavior), and the review artifact reports 2/3/5/unbounded
+   sensitivity. Five-year survival denominator is unique companies (not award
+   rows). M&A joins against every alias on the same resolved component.
 3. **`PublishedBaselineRegistry`** — Hard-coded table of cited private-capital
    and small-business baselines with source citation + as-of date. These
    baselines are agency-agnostic. Examples:

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -1,11 +1,13 @@
 # SBIR vs. Private-Capital Comparison — Requirements (agency-parameterized; NSF as initial target)
 
-**Target epistemic tier:** `pipelines`
+**Target epistemic tier:** `exploratory`
 
-> **Status:** Phase 1 implemented; Phase 2 is a gated backlog item now that the
-> Form D / M&A infrastructure from PR #286 is available. Do not start Phase 2
-> until the private-capital control-cohort comparison is selected as a current
-> research priority.
+> **Status (2026-08-09):** Phase 1 is implemented and its pinned NSF real-data
+> review artifact is materialized, but it is non-citable and awaits sign-off.
+> Phase 2 has a tested scaffold, not a valid matched comparison: it still lacks
+> a reproducible control-universe producer and symmetric FPDS/PATLINK/M&A
+> outcome inputs. Do not materialize or publish Phase 2 before the Phase 1 gate
+> and those input contracts are satisfied.
 > Supports inventory questions **F3** (private-capital comparison), **B2** (commercialization outcomes), **B3** (transition rates) in [docs/research-questions.md](../../docs/research-questions.md).
 
 **Research question anchor:** F3 / B2 / B3 — SBIR vs. private-capital cohort comparison (NSF initial target)
@@ -94,8 +96,9 @@ This spec ships in two sequential phases, each independently useful.
   artifacts to filter to NSF awardees, construct a non-SBIR Form D control
   cohort, and compute outcome deltas. Gated on PR #286 merging to main.
 
-Phase 1 is the gating deliverable. Phase 2 starts after #286 merges and our
-branch rebases on top.
+Phase 1 is the gating deliverable. Although #286 is now on main and a Phase 2
+scaffold exists, a real Phase 2 run remains gated on Phase 1 sign-off and the
+missing input contracts described above.
 
 ## Phase 1 Requirements
 
@@ -138,6 +141,12 @@ Can produce a single artifact (notebook or markdown report) that states:
 survival proxy is [X]% on cohort [vintage range, n=Y]. The difference is
 attributable to [Z]."
 Reproduces the exact reconciliation pattern of `follow-on-multiplier-analysis`.
+
+The [2026-08-09 NSF review artifact](../../docs/research/agency-private-capital-phase1-nsf.md)
+validates the Phase I→II cohort component (672/1,502, or 44.7%, for 2015–2019)
+and pins its inputs in a deterministic manifest. It does **not** close the gate:
+the transition, survival, M&A, and patent channels were unavailable, and the
+cohort estimand and identity approach still require review.
 
 ## Phase 2 Requirements
 

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -107,7 +107,11 @@ missing input contracts described above.
    initial implementation target.
 2. **SHALL** compute the following cohort outcomes, stratified by award
    vintage (5-year buckets) and Phase (I, II):
-   - Phase I → Phase II graduation rate
+   - Phase I → Phase II graduation rate, firm-level and pooled across SBIR and
+     STTR. Qualifying Phase II awards must be no earlier than Phase I and no
+     later than the configured inclusive horizon (current Phase 1 review
+     default: 5 years). The review artifact SHALL also report 2-year, 3-year,
+     5-year, and unbounded sensitivity.
    - Phase II → first non-SBIR federal contract transition rate (reuse
      existing transition detector, ≥85% precision benchmark)
    - 5-year survival proxy (firm appears as recipient/vendor in any federal
@@ -131,8 +135,11 @@ missing input contracts described above.
    narrative").
 5. **SHOULD** stratify outcomes by CET technology area (reuse CET classifier)
    so the comparison is not blurred by sector mix.
-6. **SHALL** report match rates and entity-resolution coverage as sensitivity
-   metadata (mirrors `follow-on-multiplier-analysis` requirement 7).
+6. **SHALL** resolve firms through an exact connected-component crosswalk over
+   every UEI, DUNS, and versioned normalized-name alias present on their award
+   rows, and report match rates plus UEI-backed, DUNS-only, name-only, and
+   UEI↔DUNS bridge coverage as sensitivity metadata (mirrors
+   `follow-on-multiplier-analysis` requirement 7).
 
 ### Phase 1 Gate Condition
 

--- a/specs/agency-private-capital-comparison/tasks.md
+++ b/specs/agency-private-capital-comparison/tasks.md
@@ -30,8 +30,9 @@ gated on Phase 1 sign-off and its missing real-data input contracts.
   re-running on the follow-on-multiplier fixture set reproduces transition rates
   within tolerance.
   — implemented: `packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/outcomes.py`
-  (`wilson_interval`, consumes upstream transition scores, UEI/DUNS-first M&A join
-  with name fallback, company-level survival denominator)
+  (`wilson_interval`, consumes upstream transition scores, exact connected-component
+  UEI/DUNS/name identity crosswalk, company-level survival denominator, configurable
+  graduation horizon)
 - [x] 1.3 Add `PublishedBaselineRegistry` — hard-coded YAML at
   `config/agency_private_capital/published_baselines.yaml` with source citations + as-of
   dates. Initial entries: BLS BED 5-yr survival, Lerner [L10] effect size,
@@ -72,9 +73,10 @@ gated on Phase 1 sign-off and its missing real-data input contracts.
   **Review artifact materialized 2026-08-09:**
   [NSF Phase I baseline review](../../docs/research/agency-private-capital-phase1-nsf.md)
   reports 672/1,502 (44.7%, 95% Wilson interval 42.2%–47.3%) for the 2015–2019
-  vintage with a five-year horizon. Keep this task open until the estimand and
-  identity approach are accepted and the required missing outcome channels are
-  resolved.
+  vintage with a five-year horizon. The repaired artifact also records
+  2/3/5/unbounded sensitivity, UEI/DUNS/name coverage, and output hashes. Keep
+  this task open until the estimand and identity approach are accepted and the
+  required missing outcome channels are resolved.
 
 ## Phase 2 — Agency-vs-Private-Capital Matched Cohort
 

--- a/specs/agency-private-capital-comparison/tasks.md
+++ b/specs/agency-private-capital-comparison/tasks.md
@@ -1,14 +1,17 @@
 # SBIR vs. Private-Capital Comparison — Tasks (agency-parameterized; NSF as initial target)
 
-> **Status (2026-07-02):** Phase 1 implemented — cohort/outcomes/baselines/reconciliation modules and the
+> **Status (2026-08-09):** Phase 1 implemented — cohort/outcomes/baselines/reconciliation modules and the
 > `agency_private_capital_baseline_comparison` Dagster asset live in
 > `packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/`, with unit tests
 > (`tests/unit/agency_private_capital/`) and an integration test (`tests/integration/agency_private_capital/`).
-> Phase 2 (Form D matched cohort) not started; its PR #286 prerequisites (`sbir_etl/enrichers/sec_edgar/`,
-> `form_d_scoring.py`, M&A events) are on main. Phase 1 gate (1.8) and cross-phase docs tasks remain open.
+> A pinned NSF real-data report now exists for Phase 1 review. It remains
+> non-citable and unsigned because the cohort estimand and identity handling
+> require review and four outcome channels are unavailable. A Phase 2 scaffold exists, but its tasks
+> remain open until a reproducible Form D control universe and symmetric
+> FPDS/PATLINK/M&A outcomes are wired and validated.
 
-Tasks are grouped by phase. Phase 1 ships independently of PR #286.
-Phase 2 starts after PR #286 merges to main and this branch rebases.
+Tasks are grouped by phase. Phase 1 ships independently of PR #286. Phase 2 is
+gated on Phase 1 sign-off and its missing real-data input contracts.
 
 ## Phase 1 — Published-Baseline Comparison
 
@@ -66,13 +69,21 @@ Phase 2 starts after PR #286 merges to main and this branch rebases.
   Note: patent_rate is deferred to Phase 2 (the configured funding agency,
   with NSF as the initial implementation target, does not wire PATLINK in
   Phase 1).
+  **Review artifact materialized 2026-08-09:**
+  [NSF Phase I baseline review](../../docs/research/agency-private-capital-phase1-nsf.md)
+  reports 672/1,502 (44.7%, 95% Wilson interval 42.2%–47.3%) for the 2015–2019
+  vintage with a five-year horizon. Keep this task open until the estimand and
+  identity approach are accepted and the required missing outcome channels are
+  resolved.
 
 ## Phase 2 — Agency-vs-Private-Capital Matched Cohort
 
-**Prerequisite:** PR #286 merged to main; this branch rebased on top.
-Verify post-rebase that #286's Dagster asset names and JSONL schema
-haven't drifted; if they have, fix the dependency references in tasks
-2.1–2.4 before continuing.
+**Prerequisite:** Phase 1 sign-off. PR #286 is on main and the Phase 2 code
+scaffold is present, but no maintained producer currently creates
+`data/form_d_control_universe.jsonl`. The scaffold also does not yet provide
+symmetric real FPDS/PATLINK/M&A outcome joins for treated and control firms.
+Keep tasks 2.1–2.9 open until their acceptance criteria are demonstrated on a
+pinned real-data run.
 
 - [ ] 2.1 Add `AgencyAwardeeFilter` — apply the configured agency's ALN(s)
   (e.g. NSF: 47.041 / 47.084) to #286's resolved SBIR-CIK set produced by

--- a/specs/status.md
+++ b/specs/status.md
@@ -30,9 +30,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   blocking security scan are restored. The remaining decisions concern periodic
   scanning and whether the large pre-existing Markdown-formatting backlog is worth
   addressing; do not restore the old broad lint job by default.
-- **`agency-private-capital-comparison` — Gated backlog.** Phase 1 is
-  implemented. Phase 2 depends on prioritizing the Form D / private-capital
-  control-cohort comparison.
+- **`agency-private-capital-comparison` — Active.** The NSF Phase 1 real-data
+  gate is materialized for review but remains non-citable and unsigned. Phase 2
+  stays gated on Phase 1 sign-off, a reproducible Form D control-universe
+  producer, and symmetric FPDS/PATLINK/M&A outcome inputs.
 - **`bea-nipa-tax-rates` — Active.** The NIPA provider exists; the remaining
   work is the on-disk cache and removal of hardcoded effective-rate consumers.
 - **`company-categorization` — Maintenance.** About 80% complete. Evaluate the

--- a/tests/integration/agency_private_capital/test_phase1_pipeline.py
+++ b/tests/integration/agency_private_capital/test_phase1_pipeline.py
@@ -40,11 +40,11 @@ def _make_nsf_fixture(n_phase_i: int = 200, graduation_rate: float = 0.30) -> pd
         rows.append(
             {
                 "award_id": f"NSF-I-{i:04d}",
-                "agency": "National Science Foundation",
-                "phase": "Phase I",
-                "award_year": 2015,
-                "uei": f"COMPANY{i:05d}",
-                "company_name": f"Firm {i}",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase I",
+                "Award Year": 2015,
+                "UEI": f"COMPANY{i:05d}",
+                "Company": f"Firm {i}",
             }
         )
     # First N graduate to Phase II in 2017
@@ -52,11 +52,11 @@ def _make_nsf_fixture(n_phase_i: int = 200, graduation_rate: float = 0.30) -> pd
         rows.append(
             {
                 "award_id": f"NSF-II-{i:04d}",
-                "agency": "National Science Foundation",
-                "phase": "Phase II",
-                "award_year": 2017,
-                "uei": f"COMPANY{i:05d}",
-                "company_name": f"Firm {i}",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase II",
+                "Award Year": 2017,
+                "UEI": f"COMPANY{i:05d}",
+                "Company": f"Firm {i}",
             }
         )
     # A few non-NSF rows to confirm filtering
@@ -64,11 +64,11 @@ def _make_nsf_fixture(n_phase_i: int = 200, graduation_rate: float = 0.30) -> pd
         rows.append(
             {
                 "award_id": f"DOD-I-{j:04d}",
-                "agency": "Department of Defense",
-                "phase": "Phase I",
-                "award_year": 2015,
-                "uei": f"DODFIRM{j:05d}",
-                "company_name": f"Defense Firm {j}",
+                "Agency": "Department of Defense",
+                "Phase": "Phase I",
+                "Award Year": 2015,
+                "UEI": f"DODFIRM{j:05d}",
+                "Company": f"Defense Firm {j}",
             }
         )
     return pd.DataFrame(rows)
@@ -79,7 +79,7 @@ def test_phase1_pipeline_produces_three_artifacts(tmp_path) -> None:
 
     cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
     # Filter discarded the 5 DOD rows
-    assert (cohort["agency"].str.lower() != "department of defense").all()
+    assert (cohort["Agency"].str.lower() != "department of defense").all()
     assert len(cohort) == 200 + 60
 
     federal_activity_companies = {f"uei:COMPANY{i:05d}" for i in range(36)}

--- a/tests/unit/agency_private_capital/test_cohort.py
+++ b/tests/unit/agency_private_capital/test_cohort.py
@@ -110,6 +110,33 @@ def test_filter_keeps_only_nsf_rows_by_agency_name() -> None:
     assert set(cohort["vintage_bucket"].tolist()) == {"2015-2019"}
 
 
+def test_filter_accepts_canonical_sbir_gov_column_casing() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "Company": "Raw NSF Firm",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase I",
+                "Award Year": "2017",
+                "UEI": "RAWNSF000001",
+            },
+            {
+                "Company": "Raw DOD Firm",
+                "Agency": "Department of Defense",
+                "Phase": "Phase II",
+                "Award Year": "2018",
+                "UEI": "RAWDOD000001",
+            },
+        ]
+    )
+
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    assert cohort["Company"].tolist() == ["Raw NSF Firm"]
+    assert cohort["phase_label"].tolist() == ["I"]
+    assert cohort["vintage_bucket"].tolist() == ["2015-2019"]
+
+
 def test_filter_keeps_rows_by_explicit_aln() -> None:
     df = pd.DataFrame(
         [

--- a/tests/unit/agency_private_capital/test_cohort.py
+++ b/tests/unit/agency_private_capital/test_cohort.py
@@ -137,6 +137,33 @@ def test_filter_accepts_canonical_sbir_gov_column_casing() -> None:
     assert cohort["vintage_bucket"].tolist() == ["2015-2019"]
 
 
+def test_mixed_parseable_award_years_keep_unparseable_rows_without_crashing() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "Company": "No Year Firm",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase I",
+                "Award Year": "n/a",
+            },
+            {
+                "Company": "Dated Firm",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase I",
+                "Award Year": "2016",
+            },
+        ]
+    )
+
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    assert len(cohort) == 2
+    assert pd.isna(cohort.iloc[0]["award_year_resolved"])
+    assert pd.isna(cohort.iloc[0]["vintage_bucket"])
+    assert cohort.iloc[1]["award_year_resolved"] == 2016
+    assert cohort.iloc[1]["vintage_bucket"] == "2015-2019"
+
+
 def test_filter_keeps_rows_by_explicit_aln() -> None:
     df = pd.DataFrame(
         [

--- a/tests/unit/agency_private_capital/test_outcomes.py
+++ b/tests/unit/agency_private_capital/test_outcomes.py
@@ -321,6 +321,42 @@ def test_ma_exit_rate_joins_on_uei_keyed_cohort_via_name_fallback() -> None:
     assert phase_ii_row["numerator"] == 1
 
 
+def test_ma_exit_rate_matches_aliases_from_elsewhere_in_the_component() -> None:
+    """The join is component-wide, not row-wide.
+
+    The Phase II row carries only a UEI. The name that the M&A artifact is keyed on
+    reaches the same component through the Phase I row. Matching per row would miss
+    it and undercount the exit rate.
+    """
+    awards = pd.DataFrame(
+        [
+            {
+                "award_id": "I-X",
+                "agency": "NSF",
+                "phase": "Phase I",
+                "award_year": 2016,
+                "uei": "XXX",
+                "company_name": "Alpha",
+            },
+            {
+                "award_id": "II-X",
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2017,
+                "uei": "XXX",
+            },
+        ]
+    )
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+    outcomes = OutcomeMetricsCalculator(ma_event_companies={"name:alpha"}).compute(cohort)
+
+    phase_ii_row = outcomes[
+        (outcomes["metric"] == "ma_exit_rate") & (outcomes["phase_label"] == "II")
+    ].iloc[0]
+    assert phase_ii_row["denominator"] == 1
+    assert phase_ii_row["numerator"] == 1
+
+
 def test_ma_event_rate_matches_when_uei_missing() -> None:
     awards = pd.DataFrame(
         [

--- a/tests/unit/agency_private_capital/test_outcomes.py
+++ b/tests/unit/agency_private_capital/test_outcomes.py
@@ -117,6 +117,62 @@ def test_phase_i_to_ii_graduation_uses_company_match() -> None:
     assert bool(row["available"]) is True
 
 
+def test_phase_i_to_ii_graduation_excludes_prior_phase_ii() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2014,
+                "uei": "AAA",
+            },
+            {
+                "agency": "NSF",
+                "phase": "Phase I",
+                "award_year": 2016,
+                "uei": "AAA",
+            },
+        ]
+    )
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    outcomes = OutcomeMetricsCalculator().compute(cohort)
+    row = outcomes[outcomes["metric"] == "phase_i_to_ii_graduation"].iloc[0]
+
+    assert row["denominator"] == 1
+    assert row["numerator"] == 0
+
+
+def test_phase_i_to_ii_graduation_excludes_phase_ii_outside_horizon() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "phase": "Phase I",
+                "award_year": 2015,
+                "uei": "AAA",
+            },
+            {
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2021,
+                "uei": "AAA",
+            },
+        ]
+    )
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    default_outcomes = OutcomeMetricsCalculator().compute(cohort)
+    default_row = default_outcomes[default_outcomes["metric"] == "phase_i_to_ii_graduation"].iloc[0]
+    six_year_outcomes = OutcomeMetricsCalculator(graduation_horizon_years=6).compute(cohort)
+    six_year_row = six_year_outcomes[
+        six_year_outcomes["metric"] == "phase_i_to_ii_graduation"
+    ].iloc[0]
+
+    assert default_row["numerator"] == 0
+    assert six_year_row["numerator"] == 1
+
+
 def test_metrics_with_missing_inputs_marked_unavailable() -> None:
     cohort = AgencyCohortBuilder(agency_code="NSF").build(_nsf_awards())
     outcomes = OutcomeMetricsCalculator().compute(cohort)

--- a/tests/unit/agency_private_capital/test_outcomes.py
+++ b/tests/unit/agency_private_capital/test_outcomes.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pytest
 
 from sbir_analytics.assets.agency_private_capital.cohort import AgencyCohortBuilder
+from sbir_analytics.assets.agency_private_capital.asset import AgencyPrivateCapitalConfig
 from sbir_analytics.assets.agency_private_capital.outcomes import (
     OutcomeMetricsCalculator,
     wilson_interval,
@@ -15,6 +16,13 @@ from sbir_analytics.assets.agency_private_capital.outcomes import (
 
 
 pytestmark = pytest.mark.fast
+
+
+def test_asset_config_exposes_graduation_horizon() -> None:
+    assert AgencyPrivateCapitalConfig().graduation_horizon_years == 5
+    assert (
+        AgencyPrivateCapitalConfig(graduation_horizon_years=None).graduation_horizon_years is None
+    )
 
 
 def test_wilson_interval_zero_denominator_yields_nan() -> None:
@@ -173,6 +181,91 @@ def test_phase_i_to_ii_graduation_excludes_phase_ii_outside_horizon() -> None:
     assert six_year_row["numerator"] == 1
 
 
+def test_phase_i_to_ii_graduation_supports_unbounded_horizon() -> None:
+    awards = pd.DataFrame(
+        [
+            {"agency": "NSF", "phase": "Phase I", "award_year": 2015, "uei": "AAA"},
+            {"agency": "NSF", "phase": "Phase II", "award_year": 2025, "uei": "AAA"},
+        ]
+    )
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    outcomes = OutcomeMetricsCalculator(graduation_horizon_years=None).compute(cohort)
+    row = outcomes[outcomes["metric"] == "phase_i_to_ii_graduation"].iloc[0]
+
+    assert row["numerator"] == 1
+    assert row["denominator"] == 1
+
+
+def test_phase_i_to_ii_graduation_crosswalks_mixed_uei_and_duns_rows() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "phase": "Phase I",
+                "award_year": 2015,
+                "duns": "123456789",
+                "company_name": "Alpha Research, Inc.",
+            },
+            {
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2018,
+                "uei": "ALPHAUEI001",
+                "duns": "123456789",
+                "company_name": "Alpha Research Inc",
+            },
+        ]
+    )
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    outcomes = OutcomeMetricsCalculator().compute(cohort)
+    row = outcomes[outcomes["metric"] == "phase_i_to_ii_graduation"].iloc[0]
+    coverage = OutcomeMetricsCalculator.identity_coverage(cohort)
+
+    assert row["numerator"] == 1
+    assert row["denominator"] == 1
+    assert coverage["company_count"] == 1
+    assert coverage["company_basis_counts"] == {"uei": 1, "duns": 0, "name": 0}
+    assert coverage["uei_duns_bridge_company_count"] == 1
+
+
+def test_phase_i_to_ii_graduation_crosswalk_is_transitive_across_aliases() -> None:
+    awards = pd.DataFrame(
+        [
+            {
+                "agency": "NSF",
+                "phase": "Phase I",
+                "award_year": 2015,
+                "duns": "123456789",
+                "company_name": "Alpha Research",
+            },
+            {
+                "agency": "NSF",
+                "phase": "Phase I",
+                "award_year": 2016,
+                "uei": "ALPHAUEI001",
+                "duns": "123456789",
+                "company_name": "Alpha Research",
+            },
+            {
+                "agency": "NSF",
+                "phase": "Phase II",
+                "award_year": 2019,
+                "uei": "ALPHAUEI001",
+                "company_name": "Alpha Research Labs",
+            },
+        ]
+    )
+    cohort = AgencyCohortBuilder(agency_code="NSF").build(awards)
+
+    outcomes = OutcomeMetricsCalculator().compute(cohort)
+    row = outcomes[outcomes["metric"] == "phase_i_to_ii_graduation"].iloc[0]
+
+    assert row["numerator"] == 1
+    assert row["denominator"] == 1
+
+
 def test_metrics_with_missing_inputs_marked_unavailable() -> None:
     cohort = AgencyCohortBuilder(agency_code="NSF").build(_nsf_awards())
     outcomes = OutcomeMetricsCalculator().compute(cohort)
@@ -184,6 +277,7 @@ def test_metrics_with_missing_inputs_marked_unavailable() -> None:
         rows = outcomes[outcomes["metric"] == metric]
         assert not rows.empty, metric
         assert (rows["available"] == False).all(), metric  # noqa: E712
+        assert rows["numerator"].isna().all(), metric
 
 
 def test_transition_rate_consumes_score_threshold() -> None:

--- a/tests/unit/scripts/archive/test_run_agency_private_capital_phase1.py
+++ b/tests/unit/scripts/archive/test_run_agency_private_capital_phase1.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
@@ -16,6 +17,40 @@ SPEC = importlib.util.spec_from_file_location("run_agency_private_capital_phase1
 MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(MODULE)
+
+
+def test_ma_event_loader_uses_versioned_organization_name_key(tmp_path: Path) -> None:
+    events_path = tmp_path / "events.jsonl"
+    events_path.write_text('{"company_name": "Acme Research, Inc."}\n', encoding="utf-8")
+
+    assert MODULE._load_ma_event_companies(events_path) == {"name:acme research"}
+
+
+def test_committed_review_report_is_bound_to_manifest_results_and_hash() -> None:
+    manifest_path = (
+        REPO_ROOT / "docs" / "research" / "agency-private-capital-phase1-nsf.manifest.json"
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    review = manifest["review_artifact"]
+    report_path = REPO_ROOT / review["path"]
+
+    assert MODULE._sha256_file(report_path) == review["sha256"]
+    assert report_path.stat().st_size == review["size_bytes"]
+    assert manifest["results"]["headline_graduation"] == {
+        "available": True,
+        "ci_high": pytest.approx(0.4726517838014854),
+        "ci_low": pytest.approx(0.42242349183627115),
+        "denominator": 1502,
+        "horizon_years": 5,
+        "numerator": 672,
+        "rate": pytest.approx(0.4474034620505992),
+        "vintage_bucket": "2015-2019",
+    }
+    report = report_path.read_text(encoding="utf-8")
+    assert "| 5 years | 672 | 1,502 | 44.7% |" in report
+    assert "1,160 UEI-backed" in report
+    assert "326 DUNS-backed" in report
+    assert "16 normalized-name-only" in report
 
 
 def test_runner_emits_deterministic_portable_manifest_and_labeled_report(
@@ -60,6 +95,10 @@ def test_runner_emits_deterministic_portable_manifest_and_labeled_report(
                 str(registry_path),
                 "--output-dir",
                 str(output_dir),
+                "--run-date",
+                "2026-08-11",
+                "--awards-retrieved-at",
+                "2026-08-10",
                 "--skip-download",
             ],
         )
@@ -75,17 +114,40 @@ def test_runner_emits_deterministic_portable_manifest_and_labeled_report(
         assert "`five_year_survival_proxy`" in report
         assert "`ma_exit_rate`" in report
         assert "`patent_rate`" in report
+        assert "## Graduation-horizon sensitivity" in report
+        assert "| Unbounded | 1 | 1 | 100.0% |" in report
+        assert "## Entity-resolution coverage" in report
 
     assert manifests[0] == manifests[1]
     payload = json.loads(manifests[0])
-    assert payload["schema_version"] == 1
+    assert payload["schema_version"] == 2
     assert payload["epistemic_tier"] == "exploratory"
     assert payload["citable"] is False
+    assert payload["run_date"] == "2026-08-11"
     assert payload["parameters"]["graduation_horizon_years"] == 5
     assert payload["inputs"]["awards_csv"]["path"] == awards_path.name
     assert payload["inputs"]["awards_csv"]["row_count"] == 2
     assert payload["inputs"]["awards_csv"]["size_bytes"] == awards_path.stat().st_size
     assert len(payload["inputs"]["awards_csv"]["sha256"]) == 64
+    assert payload["inputs"]["awards_csv"]["source_url"] == MODULE.SBIR_AWARDS_CSV_URL
+    assert payload["inputs"]["awards_csv"]["retrieved_at"] == "2026-08-10"
+    assert payload["inputs"]["awards_csv"]["retrieved_at_basis"] == "provided"
     assert payload["inputs"]["ma_events_jsonl"]["available"] is False
+    assert payload["results"]["headline_graduation"]["numerator"] == 1
+    assert payload["results"]["headline_graduation"]["denominator"] == 1
+    assert [
+        row["horizon_years"] for row in payload["results"]["graduation_horizon_sensitivity"]
+    ] == [2, 3, 5, None]
+    assert payload["results"]["identity_coverage"]["company_basis_counts"] == {
+        "duns": 0,
+        "name": 0,
+        "uei": 1,
+    }
+    assert set(payload["outputs"]) == {
+        "agency_baseline_comparison_json",
+        "agency_cohort_outcomes_parquet",
+        "agency_vs_published_baselines_markdown",
+    }
+    assert all(len(output["sha256"]) == 64 for output in payload["outputs"].values())
     assert str(tmp_path) not in manifests[0]
     assert "generated_at" not in payload

--- a/tests/unit/scripts/archive/test_run_agency_private_capital_phase1.py
+++ b/tests/unit/scripts/archive/test_run_agency_private_capital_phase1.py
@@ -1,0 +1,91 @@
+"""Regression tests for the standalone Phase 1 real-data runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "archive" / "data" / "run_agency_private_capital_phase1.py"
+SPEC = importlib.util.spec_from_file_location("run_agency_private_capital_phase1", SCRIPT_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_runner_emits_deterministic_portable_manifest_and_labeled_report(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    awards_path = tmp_path / "sbir_awards.csv"
+    pd.DataFrame(
+        [
+            {
+                "Company": "Acme",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase I",
+                "Award Year": "2015",
+                "UEI": "ACME00000001",
+            },
+            {
+                "Company": "Acme",
+                "Agency": "National Science Foundation",
+                "Phase": "Phase II",
+                "Award Year": "2017",
+                "UEI": "ACME00000001",
+            },
+        ]
+    ).to_csv(awards_path, index=False)
+    missing_ma_path = tmp_path / "missing_ma_events.jsonl"
+    registry_path = REPO_ROOT / "config" / "agency_private_capital" / "published_baselines.yaml"
+
+    manifests: list[str] = []
+    for output_name in ("first", "second"):
+        output_dir = tmp_path / output_name
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                str(SCRIPT_PATH),
+                "--awards-csv",
+                str(awards_path),
+                "--ma-events",
+                str(missing_ma_path),
+                "--registry",
+                str(registry_path),
+                "--output-dir",
+                str(output_dir),
+                "--skip-download",
+            ],
+        )
+
+        assert MODULE.main() == 0
+        manifests.append((output_dir / "run_manifest.json").read_text(encoding="utf-8"))
+
+        report = (output_dir / "agency_vs_published_baselines.md").read_text(encoding="utf-8")
+        assert "**Exploratory / non-citable.**" in report
+        assert "**Phase I -> Phase II graduation horizon:** 5 years." in report
+        assert "**Unavailable metrics in this run:**" in report
+        assert "`phase_ii_to_federal_contract_transition`" in report
+        assert "`five_year_survival_proxy`" in report
+        assert "`ma_exit_rate`" in report
+        assert "`patent_rate`" in report
+
+    assert manifests[0] == manifests[1]
+    payload = json.loads(manifests[0])
+    assert payload["schema_version"] == 1
+    assert payload["epistemic_tier"] == "exploratory"
+    assert payload["citable"] is False
+    assert payload["parameters"]["graduation_horizon_years"] == 5
+    assert payload["inputs"]["awards_csv"]["path"] == awards_path.name
+    assert payload["inputs"]["awards_csv"]["row_count"] == 2
+    assert payload["inputs"]["awards_csv"]["size_bytes"] == awards_path.stat().st_size
+    assert len(payload["inputs"]["awards_csv"]["sha256"]) == 64
+    assert payload["inputs"]["ma_events_jsonl"]["available"] is False
+    assert str(tmp_path) not in manifests[0]
+    assert "generated_at" not in payload


### PR DESCRIPTION
## Description

Repairs and materializes the NSF Phase 1 private-capital review gate.

The raw-data runner previously produced an empty NSF cohort because SBIR.gov uses canonical columns such as `Agency`, while cohort filtering expected normalized lowercase names. The graduation metric also counted any Phase II award for a firm, including awards before Phase I or outside a defined follow-up window.

This PR:

- accepts canonical SBIR.gov agency/ALN column aliases;
- resolves firms through exact connected components across every UEI, DUNS, and versioned normalized-name alias, including mixed-identifier and transitive cases;
- defines Phase I to Phase II graduation as a Phase II award no earlier than Phase I and within an inclusive, configurable five-year horizon;
- matches M&A events against the complete alias set for each resolved company component;
- emits a deterministic, portable `run_manifest.json` with input and output hashes, sizes, row counts, schemas, parameters, metric availability, horizon sensitivity, identity coverage, and explicit `exploratory` / `citable: false` status;
- labels unavailable outcomes as not measured rather than zero;
- materializes the pinned NSF 2015-2019 review result: 672/1,502 firms, 44.7% (95% Wilson interval 42.2%-47.3%);
- applies no external private-capital comparator and makes no relative program-performance claim;
- updates the research inventory and spec ledger to reflect that Phase 2 is a scaffold, not a validated matched comparison.

The Phase 1 checklist gate remains open pending review of the firm-level, pooled SBIR/STTR estimand, the exact-alias identity assumptions, and whether the unavailable transition, survival, M&A, and patent channels must be populated.

Scope is limited to Phase 1. A reproducible Form D control universe, symmetric FPDS/PATLINK/M&A outcomes, multi-agency matched reporting, the FY M&A trend, and filer-vs-non-filer or crowd-in/crowd-out analysis remain separate gated follow-ups.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [ ] No release impact (internal or unreleased work)
- [x] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

See [the versioning policy](../docs/steering/versioning.md). The release PR applies the selected increment across all four packages.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests pass locally

Results:

- focused Phase 1 unit and integration suite: 64 passed;
- full unit suite: 5,905 passed, 7 skipped;
- targeted Ruff: passed;
- targeted MyPy: passed for 13 source files;
- all six architecture, tier, file-size, configuration, repository-hygiene, and study-manifest checkers: passed when run directly with the existing project environment;
- real-data runner: reproduced 672/1,502 against the pinned 219,500-row SBIR.gov snapshot and regenerated provenance for the current four-entry baseline registry.

The `make lint-boundaries` and `make docs-check` wrappers were also attempted, but `uv` stopped before executing their checkers because GitHub refused the direct `en_core_web_sm` wheel HTTP/2 stream. The underlying checkers all pass directly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code where the implementation is not self-explanatory
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the fixes are effective
- [x] New and existing unit tests pass locally with my changes
