### PR TITLE
Fail CET materializations instead of publishing placeholders

### DIFF
--- a/docs/ml/cet-classifier.md
+++ b/docs/ml/cet-classifier.md
@@ -102,7 +102,7 @@ Two options:
 1) Dagster asset
 
 - `train_cet_patent_classifier` expects:
-  - `data/processed/cet_patent_training.parquet` with columns:
+  - `data/processed/cet_patent_training.parquet` or `.ndjson` with columns:
     - `title`
     - `cet_labels`
     - optional `assignee`
@@ -128,9 +128,8 @@ Two options:
       - `classified_at`, `taxonomy_version`
     - Companion checks JSON with coverage
 
-Fallback behavior:
-
-- If the artifact or dependencies are missing, the asset produces an empty schema-compatible output and a checks JSON indicating the reason.
+Missing or empty inputs, unavailable dependencies, missing model artifacts, and incomplete batch
+results fail the materialization rather than producing an empty schema-compatible output.
 
 ---
 
@@ -153,10 +152,10 @@ Store evaluation metrics in your artifact metadata by merging them into `config`
   - `artifacts/models/patent_classifier_v1.pkl` (pickle)
   - `artifacts/models/patent_classifier_v1.checks.json` (training metadata)
 - Inputs
-  - Training: `data/processed/cet_patent_training.parquet`
+  - Training: `data/processed/cet_patent_training.parquet` (preferred) or `.ndjson`
   - Inference: `data/processed/transformed_patents.parquet` (preferred) or `.ndjson`
 - Outputs
-  - Inference: `data/processed/cet_patent_classifications.parquet` (preferred) or `.json`
+  - Inference: `data/processed/cet_patent_classifications.parquet` (preferred) or `.ndjson`
   - Checks: `.checks.json` alongside outputs
 
 ---

--- a/docs/ml/cet-integration.md
+++ b/docs/ml/cet-integration.md
@@ -61,14 +61,18 @@ and [rule-engine guide](cet-rule-engine.md) for their narrow contracts.
 
 ## Training-data limitation
 
-The `ml/cet_award_training_dataset` asset looks for labeled CSV or NDJSON inputs and writes an
-empty, failed check when no input exists. When input does exist, the current code imports
-`sbir_ml.ml.data.award_training_loader`, which is absent from the repository; the asset therefore
-records `reason: load_failed` instead of producing a usable award-training dataset. Treat award
-training as unsupported until that loader is restored or the asset is redesigned and tested.
+The `ml/cet_award_training_dataset` asset requires a non-empty labeled CSV or NDJSON input with
+`text` and `labels` columns. Missing, empty, malformed, or schema-incomplete inputs fail the
+materialization; successful runs write Parquet or return the actual `.ndjson` fallback path.
+
+Award classifier inference also requires a trained `ApplicabilityModel` at
+`artifacts/models/cet_classifier_v1.pkl`. No repository asset or command currently produces that
+model, so operators must provision a validated artifact at that path before running the complete
+CET job. The materialization fails rather than publishing a placeholder when it is absent.
 
 Patent training is separate: `train_cet_patent_classifier` expects
-`data/processed/cet_patent_training.parquet` with the schema documented in the asset itself.
+`data/processed/cet_patent_training.parquet` or its `.ndjson` sibling with the schema documented in
+the asset itself.
 
 ## Validation and evidence
 

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/analytics.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/analytics.py
@@ -47,9 +47,9 @@ def transformed_cet_analytics() -> Output:
 
     # Inputs
     company_parquet = processed_dir / "cet_company_profiles.parquet"
-    company_json = processed_dir / "cet_company_profiles.json"
+    company_json = processed_dir / "cet_company_profiles.ndjson"
     awards_parquet = processed_dir / "cet_award_classifications.parquet"
-    awards_json = processed_dir / "cet_award_classifications.json"
+    awards_json = processed_dir / "cet_award_classifications.ndjson"
 
     # Read helpers (parquet preferred, NDJSON fallback)
     def _read_df(parquet_path: Path, json_path: Path, expected_cols=None):
@@ -199,9 +199,9 @@ def transformed_cet_analytics_aggregates() -> Output:
 
     # Inputs
     awards_parquet = processed_dir / "cet_award_classifications.parquet"
-    awards_json = processed_dir / "cet_award_classifications.json"
+    awards_json = processed_dir / "cet_award_classifications.ndjson"
     companies_parquet = processed_dir / "cet_company_profiles.parquet"
-    companies_json = processed_dir / "cet_company_profiles.json"
+    companies_json = processed_dir / "cet_company_profiles.ndjson"
 
     # Read helpers (parquet preferred, NDJSON fallback)
     def _read_df(parquet_path: Path, json_path: Path, expected_cols=None):

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
@@ -604,8 +604,9 @@ def enriched_cet_patent_classifications() -> Output:
                 )
                 titles.append(str(norm_title or ""))
                 patent_ids.append(p.get("patent_id") or "")
-                # Avoid double-adding assignee when text already normalized
-                assignees.append(None)
+                # normalized_title carries the title only, so the assignee still has to
+                # be passed separately for classify_batch to see it.
+                assignees.append(p.get("assignee") or None)
         else:
             # Fallback to simple normalization when only DF-based extractor is available
             from sbir_ml.ml.features.patent_features import normalize_title
@@ -613,7 +614,7 @@ def enriched_cet_patent_classifications() -> Output:
             for p in patents:
                 titles.append(normalize_title(p.get("title")))
                 patent_ids.append(p.get("patent_id") or "")
-                assignees.append(None)
+                assignees.append(p.get("assignee") or None)
     except ValueError:
         raise
     except Exception:

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
@@ -140,14 +140,15 @@ def enriched_cet_award_classifications() -> Output:
     """
     Dagster asset to perform batch CET classification over enriched award records.
 
-    Behavior (best-effort / import-safe):
-    - Attempts to load a trained ApplicabilityModel from a well-known artifacts path.
-      If the model is missing, writes an empty classification output and a checks JSON
-      explaining the missing artifact.
+    Required inputs and dependencies fail the materialization instead of producing a
+    placeholder artifact. A successful materialization therefore means that real input
+    data was processed and the returned path names the artifact that was actually written.
+
+    Behavior:
+    - Loads a trained ApplicabilityModel from a well-known artifacts path.
     - Loads the taxonomy via TaxonomyLoader and instantiates EvidenceExtractor.
     - Reads enriched award records from `data/processed/enriched_sbir_awards.ndjson`
-      (NDJSON) or `data/processed/enriched_sbir_awards.parquet` if available. If neither
-      exists, operates on a very small sample to allow the asset to run in CI.
+      (NDJSON) or `data/processed/enriched_sbir_awards.parquet` if available.
     - Classifies awards in batches (configurable via classification config) and attaches
       up to N evidence statements per CET classification.
     - Persists classifications to `data/processed/cet_award_classifications.parquet`
@@ -158,16 +159,16 @@ def enriched_cet_award_classifications() -> Output:
 
     # Local imports to keep module import-safe when optional deps are missing
 
-    # Lazy imports for ML components (may be unavailable in minimal CI)
+    # Lazy imports keep repository discovery import-safe, but materialization requires them.
     try:
         from sbir_ml.ml.features.evidence_extractor import EvidenceExtractor
-    except Exception:
-        EvidenceExtractor = None  # type: ignore
+    except Exception as exc:
+        raise RuntimeError("CET evidence extraction dependency is unavailable") from exc
 
     try:
         from sbir_ml.ml.models.cet_classifier import ApplicabilityModel
-    except Exception:
-        ApplicabilityModel = None  # type: ignore
+    except Exception as exc:
+        raise RuntimeError("CET award classifier dependency is unavailable") from exc
 
     # Paths and defaults
     awards_ndjson = Path("data/processed/enriched_sbir_awards.ndjson")
@@ -180,51 +181,11 @@ def enriched_cet_award_classifications() -> Output:
     try:
         loader = TaxonomyLoader()
         taxonomy = loader.load_taxonomy()
-    except Exception:
-        logger.exception("Failed to load taxonomy; writing empty output")
-        import pandas as pd
-
-        df_empty = pd.DataFrame(
-            columns=[
-                "award_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "evidence",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-        checks = {"ok": False, "reason": "taxonomy_load_failed", "num_awards": 0}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
-
-    try:
         classification_config = loader.load_classification_config()
-    except Exception:
-        # If classification config cannot be loaded, fall back to defaults
-        logger.warning("Could not load classification config; using defaults")
-        classification_config = {}  # type: ignore[assignment, no-redef]
+    except Exception as exc:
+        raise RuntimeError("Failed to load the CET taxonomy and classification config") from exc
 
-    # Prepare EvidenceExtractor if available
-    extractor = None
-    if EvidenceExtractor is not None:
-        try:
-            # type: ignore[arg-type]
-            extractor = EvidenceExtractor(list(taxonomy.cet_areas), classification_config)  # type: ignore[arg-type]
-        except Exception:
-            extractor = None
-            logger.exception("Failed to initialize EvidenceExtractor; evidence extraction disabled")
-
-    # Load awards (prefer parquet, then ndjson). If neither present, use a tiny sample.
+    # Load awards (prefer parquet, then ndjson).
     awards: list[dict] = []
     try:
         if awards_parquet.exists():
@@ -247,99 +208,30 @@ def enriched_cet_award_classifications() -> Output:
                     if line.strip():
                         awards.append(json.loads(line))
         else:
-            # Minimal sample so asset can run in lightweight CI
-            awards = [
-                {
-                    "award_id": "sample_001",
-                    "title": "AI for imaging",
-                    "abstract": "This project applies machine learning and deep neural networks to image analysis.",
-                    "keywords": ["machine learning", "neural networks"],
-                },
-                {
-                    "award_id": "sample_002",
-                    "title": "Quantum algorithms",
-                    "abstract": "Research on quantum optimization and qubit coherence for algorithms.",
-                    "keywords": ["quantum computing", "qubits"],
-                },
-            ]
-            logger.warning(
-                "No enriched awards found at expected paths; running classification on a small sample"
+            raise FileNotFoundError(
+                f"No enriched award input found at {awards_parquet} or {awards_ndjson}"
             )
-    except Exception:
-        logger.exception("Failed to load awards for classification; writing empty output")
-        awards = []
+    except FileNotFoundError:
+        raise
+    except Exception as exc:
+        raise RuntimeError("Failed to load enriched awards for CET classification") from exc
 
-    # If model artifact not found or loading fails, write placeholder output & checks
-    if not model_path.exists() or ApplicabilityModel is None:
-        logger.warning(
-            "Trained model not available; skipping classification (model: %s)", model_path
-        )
-        # Produce an empty DataFrame with expected columns so downstream consumers have schema
-        import pandas as pd
-
-        df_empty = pd.DataFrame(
-            columns=[
-                "award_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "evidence",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-
-        checks = {
-            "ok": False,
-            "reason": "model_missing",
-            "model_path": str(model_path),
-            "num_awards": len(awards),
-            "num_classified": 0,
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "model_present": False,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
+    if not model_path.exists():
+        raise FileNotFoundError(f"Trained CET award model not found: {model_path}")
 
     # Load trained model
     try:
         model = ApplicabilityModel.load(model_path)
-    except Exception:
-        logger.exception("Failed to load trained model from %s", model_path)
-        model = None
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load trained CET award model: {model_path}") from exc
 
     if model is None:
-        logger.warning("Model could not be loaded; aborting classification")
-        df_empty = __import__("pandas").DataFrame(
-            columns=[
-                "award_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "evidence",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-        checks = {"ok": False, "reason": "model_load_failed", "num_awards": len(awards)}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "model_present": False,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
+        raise RuntimeError(f"CET award model loader returned no model: {model_path}")
+
+    try:
+        extractor = EvidenceExtractor(list(taxonomy.cet_areas), classification_config)  # type: ignore[arg-type]
+    except Exception as exc:
+        raise RuntimeError("Failed to initialize the CET evidence extractor") from exc
 
     # Build texts for classification and perform batch classification
     texts = []
@@ -391,58 +283,27 @@ def enriched_cet_award_classifications() -> Output:
         else 1000
     )
 
-    # Perform batch classification with error handling
+    # Perform batch classification.
     try:
         classifications_by_award = model.classify_batch(texts, batch_size=batch_size)
-    except Exception:
-        logger.exception("Batch classification failed; writing empty output")
-        df_empty = pd.DataFrame(
-            columns=[
-                "award_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "evidence",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-        checks = {"ok": False, "reason": "classification_failed", "num_awards": len(awards)}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "model_present": True,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
+    except Exception as exc:
+        raise RuntimeError("CET award batch classification failed") from exc
 
     # Attach evidence if extractor available
-    if extractor is not None:
-        # Build document_parts list matching expectations of EvidenceExtractor
-        doc_parts_list = []
-        for a in awards:
-            doc_parts_list.append(
-                {
-                    "abstract": str(a.get("abstract", "")),
-                    "keywords": " ".join(a.get("keywords") or []),
-                    "title": str(a.get("title", "")),
-                }
-            )
-        try:
-            classifications_with_evidence = extractor.extract_batch_evidence(
-                classifications_by_award, doc_parts_list
-            )
-        except Exception:
-            logger.exception(
-                "Batch evidence extraction failed; falling back to classification-only results"
-            )
-            classifications_with_evidence = classifications_by_award
-    else:
-        classifications_with_evidence = classifications_by_award
+    doc_parts_list = [
+        {
+            "abstract": str(a.get("abstract", "")),
+            "keywords": " ".join(a.get("keywords") or []),
+            "title": str(a.get("title", "")),
+        }
+        for a in awards
+    ]
+    try:
+        classifications_with_evidence = extractor.extract_batch_evidence(
+            classifications_by_award, doc_parts_list
+        )
+    except Exception as exc:
+        raise RuntimeError("CET award evidence extraction failed") from exc
 
     # Flatten classification results into a DataFrame (one row per award)
     import pandas as pd
@@ -497,8 +358,8 @@ def enriched_cet_award_classifications() -> Output:
 
     df_out = pd.DataFrame(rows)
 
-    # Persist classifications (parquet preferred, NDJSON fallback).
-    output_path = save_dataframe_parquet(df_out, output_path)
+    # Persist classifications (parquet preferred, NDJSON fallback)
+    artifact_path = save_dataframe_parquet(df_out, output_path)
 
     # Build checks: coverage, high-confidence rate, evidence coverage
     num_awards = len(rows)
@@ -533,7 +394,7 @@ def enriched_cet_award_classifications() -> Output:
         json.dump(checks, fh, indent=2)
 
     metadata = {
-        "path": str(output_path),
+        "path": str(artifact_path),
         "rows": len(df_out),
         "taxonomy_version": taxonomy.version,
         "model_version": getattr(model, "model_version", None),
@@ -541,7 +402,7 @@ def enriched_cet_award_classifications() -> Output:
     }
 
     logger.info(
-        "Completed cet_award_classifications asset", rows=len(df_out), output=str(output_path)
+        "Completed cet_award_classifications asset", rows=len(df_out), output=str(artifact_path)
     )
 
     # Perform statistical analysis with CET analyzer
@@ -554,14 +415,7 @@ def enriched_cet_award_classifications() -> Output:
                 "stage": "transform",
             }
 
-            # Load the classified DataFrame from the output file
-            import pandas as pd
-
-            try:
-                classified_df = pd.read_parquet(output_path)
-            except Exception:
-                logger.warning(f"Could not load classified DataFrame from {output_path}")
-                classified_df = pd.DataFrame()
+            classified_df = df_out
 
             # Prepare module data for analysis
             module_data = {
@@ -570,9 +424,7 @@ def enriched_cet_award_classifications() -> Output:
                     "classified_records": len(classified_df),
                     "failed_records": 0,  # Assume all records were processed
                     "duration_seconds": 0.0,  # Could be enhanced with actual timing
-                    "classification_rate": len(
-                        classified_df[classified_df["primary_cet_area"].notna()]
-                    )
+                    "classification_rate": len(classified_df[classified_df["primary_cet"].notna()])
                     / len(classified_df)
                     if len(classified_df) > 0
                     else 0,
@@ -640,7 +492,7 @@ def enriched_cet_award_classifications() -> Output:
     else:
         logger.info("CET analyzer not available; skipping statistical analysis")  # type: ignore[unreachable]
 
-    return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
+    return Output(value=str(artifact_path), metadata=metadata)  # type: ignore[arg-type]
 
 
 @asset(
@@ -655,14 +507,14 @@ def enriched_cet_patent_classifications() -> Output:
     """
     Dagster asset to perform batch CET classification over patent title records.
 
