### PR TITLE
Make CET Neo4j loading failures visible

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
@@ -21,6 +21,7 @@ from .utils import (
     Output,
     asset,
     asset_check,
+    neo4j_skip_requested,
     save_dataframe_parquet,
 )
 
@@ -269,10 +270,8 @@ DEFAULT_OUTPUT_DIR = Path(os.environ.get("SBIR_ETL__CET__NEO4J_OUTPUT_DIR", "dat
 
 def _get_neo4j_client():
     """Get Neo4j client with error handling."""
-    import os
-
     # Check if Neo4j loading is explicitly skipped
-    skip_neo4j = os.getenv("SKIP_NEO4J_LOADING", "false").lower() in ("true", "1", "yes")
+    skip_neo4j = neo4j_skip_requested()
 
     if Neo4jClient is None or Neo4jConfig is None:
         if skip_neo4j:

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
@@ -15,6 +15,8 @@ from typing import Any
 import pandas as pd
 from loguru import logger
 
+from sbir_etl.utils.identifiers import normalize_uei
+
 from .utils import (
     AssetCheckResult,
     AssetCheckSeverity,
@@ -24,6 +26,67 @@ from .utils import (
     neo4j_skip_requested,
     save_dataframe_parquet,
 )
+
+
+_COMPANY_UEI_COLUMNS = ("company_uei", "uei", "recipient_uei")
+
+
+def _find_exact_column(df: pd.DataFrame, candidates: tuple[str, ...]) -> str | None:
+    columns = {str(column).lower(): str(column) for column in df.columns}
+    return next(
+        (columns[candidate.lower()] for candidate in candidates if candidate.lower() in columns),
+        None,
+    )
+
+
+def _attach_company_uei(df_cls: pd.DataFrame, df_awards: pd.DataFrame) -> pd.DataFrame:
+    """Attach an explicit UEI and use it as the aggregator's compatibility company key."""
+    result = df_cls.copy()
+    classification_uei_col = _find_exact_column(result, _COMPANY_UEI_COLUMNS)
+    if classification_uei_col:
+        result["company_uei"] = result[classification_uei_col].map(normalize_uei)
+    else:
+        result["company_uei"] = None
+
+    if not df_awards.empty and "award_id" in result.columns:
+        from sbir_etl.utils.asset_column_helper import AssetColumnHelper
+        from sbir_etl.utils.column_finder import ColumnFinder
+
+        award_id_col = AssetColumnHelper.find_award_id_column(df_awards)
+        uei_col = _find_exact_column(df_awards, _COMPANY_UEI_COLUMNS)
+        company_name_col = ColumnFinder.find_column_by_patterns(
+            df_awards, ["company_name", "company"]
+        )
+
+        if award_id_col and uei_col:
+            join_cols = [award_id_col, uei_col]
+            selected_company_name_col = (
+                company_name_col
+                if company_name_col and "company_name" not in result.columns
+                else None
+            )
+            if selected_company_name_col and selected_company_name_col not in join_cols:
+                join_cols.append(selected_company_name_col)
+
+            df_join = df_awards[join_cols].copy()
+            rename_columns = {
+                award_id_col: "award_id",
+                uei_col: "_enriched_company_uei",
+            }
+            if selected_company_name_col:
+                rename_columns[selected_company_name_col] = "company_name"
+            df_join = df_join.rename(columns=rename_columns)
+            df_join["_enriched_company_uei"] = df_join["_enriched_company_uei"].map(normalize_uei)
+            result = result.merge(df_join, on="award_id", how="left")
+            result["company_uei"] = result["_enriched_company_uei"].combine_first(
+                result["company_uei"]
+            )
+            result = result.drop(columns="_enriched_company_uei")
+
+    # CompanyCETAggregator still groups on company_id. Keep that internal alias tied
+    # strictly to a typed UEI so DUNS or arbitrary legacy IDs cannot reach a UEI match.
+    result["company_id"] = result["company_uei"]
+    return result
 
 
 @asset_check(
@@ -135,8 +198,9 @@ def transformed_cet_company_profiles() -> Output:
     if df_cls.empty:
         raise ValueError("CET award classification input is empty; no companies can be aggregated")
 
-    # Join with enriched awards to get company information if missing
-    if not df_cls.empty and "company_id" not in df_cls.columns:
+    # Join with enriched awards to attach a typed UEI. The classification artifact does
+    # not normally carry company identity, and generic company IDs are not graph keys.
+    if not df_cls.empty:
         try:
             enriched_awards_parquet = Path("data/processed/enriched_sbir_awards.parquet")
             enriched_awards_ndjson = Path("data/processed/enriched_sbir_awards.ndjson")
@@ -151,39 +215,11 @@ def transformed_cet_company_profiles() -> Output:
                 df_awards = pd.DataFrame(recs)
             else:
                 df_awards = pd.DataFrame()
-
-            if not df_awards.empty and "award_id" in df_cls.columns:
-                # Try to find award ID column in enriched awards using helper
-                from sbir_etl.utils.asset_column_helper import AssetColumnHelper
-
-                award_id_col = AssetColumnHelper.find_award_id_column(df_awards)
-
-                if award_id_col:
-                    # Try to find company identifier columns using ColumnFinder
-                    from sbir_etl.utils.column_finder import ColumnFinder
-
-                    company_id_col = ColumnFinder.find_id_column(df_awards, "company")
-                    company_name_col = ColumnFinder.find_column_by_patterns(
-                        df_awards, ["company", "company_name"]
-                    )
-
-                    # Join on award_id
-                    if company_id_col:
-                        join_cols = [award_id_col, company_id_col]
-                        if company_name_col and company_name_col not in join_cols:
-                            join_cols.append(company_name_col)
-                        df_join = df_awards[
-                            [col for col in join_cols if col in df_awards.columns]
-                        ].copy()
-                        df_join = df_join.rename(
-                            columns={award_id_col: "award_id", company_id_col: "company_id"}
-                        )
-                        if company_name_col and company_name_col != "company_id":
-                            df_join = df_join.rename(columns={company_name_col: "company_name"})
-                        df_cls = df_cls.merge(df_join, on="award_id", how="left")
-                        logger.info(
-                            f"Joined classifications with enriched awards to get company info (joined {df_cls['company_id'].notna().sum()} rows)"
-                        )
+            df_cls = _attach_company_uei(df_cls, df_awards)
+            logger.info(
+                "Joined classifications with explicit company UEIs "
+                f"(joined {df_cls['company_uei'].notna().sum()} rows)"
+            )
         except Exception as exc:
             raise RuntimeError(
                 "Failed to join CET classifications with enriched award company data"
@@ -203,6 +239,9 @@ def transformed_cet_company_profiles() -> Output:
 
     if df_comp.empty:
         raise ValueError("CET company aggregation produced no company profiles")
+
+    # Preserve the semantic identity alongside CompanyCETAggregator's compatibility field.
+    df_comp["company_uei"] = df_comp["company_id"]
 
     # Persist company profiles (parquet preferred, NDJSON fallback)
     artifact_path = save_dataframe_parquet(df_comp, output_path)

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
@@ -11,6 +11,7 @@ This module contains:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -35,6 +36,82 @@ except Exception:
     CETLoaderConfig = None
 
 
+def _skip_requested(context, operation: str) -> bool:
+    if os.getenv("SKIP_NEO4J_LOADING", "false").lower() not in {"true", "1", "yes"}:
+        return False
+    context.log.warning(f"Skipping {operation}: SKIP_NEO4J_LOADING is enabled")
+    return True
+
+
+def _require_loader() -> None:
+    if CETLoader is None or CETLoaderConfig is None:
+        raise RuntimeError("CET Neo4j loader dependencies are unavailable")
+
+
+def _connected_client():
+    client = _get_neo4j_client()
+    if client is None:
+        raise RuntimeError("Neo4j loading was not skipped, but no client was created")
+    return client
+
+
+def _close_client(client, context) -> None:
+    try:
+        client.close()
+    except Exception as exc:  # pragma: no cover - defensive cleanup
+        context.log.warning(f"Failed to close Neo4j client cleanly: {exc}")
+
+
+def _ensure_successful_metrics(metrics, operation: str) -> None:
+    errors = int(getattr(metrics, "errors", 0) or 0)
+    if errors:
+        raise RuntimeError(f"{operation} completed with {errors} loader error(s)")
+
+
+def _write_summary(filename: str, result: dict[str, Any]) -> None:
+    out_path = DEFAULT_OUTPUT_DIR / filename
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as fh:
+        json.dump(result, fh, indent=2)
+
+
+def _award_enrichments(classifications: list[dict]) -> list[dict]:
+    enrichments = []
+    for row in classifications:
+        supporting = row.get("supporting_cets") or []
+        enrichments.append(
+            {
+                "award_id": row["award_id"],
+                "cet_primary_id": row.get("primary_cet"),
+                "cet_primary_score": row.get("primary_score"),
+                "cet_supporting_ids": [
+                    item.get("cet_id") for item in supporting if isinstance(item, dict)
+                ],
+                "cet_taxonomy_version": row.get("taxonomy_version"),
+                "cet_classified_at": row.get("classified_at"),
+                "cet_model_version": row.get("model_version"),
+            }
+        )
+    return enrichments
+
+
+def _company_enrichments(profiles: list[dict]) -> list[dict]:
+    enrichments = []
+    for row in profiles:
+        cet_scores = row.get("cet_scores") or {}
+        enrichments.append(
+            {
+                "company_id": row["company_id"],
+                "cet_dominant_id": row.get("dominant_cet"),
+                "cet_dominant_score": row.get("dominant_score"),
+                "cet_specialization_score": row.get("specialization_score"),
+                "cet_areas": list(cet_scores) if isinstance(cet_scores, dict) else [],
+                "cet_taxonomy_version": row.get("taxonomy_version"),
+            }
+        )
+    return enrichments
+
+
 @asset(
     name="loaded_cet_areas",
     description="Load CETArea nodes into Neo4j from CET taxonomy artifact.",
@@ -50,13 +127,9 @@ except Exception:
 )
 def loaded_cet_areas(context, cet_taxonomy) -> dict[str, Any]:
     """Upsert CETArea nodes based on taxonomy output."""
-    if CETLoader is None or CETLoaderConfig is None:
-        context.log.warning("CETLoader unavailable; skipping CETArea loading")
-        return {"status": "skipped", "reason": "loader_unavailable"}
-
-    client = _get_neo4j_client()
-    if client is None:
-        return {"status": "skipped", "reason": "neo4j_skipped"}
+    if _skip_requested(context, "CETArea loading"):
+        return {"status": "skipped", "reason": "explicit_skip"}
+    _require_loader()
 
     # Config
     taxonomy_parquet = Path(
@@ -68,10 +141,11 @@ def loaded_cet_areas(context, cet_taxonomy) -> dict[str, Any]:
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read taxonomy (expect: cet_id, name, definition, keywords, taxonomy_version)
-    expected_cols = ("cet_id", "name", "definition", "keywords", "taxonomy_version")
+    expected_cols = ("cet_id", "name", "taxonomy_version")
     areas = _read_parquet_or_ndjson(taxonomy_parquet, taxonomy_json, expected_columns=expected_cols)
     context.log.info(f"Loaded CET taxonomy records for Neo4j: {len(areas)}")
 
+    client = _connected_client()
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
         if create_constraints:
@@ -80,33 +154,20 @@ def loaded_cet_areas(context, cet_taxonomy) -> dict[str, Any]:
             loader.create_indexes()
 
         metrics = loader.load_cet_areas(areas)
+        _ensure_successful_metrics(metrics, "CETArea loading")
         result = {
             "status": "success",
             "areas": len(areas),
             "metrics": _serialize_metrics(metrics),
         }
 
-        # Persist a small run summary
-        out_path = DEFAULT_OUTPUT_DIR / "neo4j_cetarea_nodes.checks.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with out_path.open("w", encoding="utf-8") as fh:
-                json.dump(result, fh, indent=2)
-        except Exception:
-            pass
-
-        try:
-            client.close()
-        except Exception:
-            pass
+        _write_summary("neo4j_cetarea_nodes.checks.json", result)
         return result
     except Exception as exc:
         context.log.exception(f"CETArea loading failed: {exc}")
-        try:
-            client.close()
-        except Exception:
-            pass
-        return {"status": "error", "error": str(exc)}
+        raise
+    finally:
+        _close_client(client, context)
 
 
 @asset(
@@ -129,13 +190,9 @@ def loaded_award_cet_enrichment(
     context, enriched_cet_award_classifications, loaded_cet_areas
 ) -> dict[str, Any]:
     """Upsert CET enrichment properties onto Award nodes."""
-    if CETLoader is None or CETLoaderConfig is None:
-        context.log.warning("CETLoader unavailable; skipping Award CET enrichment")
-        return {"status": "skipped", "reason": "loader_unavailable"}
-
-    client = _get_neo4j_client()
-    if client is None:
-        return {"status": "skipped", "reason": "neo4j_skipped"}
+    if _skip_requested(context, "Award CET enrichment"):
+        return {"status": "skipped", "reason": "explicit_skip"}
+    _require_loader()
 
     # Config
     award_class_parquet = Path(
@@ -147,42 +204,30 @@ def loaded_award_cet_enrichment(
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read award classifications
-    expected_cols = ("award_id", "primary_cet", "supporting_cets", "confidence", "evidence")
+    expected_cols = ("award_id", "primary_cet")
     classifications = _read_parquet_or_ndjson(
         award_class_parquet, award_class_json, expected_columns=expected_cols
     )
     context.log.info(f"Loaded award classifications for Neo4j: {len(classifications)}")
 
+    client = _connected_client()
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
-        metrics = loader.load_award_cet_enrichment(classifications)
+        metrics = loader.upsert_award_cet_enrichment(_award_enrichments(classifications))
+        _ensure_successful_metrics(metrics, "Award CET enrichment")
         result = {
             "status": "success",
             "awards": len(classifications),
             "metrics": _serialize_metrics(metrics),
         }
 
-        # Persist a small run summary
-        out_path = DEFAULT_OUTPUT_DIR / "neo4j_award_cet_enrichment.checks.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with out_path.open("w", encoding="utf-8") as fh:
-                json.dump(result, fh, indent=2)
-        except Exception:
-            pass
-
-        try:
-            client.close()
-        except Exception:
-            pass
+        _write_summary("neo4j_award_cet_enrichment.checks.json", result)
         return result
     except Exception as exc:
         context.log.exception(f"Award CET enrichment failed: {exc}")
-        try:
-            client.close()
-        except Exception:
-            pass
-        return {"status": "error", "error": str(exc)}
+        raise
+    finally:
+        _close_client(client, context)
 
 
 @asset(
@@ -203,13 +248,9 @@ def loaded_company_cet_enrichment(
     context, transformed_cet_company_profiles, loaded_cet_areas
 ) -> dict[str, Any]:
     """Upsert CET enrichment properties onto Company nodes."""
-    if CETLoader is None or CETLoaderConfig is None:
-        context.log.warning("CETLoader unavailable; skipping Company CET enrichment")
-        return {"status": "skipped", "reason": "loader_unavailable"}
-
-    client = _get_neo4j_client()
-    if client is None:
-        return {"status": "skipped", "reason": "neo4j_skipped"}
+    if _skip_requested(context, "Company CET enrichment"):
+        return {"status": "skipped", "reason": "explicit_skip"}
+    _require_loader()
 
     # Config
     company_profiles_parquet = Path(
@@ -221,48 +262,32 @@ def loaded_company_cet_enrichment(
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read company profiles
-    expected_cols = (
-        "company_uei",
-        "dominant_cet",
-        "specialization_score",
-        "award_count",
-        "total_funding",
-    )
+    expected_cols = ("company_id", "dominant_cet", "specialization_score")
     profiles = _read_parquet_or_ndjson(
         company_profiles_parquet, company_profiles_json, expected_columns=expected_cols
     )
     context.log.info(f"Loaded company profiles for Neo4j: {len(profiles)}")
 
+    client = _connected_client()
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
-        metrics = loader.load_company_cet_enrichment(profiles)
+        metrics = loader.upsert_company_cet_enrichment(
+            _company_enrichments(profiles), key_property="company_id"
+        )
+        _ensure_successful_metrics(metrics, "Company CET enrichment")
         result = {
             "status": "success",
             "companies": len(profiles),
             "metrics": _serialize_metrics(metrics),
         }
 
-        # Persist a small run summary
-        out_path = DEFAULT_OUTPUT_DIR / "neo4j_company_cet_enrichment.checks.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with out_path.open("w", encoding="utf-8") as fh:
-                json.dump(result, fh, indent=2)
-        except Exception:
-            pass
-
-        try:
-            client.close()
-        except Exception:
-            pass
+        _write_summary("neo4j_company_cet_enrichment.checks.json", result)
         return result
     except Exception as exc:
         context.log.exception(f"Company CET enrichment failed: {exc}")
-        try:
-            client.close()
-        except Exception:
-            pass
-        return {"status": "error", "error": str(exc)}
+        raise
+    finally:
+        _close_client(client, context)
 
 
 @asset(
@@ -286,13 +311,9 @@ def loaded_award_cet_relationships(
     context, enriched_cet_award_classifications, loaded_cet_areas, loaded_award_cet_enrichment
 ) -> dict[str, Any]:
     """Create Award -> CETArea relationships."""
-    if CETLoader is None or CETLoaderConfig is None:
-        context.log.warning("CETLoader unavailable; skipping Award CET relationships")
-        return {"status": "skipped", "reason": "loader_unavailable"}
-
-    client = _get_neo4j_client()
-    if client is None:
-        return {"status": "skipped", "reason": "neo4j_skipped"}
+    if _skip_requested(context, "Award CET relationships"):
+        return {"status": "skipped", "reason": "explicit_skip"}
+    _require_loader()
 
     # Config
     award_class_parquet = Path(
@@ -304,42 +325,30 @@ def loaded_award_cet_relationships(
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read award classifications
-    expected_cols = ("award_id", "primary_cet", "supporting_cets", "confidence", "evidence")
+    expected_cols = ("award_id", "primary_cet")
     classifications = _read_parquet_or_ndjson(
         award_class_parquet, award_class_json, expected_columns=expected_cols
     )
     context.log.info(f"Creating Award->CETArea relationships for {len(classifications)} awards")
 
+    client = _connected_client()
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
-        metrics = loader.load_award_cet_relationships(classifications)
+        metrics = loader.create_award_cet_relationships(classifications)
+        _ensure_successful_metrics(metrics, "Award CET relationship loading")
         result = {
             "status": "success",
             "awards": len(classifications),
             "metrics": _serialize_metrics(metrics),
         }
 
-        # Persist a small run summary
-        out_path = DEFAULT_OUTPUT_DIR / "neo4j_award_cet_relationships.checks.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with out_path.open("w", encoding="utf-8") as fh:
-                json.dump(result, fh, indent=2)
-        except Exception:
-            pass
-
-        try:
-            client.close()
-        except Exception:
-            pass
+        _write_summary("neo4j_award_cet_relationships.checks.json", result)
         return result
     except Exception as exc:
         context.log.exception(f"Award CET relationships failed: {exc}")
-        try:
-            client.close()
-        except Exception:
-            pass
-        return {"status": "error", "error": str(exc)}
+        raise
+    finally:
+        _close_client(client, context)
 
 
 @asset(
@@ -361,13 +370,9 @@ def loaded_company_cet_relationships(
     context, transformed_cet_company_profiles, loaded_cet_areas, loaded_company_cet_enrichment
 ) -> dict[str, Any]:
     """Create Company -> CETArea relationships."""
-    if CETLoader is None or CETLoaderConfig is None:
-        context.log.warning("CETLoader unavailable; skipping Company CET relationships")
-        return {"status": "skipped", "reason": "loader_unavailable"}
-
-    client = _get_neo4j_client()
-    if client is None:
-        return {"status": "skipped", "reason": "neo4j_skipped"}
+    if _skip_requested(context, "Company CET relationships"):
+        return {"status": "skipped", "reason": "explicit_skip"}
+    _require_loader()
 
     # Config
     company_profiles_parquet = Path(
@@ -379,48 +384,30 @@ def loaded_company_cet_relationships(
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read company profiles
-    expected_cols = (
-        "company_uei",
-        "dominant_cet",
-        "specialization_score",
-        "award_count",
-        "total_funding",
-    )
+    expected_cols = ("company_id", "dominant_cet", "specialization_score")
     profiles = _read_parquet_or_ndjson(
         company_profiles_parquet, company_profiles_json, expected_columns=expected_cols
     )
     context.log.info(f"Creating Company->CETArea relationships for {len(profiles)} companies")
 
+    client = _connected_client()
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
-        metrics = loader.load_company_cet_relationships(profiles)
+        metrics = loader.create_company_cet_relationships(profiles, key_property="company_id")
+        _ensure_successful_metrics(metrics, "Company CET relationship loading")
         result = {
             "status": "success",
             "companies": len(profiles),
             "metrics": _serialize_metrics(metrics),
         }
 
-        # Persist a small run summary
-        out_path = DEFAULT_OUTPUT_DIR / "neo4j_company_cet_relationships.checks.json"
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            with out_path.open("w", encoding="utf-8") as fh:
-                json.dump(result, fh, indent=2)
-        except Exception:
-            pass
-
-        try:
-            client.close()
-        except Exception:
-            pass
+        _write_summary("neo4j_company_cet_relationships.checks.json", result)
         return result
     except Exception as exc:
         context.log.exception(f"Company CET relationships failed: {exc}")
-        try:
-            client.close()
-        except Exception:
-            pass
-        return {"status": "error", "error": str(exc)}
+        raise
+    finally:
+        _close_client(client, context)
 
 
 # ============================================================================

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
@@ -160,7 +160,7 @@ def _company_enrichments(profiles: list[dict]) -> list[dict]:
         cet_scores = row.get("cet_scores") or {}
         enrichments.append(
             {
-                "company_id": row["company_id"],
+                "uei": row["company_uei"],
                 "cet_dominant_id": row.get("dominant_cet"),
                 "cet_dominant_score": row.get("dominant_score"),
                 "cet_specialization_score": row.get("specialization_score"),
@@ -322,7 +322,7 @@ def loaded_company_cet_enrichment(
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read company profiles
-    expected_cols = ("company_id", "dominant_cet", "specialization_score")
+    expected_cols = ("company_uei", "dominant_cet", "specialization_score")
     profiles = _read_parquet_or_ndjson(
         company_profiles_parquet, company_profiles_json, expected_columns=expected_cols
     )
@@ -332,7 +332,7 @@ def loaded_company_cet_enrichment(
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
         metrics = loader.upsert_company_cet_enrichment(
-            _company_enrichments(profiles), key_property="company_id"
+            _company_enrichments(profiles), key_property="uei"
         )
         return _complete_load(
             filename="neo4j_company_cet_enrichment.checks.json",
@@ -444,7 +444,7 @@ def loaded_company_cet_relationships(
     batch_size = int(context.op_config.get("batch_size", 1000))
 
     # Read company profiles
-    expected_cols = ("company_id", "dominant_cet", "specialization_score")
+    expected_cols = ("company_uei", "dominant_cet", "specialization_score")
     profiles = _read_parquet_or_ndjson(
         company_profiles_parquet, company_profiles_json, expected_columns=expected_cols
     )
@@ -453,7 +453,9 @@ def loaded_company_cet_relationships(
     client = _connected_client()
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
-        metrics = loader.create_company_cet_relationships(profiles, key_property="company_id")
+        metrics = loader.create_company_cet_relationships(
+            _company_enrichments(profiles), key_property="uei"
+        )
         return _complete_load(
             filename="neo4j_company_cet_relationships.checks.json",
             operation="Company CET relationship loading",

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
@@ -62,10 +62,59 @@ def _close_client(client, context) -> None:
         context.log.warning(f"Failed to close Neo4j client cleanly: {exc}")
 
 
-def _ensure_successful_metrics(metrics, operation: str) -> None:
+def _metric_count(metrics, field: str, key: str) -> int:
+    values = getattr(metrics, field, {}) or {}
+    if not isinstance(values, dict):
+        return int(values)
+    return int(values.get(key, 0) or 0)
+
+
+def _complete_load(
+    *,
+    filename: str,
+    operation: str,
+    count_field: str,
+    submitted: int,
+    processed: int,
+    metrics,
+    reported_count: int | None = None,
+) -> dict[str, Any]:
+    """Persist an auditable load summary and fail unless every submitted item was processed."""
     errors = int(getattr(metrics, "errors", 0) or 0)
+    match_rate = processed / submitted if submitted else 0.0
+    successful = submitted > 0 and processed == submitted and errors == 0
+    result = {
+        "status": "success" if successful else "error",
+        count_field: submitted if reported_count is None else reported_count,
+        "submitted": submitted,
+        "processed": processed,
+        "match_rate": match_rate,
+        "errors": errors,
+        "metrics": _serialize_metrics(metrics),
+    }
+    _write_summary(filename, result)
     if errors:
         raise RuntimeError(f"{operation} completed with {errors} loader error(s)")
+    if not submitted:
+        raise RuntimeError(f"{operation} received no records")
+    if processed != submitted:
+        raise RuntimeError(
+            f"{operation} processed {processed}/{submitted} submitted item(s) ({match_rate:.1%})"
+        )
+    return result
+
+
+def _expected_award_relationships(classifications: list[dict]) -> int:
+    expected = 0
+    for row in classifications:
+        if row.get("primary_cet"):
+            expected += 1
+        supporting = row.get("supporting_cets") or []
+        if isinstance(supporting, list):
+            expected += sum(
+                1 for item in supporting if isinstance(item, dict) and item.get("cet_id")
+            )
+    return expected
 
 
 def _write_summary(filename: str, result: dict[str, Any]) -> None:
@@ -154,15 +203,17 @@ def loaded_cet_areas(context, cet_taxonomy) -> dict[str, Any]:
             loader.create_indexes()
 
         metrics = loader.load_cet_areas(areas)
-        _ensure_successful_metrics(metrics, "CETArea loading")
-        result = {
-            "status": "success",
-            "areas": len(areas),
-            "metrics": _serialize_metrics(metrics),
-        }
-
-        _write_summary("neo4j_cetarea_nodes.checks.json", result)
-        return result
+        # The upsert metrics intentionally exclude content-identical matches, so successful
+        # processing is the submitted row count minus rows recorded as loader errors.
+        processed = max(0, len(areas) - int(getattr(metrics, "errors", 0) or 0))
+        return _complete_load(
+            filename="neo4j_cetarea_nodes.checks.json",
+            operation="CETArea loading",
+            count_field="areas",
+            submitted=len(areas),
+            processed=processed,
+            metrics=metrics,
+        )
     except Exception as exc:
         context.log.exception(f"CETArea loading failed: {exc}")
         raise
@@ -214,15 +265,14 @@ def loaded_award_cet_enrichment(
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
         metrics = loader.upsert_award_cet_enrichment(_award_enrichments(classifications))
-        _ensure_successful_metrics(metrics, "Award CET enrichment")
-        result = {
-            "status": "success",
-            "awards": len(classifications),
-            "metrics": _serialize_metrics(metrics),
-        }
-
-        _write_summary("neo4j_award_cet_enrichment.checks.json", result)
-        return result
+        return _complete_load(
+            filename="neo4j_award_cet_enrichment.checks.json",
+            operation="Award CET enrichment",
+            count_field="awards",
+            submitted=len(classifications),
+            processed=_metric_count(metrics, "nodes_updated", "FinancialTransaction"),
+            metrics=metrics,
+        )
     except Exception as exc:
         context.log.exception(f"Award CET enrichment failed: {exc}")
         raise
@@ -274,15 +324,14 @@ def loaded_company_cet_enrichment(
         metrics = loader.upsert_company_cet_enrichment(
             _company_enrichments(profiles), key_property="company_id"
         )
-        _ensure_successful_metrics(metrics, "Company CET enrichment")
-        result = {
-            "status": "success",
-            "companies": len(profiles),
-            "metrics": _serialize_metrics(metrics),
-        }
-
-        _write_summary("neo4j_company_cet_enrichment.checks.json", result)
-        return result
+        return _complete_load(
+            filename="neo4j_company_cet_enrichment.checks.json",
+            operation="Company CET enrichment",
+            count_field="companies",
+            submitted=len(profiles),
+            processed=_metric_count(metrics, "nodes_updated", "Organization"),
+            metrics=metrics,
+        )
     except Exception as exc:
         context.log.exception(f"Company CET enrichment failed: {exc}")
         raise
@@ -335,15 +384,16 @@ def loaded_award_cet_relationships(
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
         metrics = loader.create_award_cet_relationships(classifications)
-        _ensure_successful_metrics(metrics, "Award CET relationship loading")
-        result = {
-            "status": "success",
-            "awards": len(classifications),
-            "metrics": _serialize_metrics(metrics),
-        }
-
-        _write_summary("neo4j_award_cet_relationships.checks.json", result)
-        return result
+        expected = _expected_award_relationships(classifications)
+        return _complete_load(
+            filename="neo4j_award_cet_relationships.checks.json",
+            operation="Award CET relationship loading",
+            count_field="awards",
+            submitted=expected,
+            processed=_metric_count(metrics, "relationships_created", "APPLICABLE_TO"),
+            metrics=metrics,
+            reported_count=len(classifications),
+        )
     except Exception as exc:
         context.log.exception(f"Award CET relationships failed: {exc}")
         raise
@@ -394,15 +444,14 @@ def loaded_company_cet_relationships(
     try:
         loader = CETLoader(client, CETLoaderConfig(batch_size=batch_size))
         metrics = loader.create_company_cet_relationships(profiles, key_property="company_id")
-        _ensure_successful_metrics(metrics, "Company CET relationship loading")
-        result = {
-            "status": "success",
-            "companies": len(profiles),
-            "metrics": _serialize_metrics(metrics),
-        }
-
-        _write_summary("neo4j_company_cet_relationships.checks.json", result)
-        return result
+        return _complete_load(
+            filename="neo4j_company_cet_relationships.checks.json",
+            operation="Company CET relationship loading",
+            count_field="companies",
+            submitted=len(profiles),
+            processed=_metric_count(metrics, "relationships_created", "SPECIALIZES_IN"),
+            metrics=metrics,
+        )
     except Exception as exc:
         context.log.exception(f"Company CET relationships failed: {exc}")
         raise

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/loading.py
@@ -11,7 +11,6 @@ This module contains:
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 
@@ -25,7 +24,13 @@ from .company import (
     DEFAULT_TAXONOMY_PARQUET,
     _get_neo4j_client,
 )
-from .utils import AssetIn, _read_parquet_or_ndjson, _serialize_metrics, asset
+from .utils import (
+    AssetIn,
+    _read_parquet_or_ndjson,
+    _serialize_metrics,
+    asset,
+    neo4j_skip_requested,
+)
 
 
 # Neo4j loader imports
@@ -37,7 +42,12 @@ except Exception:
 
 
 def _skip_requested(context, operation: str) -> bool:
-    if os.getenv("SKIP_NEO4J_LOADING", "false").lower() not in {"true", "1", "yes"}:
+    """Return True when SKIP_NEO4J_LOADING requests skipping this load.
+
+    Delegates to the shared predicate so this gate cannot drift from the client
+    factory in ``company.py``; see ``SKIP_NEO4J_VALUES`` for the accepted values.
+    """
+    if not neo4j_skip_requested():
         return False
     context.log.warning(f"Skipping {operation}: SKIP_NEO4J_LOADING is enabled")
     return True

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/utils.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/utils.py
@@ -159,24 +159,37 @@ __all__ = ["save_dataframe_parquet"]
 def _read_parquet_or_ndjson(
     parquet_path: Path, json_path: Path, expected_columns: tuple
 ) -> list[dict]:
-    """Read data from parquet or fallback to NDJSON."""
-    try:
-        if parquet_path.exists():
-            df = pd.read_parquet(parquet_path)
-            return df.to_dict(orient="records")
-        elif json_path.exists():
-            records = []
-            with json_path.open("r", encoding="utf-8") as fh:
-                for line in fh:
-                    if line.strip():
-                        try:
-                            records.append(json.loads(line))
-                        except Exception:
-                            continue
-            return records
-    except Exception:
-        pass
-    return []
+    """Read and validate a parquet or NDJSON artifact without hiding malformed input."""
+    if parquet_path.exists():
+        df = pd.read_parquet(parquet_path)
+        missing = set(expected_columns) - set(df.columns)
+        if missing:
+            names = ", ".join(sorted(missing))
+            raise ValueError(f"{parquet_path} is missing required columns: {names}")
+        return df.to_dict(orient="records")
+
+    if json_path.exists():
+        records = []
+        with json_path.open("r", encoding="utf-8") as fh:
+            for line_number, line in enumerate(fh, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(f"Invalid JSON in {json_path} at line {line_number}") from exc
+                if not isinstance(record, dict):
+                    raise ValueError(f"Expected an object in {json_path} at line {line_number}")
+                missing = set(expected_columns) - set(record)
+                if missing:
+                    names = ", ".join(sorted(missing))
+                    raise ValueError(
+                        f"{json_path} line {line_number} is missing required fields: {names}"
+                    )
+                records.append(record)
+        return records
+
+    raise FileNotFoundError(f"No input artifact found at {parquet_path} or {json_path}")
 
 
 def _serialize_metrics(metrics: Any) -> dict[str, Any]:

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/utils.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/utils.py
@@ -9,10 +9,25 @@ This module provides:
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
+
+
+# Values of SKIP_NEO4J_LOADING that request a skip. Repo-wide convention, shared by
+# every Neo4j client factory (company_categorization.py, transition/utils.py,
+# uspto/utils.py, sec_edgar_enrichment.py, sbir_neo4j_loading.py). The skip gate and
+# the client factory must read the same set: if they disagree, a value one accepts
+# and the other rejects makes the asset demand a connection it has already decided
+# not to open.
+SKIP_NEO4J_VALUES = frozenset({"true", "1", "yes"})
+
+
+def neo4j_skip_requested() -> bool:
+    """Return True when SKIP_NEO4J_LOADING requests skipping Neo4j work."""
+    return os.getenv("SKIP_NEO4J_LOADING", "false").lower() in SKIP_NEO4J_VALUES
 
 
 # ============================================================================

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/utils.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/utils.py
@@ -157,7 +157,11 @@ __all__ = ["save_dataframe_parquet"]
 
 
 def _read_parquet_or_ndjson(
-    parquet_path: Path, json_path: Path, expected_columns: tuple
+    parquet_path: Path,
+    json_path: Path,
+    expected_columns: tuple,
+    *,
+    allow_empty: bool = False,
 ) -> list[dict]:
     """Read and validate a parquet or NDJSON artifact without hiding malformed input."""
     if parquet_path.exists():
@@ -166,7 +170,10 @@ def _read_parquet_or_ndjson(
         if missing:
             names = ", ".join(sorted(missing))
             raise ValueError(f"{parquet_path} is missing required columns: {names}")
-        return df.to_dict(orient="records")
+        records = df.to_dict(orient="records")
+        if not records and not allow_empty:
+            raise ValueError(f"{parquet_path} contains no records")
+        return records
 
     if json_path.exists():
         records = []
@@ -187,6 +194,8 @@ def _read_parquet_or_ndjson(
                         f"{json_path} line {line_number} is missing required fields: {names}"
                     )
                 records.append(record)
+        if not records and not allow_empty:
+            raise ValueError(f"{json_path} contains no records")
         return records
 
     raise FileNotFoundError(f"No input artifact found at {parquet_path} or {json_path}")

--- a/tests/unit/assets/cet/test_company_profiles.py
+++ b/tests/unit/assets/cet/test_company_profiles.py
@@ -1,0 +1,90 @@
+"""Company CET profile identity contract tests."""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.cet.company import (
+    _attach_company_uei,
+    transformed_cet_company_profiles,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_company_profile_identity_prefers_explicit_uei_over_legacy_company_id():
+    classifications = pd.DataFrame(
+        [{"award_id": "A-1", "company_id": "legacy-company", "primary_cet": "quantum"}]
+    )
+    awards = pd.DataFrame(
+        [
+            {
+                "award_id": "A-1",
+                "company_id": "different-legacy-company",
+                "uei": "abcd-1234-efgh",
+                "company_name": "Example Labs",
+            }
+        ]
+    )
+
+    result = _attach_company_uei(classifications, awards)
+
+    assert result.loc[0, "company_uei"] == "ABCD1234EFGH"
+    assert result.loc[0, "company_id"] == "ABCD1234EFGH"
+    assert result.loc[0, "company_name"] == "Example Labs"
+
+
+def test_company_profile_identity_does_not_relabel_duns_as_uei():
+    classifications = pd.DataFrame(
+        [{"award_id": "A-1", "company_id": "legacy-company", "primary_cet": "quantum"}]
+    )
+    awards = pd.DataFrame(
+        [{"award_id": "A-1", "company_id": "legacy-company", "duns": "123456789"}]
+    )
+
+    result = _attach_company_uei(classifications, awards)
+
+    assert result["company_uei"].isna().all()
+    assert result["company_id"].isna().all()
+
+
+def test_company_profile_artifact_emits_explicit_company_uei(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    processed = tmp_path / "data" / "processed"
+    processed.mkdir(parents=True)
+    (processed / "cet_award_classifications.ndjson").write_text(
+        json.dumps(
+            {
+                "award_id": "A-1",
+                "company_id": "legacy-company",
+                "primary_cet": "quantum",
+                "primary_score": 0.9,
+                "supporting_cets": [],
+            }
+        )
+        + "\n"
+    )
+    (processed / "enriched_sbir_awards.ndjson").write_text(
+        json.dumps(
+            {
+                "award_id": "A-1",
+                "company_id": "different-legacy-company",
+                "uei": "abcd-1234-efgh",
+                "company_name": "Example Labs",
+            }
+        )
+        + "\n"
+    )
+
+    output = transformed_cet_company_profiles()
+
+    output_path = Path(output.value)
+    if output_path.suffix == ".parquet":
+        profiles = pd.read_parquet(output_path)
+    else:
+        profiles = pd.read_json(output_path, lines=True)
+    assert profiles.loc[0, "company_uei"] == "ABCD1234EFGH"
+    assert profiles.loc[0, "company_id"] == "ABCD1234EFGH"

--- a/tests/unit/assets/cet/test_loading_contracts.py
+++ b/tests/unit/assets/cet/test_loading_contracts.py
@@ -301,7 +301,7 @@ def test_company_enrichment_fails_when_no_organizations_match(
     source.write_text(
         json.dumps(
             {
-                "company_id": "C-1",
+                "company_uei": "ABCD1234EFGH",
                 "dominant_cet": "quantum",
                 "specialization_score": 0.8,
             }
@@ -319,6 +319,9 @@ def test_company_enrichment_fails_when_no_organizations_match(
     summary = mock_write_summary.call_args.args[1]
     assert summary["status"] == "error"
     assert summary["match_rate"] == 0.0
+    loader_call = mock_loader_class.return_value.upsert_company_cet_enrichment.call_args
+    assert loader_call.kwargs["key_property"] == "uei"
+    assert loader_call.args[0][0]["uei"] == "ABCD1234EFGH"
     mock_connected_client.return_value.close.assert_called_once_with()
 
 
@@ -340,7 +343,7 @@ def test_company_enrichment_maps_profile_schema():
     result = loading._company_enrichments(
         [
             {
-                "company_id": "C-1",
+                "company_uei": "ABCD1234EFGH",
                 "dominant_cet": "quantum",
                 "dominant_score": 0.8,
                 "specialization_score": 0.6,
@@ -350,6 +353,6 @@ def test_company_enrichment_maps_profile_schema():
         ]
     )
 
-    assert result[0]["company_id"] == "C-1"
+    assert result[0]["uei"] == "ABCD1234EFGH"
     assert result[0]["cet_dominant_id"] == "quantum"
     assert result[0]["cet_areas"] == ["quantum", "ai"]

--- a/tests/unit/assets/cet/test_loading_contracts.py
+++ b/tests/unit/assets/cet/test_loading_contracts.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from dagster import build_op_context
 
-from sbir_analytics.assets.cet import loading
+from sbir_analytics.assets.cet import company, loading
 from sbir_analytics.assets.cet.utils import _read_parquet_or_ndjson
 
 pytestmark = pytest.mark.fast
@@ -35,6 +35,16 @@ def _award_context(parquet_path, json_path):
     )
 
 
+def _company_context(parquet_path, json_path):
+    return build_op_context(
+        op_config={
+            "company_profiles_parquet": str(parquet_path),
+            "company_profiles_json": str(json_path),
+            "batch_size": 10,
+        }
+    )
+
+
 def test_reader_rejects_malformed_ndjson(tmp_path):
     json_path = tmp_path / "taxonomy.json"
     json_path.write_text("not json\n")
@@ -55,6 +65,48 @@ def test_reader_rejects_missing_required_fields(tmp_path):
         _read_parquet_or_ndjson(
             tmp_path / "taxonomy.parquet",
             json_path,
+            expected_columns=("cet_id", "name"),
+        )
+
+
+def test_reader_rejects_empty_ndjson(tmp_path):
+    json_path = tmp_path / "taxonomy.json"
+    json_path.write_text("\n")
+
+    with pytest.raises(ValueError, match="contains no records"):
+        _read_parquet_or_ndjson(
+            tmp_path / "taxonomy.parquet",
+            json_path,
+            expected_columns=("cet_id", "name"),
+        )
+
+
+def test_reader_allows_empty_only_when_explicitly_requested(tmp_path):
+    json_path = tmp_path / "taxonomy.json"
+    json_path.write_text("")
+
+    assert (
+        _read_parquet_or_ndjson(
+            tmp_path / "taxonomy.parquet",
+            json_path,
+            expected_columns=("cet_id", "name"),
+            allow_empty=True,
+        )
+        == []
+    )
+
+
+def test_reader_rejects_empty_parquet(tmp_path):
+    parquet_path = tmp_path / "taxonomy.parquet"
+    pytest.importorskip("pyarrow")
+    import pandas as pd
+
+    pd.DataFrame(columns=["cet_id", "name"]).to_parquet(parquet_path)
+
+    with pytest.raises(ValueError, match="contains no records"):
+        _read_parquet_or_ndjson(
+            parquet_path,
+            tmp_path / "taxonomy.json",
             expected_columns=("cet_id", "name"),
         )
 
@@ -141,7 +193,9 @@ def test_award_enrichment_calls_real_loader_api(
         + "\n"
     )
     loader_instance = mock_loader_class.return_value
-    loader_instance.upsert_award_cet_enrichment.return_value = SimpleNamespace(errors=0)
+    loader_instance.upsert_award_cet_enrichment.return_value = SimpleNamespace(
+        errors=0, nodes_updated={"FinancialTransaction": 1}
+    )
     context = _award_context(tmp_path / "classifications.parquet", source)
 
     result = loading.loaded_award_cet_enrichment(context, None, None)
@@ -163,9 +217,94 @@ def test_award_enrichment_calls_real_loader_api(
     mock_connected_client.return_value.close.assert_called_once_with()
 
 
-def test_nonzero_loader_errors_fail_materialization():
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.loading._write_summary")
+@patch("sbir_analytics.assets.cet.loading._connected_client")
+@patch("sbir_analytics.assets.cet.loading.CETLoader")
+def test_nonzero_loader_errors_fail_asset_and_persist_summary(
+    mock_loader_class, mock_connected_client, mock_write_summary, tmp_path
+):
+    source = tmp_path / "classifications.json"
+    source.write_text(json.dumps({"award_id": "A-1", "primary_cet": "quantum"}) + "\n")
+    mock_loader_class.return_value.upsert_award_cet_enrichment.return_value = SimpleNamespace(
+        errors=2, nodes_updated={"FinancialTransaction": 1}
+    )
+    context = _award_context(tmp_path / "classifications.parquet", source)
+
     with pytest.raises(RuntimeError, match="2 loader error"):
-        loading._ensure_successful_metrics(SimpleNamespace(errors=2), "test load")
+        loading.loaded_award_cet_enrichment(context, None, None)
+
+    summary = mock_write_summary.call_args.args[1]
+    assert summary["status"] == "error"
+    assert summary["errors"] == 2
+    mock_connected_client.return_value.close.assert_called_once_with()
+
+
+@patch("sbir_analytics.assets.cet.loading._write_summary")
+def test_zero_progress_fails_after_persisting_failure_summary(mock_write_summary):
+    metrics = SimpleNamespace(errors=0, nodes_updated={"Organization": 0})
+
+    with pytest.raises(RuntimeError, match="processed 0/2"):
+        loading._complete_load(
+            filename="company.json",
+            operation="Company CET enrichment",
+            count_field="companies",
+            submitted=2,
+            processed=loading._metric_count(metrics, "nodes_updated", "Organization"),
+            metrics=metrics,
+        )
+
+    summary = mock_write_summary.call_args.args[1]
+    assert summary["status"] == "error"
+    assert summary["submitted"] == 2
+    assert summary["processed"] == 0
+    assert summary["match_rate"] == 0.0
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.loading._write_summary")
+@patch("sbir_analytics.assets.cet.loading._connected_client")
+@patch("sbir_analytics.assets.cet.loading.CETLoader")
+def test_company_enrichment_fails_when_no_organizations_match(
+    mock_loader_class, mock_connected_client, mock_write_summary, tmp_path
+):
+    source = tmp_path / "profiles.json"
+    source.write_text(
+        json.dumps(
+            {
+                "company_id": "C-1",
+                "dominant_cet": "quantum",
+                "specialization_score": 0.8,
+            }
+        )
+        + "\n"
+    )
+    mock_loader_class.return_value.upsert_company_cet_enrichment.return_value = SimpleNamespace(
+        errors=0, nodes_updated={"Organization": 0}
+    )
+    context = _company_context(tmp_path / "profiles.parquet", source)
+
+    with pytest.raises(RuntimeError, match="processed 0/1"):
+        loading.loaded_company_cet_enrichment(context, None, None)
+
+    summary = mock_write_summary.call_args.args[1]
+    assert summary["status"] == "error"
+    assert summary["match_rate"] == 0.0
+    mock_connected_client.return_value.close.assert_called_once_with()
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.company.Neo4jClient")
+@patch("sbir_analytics.assets.cet.company.Neo4jConfig")
+def test_neo4j_client_factory_uses_username_contract(mock_config, mock_client):
+    client = mock_client.return_value
+    client.session.return_value.__enter__.return_value.run.return_value = None
+
+    assert company._get_neo4j_client() is client
+
+    kwargs = mock_config.call_args.kwargs
+    assert kwargs["username"] == company.DEFAULT_NEO4J_USER
+    assert "user" not in kwargs
 
 
 def test_company_enrichment_maps_profile_schema():

--- a/tests/unit/assets/cet/test_loading_contracts.py
+++ b/tests/unit/assets/cet/test_loading_contracts.py
@@ -1,0 +1,187 @@
+"""Contract tests for CET Neo4j loading assets."""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from dagster import build_op_context
+
+from sbir_analytics.assets.cet import loading
+from sbir_analytics.assets.cet.utils import _read_parquet_or_ndjson
+
+pytestmark = pytest.mark.fast
+
+
+def _taxonomy_context(parquet_path, json_path):
+    return build_op_context(
+        op_config={
+            "create_constraints": False,
+            "create_indexes": False,
+            "taxonomy_parquet": str(parquet_path),
+            "taxonomy_json": str(json_path),
+            "batch_size": 10,
+        }
+    )
+
+
+def _award_context(parquet_path, json_path):
+    return build_op_context(
+        op_config={
+            "award_class_parquet": str(parquet_path),
+            "award_class_json": str(json_path),
+            "batch_size": 10,
+        }
+    )
+
+
+def test_reader_rejects_malformed_ndjson(tmp_path):
+    json_path = tmp_path / "taxonomy.json"
+    json_path.write_text("not json\n")
+
+    with pytest.raises(ValueError, match="line 1"):
+        _read_parquet_or_ndjson(
+            tmp_path / "taxonomy.parquet",
+            json_path,
+            expected_columns=("cet_id", "name"),
+        )
+
+
+def test_reader_rejects_missing_required_fields(tmp_path):
+    json_path = tmp_path / "taxonomy.json"
+    json_path.write_text(json.dumps({"cet_id": "quantum"}) + "\n")
+
+    with pytest.raises(ValueError, match="missing required fields: name"):
+        _read_parquet_or_ndjson(
+            tmp_path / "taxonomy.parquet",
+            json_path,
+            expected_columns=("cet_id", "name"),
+        )
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "true"})
+@patch("sbir_analytics.assets.cet.loading._connected_client")
+def test_explicit_skip_is_the_only_successful_skip(mock_client, tmp_path):
+    context = _taxonomy_context(tmp_path / "missing.parquet", tmp_path / "missing.json")
+
+    result = loading.loaded_cet_areas(context, None)
+
+    assert result == {"status": "skipped", "reason": "explicit_skip"}
+    mock_client.assert_not_called()
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.loading.CETLoader", None)
+def test_missing_loader_fails_materialization(tmp_path):
+    context = _taxonomy_context(tmp_path / "missing.parquet", tmp_path / "missing.json")
+
+    with pytest.raises(RuntimeError, match="loader dependencies"):
+        loading.loaded_cet_areas(context, None)
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.loading._connected_client")
+@patch("sbir_analytics.assets.cet.loading.CETLoader")
+def test_loader_exception_propagates_and_closes_client(
+    mock_loader_class, mock_connected_client, tmp_path
+):
+    source = tmp_path / "taxonomy.json"
+    source.write_text(
+        json.dumps({"cet_id": "quantum", "name": "Quantum", "taxonomy_version": "v1"}) + "\n"
+    )
+    client = mock_connected_client.return_value
+    mock_loader_class.return_value.load_cet_areas.side_effect = RuntimeError("database rejected")
+    context = _taxonomy_context(tmp_path / "taxonomy.parquet", source)
+
+    with pytest.raises(RuntimeError, match="database rejected"):
+        loading.loaded_cet_areas(context, None)
+
+    client.close.assert_called_once_with()
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.loading._write_summary")
+@patch("sbir_analytics.assets.cet.loading._connected_client")
+@patch("sbir_analytics.assets.cet.loading.CETLoader")
+def test_summary_persistence_failure_propagates_and_closes_client(
+    mock_loader_class, mock_connected_client, mock_write_summary, tmp_path
+):
+    source = tmp_path / "taxonomy.json"
+    source.write_text(
+        json.dumps({"cet_id": "quantum", "name": "Quantum", "taxonomy_version": "v1"}) + "\n"
+    )
+    mock_loader_class.return_value.load_cet_areas.return_value = SimpleNamespace(errors=0)
+    mock_write_summary.side_effect = OSError("disk full")
+    context = _taxonomy_context(tmp_path / "taxonomy.parquet", source)
+
+    with pytest.raises(OSError, match="disk full"):
+        loading.loaded_cet_areas(context, None)
+
+    mock_connected_client.return_value.close.assert_called_once_with()
+
+
+@patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
+@patch("sbir_analytics.assets.cet.loading._write_summary")
+@patch("sbir_analytics.assets.cet.loading._connected_client")
+@patch("sbir_analytics.assets.cet.loading.CETLoader")
+def test_award_enrichment_calls_real_loader_api(
+    mock_loader_class, mock_connected_client, mock_write_summary, tmp_path
+):
+    source = tmp_path / "classifications.json"
+    source.write_text(
+        json.dumps(
+            {
+                "award_id": "A-1",
+                "primary_cet": "quantum",
+                "primary_score": 0.91,
+                "supporting_cets": [{"cet_id": "ai"}],
+                "taxonomy_version": "v1",
+            }
+        )
+        + "\n"
+    )
+    loader_instance = mock_loader_class.return_value
+    loader_instance.upsert_award_cet_enrichment.return_value = SimpleNamespace(errors=0)
+    context = _award_context(tmp_path / "classifications.parquet", source)
+
+    result = loading.loaded_award_cet_enrichment(context, None, None)
+
+    enrichments = loader_instance.upsert_award_cet_enrichment.call_args.args[0]
+    assert enrichments == [
+        {
+            "award_id": "A-1",
+            "cet_primary_id": "quantum",
+            "cet_primary_score": 0.91,
+            "cet_supporting_ids": ["ai"],
+            "cet_taxonomy_version": "v1",
+            "cet_classified_at": None,
+            "cet_model_version": None,
+        }
+    ]
+    assert result["status"] == "success"
+    mock_write_summary.assert_called_once()
+    mock_connected_client.return_value.close.assert_called_once_with()
+
+
+def test_nonzero_loader_errors_fail_materialization():
+    with pytest.raises(RuntimeError, match="2 loader error"):
+        loading._ensure_successful_metrics(SimpleNamespace(errors=2), "test load")
+
+
+def test_company_enrichment_maps_profile_schema():
+    result = loading._company_enrichments(
+        [
+            {
+                "company_id": "C-1",
+                "dominant_cet": "quantum",
+                "dominant_score": 0.8,
+                "specialization_score": 0.6,
+                "cet_scores": {"quantum": 0.8, "ai": 0.2},
+                "taxonomy_version": "v1",
+            }
+        ]
+    )
+
+    assert result[0]["company_id"] == "C-1"
+    assert result[0]["cet_dominant_id"] == "quantum"
+    assert result[0]["cet_areas"] == ["quantum", "ai"]

--- a/tests/unit/assets/cet/test_loading_contracts.py
+++ b/tests/unit/assets/cet/test_loading_contracts.py
@@ -122,6 +122,35 @@ def test_explicit_skip_is_the_only_successful_skip(mock_client, tmp_path):
     mock_client.assert_not_called()
 
 
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes"])
+def test_skip_gate_and_client_factory_accept_the_same_values(value, tmp_path):
+    """The skip gate must never disagree with the client factory.
+
+    If one accepted a value the other rejected, the asset would decline to skip and
+    then demand a connection the factory had already given up on.
+    """
+    context = _taxonomy_context(tmp_path / "missing.parquet", tmp_path / "missing.json")
+
+    with patch.dict("os.environ", {"SKIP_NEO4J_LOADING": value}):
+        assert loading._skip_requested(context, "CETArea loading") is True
+        with patch.object(company, "Neo4jClient", None), patch.object(company, "Neo4jConfig", None):
+            assert company._get_neo4j_client() is None
+
+
+@pytest.mark.parametrize("value", ["false", "no", "0", ""])
+def test_skip_gate_and_client_factory_reject_the_same_values(value, tmp_path):
+    context = _taxonomy_context(tmp_path / "missing.parquet", tmp_path / "missing.json")
+
+    with patch.dict("os.environ", {"SKIP_NEO4J_LOADING": value}):
+        assert loading._skip_requested(context, "CETArea loading") is False
+        with (
+            patch.object(company, "Neo4jClient", None),
+            patch.object(company, "Neo4jConfig", None),
+            pytest.raises(RuntimeError, match="not skipped"),
+        ):
+            company._get_neo4j_client()
+
+
 @patch.dict("os.environ", {"SKIP_NEO4J_LOADING": "false"})
 @patch("sbir_analytics.assets.cet.loading.CETLoader", None)
 def test_missing_loader_fails_materialization(tmp_path):

--- a/tests/unit/assets/cet/test_materialization_contracts.py
+++ b/tests/unit/assets/cet/test_materialization_contracts.py
@@ -97,7 +97,7 @@ def test_company_profiles_return_real_ndjson_fallback(
     mock_save_parquet, mock_aggregator_class, monkeypatch, tmp_path
 ):
     mock_aggregator_class.return_value.to_dataframe.return_value = pd.DataFrame(
-        [{"company_id": "C-1", "company_name": "Example"}]
+        [{"company_id": "ABCD1234EFGH", "company_name": "Example"}]
     )
 
     def save_as_ndjson(df, path):
@@ -110,7 +110,7 @@ def test_company_profiles_return_real_ndjson_fallback(
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "data/processed/cet_award_classifications.ndjson"
     source.parent.mkdir(parents=True)
-    source.write_text(json.dumps({"award_id": "A-1", "company_id": "C-1"}) + "\n")
+    source.write_text(json.dumps({"award_id": "A-1", "company_uei": "ABCD1234EFGH"}) + "\n")
 
     result = transformed_cet_company_profiles()
 
@@ -162,7 +162,7 @@ def test_company_profiles_reject_empty_aggregation(
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "data/processed/cet_award_classifications.ndjson"
     source.parent.mkdir(parents=True)
-    source.write_text(json.dumps({"award_id": "A-1", "company_id": "C-1"}) + "\n")
+    source.write_text(json.dumps({"award_id": "A-1", "company_uei": "ABCD1234EFGH"}) + "\n")
 
     with pytest.raises(ValueError, match="produced no company profiles"):
         transformed_cet_company_profiles()

--- a/tests/unit/test_cet_award_relationships.py
+++ b/tests/unit/test_cet_award_relationships.py
@@ -137,7 +137,7 @@ def test_asset_neo4j_award_cet_relationships_invokes_loader(monkeypatch, tmp_pat
     """
     Validate that the Dagster asset:
     - Reads classification rows via helper
-    - Invokes CETLoader.load_award_cet_relationships with those rows
+    - Invokes CETLoader.create_award_cet_relationships with those rows
     - Returns a serialized metrics dict
     """
     # Skip if dagster or sbir_analytics are unavailable in this environment
@@ -175,8 +175,8 @@ def test_asset_neo4j_award_cet_relationships_invokes_loader(monkeypatch, tmp_pat
             self.config = config
             self.rows_received = None
 
-        def load_award_cet_relationships(self, rows_in):
-            """Match the actual method name in CETLoader."""
+        def create_award_cet_relationships(self, rows_in):
+            """Match the production CETLoader API."""
             self.rows_received = list(rows_in)
             # emulate counting relationships from rows
             count = 0
@@ -227,13 +227,10 @@ def test_asset_neo4j_award_cet_relationships_invokes_loader(monkeypatch, tmp_pat
     assert result["awards"] == len(rows)
     assert result["metrics"]["relationships_created"]["APPLICABLE_TO"] == expected_rels
 
-    # The asset attempts to write a checks JSON; it tolerates missing dirs.
-    # If created, validate structure; otherwise, just ensure no exception occurred.
     checks_path = (
         tmp_path / "data" / "loaded" / "neo4j" / "neo4j_award_cet_relationships.checks.json"
     )
-    if checks_path.exists():
-        with checks_path.open("r", encoding="utf-8") as fh:
-            payload = json.load(fh)
-        assert payload.get("status") == "success"
-        assert payload.get("awards") == len(rows)
+    with checks_path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    assert payload.get("status") == "success"
+    assert payload.get("awards") == len(rows)

--- a/tests/unit/test_cet_company_relationships.py
+++ b/tests/unit/test_cet_company_relationships.py
@@ -220,14 +220,14 @@ def test_asset_neo4j_company_cet_relationships_invokes_loader(monkeypatch, tmp_p
     # Prepare fake input rows using the company profile artifact schema.
     rows = [
         {
-            "company_id": "COMPANY-1",
+            "company_uei": "ABCD1234EFGH",
             "dominant_cet": "artificial_intelligence",
             "specialization_score": 0.5,
             "award_count": 10,
             "total_funding": 1000000,
         },
         {
-            "company_id": "COMPANY-2",
+            "company_uei": "JKLM5678NPQR",
             "dominant_cet": "quantum_information_science",
             "specialization_score": 0.3,
             "award_count": 5,
@@ -253,10 +253,14 @@ def test_asset_neo4j_company_cet_relationships_invokes_loader(monkeypatch, tmp_p
 
         def create_company_cet_relationships(self, rows_in, *, key_property):
             """Match the production CETLoader API."""
-            assert key_property == "company_id"
+            assert key_property == "uei"
             self.rows_received = list(rows_in)
-            # Count relationships as the number of rows with dominant CET present
-            count = sum(1 for r in self.rows_received if r.get("dominant_cet"))
+            assert [row["uei"] for row in self.rows_received] == [
+                "ABCD1234EFGH",
+                "JKLM5678NPQR",
+            ]
+            # Count relationships as the production loader does after schema adaptation.
+            count = sum(1 for r in self.rows_received if r.get("cet_dominant_id"))
             return FakeMetrics(count)
 
         def close(self):

--- a/tests/unit/test_cet_company_relationships.py
+++ b/tests/unit/test_cet_company_relationships.py
@@ -210,24 +210,24 @@ def test_asset_neo4j_company_cet_relationships_invokes_loader(monkeypatch, tmp_p
     """
     Validate that the Dagster asset:
     - Reads input rows via helper
-    - Invokes CETLoader.load_company_cet_relationships with those rows and returns serialized metrics
+    - Invokes CETLoader.create_company_cet_relationships with those rows and returns serialized metrics
     """
     # Skip if dagster or sbir_analytics are unavailable in this environment
     pytest.importorskip("dagster")
     pytest.importorskip("sbir_analytics")
     monkeypatch.chdir(tmp_path)
 
-    # Prepare fake input rows (using company_uei as expected by the asset)
+    # Prepare fake input rows using the company profile artifact schema.
     rows = [
         {
-            "company_uei": "UEI-1",
+            "company_id": "COMPANY-1",
             "dominant_cet": "artificial_intelligence",
             "specialization_score": 0.5,
             "award_count": 10,
             "total_funding": 1000000,
         },
         {
-            "company_uei": "UEI-2",
+            "company_id": "COMPANY-2",
             "dominant_cet": "quantum_information_science",
             "specialization_score": 0.3,
             "award_count": 5,
@@ -251,8 +251,9 @@ def test_asset_neo4j_company_cet_relationships_invokes_loader(monkeypatch, tmp_p
             self.config = config
             self.rows_received = None
 
-        def load_company_cet_relationships(self, rows_in):
-            """Match the actual method name in CETLoader."""
+        def create_company_cet_relationships(self, rows_in, *, key_property):
+            """Match the production CETLoader API."""
+            assert key_property == "company_id"
             self.rows_received = list(rows_in)
             # Count relationships as the number of rows with dominant CET present
             count = sum(1 for r in self.rows_received if r.get("dominant_cet"))
@@ -293,12 +294,10 @@ def test_asset_neo4j_company_cet_relationships_invokes_loader(monkeypatch, tmp_p
     assert result["companies"] == len(rows)
     assert result["metrics"]["relationships_created"]["SPECIALIZES_IN"] == expected_rels
 
-    # If the asset created a checks file, validate JSON structure (best-effort)
     checks_path = (
         tmp_path / "data" / "loaded" / "neo4j" / "neo4j_company_cet_relationships.checks.json"
     )
-    if checks_path.exists():
-        with checks_path.open("r", encoding="utf-8") as fh:
-            payload = json.load(fh)
-        assert payload.get("status") == "success"
-        assert payload.get("companies") == len(rows)
+    with checks_path.open("r", encoding="utf-8") as fh:
+        payload = json.load(fh)
+    assert payload.get("status") == "success"
+    assert payload.get("companies") == len(rows)


### PR DESCRIPTION
## Summary

- fail CET Neo4j materializations on missing loaders, missing/malformed/empty artifacts, connection or loader failures, summary persistence failures, loader errors, and incomplete submitted-vs-processed counts
- call the production `CETLoader` APIs and persist a failure summary before raising
- close the Neo4j client on every path and share one repository-consistent `SKIP_NEO4J_LOADING` predicate between the gate and client factory
- carry a normalized `company_uei` through company profile generation, adapt it to loader field `uei`, and MATCH existing `Organization` nodes on `uei`
- keep legacy `company_id` only as the company aggregator compatibility alias; arbitrary company IDs and DUNS-only records are never relabeled as UEIs
- rebase onto main at `57514c9a` after #578 merged, preserving its fail-fast CET materialization and canonical artifact-path contracts

## Identity contract

The company profile artifact now names its graph identity explicitly as `company_uei`. The producer accepts only semantic UEI columns and validates/normalizes them; it does not infer UEI from `company_id` or `duns`. Both company enrichment and company-to-CET relationship assets map `company_uei` to `uei` and invoke the loader with `key_property="uei"`.

DUNS-only organizations remain outside this CET load until a typed DUNS-to-`organization_id` resolution path exists.

## Verification

- focused combined CET profile/loading/loader contracts: 144 passed
- full unit suite: 5,893 passed, 7 skipped
- Ruff lint and format checks across `sbir_etl`, all packages, and tests
- mypy: 305 source files
- architecture, epistemic-tier, file-size, config, repository-hygiene, study-manifest, and identity-boundary guards
- `git diff --check`

The focused Dagster tests still emit intermittent SQLAlchemy closed-database cleanup noise after successful execution; the suite exits successfully.