-    Behavior (best-effort / import-safe):
-    - Attempts to load a trained PatentCETClassifier from a well-known artifacts path.
-      If the model is missing, writes an empty classification output and a checks JSON
-      explaining the missing artifact.
+    Required inputs and dependencies fail the materialization instead of producing a
+    placeholder artifact.
+
+    Behavior:
+    - Loads a trained PatentCETClassifier from a well-known artifacts path.
     - Loads the taxonomy via TaxonomyLoader for metadata.
     - Reads transformed patent records from `data/processed/transformed_patents.ndjson`
-      (NDJSON) or `data/processed/transformed_patents.parquet` if available. If neither
-      exists, operates on a very small sample so the asset can run in CI.
+      (NDJSON) or `data/processed/transformed_patents.parquet` if available.
     - Classifies patent titles in batches and persists outputs with NDJSON/parquet fallback.
     - Writes a companion checks JSON summarizing classification coverage.
     """
@@ -670,11 +522,11 @@ def enriched_cet_patent_classifications() -> Output:
 
     # Local imports to keep module import-safe when optional deps are missing
 
-    # Lazy import of classifier implementation (may be unavailable in minimal CI)
+    # Lazy import keeps repository discovery import-safe, but materialization requires it.
     try:
         from sbir_ml.ml.models.patent_classifier import PatentCETClassifier
-    except Exception:
-        PatentCETClassifier = None  # type: ignore
+    except Exception as exc:
+        raise RuntimeError("CET patent classifier dependency is unavailable") from exc
 
     # Paths and defaults
     patents_ndjson = Path("data/processed/transformed_patents.ndjson")
@@ -683,14 +535,14 @@ def enriched_cet_patent_classifications() -> Output:
     output_path = Path("data/processed/cet_patent_classifications.parquet")
     checks_path = output_path.with_suffix(".checks.json")
 
-    # Load taxonomy for metadata (non-fatal)
-    loader = TaxonomyLoader()
     try:
+        loader = TaxonomyLoader()
         taxonomy = loader.load_taxonomy()
-    except Exception:
-        taxonomy = None
+        classification_config = loader.load_classification_config()
+    except Exception as exc:
+        raise RuntimeError("Failed to load the CET taxonomy and classification config") from exc
 
-    # Load patent records (prefer parquet, then ndjson). If neither present, use a tiny sample.
+    # Load patent records (prefer parquet, then ndjson).
     patents: list[dict] = []
     try:
         if patents_parquet.exists():
@@ -712,95 +564,25 @@ def enriched_cet_patent_classifications() -> Output:
                     if line.strip():
                         patents.append(json.loads(line))
         else:
-            # Minimal sample so asset can run in lightweight CI
-            patents = [
-                {
-                    "patent_id": "sample_p1",
-                    "title": "Machine learning for image analysis",
-                    "assignee": "Acme Labs",
-                },
-                {
-                    "patent_id": "sample_p2",
-                    "title": "Quantum computing improvements for qubit stability",
-                    "assignee": "QuantumCorp",
-                },
-            ]
-            logger.warning(
-                "No transformed patents found at expected paths; running classification on a small sample"
+            raise FileNotFoundError(
+                f"No transformed patent input found at {patents_parquet} or {patents_ndjson}"
             )
-    except Exception:
-        logger.exception("Failed to load patent records for classification; writing empty output")
-        patents = []
+    except FileNotFoundError:
+        raise
+    except Exception as exc:
+        raise RuntimeError("Failed to load patents for CET classification") from exc
 
-    # If model artifact not found or loading fails, write placeholder output & checks
-    if not model_path.exists() or PatentCETClassifier is None:
-        logger.warning(
-            "Trained patent model not available; skipping classification (model: %s)", model_path
-        )
-        # Produce an empty DataFrame with expected columns so downstream consumers have schema
-        import pandas as pd
-
-        df_empty = pd.DataFrame(
-            columns=[
-                "patent_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-
-        checks = {
-            "ok": False,
-            "reason": "model_missing",
-            "model_path": str(model_path),
-            "num_patents": len(patents),
-            "num_classified": 0,
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "model_present": False,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
+    if not model_path.exists():
+        raise FileNotFoundError(f"Trained CET patent model not found: {model_path}")
 
     # Load trained model
     try:
         classifier = PatentCETClassifier.load(model_path)
-    except Exception:
-        logger.exception("Failed to load patent classifier from %s", model_path)
-        classifier = None
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load trained CET patent model: {model_path}") from exc
 
     if classifier is None:
-        logger.warning("Patent model could not be loaded; aborting classification")
-        df_empty = __import__("pandas").DataFrame(
-            columns=[
-                "patent_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-        checks = {"ok": False, "reason": "model_load_failed", "num_patents": len(patents)}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "model_present": False,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
+        raise RuntimeError(f"CET patent model loader returned no model: {model_path}")
 
     # Build texts for classification and perform batch classification
     titles = []
@@ -839,19 +621,18 @@ def enriched_cet_patent_classifications() -> Output:
             patent_ids.append(p.get("patent_id") or "")
             assignees.append(p.get("assignee") or None)
 
-    # batch_size: try to read from classification config if loader provided it, else default 1000
-    try:
-        classification_config = loader.load_classification_config()
-    except Exception:
-        classification_config = {}  # type: ignore[assignment, no-redef]
-
     batch_size = (
         classification_config.get("batch", {}).get("size", 1000)
         if isinstance(classification_config, dict)
         else 1000
     )
 
-    classifications_by_patent = classifier.classify_batch(titles, assignees, batch_size=batch_size)
+    try:
+        classifications_by_patent = classifier.classify_batch(
+            titles, assignees, batch_size=batch_size
+        )
+    except Exception as exc:
+        raise RuntimeError("CET patent batch classification failed") from exc
 
     # Flatten classification results into a DataFrame (one row per patent)
     import pandas as pd
@@ -890,8 +671,8 @@ def enriched_cet_patent_classifications() -> Output:
 
     df_out = pd.DataFrame(rows)
 
-    # Persist classifications (parquet preferred, NDJSON fallback).
-    output_path = save_dataframe_parquet(df_out, output_path)
+    # Persist classifications (parquet preferred, NDJSON fallback)
+    artifact_path = save_dataframe_parquet(df_out, output_path)
 
     # Build checks: coverage and counts
     num_patents = len(rows)
@@ -908,7 +689,7 @@ def enriched_cet_patent_classifications() -> Output:
         json.dump(checks, fh, indent=2)
 
     metadata = {
-        "path": str(output_path),
+        "path": str(artifact_path),
         "rows": len(df_out),
         "taxonomy_version": taxonomy.version if taxonomy else None,
         "model_version": getattr(classifier, "model_version", None),
@@ -916,7 +697,7 @@ def enriched_cet_patent_classifications() -> Output:
     }
 
     logger.info(
-        "Completed cet_patent_classifications asset", rows=len(df_out), output=str(output_path)
+        "Completed cet_patent_classifications asset", rows=len(df_out), output=str(artifact_path)
     )
 
-    return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
+    return Output(value=str(artifact_path), metadata=metadata)  # type: ignore[arg-type]

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
@@ -216,8 +216,14 @@ def enriched_cet_award_classifications() -> Output:
     except Exception as exc:
         raise RuntimeError("Failed to load enriched awards for CET classification") from exc
 
+    if not awards:
+        raise ValueError("Enriched award input is empty; no awards are available to classify")
+
     if not model_path.exists():
-        raise FileNotFoundError(f"Trained CET award model not found: {model_path}")
+        raise FileNotFoundError(
+            f"Trained CET award model not found: {model_path}. "
+            "Provision a trained ApplicabilityModel artifact at this path before materializing."
+        )
 
     # Load trained model
     try:
@@ -250,33 +256,6 @@ def enriched_cet_award_classifications() -> Output:
         texts.append(combined)
         award_ids.append(a.get("award_id") or "")
 
-    # Handle empty awards list
-    if not texts or not award_ids:
-        logger.warning("No award texts to classify; writing empty output")
-        df_empty = pd.DataFrame(
-            columns=[
-                "award_id",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "evidence",
-                "classified_at",
-                "taxonomy_version",
-            ]
-        )
-        output_path = save_dataframe_parquet(df_empty, output_path)
-        checks = {"ok": False, "reason": "no_awards_to_classify", "num_awards": len(awards)}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "model_present": True,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]  # type: ignore[arg-type]
-
     batch_size = (
         classification_config.get("batch", {}).get("size", 1000)
         if isinstance(classification_config, dict)
@@ -285,9 +264,15 @@ def enriched_cet_award_classifications() -> Output:
 
     # Perform batch classification.
     try:
-        classifications_by_award = model.classify_batch(texts, batch_size=batch_size)
+        classifications_by_award = list(model.classify_batch(texts, batch_size=batch_size))
     except Exception as exc:
         raise RuntimeError("CET award batch classification failed") from exc
+
+    if len(classifications_by_award) != len(awards):
+        raise ValueError(
+            "CET award classifier returned "
+            f"{len(classifications_by_award)} results for {len(awards)} source rows"
+        )
 
     # Attach evidence if extractor available
     doc_parts_list = [
@@ -299,17 +284,23 @@ def enriched_cet_award_classifications() -> Output:
         for a in awards
     ]
     try:
-        classifications_with_evidence = extractor.extract_batch_evidence(
-            classifications_by_award, doc_parts_list
+        classifications_with_evidence = list(
+            extractor.extract_batch_evidence(classifications_by_award, doc_parts_list)
         )
     except Exception as exc:
         raise RuntimeError("CET award evidence extraction failed") from exc
+
+    if len(classifications_with_evidence) != len(awards):
+        raise ValueError(
+            "CET award evidence extractor returned "
+            f"{len(classifications_with_evidence)} results for {len(awards)} source rows"
+        )
 
     # Flatten classification results into a DataFrame (one row per award)
     import pandas as pd
 
     rows: list[Any] = []
-    for aid, cls_list in zip(award_ids, classifications_with_evidence, strict=False):
+    for aid, cls_list in zip(award_ids, classifications_with_evidence, strict=True):
         if not cls_list:
             rows.append(
                 {
@@ -572,6 +563,9 @@ def enriched_cet_patent_classifications() -> Output:
     except Exception as exc:
         raise RuntimeError("Failed to load patents for CET classification") from exc
 
+    if not patents:
+        raise ValueError("Transformed patent input is empty; no patents are available to classify")
+
     if not model_path.exists():
         raise FileNotFoundError(f"Trained CET patent model not found: {model_path}")
 
@@ -596,8 +590,13 @@ def enriched_cet_patent_classifications() -> Output:
         kw_map = get_keywords_map()
         extractor = PatentFeatureExtractor(keywords_map=kw_map)
         if hasattr(extractor, "transform"):
-            feature_dicts = extractor.transform(patents)
-            for p, fv in zip(patents, feature_dicts, strict=False):
+            feature_dicts = list(extractor.transform(patents))
+            if len(feature_dicts) != len(patents):
+                raise ValueError(
+                    "CET patent feature extractor returned "
+                    f"{len(feature_dicts)} results for {len(patents)} source rows"
+                )
+            for p, fv in zip(patents, feature_dicts, strict=True):
                 norm_title = (
                     fv.get("normalized_title")
                     if isinstance(fv, dict)
@@ -615,6 +614,8 @@ def enriched_cet_patent_classifications() -> Output:
                 titles.append(normalize_title(p.get("title")))
                 patent_ids.append(p.get("patent_id") or "")
                 assignees.append(None)
+    except ValueError:
+        raise
     except Exception:
         for p in patents:
             titles.append(str(p.get("title") or ""))
@@ -628,17 +629,23 @@ def enriched_cet_patent_classifications() -> Output:
     )
 
     try:
-        classifications_by_patent = classifier.classify_batch(
-            titles, assignees, batch_size=batch_size
+        classifications_by_patent = list(
+            classifier.classify_batch(titles, assignees, batch_size=batch_size)
         )
     except Exception as exc:
         raise RuntimeError("CET patent batch classification failed") from exc
+
+    if len(classifications_by_patent) != len(patents):
+        raise ValueError(
+            "CET patent classifier returned "
+            f"{len(classifications_by_patent)} results for {len(patents)} source rows"
+        )
 
     # Flatten classification results into a DataFrame (one row per patent)
     import pandas as pd
 
     rows: list[Any] = []
-    for pid, cls_list in zip(patent_ids, classifications_by_patent, strict=False):
+    for pid, cls_list in zip(patent_ids, classifications_by_patent, strict=True):
         if not cls_list:
             rows.append(
                 {

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
@@ -85,10 +85,9 @@ def transformed_cet_company_profiles() -> Output:
     """
     Dagster asset to perform company-level aggregation of CET classifications.
 
-    Behavior (best-effort / import-safe):
+    Behavior:
     - Attempts to load `data/processed/cet_award_classifications.parquet` or `.json` NDJSON fallback.
-      If the classifications input is missing, produces an empty company profiles output so downstream
-      consumers have a deterministic schema.
+      Missing or unreadable classification inputs fail the materialization.
     - Uses `CompanyCETAggregator` (from `src.transformers.company_cet_aggregator`) to compute per-company
       CET aggregates: coverage, dominant CET, specialization (HHI), CET score map, and trend.
     - Persists company profiles to `data/processed/cet_company_profiles.parquet` with NDJSON fallback.
@@ -101,62 +100,15 @@ def transformed_cet_company_profiles() -> Output:
     from pathlib import Path
 
     try:
-        import pandas as pd
-    except Exception:
-        pd = None  # type: ignore
-
-    try:
         from sbir_etl.transformers.company_cet_aggregator import CompanyCETAggregator
-    except Exception:
-        CompanyCETAggregator = None  # type: ignore
+    except Exception as exc:
+        raise RuntimeError("CET company aggregation dependency is unavailable") from exc
 
     # Paths
     classifications_parquet = Path("data/processed/cet_award_classifications.parquet")
     classifications_ndjson = Path("data/processed/cet_award_classifications.json")
     output_path = Path("data/processed/cet_company_profiles.parquet")
     checks_path = output_path.with_suffix(".checks.json")
-
-    # If dependencies missing, write placeholder output & checks
-    if pd is None or CompanyCETAggregator is None:
-        logger.warning(  # type: ignore[unreachable]
-            "Missing dependencies for company aggregation (pandas: %s, aggregator: %s). Writing placeholder output.",
-            pd is not None,
-            CompanyCETAggregator is not None,
-        )
-        # Produce an empty DataFrame with expected columns so downstream consumers have schema
-        if pd is not None:
-            df_empty = pd.DataFrame(
-                columns=[
-                    "company_id",
-                    "company_name",
-                    "total_awards",
-                    "awards_with_cet",
-                    "coverage",
-                    "dominant_cet",
-                    "dominant_score",
-                    "specialization_score",
-                    "cet_scores",
-                    "first_award_date",
-                    "last_award_date",
-                    "cet_trend",
-                ]
-            )
-            output_path = save_dataframe_parquet(df_empty, output_path)
-        checks = {
-            "ok": False,
-            "reason": "missing_dependency",
-            "pandas_present": pd is not None,
-            "aggregator_present": CompanyCETAggregator is not None,
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "checks_path": str(checks_path),
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
 
     # Load classifications (prefer parquet, then NDJSON)
     try:
@@ -170,37 +122,14 @@ def transformed_cet_company_profiles() -> Output:
                         recs.append(json.loads(line))
             df_cls = pd.DataFrame(recs)
         else:
-            logger.warning(
-                "No cet_award_classifications found at expected paths; producing empty company profiles"
+            raise FileNotFoundError(
+                "No CET award classifications found at "
+                f"{classifications_parquet} or {classifications_ndjson}"
             )
-            df_cls = pd.DataFrame(
-                columns=[
-                    "award_id",
-                    "company_id",
-                    "company_name",
-                    "primary_cet",
-                    "primary_score",
-                    "supporting_cets",
-                    "classified_at",
-                    "award_date",
-                    "phase",
-                ]
-            )
-    except Exception:
-        logger.exception("Failed to load award classifications; producing empty company profiles")
-        df_cls = pd.DataFrame(
-            columns=[
-                "award_id",
-                "company_id",
-                "company_name",
-                "primary_cet",
-                "primary_score",
-                "supporting_cets",
-                "classified_at",
-                "award_date",
-                "phase",
-            ]
-        )
+    except FileNotFoundError:
+        raise
+    except Exception as exc:
+        raise RuntimeError("Failed to load CET award classifications") from exc
 
     # Join with enriched awards to get company information if missing
     if not df_cls.empty and "company_id" not in df_cls.columns:
@@ -251,10 +180,10 @@ def transformed_cet_company_profiles() -> Output:
                         logger.info(
                             f"Joined classifications with enriched awards to get company info (joined {df_cls['company_id'].notna().sum()} rows)"
                         )
-        except Exception:
-            logger.exception(
-                "Failed to join classifications with enriched awards; proceeding without company info"
-            )
+        except Exception as exc:
+            raise RuntimeError(
+                "Failed to join CET classifications with enriched award company data"
+            ) from exc
 
     # Ensure company_id and company_name columns exist (CompanyCETAggregator expects them)
     if not df_cls.empty:
@@ -267,27 +196,11 @@ def transformed_cet_company_profiles() -> Output:
     try:
         aggregator = CompanyCETAggregator(df_cls)
         df_comp = aggregator.to_dataframe()
-    except Exception:
-        logger.exception("Company aggregation failed; producing empty company profiles")
-        df_comp = pd.DataFrame(
-            columns=[
-                "company_id",
-                "company_name",
-                "total_awards",
-                "awards_with_cet",
-                "coverage",
-                "dominant_cet",
-                "dominant_score",
-                "specialization_score",
-                "cet_scores",
-                "first_award_date",
-                "last_award_date",
-                "cet_trend",
-            ]
-        )
+    except Exception as exc:
+        raise RuntimeError("CET company aggregation failed") from exc
 
-    # Persist company profiles (parquet preferred, NDJSON fallback).
-    output_path = save_dataframe_parquet(df_comp, output_path)
+    # Persist company profiles (parquet preferred, NDJSON fallback)
+    artifact_path = save_dataframe_parquet(df_comp, output_path)
 
     # Build checks
     num_companies = len(df_comp)
@@ -301,14 +214,16 @@ def transformed_cet_company_profiles() -> Output:
         json.dump(checks, fh, indent=2)
 
     metadata = {
-        "path": str(output_path),
+        "path": str(artifact_path),
         "rows": len(df_comp),
         "checks_path": str(checks_path),
     }
 
-    logger.info("Completed cet_company_profiles asset", rows=len(df_comp), output=str(output_path))
+    logger.info(
+        "Completed cet_company_profiles asset", rows=len(df_comp), output=str(artifact_path)
+    )
 
-    return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
+    return Output(value=str(artifact_path), metadata=metadata)  # type: ignore[arg-type]
 
 
 # ============================================================================

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
@@ -86,7 +86,7 @@ def transformed_cet_company_profiles() -> Output:
     Dagster asset to perform company-level aggregation of CET classifications.
 
     Behavior:
-    - Attempts to load `data/processed/cet_award_classifications.parquet` or `.json` NDJSON fallback.
+    - Attempts to load `data/processed/cet_award_classifications.parquet` or `.ndjson` fallback.
       Missing or unreadable classification inputs fail the materialization.
     - Uses `CompanyCETAggregator` (from `src.transformers.company_cet_aggregator`) to compute per-company
       CET aggregates: coverage, dominant CET, specialization (HHI), CET score map, and trend.
@@ -106,7 +106,7 @@ def transformed_cet_company_profiles() -> Output:
 
     # Paths
     classifications_parquet = Path("data/processed/cet_award_classifications.parquet")
-    classifications_ndjson = Path("data/processed/cet_award_classifications.json")
+    classifications_ndjson = Path("data/processed/cet_award_classifications.ndjson")
     output_path = Path("data/processed/cet_company_profiles.parquet")
     checks_path = output_path.with_suffix(".checks.json")
 
@@ -130,6 +130,9 @@ def transformed_cet_company_profiles() -> Output:
         raise
     except Exception as exc:
         raise RuntimeError("Failed to load CET award classifications") from exc
+
+    if df_cls.empty:
+        raise ValueError("CET award classification input is empty; no companies can be aggregated")
 
     # Join with enriched awards to get company information if missing
     if not df_cls.empty and "company_id" not in df_cls.columns:
@@ -185,12 +188,10 @@ def transformed_cet_company_profiles() -> Output:
                 "Failed to join CET classifications with enriched award company data"
             ) from exc
 
-    # Ensure company_id and company_name columns exist (CompanyCETAggregator expects them)
-    if not df_cls.empty:
-        if "company_id" not in df_cls.columns:
-            df_cls["company_id"] = None
-        if "company_name" not in df_cls.columns:
-            df_cls["company_name"] = None
+    if "company_id" not in df_cls.columns or not df_cls["company_id"].notna().any():
+        raise ValueError("CET award classifications contain no usable company identifiers")
+    if "company_name" not in df_cls.columns:
+        df_cls["company_name"] = None
 
     # Run aggregation
     try:
@@ -198,6 +199,9 @@ def transformed_cet_company_profiles() -> Output:
         df_comp = aggregator.to_dataframe()
     except Exception as exc:
         raise RuntimeError("CET company aggregation failed") from exc
+
+    if df_comp.empty:
+        raise ValueError("CET company aggregation produced no company profiles")
 
     # Persist company profiles (parquet preferred, NDJSON fallback)
     artifact_path = save_dataframe_parquet(df_comp, output_path)
@@ -255,10 +259,10 @@ DEFAULT_TAXONOMY_PARQUET = DEFAULT_PROCESSED_DIR_NEO4J / "cet_taxonomy.parquet"
 DEFAULT_TAXONOMY_JSON = DEFAULT_PROCESSED_DIR_NEO4J / "cet_taxonomy.json"
 
 DEFAULT_AWARD_CLASS_PARQUET = DEFAULT_PROCESSED_DIR_NEO4J / "cet_award_classifications.parquet"
-DEFAULT_AWARD_CLASS_JSON = DEFAULT_PROCESSED_DIR_NEO4J / "cet_award_classifications.json"
+DEFAULT_AWARD_CLASS_JSON = DEFAULT_PROCESSED_DIR_NEO4J / "cet_award_classifications.ndjson"
 
 DEFAULT_COMPANY_PROFILES_PARQUET = DEFAULT_PROCESSED_DIR_NEO4J / "cet_company_profiles.parquet"
-DEFAULT_COMPANY_PROFILES_JSON = DEFAULT_PROCESSED_DIR_NEO4J / "cet_company_profiles.json"
+DEFAULT_COMPANY_PROFILES_JSON = DEFAULT_PROCESSED_DIR_NEO4J / "cet_company_profiles.ndjson"
 
 DEFAULT_OUTPUT_DIR = Path(os.environ.get("SBIR_ETL__CET__NEO4J_OUTPUT_DIR", "data/loaded/neo4j"))
 

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
@@ -118,7 +118,8 @@ def train_cet_patent_classifier() -> Output:
     name="cet_award_training_dataset",
     key_prefix=["ml"],
     description=(
-        "Load labeled CET award training dataset from CSV or NDJSON, validate and persist to "
+        "Load labeled CET award training dataset with required `text` and `labels` columns "
+        "from CSV or NDJSON, validate and persist to "
         "`data/processed/cet_award_training.parquet` and emit a companion checks JSON. "
         "The returned path always identifies the artifact that was actually written."
     ),

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
@@ -20,92 +20,55 @@ from .utils import Output, asset, save_dataframe_parquet
     description=(
         "Train and persist a Patent CET classifier artifact at "
         "`artifacts/models/patent_classifier_v1.pkl`. Emits a companion checks JSON "
-        "with training metadata. If training data or dependencies are missing, "
-        "writes a minimal checks file and returns the intended model path."
+        "with training metadata. Missing prerequisites fail the materialization."
     ),
 )
 def train_cet_patent_classifier() -> Output:
-    """
-    Dagster asset that trains the PatentCETClassifier from a labeled dataset.
-
-    Behavior (import-safe):
-    - Expects a labeled training dataset at `data/processed/cet_patent_training.parquet`
-      with columns: `title`, `cet_labels` (iterable[str] or comma-delimited), and optional `assignee`.
-    - When training data or pandas is missing, writes a checks JSON with ok=False and
-      returns the model path without creating the artifact.
-    """
-
+    """Train the patent classifier, failing unless a real model artifact is created."""
     model_path = Path("artifacts/models/patent_classifier_v1.pkl")
     checks_path = model_path.with_suffix(".checks.json")
     train_data_parquet = Path("data/processed/cet_patent_training.parquet")
+    train_data_ndjson = train_data_parquet.with_suffix(".ndjson")
 
     try:
         import pandas as pd
-    except Exception:
-        # Missing pandas; write checks and exit
-        checks = {"ok": False, "reason": "pandas_missing", "model_path": str(model_path)}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        return Output(
-            value=str(model_path), metadata={"model_path": str(model_path), "trained": False}
-        )
+    except Exception as exc:
+        raise RuntimeError("pandas is required to train the CET patent classifier") from exc
 
-    # Attempt to import training helper and dummy pipeline for simple factory
     try:
         from sbir_ml.ml.features.patent_features import get_keywords_map
         from sbir_ml.ml.models.dummy_pipeline import DummyPipeline
         from sbir_ml.ml.train.patent_training import train_patent_classifier
-    except Exception:
-        checks = {"ok": False, "reason": "training_helper_missing", "model_path": str(model_path)}
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        return Output(
-            value=str(model_path), metadata={"model_path": str(model_path), "trained": False}
+    except Exception as exc:
+        raise RuntimeError("CET patent training dependencies are unavailable") from exc
+
+    if not train_data_parquet.exists() and not train_data_ndjson.exists():
+        raise FileNotFoundError(
+            f"CET patent training data not found at {train_data_parquet} or {train_data_ndjson}"
         )
 
-    if not train_data_parquet.exists():
-        checks = {
-            "ok": False,
-            "reason": "training_data_missing",
-            "expected_path": str(train_data_parquet),
-            "model_path": str(model_path),
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        return Output(
-            value=str(model_path), metadata={"model_path": str(model_path), "trained": False}
-        )
-
-    # Load training data
-    try:
-        df = pd.read_parquet(train_data_parquet)
-    except Exception:
-        # Try NDJSON fallback
-        ndjson_path = train_data_parquet.with_suffix(".ndjson")
-        records = []
-        if ndjson_path.exists():
-            with open(ndjson_path, encoding="utf-8") as fh:
+    if train_data_parquet.exists():
+        try:
+            df = pd.read_parquet(train_data_parquet)
+        except Exception as exc:
+            if not train_data_ndjson.exists():
+                raise RuntimeError(f"Failed to read training data: {train_data_parquet}") from exc
+            records = []
+            with open(train_data_ndjson, encoding="utf-8") as fh:
                 for line in fh:
                     if line.strip():
                         records.append(json.loads(line))
+            df = pd.DataFrame(records)
+    else:
+        records = []
+        with open(train_data_ndjson, encoding="utf-8") as fh:
+            for line in fh:
+                if line.strip():
+                    records.append(json.loads(line))
         df = pd.DataFrame(records)
 
     if df is None or len(df) == 0:
-        checks = {
-            "ok": False,
-            "reason": "empty_training_data",
-            "model_path": str(model_path),
-            "rows": 0,
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        return Output(
-            value=str(model_path), metadata={"model_path": str(model_path), "trained": False}
-        )
+        raise ValueError("CET patent training data is empty")
 
     # Provide a simple pipelines factory using DummyPipeline with CET id as keyword cue
     def _factory(cet_id: str):
@@ -113,7 +76,6 @@ def train_cet_patent_classifier() -> Output:
         kw = cet_id.replace("_", " ")
         return DummyPipeline(cet_id=cet_id, keywords=[kw], keyword_boost=1.0)
 
-    # Train and persist
     try:
         meta = train_patent_classifier(
             df=df,
@@ -122,22 +84,22 @@ def train_cet_patent_classifier() -> Output:
             title_col="title",
             assignee_col="assignee" if "assignee" in df.columns else None,
             cet_label_col="cet_labels",
+            use_feature_extraction=True,
             keywords_map={k: list(v) for k, v in get_keywords_map().items()}
             if get_keywords_map()
             else None,  # type: ignore[arg-type]
         )
-        checks = {
-            "ok": True,
-            "model_path": str(model_path),
-            "trained_on_rows": meta.get("trained_on_rows", 0),
-        }
-    except Exception as e:
-        checks = {
-            "ok": False,
-            "reason": "training_failed",
-            "error": str(e),
-            "model_path": str(model_path),
-        }
+    except Exception as exc:
+        raise RuntimeError("CET patent classifier training failed") from exc
+
+    if not model_path.exists():
+        raise RuntimeError(f"Training completed without creating model artifact: {model_path}")
+
+    checks = {
+        "ok": True,
+        "model_path": str(model_path),
+        "trained_on_rows": meta.get("trained_on_rows", 0),
+    }
 
     checks_path.parent.mkdir(parents=True, exist_ok=True)
     with open(checks_path, "w", encoding="utf-8") as fh:
@@ -146,7 +108,7 @@ def train_cet_patent_classifier() -> Output:
     metadata = {
         "model_path": str(model_path),
         "checks_path": str(checks_path),
-        "trained": checks.get("ok", False),
+        "trained": True,
     }
     return Output(value=str(model_path), metadata=metadata)  # type: ignore[arg-type]
 
@@ -158,10 +120,11 @@ def train_cet_patent_classifier() -> Output:
     description=(
         "Load labeled CET award training dataset from CSV or NDJSON, validate and persist to "
         "`data/processed/cet_award_training.parquet` and emit a companion checks JSON. "
-        "Import-safe with NDJSON fallback when parquet engine or pandas is unavailable."
+        "The returned path always identifies the artifact that was actually written."
     ),
 )
 def cet_award_training_dataset() -> Output:
+    """Validate labeled award examples and persist a real training artifact."""
     output_path = Path("data/processed/cet_award_training.parquet")
     checks_path = output_path.with_suffix(".checks.json")
 
@@ -176,197 +139,70 @@ def cet_award_training_dataset() -> Output:
     ]
     input_path = next((p for p in candidate_inputs if p.exists()), None)
 
-    # Load taxonomy for metadata
-    loader = TaxonomyLoader()
     try:
+        loader = TaxonomyLoader()
         taxonomy = loader.load_taxonomy()
         taxonomy_version = taxonomy.version
-    except Exception:
-        taxonomy = None
-        taxonomy_version = None
+    except Exception as exc:
+        raise RuntimeError("Failed to load the CET taxonomy for award training data") from exc
 
-    # If no input, write empty output and checks
     if input_path is None:
-        try:
-            import pandas as pd
+        expected = ", ".join(str(path) for path in candidate_inputs)
+        raise FileNotFoundError(f"CET award training data not found; checked: {expected}")
 
-            df_empty = pd.DataFrame(
-                columns=[
-                    "example_id",
-                    "text",
-                    "title",
-                    "keywords",
-                    "keywords_joined",
-                    "solicitation",
-                    "labels",
-                    "labels_joined",
-                    "source",
-                    "annotated_by",
-                    "annotated_at",
-                    "notes",
-                    "taxonomy_version",
-                ]
-            )
-            output_path = save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            # Pandas itself may be unavailable; keep the empty artifact readable.
-            out_json = output_path.with_suffix(".ndjson")
-            out_json.parent.mkdir(parents=True, exist_ok=True)
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
-            output_path = out_json
-
-        checks = {
-            "ok": False,
-            "reason": "training_data_missing",
-            "expected_paths": [str(p) for p in candidate_inputs],
-            "rows": 0,
-            "taxonomy_version": taxonomy_version,
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "checks_path": str(checks_path),
-            "input_path": None,
-            "taxonomy_version": taxonomy_version,
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
-
-    # Load dataset using the training loader
-    try:
-        from sbir_ml.ml.data.award_training_loader import AwardTrainingLoader, save_dataset_ndjson
-
-        atl = AwardTrainingLoader(taxonomy_version=taxonomy_version or "unknown")
-        # Dispatch based on extension
-        if input_path.suffix.lower() in (".ndjson", ".jsonl"):
-            dataset = atl.load_ndjson(input_path)
-        elif input_path.suffix.lower() == ".csv":
-            dataset = atl.load_csv(input_path)
-        else:
-            # Try CSV then NDJSON as fallback
-            try:
-                dataset = atl.load_csv(input_path)
-            except Exception:
-                dataset = atl.load_ndjson(input_path)
-        stats = atl.last_stats.as_dict() if getattr(atl, "last_stats", None) else {}
-    except Exception as e:
-        # Failed to load training dataset; write checks and empty output
-        try:
-            import pandas as pd
-
-            df_empty = pd.DataFrame(
-                columns=[
-                    "example_id",
-                    "text",
-                    "title",
-                    "keywords",
-                    "keywords_joined",
-                    "solicitation",
-                    "labels",
-                    "labels_joined",
-                    "source",
-                    "annotated_by",
-                    "annotated_at",
-                    "notes",
-                    "taxonomy_version",
-                ]
-            )
-            output_path = save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            out_json = output_path.with_suffix(".ndjson")
-            out_json.parent.mkdir(parents=True, exist_ok=True)
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
-            output_path = out_json
-
-        checks = {
-            "ok": False,
-            "reason": "load_failed",
-            "error": str(e),
-            "input_path": str(input_path),
-            "taxonomy_version": taxonomy_version,
-        }
-        checks_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(checks_path, "w", encoding="utf-8") as fh:
-            json.dump(checks, fh, indent=2)
-        metadata = {
-            "path": str(output_path),
-            "rows": 0,
-            "checks_path": str(checks_path),
-            "input_path": str(input_path),
-            "taxonomy_version": taxonomy_version,
-        }
-        return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
-
-    # Persist dataset to parquet (preferred) with NDJSON fallback
     try:
         import pandas as pd
 
-        rows = []
-        for ex in dataset.examples:
-            rows.append(
-                {
-                    "example_id": ex.example_id,
-                    "text": ex.text,
-                    "title": ex.title,
-                    "keywords": ex.keywords,
-                    "keywords_joined": (ex.keywords or ""),
-                    "solicitation": ex.solicitation,
-                    "labels": ex.labels,
-                    "labels_joined": ", ".join(ex.labels or []),
-                    "source": ex.source,
-                    "annotated_by": ex.annotated_by,
-                    "annotated_at": ex.annotated_at.isoformat() if ex.annotated_at else None,
-                    "notes": ex.notes,
-                    "taxonomy_version": dataset.taxonomy_version,
-                }
-            )
-        df = pd.DataFrame(rows)
-        output_path = save_dataframe_parquet(df, output_path)
-    except Exception:
-        # Fallback to NDJSON using helper
-        try:
-            out_json = output_path.with_suffix(".ndjson")
-            save_dataset_ndjson(dataset, out_json)
-            output_path = out_json
-        except Exception:
-            # As a last resort, write minimal NDJSON manually
-            out_json = output_path.with_suffix(".ndjson")
-            out_json.parent.mkdir(parents=True, exist_ok=True)
-            with open(out_json, "w", encoding="utf-8") as fh:
-                for ex in dataset.examples:
-                    fh.write(
-                        json.dumps(
-                            {
-                                "example_id": ex.example_id,
-                                "text": ex.text,
-                                "labels": ex.labels,
-                            }
-                        )
-                        + "\n"
-                    )
-            output_path = out_json
+        if input_path.suffix.lower() in (".ndjson", ".jsonl"):
+            records = []
+            with input_path.open(encoding="utf-8") as fh:
+                for line_number, line in enumerate(fh, start=1):
+                    if not line.strip():
+                        continue
+                    try:
+                        records.append(json.loads(line))
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"Invalid JSON in {input_path} at line {line_number}"
+                        ) from exc
+            df = pd.DataFrame(records)
+        elif input_path.suffix.lower() == ".csv":
+            df = pd.read_csv(input_path)
+        else:  # pragma: no cover - candidates above constrain extensions
+            raise ValueError(f"Unsupported CET award training format: {input_path.suffix}")
+    except Exception as exc:
+        raise RuntimeError(f"Failed to load CET award training data: {input_path}") from exc
 
-    # Build checks JSON
+    if df.empty:
+        raise ValueError(f"CET award training data is empty: {input_path}")
+
+    required_columns = {"text", "labels"}
+    missing_columns = required_columns - set(df.columns)
+    if missing_columns:
+        missing = ", ".join(sorted(missing_columns))
+        raise ValueError(f"CET award training data is missing required columns: {missing}")
+
+    if "taxonomy_version" not in df.columns:
+        df["taxonomy_version"] = taxonomy_version
+
+    artifact_path = save_dataframe_parquet(df, output_path)
+
     checks = {
         "ok": True,
-        "rows": len(dataset.examples),
+        "rows": len(df),
         "input_path": str(input_path),
-        "taxonomy_version": dataset.taxonomy_version,
-        "stats": stats if isinstance(stats, dict) else {},
+        "taxonomy_version": taxonomy_version,
+        "columns": sorted(df.columns.tolist()),
     }
     checks_path.parent.mkdir(parents=True, exist_ok=True)
     with open(checks_path, "w", encoding="utf-8") as fh:
         json.dump(checks, fh, indent=2)
 
     metadata = {
-        "path": str(output_path),
-        "rows": len(dataset.examples),
+        "path": str(artifact_path),
+        "rows": len(df),
         "checks_path": str(checks_path),
         "input_path": str(input_path),
-        "taxonomy_version": dataset.taxonomy_version,
+        "taxonomy_version": taxonomy_version,
     }
-    return Output(value=str(output_path), metadata=metadata)  # type: ignore[arg-type]
+    return Output(value=str(artifact_path), metadata=metadata)  # type: ignore[arg-type]

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
@@ -171,6 +171,10 @@ def cet_award_training_dataset() -> Output:
             df = pd.read_csv(input_path)
         else:  # pragma: no cover - candidates above constrain extensions
             raise ValueError(f"Unsupported CET award training format: {input_path.suffix}")
+    except ValueError:
+        # Malformed NDJSON lines and unsupported suffixes already name the defect;
+        # re-wrapping them as RuntimeError would hide it from callers and tests.
+        raise
     except Exception as exc:
         raise RuntimeError(f"Failed to load CET award training data: {input_path}") from exc
 

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/validation.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/validation.py
@@ -24,7 +24,7 @@ def raw_cet_human_sampling() -> Output:
     """
     Produce a small, human-readable sample for annotation.
 
-    - Reads `data/processed/cet_award_classifications.parquet` (preferred) or `.json` NDJSON.
+    - Reads `data/processed/cet_award_classifications.parquet` (preferred) or `.ndjson`.
     - Writes NDJSON sample to `data/processed/cet_human_sample.ndjson`.
     - Writes a checks JSON to `data/processed/cet_human_sample.checks.json`.
 
@@ -46,7 +46,7 @@ def raw_cet_human_sampling() -> Output:
 
     processed_dir = Path("data/processed")
     input_parquet = processed_dir / "cet_award_classifications.parquet"
-    input_json = processed_dir / "cet_award_classifications.json"
+    input_json = processed_dir / "cet_award_classifications.ndjson"
 
     output_ndjson = processed_dir / "cet_human_sample.ndjson"
     checks_path = processed_dir / "cet_human_sample.checks.json"
@@ -396,7 +396,7 @@ def validated_cet_drift_detection() -> Output:
 
     processed_dir = Path("data/processed")
     awards_parquet = processed_dir / "cet_award_classifications.parquet"
-    awards_json = processed_dir / "cet_award_classifications.json"
+    awards_json = processed_dir / "cet_award_classifications.ndjson"
 
     benchmarks_dir = Path("reports/benchmarks")
     benchmarks_dir.mkdir(parents=True, exist_ok=True)

--- a/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
@@ -429,22 +429,24 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
             for col in category_columns:
                 if col in classified_df.columns:
                     count += (classified_df[col].str.lower() == area).sum()
-            records_per_category[area] = count
+            records_per_category[area] = int(count)
 
         return {
             "total_cet_areas": len(self.cet_areas),
-            "covered_areas": list(covered_areas),
-            "uncovered_areas": list(uncovered_areas),
-            "coverage_rate": coverage_rate,
+            "covered_areas": sorted(covered_areas),
+            "uncovered_areas": sorted(uncovered_areas),
+            "coverage_rate": float(coverage_rate),
             "areas_covered_count": len(covered_areas),
             "areas_uncovered_count": len(uncovered_areas),
             "records_per_category": records_per_category,
-            "average_records_per_area": sum(records_per_category.values()) / len(covered_areas)
+            "average_records_per_area": float(
+                sum(records_per_category.values()) / len(covered_areas)
+            )
             if covered_areas
-            else 0,
-            "taxonomy_utilization": len(classified_categories) / len(self.cet_areas)
+            else 0.0,
+            "taxonomy_utilization": float(len(classified_categories) / len(self.cet_areas))
             if self.cet_areas
-            else 0,
+            else 0.0,
         }
 
     def _calculate_classification_success(

--- a/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
+++ b/sbir_etl/utils/reporting/analyzers/cet_analyzer.py
@@ -284,6 +284,7 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
 
         # Check for CET classification columns
         cet_columns = [
+            "primary_cet",
             "primary_cet_area",
             "cet_classification",
             "technology_category",
@@ -294,7 +295,12 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
         for col in cet_columns:
             if col in classified_df.columns:
                 # Handle single category assignments
-                if col in ["primary_cet_area", "cet_classification", "technology_category"]:
+                if col in [
+                    "primary_cet",
+                    "primary_cet_area",
+                    "cet_classification",
+                    "technology_category",
+                ]:
                     category_counts = classified_df[col].value_counts()
                     for category, count in category_counts.items():
                         if pd.notna(category):  # type: ignore[call-overload]
@@ -398,7 +404,12 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
 
         # Get classified categories
         classified_categories: set[Any] = set()
-        category_columns = ["primary_cet_area", "cet_classification", "technology_category"]
+        category_columns = [
+            "primary_cet",
+            "primary_cet_area",
+            "cet_classification",
+            "technology_category",
+        ]
 
         for col in category_columns:
             if col in classified_df.columns:
@@ -456,6 +467,7 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
 
         # Check for classification indicator columns
         classification_columns = [
+            "primary_cet",
             "primary_cet_area",
             "cet_classification",
             "technology_category",
@@ -571,6 +583,7 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
             # Base score from classification presence
             has_classification = False
             classification_columns = [
+                "primary_cet",
                 "primary_cet_area",
                 "cet_classification",
                 "technology_category",
@@ -646,6 +659,7 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
 
         # Fields added during classification
         classification_fields = [
+            "primary_cet",
             "primary_cet_area",
             "cet_classification",
             "technology_category",
@@ -661,7 +675,12 @@ class CetClassificationAnalyzer(ModuleAnalyzer):
 
         # Count records that received classifications
         classified_records = 0
-        for field in ["primary_cet_area", "cet_classification", "technology_category"]:
+        for field in [
+            "primary_cet",
+            "primary_cet_area",
+            "cet_classification",
+            "technology_category",
+        ]:
             if field in classified_df.columns:
                 classified_records = max(classified_records, classified_df[field].notna().sum())
 

--- a/tests/functional/test_pipelines.py
+++ b/tests/functional/test_pipelines.py
@@ -7,6 +7,8 @@ Tests each major pipeline function end-to-end:
 - ModernBert embeddings
 """
 
+import pytest
+
 
 class TestTransitionPipeline:
     """Functional tests for transition detection pipeline."""

--- a/tests/functional/test_pipelines.py
+++ b/tests/functional/test_pipelines.py
@@ -26,19 +26,25 @@ class TestTransitionPipeline:
 class TestCETPipeline:
     """Functional tests for CET classification pipeline."""
 
-    def test_cet_run_produces_outputs(self):
-        """Test that CET pipeline produces expected outputs."""
+    def test_cet_run_fails_without_required_inputs(self, monkeypatch, tmp_path):
+        """CET materialization must not publish a placeholder without source data."""
         from dagster import materialize
         from sbir_analytics.assets.cet import enriched_cet_award_classifications
+        from sbir_analytics.assets.cet import classifications
 
-        result = materialize([enriched_cet_award_classifications])
-
-        assert result.success
-        # Asset uses key_prefix="ml", so node name includes prefix
-        materializations = result.asset_materializations_for_node(
-            "ml__enriched_cet_award_classifications"
+        loader = type(
+            "Loader",
+            (),
+            {
+                "load_taxonomy": lambda self: type("Taxonomy", (), {"cet_areas": []})(),
+                "load_classification_config": lambda self: {},
+            },
         )
-        assert len(materializations) > 0
+        monkeypatch.setattr(classifications, "TaxonomyLoader", loader)
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(FileNotFoundError, match="No enriched award input"):
+            materialize([enriched_cet_award_classifications])
 
 
 class TestFiscalPipeline:
@@ -74,16 +80,41 @@ class TestModernBertPipeline:
 class TestPipelineIntegration:
     """Integration tests across multiple pipelines."""
 
-    def test_pipelines_can_run_sequentially(self):
-        """Test that pipelines can run in sequence without conflicts."""
+    def test_pipelines_can_run_sequentially(self, monkeypatch, tmp_path):
+        """A valid pipeline run does not mask a later CET prerequisite failure."""
         from dagster import materialize
         from sbir_analytics.assets.transition import validated_contracts_sample
         from sbir_analytics.assets.cet import enriched_cet_award_classifications
+        from sbir_analytics.assets.cet import classifications
 
         # Run transition first
         result1 = materialize([validated_contracts_sample])
         assert result1.success
 
-        # Run CET second
-        result2 = materialize([enriched_cet_award_classifications])
-        assert result2.success
+        loader = type(
+            "Loader",
+            (),
+            {
+                "load_taxonomy": lambda self: type("Taxonomy", (), {"cet_areas": []})(),
+                "load_classification_config": lambda self: {},
+            },
+        )
+        monkeypatch.setattr(classifications, "TaxonomyLoader", loader)
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(FileNotFoundError, match="No enriched award input"):
+            materialize([enriched_cet_award_classifications])
+
+    def test_pipeline_outputs_dont_conflict(self):
+        """Test that pipeline outputs use separate files."""
+        outputs = [
+            "data/processed/transitions.parquet",
+            "data/processed/cet_classifications.parquet",
+            "data/processed/fiscal_returns.parquet",
+            "data/processed/modernbert_embeddings_awards.parquet",
+            "data/processed/modernbert_embeddings_patents.parquet",
+            "data/processed/modernbert_award_patent_similarity.parquet",
+        ]
+
+        # Check that outputs are distinct
+        assert len(outputs) == len(set(outputs))

--- a/tests/unit/assets/cet/test_classifications.py
+++ b/tests/unit/assets/cet/test_classifications.py
@@ -3,7 +3,6 @@
 import json
 from unittest.mock import Mock, patch
 
-import pandas as pd
 import pytest
 
 from sbir_analytics.assets.cet.classifications import (
@@ -40,83 +39,6 @@ def sample_checks_data():
         "with_evidence_count": 850,
         "reason": "success",
     }
-
-
-@pytest.fixture
-def sample_awards_df():
-    """Sample awards DataFrame."""
-    return pd.DataFrame(
-        {
-            "Award Number": ["AWD001", "AWD002", "AWD003"],
-            "Company": ["TechCo", "BioCo", "AeroCo"],
-            "Abstract": [
-                "Artificial intelligence and machine learning for data analysis",
-                "Biotechnology research for drug development",
-                "Aerospace engineering and quantum computing systems",
-            ],
-            "Amount": [100000, 150000, 200000],
-        }
-    )
-
-
-@pytest.fixture
-def sample_patents_df():
-    """Sample patents DataFrame."""
-    return pd.DataFrame(
-        {
-            "patent_id": ["PAT001", "PAT002", "PAT003"],
-            "title": ["AI System", "Bio Method", "Quantum Computer"],
-            "abstract": [
-                "Machine learning system for pattern recognition",
-                "Biotechnology method for gene therapy",
-                "Quantum computing hardware design",
-            ],
-        }
-    )
-
-
-@pytest.fixture
-def sample_taxonomy():
-    """Sample CET taxonomy."""
-    return {
-        "cet_areas": [
-            {
-                "id": "ai_ml",
-                "name": "Artificial Intelligence and Machine Learning",
-                "keywords": ["artificial intelligence", "machine learning", "neural networks"],
-            },
-            {
-                "id": "quantum",
-                "name": "Quantum Information Science",
-                "keywords": ["quantum computing", "quantum", "qubit"],
-            },
-            {
-                "id": "biotechnology",
-                "name": "Biotechnology",
-                "keywords": ["biotechnology", "gene therapy", "biotech"],
-            },
-        ]
-    }
-
-
-@pytest.fixture
-def sample_classification_results():
-    """Sample classification results."""
-    return pd.DataFrame(
-        {
-            "award_id": ["AWD001", "AWD002", "AWD003"],
-            "primary_cet": ["ai_ml", "biotechnology", "quantum"],
-            "primary_score": [0.95, 0.88, 0.92],
-            "supporting_cets": [["quantum"], ["ai_ml"], ["ai_ml"]],
-            "evidence": [
-                ["machine learning mentioned in abstract"],
-                ["biotechnology research mentioned"],
-                ["quantum computing in abstract"],
-            ],
-            "classified_at": ["2023-01-01T10:00:00"] * 3,
-            "taxonomy_version": ["v1.0"] * 3,
-        }
-    )
 
 
 # ==================== Quality Check Tests ====================
@@ -372,6 +294,22 @@ class TestEnrichedCETAwardClassifications:
             enriched_cet_award_classifications()
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    def test_award_classifications_reject_empty_input(
+        self, mock_taxonomy_loader, monkeypatch, tmp_path
+    ):
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock(cet_areas=[])
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/enriched_sbir_awards.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text("")
+
+        with pytest.raises(ValueError, match="Enriched award input is empty"):
+            enriched_cet_award_classifications()
+
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
     def test_award_classifications_model_missing(
         self,
@@ -391,6 +329,88 @@ class TestEnrichedCETAwardClassifications:
         input_path.write_text(json.dumps({"award_id": "AWD-1", "title": "Quantum sensor"}) + "\n")
 
         with pytest.raises(FileNotFoundError, match="Trained CET award model not found"):
+            enriched_cet_award_classifications()
+
+        mock_save.assert_not_called()
+
+    @patch("sbir_ml.ml.features.evidence_extractor.EvidenceExtractor")
+    @patch("sbir_ml.ml.models.cet_classifier.ApplicabilityModel.load")
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
+    def test_award_classifications_reject_short_classifier_results(
+        self,
+        mock_save,
+        mock_taxonomy_loader,
+        mock_model_load,
+        mock_extractor,
+        monkeypatch,
+        tmp_path,
+    ):
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock(cet_areas=[], version="v1")
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        model = Mock(taxonomy_version="v1")
+        model.classify_batch.return_value = [[]]
+        mock_model_load.return_value = model
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/enriched_sbir_awards.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text(
+            "\n".join(
+                json.dumps({"award_id": award_id, "title": "Quantum sensor", "keywords": []})
+                for award_id in ("A-1", "A-2")
+            )
+            + "\n"
+        )
+        model_path = tmp_path / "artifacts/models/cet_classifier_v1.pkl"
+        model_path.parent.mkdir(parents=True)
+        model_path.touch()
+
+        with pytest.raises(ValueError, match="classifier returned 1 results for 2 source rows"):
+            enriched_cet_award_classifications()
+
+        mock_extractor.return_value.extract_batch_evidence.assert_not_called()
+        mock_save.assert_not_called()
+
+    @patch("sbir_ml.ml.features.evidence_extractor.EvidenceExtractor")
+    @patch("sbir_ml.ml.models.cet_classifier.ApplicabilityModel.load")
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
+    def test_award_classifications_reject_short_evidence_results(
+        self,
+        mock_save,
+        mock_taxonomy_loader,
+        mock_model_load,
+        mock_extractor_class,
+        monkeypatch,
+        tmp_path,
+    ):
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock(cet_areas=[], version="v1")
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        model = Mock(taxonomy_version="v1")
+        model.classify_batch.return_value = [[], []]
+        mock_model_load.return_value = model
+        mock_extractor_class.return_value.extract_batch_evidence.return_value = [[]]
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/enriched_sbir_awards.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text(
+            "\n".join(
+                json.dumps({"award_id": award_id, "title": "Quantum sensor", "keywords": []})
+                for award_id in ("A-1", "A-2")
+            )
+            + "\n"
+        )
+        model_path = tmp_path / "artifacts/models/cet_classifier_v1.pkl"
+        model_path.parent.mkdir(parents=True)
+        model_path.touch()
+
+        with pytest.raises(
+            ValueError, match="evidence extractor returned 1 results for 2 source rows"
+        ):
             enriched_cet_award_classifications()
 
         mock_save.assert_not_called()
@@ -428,6 +448,105 @@ class TestEnrichedCETPatentClassifications:
 
         with pytest.raises(FileNotFoundError, match="No transformed patent input"):
             enriched_cet_patent_classifications()
+
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    def test_patent_classifications_reject_empty_input(
+        self, mock_taxonomy_loader, monkeypatch, tmp_path
+    ):
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock()
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/transformed_patents.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text("")
+
+        with pytest.raises(ValueError, match="Transformed patent input is empty"):
+            enriched_cet_patent_classifications()
+
+    @patch("sbir_ml.ml.models.patent_classifier.PatentFeatureExtractor")
+    @patch("sbir_ml.ml.models.patent_classifier.PatentCETClassifier.load")
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
+    def test_patent_classifications_reject_short_feature_results(
+        self,
+        mock_save,
+        mock_taxonomy_loader,
+        mock_model_load,
+        mock_extractor_class,
+        monkeypatch,
+        tmp_path,
+    ):
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock(version="v1")
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        mock_extractor_class.return_value.transform.return_value = [{"normalized_title": "one"}]
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/transformed_patents.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text(
+            "\n".join(
+                json.dumps({"patent_id": patent_id, "title": "Quantum sensor"})
+                for patent_id in ("P-1", "P-2")
+            )
+            + "\n"
+        )
+        model_path = tmp_path / "artifacts/models/patent_classifier_v1.pkl"
+        model_path.parent.mkdir(parents=True)
+        model_path.touch()
+
+        with pytest.raises(
+            ValueError, match="feature extractor returned 1 results for 2 source rows"
+        ):
+            enriched_cet_patent_classifications()
+
+        mock_model_load.return_value.classify_batch.assert_not_called()
+        mock_save.assert_not_called()
+
+    @patch("sbir_ml.ml.models.patent_classifier.PatentFeatureExtractor")
+    @patch("sbir_ml.ml.models.patent_classifier.PatentCETClassifier.load")
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
+    def test_patent_classifications_reject_short_classifier_results(
+        self,
+        mock_save,
+        mock_taxonomy_loader,
+        mock_model_load,
+        mock_extractor_class,
+        monkeypatch,
+        tmp_path,
+    ):
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock(version="v1")
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        mock_extractor_class.return_value.transform.return_value = [
+            {"normalized_title": "one"},
+            {"normalized_title": "two"},
+        ]
+        classifier = Mock(taxonomy_version="v1")
+        classifier.classify_batch.return_value = [[]]
+        mock_model_load.return_value = classifier
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/transformed_patents.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text(
+            "\n".join(
+                json.dumps({"patent_id": patent_id, "title": "Quantum sensor"})
+                for patent_id in ("P-1", "P-2")
+            )
+            + "\n"
+        )
+        model_path = tmp_path / "artifacts/models/patent_classifier_v1.pkl"
+        model_path.parent.mkdir(parents=True)
+        model_path.touch()
+
+        with pytest.raises(ValueError, match="classifier returned 1 results for 2 source rows"):
+            enriched_cet_patent_classifications()
+
+        mock_save.assert_not_called()
 
 
 # ==================== Edge Cases ====================
@@ -487,19 +606,6 @@ class TestEdgeCases:
 
         assert result.passed is False
         assert "missing quality metrics" in result.description.lower()
-
-    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    def test_award_classifications_prerequisite_failure_does_not_write(
-        self, mock_save, mock_taxonomy_loader
-    ):
-        """A prerequisite failure never creates a misleading placeholder artifact."""
-        mock_taxonomy_loader.side_effect = Exception("Load failed")
-
-        with pytest.raises(RuntimeError, match="taxonomy and classification config"):
-            enriched_cet_award_classifications()
-
-        mock_save.assert_not_called()
 
     def test_quality_check_file_permission_error(self, tmp_path):
         """Test quality check handles file permission errors."""

--- a/tests/unit/assets/cet/test_classifications.py
+++ b/tests/unit/assets/cet/test_classifications.py
@@ -1,7 +1,7 @@
 """Tests for CET classification assets."""
 
 import json
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import Mock, patch
 
 import pandas as pd
 import pytest
@@ -349,96 +349,51 @@ class TestEnrichedCETAwardClassifications:
     """Tests for enriched CET award classifications asset."""
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.Path")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_award_classifications_taxonomy_load_failure(
-        self, mock_file, mock_save, mock_path_class, mock_taxonomy_loader
-    ):
-        """Test asset handles taxonomy load failure gracefully."""
+    def test_award_classifications_taxonomy_load_failure(self, mock_save, mock_taxonomy_loader):
+        """A taxonomy failure fails the materialization without publishing output."""
         mock_taxonomy_loader.side_effect = Exception("Taxonomy load failed")
 
-        # Mock Path behaviors
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-        mock_checks_path = Mock()
-        mock_checks_path.parent = Mock()
-        mock_checks_path.parent.mkdir = Mock()
-        mock_path.with_suffix.return_value = mock_checks_path
-        mock_path_class.return_value = mock_path
+        with pytest.raises(RuntimeError, match="taxonomy and classification config"):
+            enriched_cet_award_classifications()
 
-        enriched_cet_award_classifications()
-
-        # Should write empty output and checks JSON indicating failure
-        assert mock_save.called
+        mock_save.assert_not_called()
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.Path")
-    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_award_classifications_no_input_data(
-        self, mock_file, mock_save, mock_path_class, mock_taxonomy_loader, sample_taxonomy
-    ):
-        """Test asset handles missing input data."""
-        # Mock taxonomy loader
+    def test_award_classifications_no_input_data(self, mock_taxonomy_loader, monkeypatch, tmp_path):
+        """Missing source data fails instead of classifying built-in samples."""
         mock_loader = Mock()
-        mock_loader.load_taxonomy.return_value = sample_taxonomy
+        mock_loader.load_taxonomy.return_value = Mock(cet_areas=[])
+        mock_loader.load_classification_config.return_value = {}
         mock_taxonomy_loader.return_value = mock_loader
+        monkeypatch.chdir(tmp_path)
 
-        # Mock Path to indicate no input files exist
-        def path_side_effect(path_str):
-            mock_path = Mock()
-            mock_path.exists.return_value = False
-            mock_path.with_suffix.return_value = Mock()
-            return mock_path
-
-        mock_path_class.side_effect = path_side_effect
-
-        enriched_cet_award_classifications()
-
-        # Should handle gracefully and write output
-        assert mock_save.called
+        with pytest.raises(FileNotFoundError, match="No enriched award input"):
+            enriched_cet_award_classifications()
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.Path")
-    @patch("pandas.read_parquet")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    @patch("builtins.open", new_callable=mock_open)
     def test_award_classifications_model_missing(
         self,
-        mock_file,
         mock_save,
-        mock_read_parquet,
-        mock_path_class,
         mock_taxonomy_loader,
-        sample_taxonomy,
-        sample_awards_df,
+        monkeypatch,
+        tmp_path,
     ):
-        """Test asset handles missing ML model."""
-        # Mock taxonomy loader
+        """Missing model fails without writing a schema-only artifact."""
         mock_loader = Mock()
-        mock_loader.load_taxonomy.return_value = sample_taxonomy
+        mock_loader.load_taxonomy.return_value = Mock(cet_areas=[])
+        mock_loader.load_classification_config.return_value = {}
         mock_taxonomy_loader.return_value = mock_loader
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/enriched_sbir_awards.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text(json.dumps({"award_id": "AWD-1", "title": "Quantum sensor"}) + "\n")
 
-        # Mock parquet reader
-        mock_read_parquet.return_value = sample_awards_df
+        with pytest.raises(FileNotFoundError, match="Trained CET award model not found"):
+            enriched_cet_award_classifications()
 
-        # Mock Path to indicate model doesn't exist but data does
-        def path_side_effect(path_str):
-            mock_path = Mock()
-            if "model" in str(path_str):
-                mock_path.exists.return_value = False
-            else:
-                mock_path.exists.return_value = True
-            mock_path.with_suffix.return_value = Mock()
-            return mock_path
-
-        mock_path_class.side_effect = path_side_effect
-
-        enriched_cet_award_classifications()
-
-        # Should write checks JSON indicating model is missing
-        mock_file.assert_called()
+        mock_save.assert_not_called()
 
 
 # ==================== Patent Classifications Asset Tests ====================
@@ -448,58 +403,31 @@ class TestEnrichedCETPatentClassifications:
     """Tests for enriched CET patent classifications asset."""
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.Path")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_patent_classifications_taxonomy_load_failure(
-        self, mock_file, mock_save, mock_path_class, mock_taxonomy_loader
-    ):
-        """Test patent asset handles taxonomy load failure."""
-        # Mock taxonomy loader to raise exception on load_taxonomy() call
+    def test_patent_classifications_taxonomy_load_failure(self, mock_save, mock_taxonomy_loader):
+        """A taxonomy failure fails the patent materialization without output."""
         mock_loader = Mock()
         mock_loader.load_taxonomy.side_effect = Exception("Taxonomy load failed")
         mock_taxonomy_loader.return_value = mock_loader
 
-        # Mock Path behaviors
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-        mock_checks_path = Mock()
-        mock_checks_path.parent = Mock()
-        mock_checks_path.parent.mkdir = Mock()
-        mock_path.with_suffix.return_value = mock_checks_path
-        mock_path_class.return_value = mock_path
+        with pytest.raises(RuntimeError, match="taxonomy and classification config"):
+            enriched_cet_patent_classifications()
 
-        enriched_cet_patent_classifications()
-
-        # Should write empty output
-        assert mock_save.called
+        mock_save.assert_not_called()
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.Path")
-    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    @patch("builtins.open", new_callable=mock_open)
     def test_patent_classifications_no_input_data(
-        self, mock_file, mock_save, mock_path_class, mock_taxonomy_loader, sample_taxonomy
+        self, mock_taxonomy_loader, monkeypatch, tmp_path
     ):
-        """Test patent asset handles missing input data."""
-        # Mock taxonomy loader
+        """Missing patent input fails instead of classifying built-in samples."""
         mock_loader = Mock()
-        mock_loader.load_taxonomy.return_value = sample_taxonomy
+        mock_loader.load_taxonomy.return_value = Mock()
+        mock_loader.load_classification_config.return_value = {}
         mock_taxonomy_loader.return_value = mock_loader
+        monkeypatch.chdir(tmp_path)
 
-        # Mock Path to indicate no input files exist
-        def path_side_effect(path_str):
-            mock_path = Mock()
-            mock_path.exists.return_value = False
-            mock_path.with_suffix.return_value = Mock()
-            return mock_path
-
-        mock_path_class.side_effect = path_side_effect
-
-        enriched_cet_patent_classifications()
-
-        # Should handle gracefully
-        assert mock_save.called
+        with pytest.raises(FileNotFoundError, match="No transformed patent input"):
+            enriched_cet_patent_classifications()
 
 
 # ==================== Edge Cases ====================
@@ -561,32 +489,17 @@ class TestEdgeCases:
         assert "missing quality metrics" in result.description.lower()
 
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
-    @patch("sbir_analytics.assets.cet.classifications.Path")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
-    @patch("builtins.open", new_callable=mock_open)
-    def test_award_classifications_save_failure_propagates(
-        self, mock_file, mock_save, mock_path_class, mock_taxonomy_loader
+    def test_award_classifications_prerequisite_failure_does_not_write(
+        self, mock_save, mock_taxonomy_loader
     ):
-        """A helper failure means neither Parquet nor NDJSON could be written."""
+        """A prerequisite failure never creates a misleading placeholder artifact."""
         mock_taxonomy_loader.side_effect = Exception("Load failed")
-        mock_save.side_effect = OSError("Save failed")
 
-        # Mock Path behaviors
-        mock_path = Mock()
-        mock_path.exists.return_value = False
-        mock_json_path = Mock()
-        mock_json_path.parent = Mock()
-        mock_json_path.parent.mkdir = Mock()
-        mock_checks_path = Mock()
-        mock_checks_path.parent = Mock()
-        mock_checks_path.parent.mkdir = Mock()
-        mock_path.with_suffix.side_effect = lambda suffix: (
-            mock_json_path if suffix == ".json" else mock_checks_path
-        )
-        mock_path_class.return_value = mock_path
-
-        with pytest.raises(OSError, match="Save failed"):
+        with pytest.raises(RuntimeError, match="taxonomy and classification config"):
             enriched_cet_award_classifications()
+
+        mock_save.assert_not_called()
 
     def test_quality_check_file_permission_error(self, tmp_path):
         """Test quality check handles file permission errors."""

--- a/tests/unit/assets/cet/test_classifications.py
+++ b/tests/unit/assets/cet/test_classifications.py
@@ -509,6 +509,45 @@ class TestEnrichedCETPatentClassifications:
     @patch("sbir_ml.ml.models.patent_classifier.PatentCETClassifier.load")
     @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
+    def test_patent_classifications_pass_assignees_on_the_extractor_path(
+        self,
+        mock_save,
+        mock_taxonomy_loader,
+        mock_model_load,
+        mock_extractor_class,
+        monkeypatch,
+        tmp_path,
+    ):
+        """normalized_title is title-only, so the assignee must still reach classify_batch."""
+        mock_loader = Mock()
+        mock_loader.load_taxonomy.return_value = Mock(version="v1")
+        mock_loader.load_classification_config.return_value = {}
+        mock_taxonomy_loader.return_value = mock_loader
+        mock_extractor_class.return_value.transform.return_value = [
+            {"normalized_title": "quantum sensor"}
+        ]
+        mock_model_load.return_value.classify_batch.return_value = [[]]
+        monkeypatch.chdir(tmp_path)
+        input_path = tmp_path / "data/processed/transformed_patents.ndjson"
+        input_path.parent.mkdir(parents=True)
+        input_path.write_text(
+            json.dumps({"patent_id": "P-1", "title": "Quantum sensor", "assignee": "Example Corp"})
+            + "\n"
+        )
+        model_path = tmp_path / "artifacts/models/patent_classifier_v1.pkl"
+        model_path.parent.mkdir(parents=True)
+        model_path.touch()
+
+        enriched_cet_patent_classifications()
+
+        titles, assignees = mock_model_load.return_value.classify_batch.call_args[0][:2]
+        assert titles == ["quantum sensor"]
+        assert assignees == ["Example Corp"]
+
+    @patch("sbir_ml.ml.models.patent_classifier.PatentFeatureExtractor")
+    @patch("sbir_ml.ml.models.patent_classifier.PatentCETClassifier.load")
+    @patch("sbir_analytics.assets.cet.classifications.TaxonomyLoader")
+    @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
     def test_patent_classifications_reject_short_classifier_results(
         self,
         mock_save,

--- a/tests/unit/assets/cet/test_materialization_contracts.py
+++ b/tests/unit/assets/cet/test_materialization_contracts.py
@@ -37,6 +37,21 @@ def test_award_training_requires_source_data(mock_taxonomy_loader, monkeypatch, 
     assert not (tmp_path / "data/processed/cet_award_training.parquet").exists()
 
 
+@patch("sbir_analytics.assets.cet.training.TaxonomyLoader")
+def test_award_training_reports_malformed_ndjson_as_value_error(
+    mock_taxonomy_loader, monkeypatch, tmp_path
+):
+    """A malformed line names its own defect; wrapping it as RuntimeError would hide it."""
+    mock_taxonomy_loader.return_value.load_taxonomy.return_value = SimpleNamespace(version="v1")
+    monkeypatch.chdir(tmp_path)
+    training_input = tmp_path / "data/processed/cet_award_training.ndjson"
+    training_input.parent.mkdir(parents=True, exist_ok=True)
+    training_input.write_text('{"text": "ok", "labels": ["a"]}\nnot json\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Invalid JSON in .* at line 2"):
+        cet_award_training_dataset()
+
+
 @patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
 def test_company_profiles_require_classification_input(mock_save, monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)

--- a/tests/unit/assets/cet/test_materialization_contracts.py
+++ b/tests/unit/assets/cet/test_materialization_contracts.py
@@ -1,0 +1,89 @@
+"""Failure and artifact-path contracts for CET materializations."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.cet.company import transformed_cet_company_profiles
+from sbir_analytics.assets.cet.training import (
+    cet_award_training_dataset,
+    train_cet_patent_classifier,
+)
+
+pytestmark = pytest.mark.fast
+
+
+def test_patent_training_requires_source_data(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="CET patent training data not found"):
+        train_cet_patent_classifier()
+
+    assert not (tmp_path / "artifacts/models/patent_classifier_v1.pkl").exists()
+
+
+@patch("sbir_analytics.assets.cet.training.TaxonomyLoader")
+def test_award_training_requires_source_data(mock_taxonomy_loader, monkeypatch, tmp_path):
+    mock_taxonomy_loader.return_value.load_taxonomy.return_value = SimpleNamespace(version="v1")
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="CET award training data not found"):
+        cet_award_training_dataset()
+
+    assert not (tmp_path / "data/processed/cet_award_training.parquet").exists()
+
+
+@patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
+def test_company_profiles_require_classification_input(mock_save, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="No CET award classifications found"):
+        transformed_cet_company_profiles()
+
+    mock_save.assert_not_called()
+
+
+@patch("sbir_analytics.assets.cet.training.TaxonomyLoader")
+@patch("sbir_analytics.assets.cet.training.save_dataframe_parquet")
+def test_award_training_returns_real_ndjson_fallback(
+    mock_save_parquet,
+    mock_taxonomy_loader,
+    monkeypatch,
+    tmp_path,
+):
+    mock_taxonomy_loader.return_value.load_taxonomy.return_value = SimpleNamespace(version="v1")
+    mock_save_parquet.side_effect = RuntimeError("parquet unavailable")
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "data/processed/cet_award_training.ndjson"
+    source.parent.mkdir(parents=True)
+    source.write_text(json.dumps({"text": "quantum sensor", "labels": ["quantum"]}) + "\n")
+
+    result = cet_award_training_dataset()
+
+    assert result.value == "data/processed/cet_award_training.ndjson"
+    assert (tmp_path / result.value).is_file()
+    assert not (tmp_path / "data/processed/cet_award_training.parquet").exists()
+
+
+@patch("sbir_etl.transformers.company_cet_aggregator.CompanyCETAggregator")
+@patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
+def test_company_profiles_return_real_json_fallback(
+    mock_save_parquet, mock_aggregator_class, monkeypatch, tmp_path
+):
+    mock_aggregator_class.return_value.to_dataframe.return_value = pd.DataFrame(
+        [{"company_id": "C-1", "company_name": "Example"}]
+    )
+    mock_save_parquet.side_effect = RuntimeError("parquet unavailable")
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "data/processed/cet_award_classifications.json"
+    source.parent.mkdir(parents=True)
+    source.write_text(json.dumps({"award_id": "A-1", "company_id": "C-1"}) + "\n")
+
+    result = transformed_cet_company_profiles()
+
+    assert result.value == "data/processed/cet_company_profiles.json"
+    assert (tmp_path / result.value).is_file()
+    assert not (tmp_path / "data/processed/cet_company_profiles.parquet").exists()

--- a/tests/unit/assets/cet/test_materialization_contracts.py
+++ b/tests/unit/assets/cet/test_materialization_contracts.py
@@ -1,6 +1,7 @@
 """Failure and artifact-path contracts for CET materializations."""
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -55,7 +56,14 @@ def test_award_training_returns_real_ndjson_fallback(
     tmp_path,
 ):
     mock_taxonomy_loader.return_value.load_taxonomy.return_value = SimpleNamespace(version="v1")
-    mock_save_parquet.side_effect = RuntimeError("parquet unavailable")
+
+    def save_as_ndjson(df, path):
+        actual_path = Path(path).with_suffix(".ndjson")
+        actual_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_json(actual_path, orient="records", lines=True)
+        return actual_path
+
+    mock_save_parquet.side_effect = save_as_ndjson
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "data/processed/cet_award_training.ndjson"
     source.parent.mkdir(parents=True)
@@ -70,20 +78,78 @@ def test_award_training_returns_real_ndjson_fallback(
 
 @patch("sbir_etl.transformers.company_cet_aggregator.CompanyCETAggregator")
 @patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
-def test_company_profiles_return_real_json_fallback(
+def test_company_profiles_return_real_ndjson_fallback(
     mock_save_parquet, mock_aggregator_class, monkeypatch, tmp_path
 ):
     mock_aggregator_class.return_value.to_dataframe.return_value = pd.DataFrame(
         [{"company_id": "C-1", "company_name": "Example"}]
     )
-    mock_save_parquet.side_effect = RuntimeError("parquet unavailable")
+
+    def save_as_ndjson(df, path):
+        actual_path = Path(path).with_suffix(".ndjson")
+        actual_path.parent.mkdir(parents=True, exist_ok=True)
+        df.to_json(actual_path, orient="records", lines=True)
+        return actual_path
+
+    mock_save_parquet.side_effect = save_as_ndjson
     monkeypatch.chdir(tmp_path)
-    source = tmp_path / "data/processed/cet_award_classifications.json"
+    source = tmp_path / "data/processed/cet_award_classifications.ndjson"
     source.parent.mkdir(parents=True)
     source.write_text(json.dumps({"award_id": "A-1", "company_id": "C-1"}) + "\n")
 
     result = transformed_cet_company_profiles()
 
-    assert result.value == "data/processed/cet_company_profiles.json"
+    assert result.value == "data/processed/cet_company_profiles.ndjson"
     assert (tmp_path / result.value).is_file()
     assert not (tmp_path / "data/processed/cet_company_profiles.parquet").exists()
+
+
+@patch("sbir_etl.transformers.company_cet_aggregator.CompanyCETAggregator")
+@patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
+def test_company_profiles_reject_empty_classification_input(
+    mock_save_parquet, mock_aggregator_class, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "data/processed/cet_award_classifications.ndjson"
+    source.parent.mkdir(parents=True)
+    source.write_text("")
+
+    with pytest.raises(ValueError, match="classification input is empty"):
+        transformed_cet_company_profiles()
+
+    mock_aggregator_class.assert_not_called()
+    mock_save_parquet.assert_not_called()
+
+
+@patch("sbir_etl.transformers.company_cet_aggregator.CompanyCETAggregator")
+@patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
+def test_company_profiles_require_usable_company_identifiers(
+    mock_save_parquet, mock_aggregator_class, monkeypatch, tmp_path
+):
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "data/processed/cet_award_classifications.ndjson"
+    source.parent.mkdir(parents=True)
+    source.write_text(json.dumps({"award_id": "A-1", "primary_cet": "quantum"}) + "\n")
+
+    with pytest.raises(ValueError, match="no usable company identifiers"):
+        transformed_cet_company_profiles()
+
+    mock_aggregator_class.assert_not_called()
+    mock_save_parquet.assert_not_called()
+
+
+@patch("sbir_etl.transformers.company_cet_aggregator.CompanyCETAggregator")
+@patch("sbir_analytics.assets.cet.company.save_dataframe_parquet")
+def test_company_profiles_reject_empty_aggregation(
+    mock_save_parquet, mock_aggregator_class, monkeypatch, tmp_path
+):
+    mock_aggregator_class.return_value.to_dataframe.return_value = pd.DataFrame()
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "data/processed/cet_award_classifications.ndjson"
+    source.parent.mkdir(parents=True)
+    source.write_text(json.dumps({"award_id": "A-1", "company_id": "C-1"}) + "\n")
+
+    with pytest.raises(ValueError, match="produced no company profiles"):
+        transformed_cet_company_profiles()
+
+    mock_save_parquet.assert_not_called()

--- a/tests/unit/ml/test_cet_award_asset.py
+++ b/tests/unit/ml/test_cet_award_asset.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
-
 from sbir_analytics.assets.cet import enriched_cet_award_classifications
 from sbir_ml.ml.models.dummy_pipeline import DummyPipeline
 
@@ -102,12 +101,8 @@ def _read_output_records(root: Path):
     return []
 
 
-def test_cet_award_asset_writes_placeholder_when_model_missing(tmp_path, monkeypatch):
-    """
-    When the trained model artifact is missing, the asset should still run and
-    write a schema-compatible placeholder output plus a checks JSON describing
-    the missing model.
-    """
+def test_cet_award_asset_fails_when_model_missing(tmp_path, monkeypatch):
+    """A missing trained model fails without publishing placeholder artifacts."""
     # run in isolated tmp dir so asset reads/writes local paths
     monkeypatch.chdir(tmp_path)
 
@@ -136,20 +131,13 @@ def test_cet_award_asset_writes_placeholder_when_model_missing(tmp_path, monkeyp
     if model_path.exists():
         model_path.unlink()
 
-    # Execute asset
-    enriched_cet_award_classifications()
+    with pytest.raises(FileNotFoundError, match="Trained CET award model not found"):
+        enriched_cet_award_classifications()
 
-    # Validate checks JSON indicates missing model and contains correct counts
-    checks = _read_checks(tmp_path)
-    assert checks.get("reason") == "model_missing"
-    assert checks.get("num_awards") == 2
-    assert checks.get("num_classified") == 0
-
-    # Output placeholder should exist (either parquet placeholder or json)
-    out_records = _read_output_records(tmp_path)
-    # When placeholder is used, likely no records; ensure schema is present by checking file existence
-    # but also accept empty records list as valid placeholder behavior.
-    assert isinstance(out_records, list)
+    processed = tmp_path / "data" / "processed"
+    assert not (processed / "cet_award_classifications.parquet").exists()
+    assert not (processed / "cet_award_classifications.json").exists()
+    assert not (processed / "cet_award_classifications.checks.json").exists()
 
 
 def test_cet_award_asset_classifies_with_synthetic_model(tmp_path, monkeypatch):

--- a/tests/unit/ml/test_cet_patent_asset.py
+++ b/tests/unit/ml/test_cet_patent_asset.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
-
 from sbir_analytics.assets.cet import enriched_cet_patent_classifications
 from sbir_ml.ml.models.dummy_pipeline import DummyPipeline
 
@@ -110,12 +109,8 @@ def _read_patent_output_records(root: Path):
     return []
 
 
-def test_cet_patent_asset_writes_placeholder_when_model_missing(tmp_path, monkeypatch):
-    """
-    When the trained patent model artifact is missing, the asset should still run and
-    write a schema-compatible placeholder output plus a checks JSON describing
-    the missing model.
-    """
+def test_cet_patent_asset_fails_when_model_missing(tmp_path, monkeypatch):
+    """A missing trained model fails without publishing placeholder artifacts."""
     # run in isolated tmp dir so asset reads/writes local paths
     monkeypatch.chdir(tmp_path)
 
@@ -134,18 +129,13 @@ def test_cet_patent_asset_writes_placeholder_when_model_missing(tmp_path, monkey
     if model_path.exists():
         model_path.unlink()
 
-    # Execute asset
-    enriched_cet_patent_classifications()
+    with pytest.raises(FileNotFoundError, match="Trained CET patent model not found"):
+        enriched_cet_patent_classifications()
 
-    # Validate checks JSON indicates missing model and contains correct counts
-    checks = _read_patent_checks(tmp_path)
-    assert checks.get("reason") == "model_missing"
-    assert checks.get("num_patents") == 2
-    assert checks.get("num_classified") == 0 or checks.get("num_classified") is None
-
-    # Output placeholder should exist (either parquet placeholder or json)
-    out_records = _read_patent_output_records(tmp_path)
-    assert isinstance(out_records, list)
+    processed = tmp_path / "data" / "processed"
+    assert not (processed / "cet_patent_classifications.parquet").exists()
+    assert not (processed / "cet_patent_classifications.json").exists()
+    assert not (processed / "cet_patent_classifications.checks.json").exists()
 
 
 def test_cet_patent_asset_classifies_with_synthetic_model(tmp_path, monkeypatch):

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -8,6 +8,7 @@ Tests for base analyzer class and all specialized analyzer implementations:
 - TransitionDetectionAnalyzer: Transition detection analysis
 """
 
+import json
 from typing import Any
 
 import pandas as pd
@@ -639,6 +640,9 @@ class TestCetClassificationAnalyzer:
             "artificial_intelligence": 0.5,
             "quantum_information_science": 0.5,
         }
+
+        taxonomy_coverage = analyzer._calculate_taxonomy_coverage(classified_df, {})
+        assert json.loads(json.dumps(taxonomy_coverage)) == taxonomy_coverage
 
     def test_calculate_confidence_distribution(self, sample_classified_df):
         """Test calculating confidence score distribution."""

--- a/tests/unit/utils/reporting/test_analyzers.py
+++ b/tests/unit/utils/reporting/test_analyzers.py
@@ -627,6 +627,19 @@ class TestCetClassificationAnalyzer:
 
         assert distribution == {}
 
+    def test_calculate_category_distribution_accepts_asset_primary_cet_column(self):
+        analyzer = CetClassificationAnalyzer()
+        classified_df = pd.DataFrame(
+            {"primary_cet": ["artificial_intelligence", "quantum_information_science"]}
+        )
+
+        distribution = analyzer._calculate_category_distribution(classified_df)
+
+        assert distribution == {
+            "artificial_intelligence": 0.5,
+            "quantum_information_science": 0.5,
+        }
+
     def test_calculate_confidence_distribution(self, sample_classified_df):
         """Test calculating confidence score distribution."""
         analyzer = CetClassificationAnalyzer()


### PR DESCRIPTION
## Summary

- Fail CET award/patent classification when taxonomy, source data, models, or compute steps are unavailable.
- Fail CET training and company aggregation instead of publishing schema-only or zero-byte artifacts.
- Reject empty inputs and short classifier/extractor result sets so source rows cannot be silently dropped.
- Return the actual Parquet or NDJSON artifact path from every changed materialization.
- Preserve patent assignees through the normal feature-extractor path.
- Preserve actionable `ValueError` messages for malformed training data.
- Align CET documentation, analyzer field names, fallback suffixes, and functional tests with the fail-fast contract.

This branch is rebased onto `main` at `65212e25`, including the shared persistence and Neo4j configuration fixes from #581.

## Operational Note

The patent classifier has an in-repository training asset. The award classifier still requires a pre-provisioned `artifacts/models/cet_classifier_v1.pkl`; this PR makes that missing prerequisite explicit instead of reporting a successful empty materialization.

## Versioning Impact

- [x] No release impact: internal materialization correctness
- [ ] PATCH
- [ ] MINOR
- [ ] MAJOR

## Verification

- `pytest -o addopts='' -q tests/unit -m 'not slow'`: **5,865 passed, 7 skipped, 2 deselected**
- CET, analyzer, and functional surface: **116 passed, 1 skipped**
- Full Ruff lint and format scope: passing
- Mypy core/graph/ML scope: passing, 305 files
- All architecture, epistemic-tier, file-size, configuration, hygiene, study-manifest, and identity guards: passing
- `git diff --check`: passing
