### PR TITLE
Fix review findings: CET Neo4j config keyword, parquet-fallback path, and three merged-PR follow-ups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,8 @@ repos:
       - id: ruff-format
         files: ^(sbir_etl|packages/sbir-(analytics/sbir_analytics|ml/sbir_ml|graph/sbir_graph)|tests)/
 
-  # Type checking (matches blocking CI scope: sbir_etl only)
-  # CI equivalent: mypy sbir_etl
+  # Type checking (local subset of the blocking CI scope: sbir_etl only)
+  # CI equivalent: mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml
   # Note: mypy is configured in pyproject.toml with exclude patterns for
   # scripts/, tests/, and examples/ to match this scope
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -65,7 +65,7 @@ repos:
 #
 #   Tool Scope Mapping:
 #   - Ruff (lint/format): all production package roots and tests
-#   - MyPy (type check):  sbir_etl/      [CI also checks sbir-graph]
+#   - MyPy (type check):  sbir_etl/      [CI also checks sbir-graph, sbir-ml]
 #   - Bandit (security):  all production package roots  [manual only]
 #   - Standard hooks:     all files       [good practice, not in CI]
 #   - Detect-secrets:     all files       [manual only]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,8 +21,7 @@ repos:
 
   # Type checking (local subset of the blocking CI scope: sbir_etl only)
   # CI equivalent: mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml
-  # Note: mypy is configured in pyproject.toml with exclude patterns for
-  # scripts/, tests/, and examples/ to match this scope
+  # The files filter keeps the local hook narrower than CI by design.
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.2
     hooks:
@@ -50,25 +49,25 @@ repos:
         pass_filenames: false
         always_run: true
 
-# Security scanning (bandit and detect-secrets) is NOT automated anywhere. It
-# ran in weekly.yml's security-scan job until that workflow was retired, and it
-# is not a pre-commit hook. Run it by hand, or schedule it off GitHub Actions:
-# Run manually with: uv run bandit -r sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph -c pyproject.toml
+# Security scanning is intentionally not a local pre-commit hook. CI runs both
+# commands in its blocking `security` / "Security Scan" job. To reproduce it:
+# Run manually with: uv run python -m bandit -r sbir_etl packages -c pyproject.toml
+# Install as CI does:  uv pip install detect-secrets
 # Run manually with: uv run detect-secrets scan --baseline .secrets.baseline
 
 # Configuration notes for maintainers:
 #
 # SCOPE ALIGNMENT WITH CI:
-#   This pre-commit configuration is designed to match the checks in
-#   .github/workflows/ci.yml (the `quality` job), which is the only workflow
-#   left. Both run on the same paths so local and CI results agree.
+#   This pre-commit configuration overlaps with, but does not duplicate, the
+#   blocking checks in .github/workflows/ci.yml. Ruff has the same scope in
+#   both places; CI deliberately has broader MyPy and security coverage.
 #
 #   Tool Scope Mapping:
 #   - Ruff (lint/format): all production package roots and tests
 #   - MyPy (type check):  sbir_etl/      [CI also checks sbir-graph, sbir-ml]
-#   - Bandit (security):  all production package roots  [manual only]
+#   - Bandit (security):  no local hook  [CI checks sbir_etl/ and packages/]
 #   - Standard hooks:     all files       [good practice, not in CI]
-#   - Detect-secrets:     all files       [manual only]
+#   - Detect-secrets:     no local hook  [CI scans the working tree against the baseline]
 #
 # SETUP:
 #   Install pre-commit:
@@ -79,9 +78,9 @@ repos:
 #     pre-commit run --all-files
 #
 # TESTING:
-#   The detect-secrets hook uses .secrets.baseline for approved secrets.
+#   The CI detect-secrets scan uses .secrets.baseline for approved secrets.
 #   When the baseline is updated, commit it with your PR.
 #
 # CI ENFORCEMENT:
-#   For additional CI enforcement, run pre-commit via GitHub Actions.
-#   See .github/workflows/ci.yml for the complete set of checks.
+#   CI invokes the underlying tools directly rather than running pre-commit.
+#   See .github/workflows/ci.yml for its complete, broader set of checks.

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -26,7 +26,7 @@ Local pre-commit hook            Runs in CI as
 ─────────────────────            ──────────────
 Standard file checks       →     (local only)
 Ruff (lint/format)         →     ci.yml · quality job
-MyPy (types)               →     ci.yml · quality job (sbir_etl + sbir-graph)
+MyPy (types)               →     ci.yml · quality job (sbir_etl + sbir-graph + sbir-ml)
 Bandit (security)          →     (nowhere — manual only)
 Detect-secrets             →     (nowhere — manual only)
 (no local hook)            →     ci.yml · quality job (actionlint)
@@ -172,27 +172,22 @@ This workflow runs on:
 
 **Jobs (in parallel/sequence):**
 
-1. **code-quality**
-   - Runs: `ruff check`, `ruff format --check`, `mypy sbir_etl`, and a removed-source-root reference check (`scripts/ci/check_removed_src_references.py`, the "Reject removed source-root references" step).
+1. **quality** ("Lint, Types, and Guards")
+   - Runs: `ruff check`, `ruff format --check`, `mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml`, Dagster definition validation, the architecture/documentation/hygiene guards, compose-file validation, and actionlint.
    - Purpose: Pull-request and push quality gate for checks that mirror the local Ruff/MyPy pre-commit hooks.
    - Time: ~5-10 minutes.
 
-2. **package-type-checks**
-   - Runs: package-specific MyPy checks for `sbir-analytics`, `sbir-ml`, and `sbir-graph`.
-   - Purpose: Package-level type-checking visibility beyond the core `sbir_etl` check.
-   - Time: ~1-2 minutes per package.
+   There is no separate package-type-check job: all three type-checked roots are
+   arguments to the single blocking MyPy step above. `sbir-analytics` is not yet
+   type-checked in CI.
 
-3. **workflow-lint**
-   - Runs: GitHub Actions workflow syntax/lint validation.
-   - Purpose: Keeps the current workflow set valid as `.github/workflows/` changes.
-
-4. **test**, **container-build-test**, **performance-check**, **e2e-docker**, and related CI jobs
+2. **test**, **container-build-test**, **performance-check**, **e2e-docker**, and related CI jobs
    - Runs: unit/integration tests, container checks, performance regression checks, E2E Docker checks, and transition MVP checks as configured in `ci.yml`.
    - Purpose: Keeps PR/push feedback consolidated in the current CI workflow.
 
 ### Why Multiple Jobs?
 
-- **code-quality:** Ensures core local style checks pass in CI
+- **quality:** Ensures core local style checks pass in CI
 - **Individual jobs:** Provide clear, separate visibility in GitHub checks for linting, typing, workflow validation, tests, containers, performance, and E2E coverage
 - **Parallelization:** Faster overall execution
 - **Debugging:** Easier to identify which check failed
@@ -253,7 +248,7 @@ Tool versions are pinned in:
 | Tool versions | `.pre-commit-config.yaml` | `.pre-commit-config.yaml` | Identical |
 | Ruff scope | `.pre-commit-config.yaml` | `ci.yml` | Both: all production roots plus `tests` |
 | Ruff config | `pyproject.toml` | `pyproject.toml` | Identical |
-| MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `ci.yml` | Local: `sbir_etl`. CI: `sbir_etl` **plus** `sbir-graph`, both in the `quality` job |
+| MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `ci.yml` | Local: `sbir_etl`. CI: `sbir_etl` **plus** `sbir-graph` and `sbir-ml`, all in the `quality` job |
 | MyPy config | `pyproject.toml` | `pyproject.toml` | Identical |
 | Bandit scope | `.pre-commit-config.yaml` | not run in CI | Manual only since the security-scan job was retired |
 | Bandit config | `pyproject.toml` | `pyproject.toml` | Identical |

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -1,23 +1,27 @@
 # Pre-commit and CI Consistency
 
-This document explains how SBIR Analytics maintains consistency between local development (`pre-commit` hooks) and CI (`GitHub Actions` workflows). This consistency ensures that code which passes local checks will also pass CI, and vice versa.
+This document records how local development checks (`pre-commit` hooks) relate
+to CI (`GitHub Actions` workflows). The scopes overlap, but are not identical:
+CI is authoritative and deliberately runs checks that have no local hook.
 
 **Document Type:** Explanation
 **Owner:** @hollomancer
-**Last-Reviewed:** 2025-11-28
+**Last-Reviewed:** 2026-08-09
 **Status:** Active
 
 ## Overview
 
 ### Why Consistency Matters
 
-Developers should never encounter a situation where:
+Developers should not encounter an *undocumented* difference where:
 
 - Code passes local pre-commit checks but fails in CI
 - Code fails locally but passes in CI
 - Different tools are used in different environments
 
-This document defines the **single source of truth** for code quality tools and ensures all developers and CI use identical configurations.
+This document explains the differences. The executable configurations remain
+the source of truth: `.pre-commit-config.yaml` for local hooks and
+`.github/workflows/ci.yml` for CI.
 
 ### Architecture
 
@@ -26,45 +30,49 @@ Local pre-commit hook            Runs in CI as
 ─────────────────────            ──────────────
 Standard file checks       →     (local only)
 Ruff (lint/format)         →     ci.yml · quality job
-MyPy (types)               →     ci.yml · quality job (sbir_etl + sbir-graph + sbir-ml)
-Bandit (security)          →     (nowhere — manual only)
-Detect-secrets             →     (nowhere — manual only)
+MyPy (sbir_etl only)       →     ci.yml · quality job (also sbir-graph + sbir-ml)
+(no local hook)            →     ci.yml · security job (Bandit)
+(no local hook)            →     ci.yml · security job (detect-secrets)
 (no local hook)            →     ci.yml · quality job (actionlint)
 ```
 
-**Key Principle:** Pre-commit hooks define what developers must fix locally. CI
-runs the same Ruff + MyPy gates in its single `quality` job, alongside the
-architecture guards and actionlint.
+**Key Principle:** Pre-commit provides fast local feedback. CI repeats Ruff,
+supersets the local MyPy scope, and adds blocking security, architecture, and
+workflow checks.
 
-**Gap:** Bandit and Detect-secrets are not automated anywhere. They ran in
-`weekly.yml`'s `security-scan` job until GitHub Actions was rescoped to tests
-only, and they are not pre-commit hooks. Run them by hand or schedule them
-outside Actions — see the commands at the foot of `.pre-commit-config.yaml`.
+**Intentional local gaps:** Bandit and detect-secrets are not pre-commit hooks.
+Both run in CI's blocking `security` / "Security Scan" job. The local
+reproduction commands are documented at the foot of `.pre-commit-config.yaml`.
 
 ---
 
 ## Tool Scope Mapping
 
-All tools are configured to run on consistent scopes:
+The scopes below are the current contract, including intentional differences:
 
 | Tool | Local Scope | CI Scope | Configuration | Notes |
 |------|------------|----------|---------------|-------|
-| **Ruff** (lint) | `packages/` `sbir_etl/` `tests/` | `packages/` `sbir_etl/` `tests/` | `.pre-commit-config.yaml` + `pyproject.toml` | Code style and import ordering |
-| **Ruff** (format) | `packages/` `sbir_etl/` `tests/` | `packages/` `sbir_etl/` `tests/` | `.pre-commit-config.yaml` + `pyproject.toml` | Format check (not auto-fix in CI) |
-| **MyPy** (types) | `packages/` `sbir_etl/` only | `packages/` `sbir_etl/` only | `.pre-commit-config.yaml` + `pyproject.toml` | Excludes: `scripts/`, `tests/`, `examples/` |
-| **Bandit** (security) | `packages/` `sbir_etl/` only | `packages/` `sbir_etl/` only | `.pre-commit-config.yaml` + `pyproject.toml` | Security scanning |
+| **Ruff** (lint) | Four production roots + `tests/` | Same | `.pre-commit-config.yaml` + `pyproject.toml` | Local hook fixes; CI only checks |
+| **Ruff** (format) | Four production roots + `tests/` | Same | `.pre-commit-config.yaml` + `pyproject.toml` | Local hook formats; CI only checks |
+| **MyPy** (types) | `sbir_etl/` | `sbir_etl/`, `sbir-graph`, `sbir-ml` | `.pre-commit-config.yaml` + `pyproject.toml` | CI is deliberately broader |
+| **Bandit** (security) | No hook | `sbir_etl/` and `packages/` | `ci.yml` + `pyproject.toml` | Blocking `security` job |
 | **Standard hooks** | All files | N/A | `.pre-commit-config.yaml` | YAML validation, EOL, trailing whitespace (local only) |
-| **Detect-secrets** | All files* | N/A | `.pre-commit-config.yaml` | Secret detection (local best practice) |
-
-*Excludes: vendor directories, build artifacts, docs, environment files (see `.pre-commit-config.yaml`)
+| **Detect-secrets** | No hook | Working tree against `.secrets.baseline` | `ci.yml` + `.secrets.baseline` | Blocking `security` job |
 
 ### Scope Rationale
 
-**Why `packages/` and `sbir_etl/` only for MyPy and Bandit?**
+**Why is local MyPy limited to `sbir_etl/`?**
 
 - Tests, scripts, and examples are not production code
-- These files often use different patterns and are lower priority
-- Focusing on production packages ensures production code quality
+- CI adds the production `sbir-graph` and `sbir-ml` roots
+- The narrower local hook keeps commit-time feedback fast; run the CI command
+  below before pushing changes to either additional package
+
+**Why does Bandit scan `sbir_etl/` and all of `packages/` only in CI?**
+
+- The security job provides one blocking, repository-controlled scan
+- Bandit's `pyproject.toml` configuration excludes tests
+- Avoiding a local hook keeps pre-commit focused on fast checks
 
 **Why production packages + `tests/` for Ruff?**
 
@@ -139,7 +147,7 @@ git commit --no-verify
 # This skips hooks, but CI will still check!
 ```
 
-### Understanding Hook Failures
+### Understanding Local and CI Failures
 
 When a hook fails, you'll see output like:
 
@@ -156,8 +164,8 @@ Some rule failed
 
 - **Ruff errors:** Run `ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests --fix` to auto-fix many issues
 - **MyPy errors:** Read the error message and add type hints or `# type: ignore` comments
-- **Bandit alerts:** Review and fix security issues, or add `# nosec` if false positive
-- **Detect-secrets alerts:** Review the secret, or add to `.secrets.baseline` if approved
+- **CI Bandit alerts:** Review and fix security issues, or add a justified `# nosec` for a false positive
+- **CI detect-secrets alerts:** Review the secret, or update `.secrets.baseline` if approved
 
 ---
 
@@ -174,20 +182,27 @@ This workflow runs on:
 
 1. **quality** ("Lint, Types, and Guards")
    - Runs: `ruff check`, `ruff format --check`, `mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml`, Dagster definition validation, the architecture/documentation/hygiene guards, compose-file validation, and actionlint.
-   - Purpose: Pull-request and push quality gate for checks that mirror the local Ruff/MyPy pre-commit hooks.
+   - Purpose: Pull-request and push quality gate. Ruff mirrors the local scope;
+     MyPy adds `sbir-graph` and `sbir-ml` to the local `sbir_etl` scope.
    - Time: ~5-10 minutes.
 
    There is no separate package-type-check job: all three type-checked roots are
    arguments to the single blocking MyPy step above. `sbir-analytics` is not yet
    type-checked in CI.
 
-2. **test**, **container-build-test**, **performance-check**, **e2e-docker**, and related CI jobs
+2. **security** ("Security Scan")
+   - Runs: `bandit -r sbir_etl packages -c pyproject.toml` and
+     `detect-secrets scan --baseline .secrets.baseline`.
+   - Purpose: Blocking security coverage that has no local pre-commit hook.
+
+3. **test**, **container-build-test**, **performance-check**, **e2e-docker**, and related CI jobs
    - Runs: unit/integration tests, container checks, performance regression checks, E2E Docker checks, and transition MVP checks as configured in `ci.yml`.
    - Purpose: Keeps PR/push feedback consolidated in the current CI workflow.
 
 ### Why Multiple Jobs?
 
 - **quality:** Ensures core local style checks pass in CI
+- **security:** Runs the blocking Bandit and detect-secrets scans
 - **Individual jobs:** Provide clear, separate visibility in GitHub checks for linting, typing, workflow validation, tests, containers, performance, and E2E coverage
 - **Parallelization:** Faster overall execution
 - **Debugging:** Easier to identify which check failed
@@ -198,23 +213,27 @@ This workflow runs on:
 
 ### When to Update Tool Versions
 
-Tool versions are pinned in:
+Local hook environments and CI select tool versions independently:
 
-- `.pre-commit-config.yaml` (local)
-- `.github/workflows/ci.yml` (CI)
-- `pyproject.toml` (tool configuration)
+- `.pre-commit-config.yaml` pins local hook repository revisions.
+- `uv.lock` pins the tools installed by CI's locked environment sync.
+- `pyproject.toml` constrains CI dependencies and holds shared tool settings.
+- detect-secrets is currently installed without a version pin in `ci.yml`.
 
 **Update process:**
 
-1. **Update all three locations together:**
+1. **Review each version source:**
 
    ```bash
-   # Don't update just one - keep them in sync!
-   # Update in:
-   # - .pre-commit-config.yaml (rev field)
-   # - .github/workflows/ci.yml (setup-python-uv action versions)
-   # - pyproject.toml (if tool config changes)
+   # Local hook revisions
+   pre-commit autoupdate
+
+   # CI dependency resolution, after editing pyproject.toml constraints
+   uv lock
    ```
+
+   Exact local/CI version alignment is preferred for Ruff and MyPy but is not
+   guaranteed by the current configuration, so verify both after an update.
 
 2. **Test locally:**
 
@@ -222,36 +241,36 @@ Tool versions are pinned in:
    pre-commit run --all-files
    ```
 
-3. **Commit the changes:**
+3. **Commit only the files that changed:**
 
    ```bash
-   git add .pre-commit-config.yaml .github/workflows/ci.yml pyproject.toml
+   git add .pre-commit-config.yaml pyproject.toml uv.lock
    git commit -m "chore: update pre-commit tools to [version]"
    ```
 
-4. **PR will verify CI consistency**
+4. **The PR will verify the CI-installed versions and behavior.**
 
 ### Current Tool Versions
 
-| Tool | Version | Source |
-|------|---------|--------|
-| Pre-commit hooks | v6.0.0 | `.pre-commit-config.yaml` |
-| Ruff | v0.14.4 | `.pre-commit-config.yaml` |
-| MyPy | v1.18.2 | `.pre-commit-config.yaml` |
-| Bandit | 1.8.6 | `.pre-commit-config.yaml` |
-| Detect-secrets | v1.5.0 | `.pre-commit-config.yaml` |
+| Tool | Local pre-commit | CI | Source |
+|------|------------------|----|--------|
+| Standard hooks | v6.0.0 | Not run | `.pre-commit-config.yaml` |
+| Ruff | v0.14.4 | 0.14.5 | `.pre-commit-config.yaml`; `uv.lock` |
+| MyPy | v1.18.2 | 1.18.2 | `.pre-commit-config.yaml`; `uv.lock` |
+| Bandit | No hook | 1.8.6 | `uv.lock` |
+| Detect-secrets | No hook | Not pinned | `uv pip install detect-secrets` in `ci.yml` |
 
 ### Configuration Locations
 
 | Item | Local | CI | Notes |
 |------|-------|----|----|
-| Tool versions | `.pre-commit-config.yaml` | `.pre-commit-config.yaml` | Identical |
 | Ruff scope | `.pre-commit-config.yaml` | `ci.yml` | Both: all production roots plus `tests` |
 | Ruff config | `pyproject.toml` | `pyproject.toml` | Identical |
 | MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `ci.yml` | Local: `sbir_etl`. CI: `sbir_etl` **plus** `sbir-graph` and `sbir-ml`, all in the `quality` job |
 | MyPy config | `pyproject.toml` | `pyproject.toml` | Identical |
-| Bandit scope | `.pre-commit-config.yaml` | not run in CI | Manual only since the security-scan job was retired |
-| Bandit config | `pyproject.toml` | `pyproject.toml` | Identical |
+| Bandit scope | No hook; manual command available | `ci.yml` | CI scans `sbir_etl/` and `packages/` in the `security` job |
+| Bandit config | `pyproject.toml` | `pyproject.toml` | Same when reproduced locally |
+| Detect-secrets scope | No hook; manual command available | `ci.yml` | CI scans the working tree against `.secrets.baseline` |
 
 ---
 
@@ -259,18 +278,21 @@ Tool versions are pinned in:
 
 ### "Pre-commit check failed locally but passed in CI"
 
-**This should not happen.** If it does:
+This can happen because standard file hooks are local-only and Ruff can modify
+files locally. If the same tool and file fail differently:
 
-1. Verify pre-commit version matches:
+1. Record the local runner and hook output:
 
    ```bash
    pre-commit --version
+   pre-commit run --all-files --verbose
    ```
 
-2. Update pre-commit hooks:
+2. Rebuild the pinned local hook environments if they are stale:
 
    ```bash
-   pre-commit autoupdate
+   pre-commit clean
+   pre-commit install-hooks
    pre-commit run --all-files
    ```
 
@@ -283,15 +305,14 @@ Tool versions are pinned in:
 **Check scope:**
 
 ```bash
-# Local pre-commit runs on packages/ sbir_etl/ and tests/
-# CI runs on packages/ sbir_etl/ and tests/
+# Local pre-commit and CI use the same four production roots plus tests/
 # Make sure you're checking the same files
 
-pre-commit run ruff --all-files  # Should match CI
+pre-commit run ruff --all-files  # Same file scope; see version table above
 
 # Or manually
-ruff check packages sbir_etl tests
-ruff format --check packages sbir_etl tests
+uv run python -m ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests
+uv run python -m ruff format --check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests
 ```
 
 ### "MyPy passes locally but fails in CI"
@@ -299,12 +320,12 @@ ruff format --check packages sbir_etl tests
 **Check scope:**
 
 ```bash
-# Local pre-commit runs on packages/ sbir_etl/ only
-# CI runs on packages/ sbir_etl/ only via: mypy packages sbir_etl
-
-# These should match
+# Local pre-commit checks sbir_etl/ only
 pre-commit run mypy --all-files
-uv run python -m mypy packages sbir_etl
+uv run python -m mypy sbir_etl
+
+# CI deliberately adds sbir-graph and sbir-ml
+uv run python -m mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml
 ```
 
 ### "Hook modified files I didn't touch"
@@ -321,17 +342,24 @@ Some hooks auto-fix issues:
 2. Re-add: `git add .`
 3. Re-commit: `git commit -m "..."`
 
-### "Detect-secrets keeps flagging a false positive"
+### "The CI detect-secrets scan flags a false positive"
 
 1. Review the suspected secret cautiously
-2. If approved, add to baseline:
+2. Install and rerun the scanner exactly as CI does:
+
+   ```bash
+   uv pip install detect-secrets
+   uv run detect-secrets scan --baseline .secrets.baseline
+   ```
+
+3. If the baseline change is approved, commit it:
 
    ```bash
    git add .secrets.baseline
    git commit -m "chore: add approved secret to detect-secrets baseline"
    ```
 
-3. New secrets will still be flagged
+4. New secrets will still be flagged
 
 ---
 
@@ -347,6 +375,8 @@ No, but it's strongly recommended. Pre-commit:
 - Ensures team consistency
 
 If you skip it: `git commit --no-verify`, but CI will still check.
+CI also runs broader MyPy and security checks, regardless of whether the local
+hooks are enabled.
 
 ### What if pre-commit is slow?
 
@@ -370,7 +400,7 @@ pre-commit run ruff
 ### How do I add a new pre-commit hook?
 
 1. Add to `.pre-commit-config.yaml`
-2. Add equivalent CI job to `.github/workflows/ci.yml`
+2. Decide whether CI should run the same tool and document any scope difference
 3. Update this documentation
 4. Test locally: `pre-commit run --all-files`
 5. Submit PR with changes to all three files
@@ -387,7 +417,9 @@ exclude = [
 ]
 ```
 
-**Reason:** These are not production code. Focusing on `packages/` and `sbir_etl/` ensures critical code is type-safe while allowing flexibility in test/example code.
+**Reason:** These are not production code. Local pre-commit focuses on
+`sbir_etl/`; CI also type-checks the `sbir-graph` and `sbir-ml` production
+packages while leaving tests, scripts, and examples out of scope.
 
 If you need type checking for a specific file, add:
 

--- a/docs/ml/cet-classifier.md
+++ b/docs/ml/cet-classifier.md
@@ -65,7 +65,7 @@ This module avoids heavy NLP dependencies and only uses Python and `re`.
 - `PatentCETClassifier(pipelines: Dict[cet_id, pipeline])`
   - `classify(title, assignee=None, top_k=3) -> List[PatentClassification]`
   - `classify_batch(titles, assignees=None, batch_size=1000, top_k=3) -> List[List[PatentClassification]]`
-  - `train_from_dataframe(df, ... use_feature_extraction=True, feature_matrix_builder=None, ...)`
+  - `train_from_dataframe(df, ... feature_matrix_builder=None, ...)`
   - `save(path)`, `load(path)`, `get_metadata()`
 - `PatentFeatureExtractor(keywords_map=None, stopwords=None)`
   - `features_for_dataframe(df, title_col="title", assignee_col=None) -> (texts, feature_vectors)`
@@ -182,7 +182,8 @@ Store evaluation metrics in your artifact metadata by merging them into `config`
 
 ## Practical Tips
 
-- Start simple: use `use_feature_extraction=True` to feed normalized text to text-based pipelines (or `DummyPipeline` for CI).
+- Start simple: `train_from_dataframe` always feeds normalized extractor text to
+  text-based pipelines (or `DummyPipeline` for CI); no flag selects this.
 - To use numeric features, supply a caller-owned builder with `fit_transform`
   and, optionally, `get_feature_names`, then pass it to `train_from_dataframe`
   as `feature_matrix_builder`.

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/classifications.py
@@ -195,12 +195,7 @@ def enriched_cet_award_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        try:
-            save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            out_json = output_path.with_suffix(".json")
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
+        output_path = save_dataframe_parquet(df_empty, output_path)
         checks = {"ok": False, "reason": "taxonomy_load_failed", "num_awards": 0}
         checks_path.parent.mkdir(parents=True, exist_ok=True)
         with open(checks_path, "w", encoding="utf-8") as fh:
@@ -293,14 +288,7 @@ def enriched_cet_award_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        # Use existing save helper for parquet/NDJSON fallback
-        try:
-            save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            # If save failed, attempt NDJSON write
-            out_json = output_path.with_suffix(".json")
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
+        output_path = save_dataframe_parquet(df_empty, output_path)
 
         checks = {
             "ok": False,
@@ -340,7 +328,7 @@ def enriched_cet_award_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        save_dataframe_parquet(df_empty, output_path)
+        output_path = save_dataframe_parquet(df_empty, output_path)
         checks = {"ok": False, "reason": "model_load_failed", "num_awards": len(awards)}
         checks_path.parent.mkdir(parents=True, exist_ok=True)
         with open(checks_path, "w", encoding="utf-8") as fh:
@@ -384,12 +372,7 @@ def enriched_cet_award_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        try:
-            save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            out_json = output_path.with_suffix(".json")
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
+        output_path = save_dataframe_parquet(df_empty, output_path)
         checks = {"ok": False, "reason": "no_awards_to_classify", "num_awards": len(awards)}
         checks_path.parent.mkdir(parents=True, exist_ok=True)
         with open(checks_path, "w", encoding="utf-8") as fh:
@@ -424,12 +407,7 @@ def enriched_cet_award_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        try:
-            save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            out_json = output_path.with_suffix(".json")
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
+        output_path = save_dataframe_parquet(df_empty, output_path)
         checks = {"ok": False, "reason": "classification_failed", "num_awards": len(awards)}
         checks_path.parent.mkdir(parents=True, exist_ok=True)
         with open(checks_path, "w", encoding="utf-8") as fh:
@@ -519,22 +497,8 @@ def enriched_cet_award_classifications() -> Output:
 
     df_out = pd.DataFrame(rows)
 
-    # Persist classifications (parquet preferred, NDJSON fallback)
-    try:
-        save_dataframe_parquet(df_out, output_path)
-    except Exception:
-        # Fallback: write NDJSON manually
-        json_out = output_path.with_suffix(".json")
-        json_out.parent.mkdir(parents=True, exist_ok=True)
-        with open(json_out, "w", encoding="utf-8") as fh:
-            for rec in rows:
-                fh.write(json.dumps(rec) + "\n")
-        # Touch parquet placeholder for consumers that assert its existence
-        try:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.touch()
-        except Exception:
-            logger.exception("Failed to touch parquet placeholder file for classifications")
+    # Persist classifications (parquet preferred, NDJSON fallback).
+    output_path = save_dataframe_parquet(df_out, output_path)
 
     # Build checks: coverage, high-confidence rate, evidence coverage
     num_awards = len(rows)
@@ -786,14 +750,7 @@ def enriched_cet_patent_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        # Use existing save helper for parquet/NDJSON fallback
-        try:
-            save_dataframe_parquet(df_empty, output_path)
-        except Exception:
-            # If save failed, attempt NDJSON write
-            out_json = output_path.with_suffix(".json")
-            with open(out_json, "w", encoding="utf-8") as fh:
-                fh.write("")
+        output_path = save_dataframe_parquet(df_empty, output_path)
 
         checks = {
             "ok": False,
@@ -832,7 +789,7 @@ def enriched_cet_patent_classifications() -> Output:
                 "taxonomy_version",
             ]
         )
-        save_dataframe_parquet(df_empty, output_path)
+        output_path = save_dataframe_parquet(df_empty, output_path)
         checks = {"ok": False, "reason": "model_load_failed", "num_patents": len(patents)}
         checks_path.parent.mkdir(parents=True, exist_ok=True)
         with open(checks_path, "w", encoding="utf-8") as fh:
@@ -933,22 +890,8 @@ def enriched_cet_patent_classifications() -> Output:
 
     df_out = pd.DataFrame(rows)
 
-    # Persist classifications (parquet preferred, NDJSON fallback)
-    try:
-        save_dataframe_parquet(df_out, output_path)
-    except Exception:
-        # Fallback: write NDJSON manually
-        json_out = output_path.with_suffix(".json")
-        json_out.parent.mkdir(parents=True, exist_ok=True)
-        with open(json_out, "w", encoding="utf-8") as fh:
-            for rec in rows:
-                fh.write(json.dumps(rec) + "\n")
-        # Touch parquet placeholder for consumers that assert its existence
-        try:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.touch()
-        except Exception:
-            logger.exception("Failed to touch parquet placeholder file for patent classifications")
+    # Persist classifications (parquet preferred, NDJSON fallback).
+    output_path = save_dataframe_parquet(df_out, output_path)
 
     # Build checks: coverage and counts
     num_patents = len(rows)

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
@@ -141,13 +141,7 @@ def transformed_cet_company_profiles() -> Output:
                     "cet_trend",
                 ]
             )
-            try:
-                save_dataframe_parquet(df_empty, output_path)
-            except Exception:
-                out_json = output_path.with_suffix(".json")
-                out_json.parent.mkdir(parents=True, exist_ok=True)
-                with open(out_json, "w", encoding="utf-8") as fh:
-                    fh.write("")
+            output_path = save_dataframe_parquet(df_empty, output_path)
         checks = {
             "ok": False,
             "reason": "missing_dependency",
@@ -292,22 +286,8 @@ def transformed_cet_company_profiles() -> Output:
             ]
         )
 
-    # Persist company profiles (parquet preferred, NDJSON fallback)
-    try:
-        save_dataframe_parquet(df_comp, output_path)
-    except Exception:
-        # Fallback: write NDJSON manually
-        json_out = output_path.with_suffix(".json")
-        json_out.parent.mkdir(parents=True, exist_ok=True)
-        with open(json_out, "w", encoding="utf-8") as fh:
-            for rec in df_comp.to_dict(orient="records"):
-                fh.write(json.dumps(rec) + "\n")
-        # Touch parquet placeholder for consumers that assert its existence
-        try:
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.touch()
-        except Exception:
-            logger.exception("Failed to touch parquet placeholder file for company profiles")
+    # Persist company profiles (parquet preferred, NDJSON fallback).
+    output_path = save_dataframe_parquet(df_comp, output_path)
 
     # Build checks
     num_companies = len(df_comp)

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/company.py
@@ -386,7 +386,7 @@ def _get_neo4j_client():
     try:
         config = Neo4jConfig(
             uri=DEFAULT_NEO4J_URI,
-            user=DEFAULT_NEO4J_USER,
+            username=DEFAULT_NEO4J_USER,
             password=DEFAULT_NEO4J_PASSWORD,
             database=DEFAULT_NEO4J_DATABASE,
         )

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/taxonomy.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/taxonomy.py
@@ -163,7 +163,7 @@ def raw_cet_taxonomy() -> Output:
 
     # Persist DataFrame to parquet
     output_path = DEFAULT_OUTPUT_PATH
-    save_dataframe_parquet(df, output_path)
+    output_path = save_dataframe_parquet(df, output_path)
 
     # Run completeness checks via the loader helper (non-fatal)
     completeness = {}

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
@@ -122,7 +122,6 @@ def train_cet_patent_classifier() -> Output:
             title_col="title",
             assignee_col="assignee" if "assignee" in df.columns else None,
             cet_label_col="cet_labels",
-            use_feature_extraction=True,
             keywords_map={k: list(v) for k, v in get_keywords_map().items()}
             if get_keywords_map()
             else None,  # type: ignore[arg-type]

--- a/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/cet/training.py
@@ -207,18 +207,14 @@ def cet_award_training_dataset() -> Output:
                     "taxonomy_version",
                 ]
             )
-            save_dataframe_parquet(df_empty, output_path)
+            output_path = save_dataframe_parquet(df_empty, output_path)
         except Exception:
-            # Ensure a placeholder parquet file exists and write empty NDJSON
+            # Pandas itself may be unavailable; keep the empty artifact readable.
             out_json = output_path.with_suffix(".ndjson")
             out_json.parent.mkdir(parents=True, exist_ok=True)
             with open(out_json, "w", encoding="utf-8") as fh:
                 fh.write("")
-            try:
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                output_path.touch()
-            except Exception:
-                pass
+            output_path = out_json
 
         checks = {
             "ok": False,
@@ -278,17 +274,13 @@ def cet_award_training_dataset() -> Output:
                     "taxonomy_version",
                 ]
             )
-            save_dataframe_parquet(df_empty, output_path)
+            output_path = save_dataframe_parquet(df_empty, output_path)
         except Exception:
             out_json = output_path.with_suffix(".ndjson")
             out_json.parent.mkdir(parents=True, exist_ok=True)
             with open(out_json, "w", encoding="utf-8") as fh:
                 fh.write("")
-            try:
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                output_path.touch()
-            except Exception:
-                pass
+            output_path = out_json
 
         checks = {
             "ok": False,
@@ -333,17 +325,13 @@ def cet_award_training_dataset() -> Output:
                 }
             )
         df = pd.DataFrame(rows)
-        save_dataframe_parquet(df, output_path)
+        output_path = save_dataframe_parquet(df, output_path)
     except Exception:
         # Fallback to NDJSON using helper
         try:
             out_json = output_path.with_suffix(".ndjson")
             save_dataset_ndjson(dataset, out_json)
-            try:
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                output_path.touch()
-            except Exception:
-                pass
+            output_path = out_json
         except Exception:
             # As a last resort, write minimal NDJSON manually
             out_json = output_path.with_suffix(".ndjson")
@@ -360,11 +348,7 @@ def cet_award_training_dataset() -> Output:
                         )
                         + "\n"
                     )
-            try:
-                output_path.parent.mkdir(parents=True, exist_ok=True)
-                output_path.touch()
-            except Exception:
-                pass
+            output_path = out_json
 
     # Build checks JSON
     checks = {

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/detections.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/detections.py
@@ -59,7 +59,7 @@ def transformed_transition_detections(
     )
 
     # Persist detections table
-    save_dataframe_parquet(df, out_path)
+    out_path = save_dataframe_parquet(df, out_path)
 
     # Log and return with metadata
     metrics = {

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/evidence.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/evidence.py
@@ -88,12 +88,17 @@ def transformed_transition_evidence(
             if float(row.get("score") or 0.0) >= float(threshold):
                 count_above += 1
 
+    transitions_path = Path("data/processed/transitions.parquet")
+    transitions_fallback = transitions_path.with_suffix(".ndjson")
+    if not transitions_path.exists() and transitions_fallback.exists():
+        transitions_path = transitions_fallback
+
     # Emit a lightweight validation summary for the MVP
     try:
         summary = {
             "generated_at": now_utc_iso(),
             "artifacts": {
-                "transitions": "data/processed/transitions.parquet",
+                "transitions": str(transitions_path),
                 "evidence": str(out_path),
                 "evidence_checks": str(out_path.with_suffix(".checks.json")),
                 "vendor_resolution_checks": "data/processed/vendor_resolution.checks.json",

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/ot_tiering.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/ot_tiering.py
@@ -134,7 +134,7 @@ def ot_consortium_verification_tiers(
     # Evidence is a list-of-dicts; serialize for a stable parquet schema.
     if not df.empty and "evidence" in df.columns:
         df["evidence"] = df["evidence"].apply(json.dumps)
-    save_dataframe_parquet(df, out_path)
+    out_path = save_dataframe_parquet(df, out_path)
 
     by_tier = df["tier"].value_counts(dropna=False).to_dict() if not df.empty else {}
     unverifiable = (

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/scoring.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/scoring.py
@@ -233,7 +233,7 @@ def transformed_transition_scores(
         df_out = df_out.sort_values(
             by=["award_id", "score", "contract_id"], ascending=[True, False, True]
         ).reset_index(drop=True)
-    save_dataframe_parquet(df_out, out_path)
+    out_path = save_dataframe_parquet(df_out, out_path)
 
     checks = {
         "ok": True,

--- a/packages/sbir-analytics/sbir_analytics/assets/transition/vendor_resolution.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition/vendor_resolution.py
@@ -95,7 +95,7 @@ def enriched_vendor_resolution(
             )
 
     df_out = pd.DataFrame(rows)
-    save_dataframe_parquet(df_out, out_path)
+    out_path = save_dataframe_parquet(df_out, out_path)
 
     # Checks
     total_contracts = len(df_out)

--- a/packages/sbir-ml/sbir_ml/ml/models/patent_classifier.py
+++ b/packages/sbir-ml/sbir_ml/ml/models/patent_classifier.py
@@ -216,7 +216,6 @@ class PatentCETClassifier:
         assignee_col: str | None = None,
         cet_label_col: str = "cet_labels",
         pipelines_factory: Any | None = None,
-        use_feature_extraction: bool = False,
         keywords_map: dict[str, list[str]] | None = None,
         feature_matrix_builder: Any | None = None,
     ) -> None:
@@ -258,6 +257,8 @@ class PatentCETClassifier:
         # Use PatentFeatureExtractor to derive training texts and feature vectors.
         # The pipelines consume text; the extractor normalizes titles and adds simple
         # assignee/keyword signals to the text so pipelines receive consistent inputs.
+        # Extraction is unconditional here. `build_training_inputs` in
+        # ml.train.patent_training is the helper that can fall back to raw titles.
         extractor = PatentFeatureExtractor(keywords_map=keywords_map)
         texts, feature_vectors = extractor.features_for_dataframe(
             df, title_col=title_col, assignee_col=assignee_col

--- a/packages/sbir-ml/sbir_ml/ml/train/patent_training.py
+++ b/packages/sbir-ml/sbir_ml/ml/train/patent_training.py
@@ -134,7 +134,6 @@ def train_patent_classifier(
     title_col: str = "title",
     assignee_col: str | None = None,
     cet_label_col: str = "cet_labels",
-    use_feature_extraction: bool = True,
     keywords_map: dict[str, list[str]] | None = None,
     taxonomy_version: str | None = None,
     model_version: str | None = None,
@@ -156,9 +155,6 @@ def train_patent_classifier(
         Optional column for assignee/owner, used for small additional signal in text.
     cet_label_col : str
         Column name for label sets per row (iterable[str] or delimited string).
-    use_feature_extraction : bool
-        Whether to leverage the lightweight feature extractor to produce normalized
-        texts for training.
     keywords_map : Optional[Dict[str, List[str]]]
         Optional keyword map passed through to feature extraction; used when your
         extractor relies on custom keywords (safe to leave None).
@@ -212,7 +208,6 @@ def train_patent_classifier(
         assignee_col=assignee_col,
         cet_label_col=cet_label_col,
         pipelines_factory=pipelines_factory,
-        use_feature_extraction=use_feature_extraction,
         keywords_map=keywords_map,
     )
 
@@ -320,7 +315,6 @@ def train_and_evaluate(
     title_col: str = "title",
     assignee_col: str | None = None,
     cet_label_col: str = "cet_labels",
-    use_feature_extraction: bool = True,
     keywords_map: dict[str, list[str]] | None = None,
     taxonomy_version: str | None = None,
     model_version: str | None = None,
@@ -339,7 +333,6 @@ def train_and_evaluate(
         title_col=title_col,
         assignee_col=assignee_col,
         cet_label_col=cet_label_col,
-        use_feature_extraction=use_feature_extraction,
         keywords_map=keywords_map,
         taxonomy_version=taxonomy_version,
         model_version=model_version,

--- a/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
+++ b/packages/sbir-ml/sbir_ml/transition/features/vendor_crosswalk.py
@@ -475,7 +475,7 @@ class VendorCrosswalk:
         path = Path(path)
         from sbir_etl.utils.data.file_io import save_dataframe_parquet
 
-        save_dataframe_parquet(df, path, index=False)
+        save_dataframe_parquet(df, path, index=False, fallback_to_ndjson=False)
         logger.info("VendorCrosswalk saved to parquet: %s", path)
 
     def save_jsonl(self, path: str | Path) -> None:

--- a/sbir_etl/enrichers/naics/core.py
+++ b/sbir_etl/enrichers/naics/core.py
@@ -178,7 +178,7 @@ class NAICSEnricher:
             df = pd.DataFrame(columns=["key_type", "key", "naics_candidates"])
         from sbir_etl.utils.data.file_io import save_dataframe_parquet
 
-        save_dataframe_parquet(df, cache, index=False)
+        save_dataframe_parquet(df, cache, index=False, fallback_to_ndjson=False)
         logger.info("Persisted NAICS index to %s (rows=%d)", cache, len(df))
 
     def _process_line(self, line: str) -> None:

--- a/sbir_etl/reporting/procurement_transition/cet_vocabulary.py
+++ b/sbir_etl/reporting/procurement_transition/cet_vocabulary.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -11,6 +12,8 @@ from sbir_etl.exceptions import ConfigurationError
 from sbir_etl.utils.procurement_text import find_lineage_phrases
 
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_TAXONOMY_PATH = Path("config/cet/taxonomy.yaml")
 
 
@@ -18,8 +21,11 @@ DEFAULT_TAXONOMY_PATH = Path("config/cet/taxonomy.yaml")
 def load_cet_vocabulary(path: str | None = None) -> dict[str, tuple[str, ...]]:
     """Map lowercased CET-area display name → keyword phrases.
 
-    Returns an empty mapping when the taxonomy file is missing or unreadable —
-    the packet degrades to no CET fact rather than failing.
+    Returns an empty mapping when the taxonomy file is missing, unreadable, or
+    not a mapping — the packet degrades to no CET fact rather than failing. The
+    degradation is logged, because a structurally invalid taxonomy is an
+    authoring error rather than an expected absence, and this result is cached
+    for the process lifetime.
     """
 
     taxonomy_path = Path(path) if path is not None else DEFAULT_TAXONOMY_PATH
@@ -29,7 +35,12 @@ def load_cet_vocabulary(path: str | None = None) -> dict[str, tuple[str, ...]]:
             description="CET taxonomy",
             allow_empty=True,
         )
-    except ConfigurationError:
+    except ConfigurationError as error:
+        logger.warning(
+            "CET taxonomy at %s is unusable, degrading to no CET fact: %s",
+            taxonomy_path,
+            error,
+        )
         return {}
     vocabulary: dict[str, tuple[str, ...]] = {}
     for area in data.get("cet_areas", []):

--- a/sbir_etl/transformers/bea_io_adapter.py
+++ b/sbir_etl/transformers/bea_io_adapter.py
@@ -153,7 +153,12 @@ class BEAIOAdapter:
         try:
             from sbir_etl.utils.data.file_io import save_dataframe_parquet
 
-            save_dataframe_parquet(result_df, cache_file, index=False)
+            save_dataframe_parquet(
+                result_df,
+                cache_file,
+                index=False,
+                fallback_to_ndjson=False,
+            )
             logger.debug(f"Cached results to {cache_file}")
         except Exception as e:
             logger.warning(f"Failed to save cache file {cache_file}: {e}")

--- a/sbir_etl/utils/cache/api_cache.py
+++ b/sbir_etl/utils/cache/api_cache.py
@@ -193,7 +193,12 @@ class APICache:
 
             from sbir_etl.utils.data.file_io import save_dataframe_parquet
 
-            save_dataframe_parquet(df, cache_path, index=False)
+            save_dataframe_parquet(
+                df,
+                cache_path,
+                index=False,
+                fallback_to_ndjson=False,
+            )
 
             metadata_dict = {
                 "cached_at": datetime.now().isoformat(),

--- a/sbir_etl/utils/data/file_io.py
+++ b/sbir_etl/utils/data/file_io.py
@@ -81,11 +81,16 @@ def save_dataframe_parquet(
     index: bool = False,
     fallback_to_ndjson: bool = True,
     **kwargs: Any,
-) -> None:
+) -> Path:
     """Save DataFrame to Parquet format with NDJSON fallback.
 
     Attempts to save as Parquet first. If that fails and fallback_to_ndjson is True,
     falls back to NDJSON format in the same directory with .ndjson suffix.
+
+    The fallback is handled here rather than raised, so a caller that assumes the
+    data landed at ``path`` is wrong whenever it fires — the Parquet file is
+    deleted and the rows are at the ``.ndjson`` sibling. Use the returned path
+    rather than the one passed in.
 
     Args:
         df: DataFrame to save
@@ -93,13 +98,17 @@ def save_dataframe_parquet(
         index: Whether to include DataFrame index in output
         fallback_to_ndjson: If True, fall back to NDJSON if Parquet save fails
         **kwargs: Additional arguments passed to pandas.DataFrame.to_parquet()
+
+    Returns:
+        The path actually written: ``path`` on success, or the ``.ndjson``
+        sibling when the Parquet write failed and the fallback was taken.
     """
     _ensure_parent_dir(path)
 
     try:
         df.to_parquet(path, index=index, **kwargs)
         logger.debug(f"Saved DataFrame to Parquet: {path}")
-        return
+        return path
     except Exception as e:
         if not fallback_to_ndjson:
             logger.error(f"Failed to save Parquet and fallback disabled: {e}")
@@ -125,6 +134,7 @@ def save_dataframe_parquet(
                 pass
 
         logger.info(f"Saved DataFrame to NDJSON fallback: {ndjson_path}")
+        return ndjson_path
 
 
 def write_json_atomic(

--- a/scripts/ci/check_config_boundaries.py
+++ b/scripts/ci/check_config_boundaries.py
@@ -17,6 +17,21 @@ CANONICAL_YAML_READERS = frozenset(
     }
 )
 IGNORED_PREFIXES = ("scripts/archive/", "tests/")
+# Every PyYAML entry point that parses a document. Matching only ``safe_load``
+# would let the pre-``safe_load`` idiom ``yaml.load(f, Loader=yaml.SafeLoader)``
+# through, which is the form most likely to be written from habit.
+PYYAML_READERS = frozenset(
+    {
+        "safe_load",
+        "safe_load_all",
+        "load",
+        "load_all",
+        "full_load",
+        "full_load_all",
+        "unsafe_load",
+        "unsafe_load_all",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -25,20 +40,21 @@ class ConfigBoundaryViolation:
 
     path: str
     line_number: int
+    function_name: str
 
     def format(self) -> str:
         return (
-            f"{self.path}:{self.line_number}: direct yaml.safe_load bypasses the "
+            f"{self.path}:{self.line_number}: direct yaml.{self.function_name} bypasses the "
             "configuration primitive; use sbir_etl.config.yaml_io.read_yaml_mapping "
             "or sbir_etl.config.get_config"
         )
 
 
-def _safe_load_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
-    """Return aliases for the yaml module and directly imported safe_load function."""
+def _reader_aliases(tree: ast.AST) -> tuple[set[str], dict[str, str]]:
+    """Return yaml module aliases and directly imported reader aliases by local name."""
 
     module_aliases: set[str] = set()
-    function_aliases: set[str] = set()
+    function_aliases: dict[str, str] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
@@ -46,49 +62,55 @@ def _safe_load_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
                     module_aliases.add(alias.asname or alias.name)
         elif isinstance(node, ast.ImportFrom) and node.module == "yaml":
             for alias in node.names:
-                if alias.name == "safe_load":
-                    function_aliases.add(alias.asname or alias.name)
+                if alias.name in PYYAML_READERS:
+                    function_aliases[alias.asname or alias.name] = alias.name
     return module_aliases, function_aliases
 
 
-def _is_safe_load_call(
+def _read_function_name(
     node: ast.Call,
     *,
     module_aliases: set[str],
-    function_aliases: set[str],
-) -> bool:
+    function_aliases: dict[str, str],
+) -> str | None:
+    """Return the PyYAML reader this call invokes, or None when it is not one."""
+
     function = node.func
     if isinstance(function, ast.Name):
-        return function.id in function_aliases
-    return (
+        return function_aliases.get(function.id)
+    if (
         isinstance(function, ast.Attribute)
-        and function.attr == "safe_load"
+        and function.attr in PYYAML_READERS
         and isinstance(function.value, ast.Name)
         and function.value.id in module_aliases
-    )
+    ):
+        return function.attr
+    return None
 
 
 def scan_file(
     path: Path, *, repository_root: Path = REPOSITORY_ROOT
 ) -> list[ConfigBoundaryViolation]:
-    """Find direct ``yaml.safe_load`` calls in one production Python file."""
+    """Find direct PyYAML document reads in one production Python file."""
 
     relative = path.resolve().relative_to(repository_root.resolve()).as_posix()
     if relative in CANONICAL_YAML_READERS or relative.startswith(IGNORED_PREFIXES):
         return []
 
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    module_aliases, function_aliases = _safe_load_aliases(tree)
-    return [
-        ConfigBoundaryViolation(relative, node.lineno)
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and _is_safe_load_call(
+    module_aliases, function_aliases = _reader_aliases(tree)
+    violations: list[ConfigBoundaryViolation] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function_name = _read_function_name(
             node,
             module_aliases=module_aliases,
             function_aliases=function_aliases,
         )
-    ]
+        if function_name is not None:
+            violations.append(ConfigBoundaryViolation(relative, node.lineno, function_name))
+    return violations
 
 
 def tracked_python_files(*, repository_root: Path = REPOSITORY_ROOT) -> list[Path]:

--- a/tests/slow/ml/test_patent_feature_integration.py
+++ b/tests/slow/ml/test_patent_feature_integration.py
@@ -91,7 +91,7 @@ def test_train_classifier_with_feature_extraction_and_dummy_pipelines(tmp_path):
     # Classifier starts with no pipelines; we'll provide a pipelines_factory
     classifier = PatentCETClassifier(pipelines={})
 
-    # Train using feature extraction (use_feature_extraction=True)
+    # train_from_dataframe always runs PatentFeatureExtractor
     pipelines_factory = make_pipelines_factory()
     classifier.train_from_dataframe(
         df,
@@ -99,7 +99,6 @@ def test_train_classifier_with_feature_extraction_and_dummy_pipelines(tmp_path):
         assignee_col="assignee",
         cet_label_col="cet_labels",
         pipelines_factory=pipelines_factory,
-        use_feature_extraction=True,
     )
 
     # After training, classifier should be marked trained and pipelines should be present

--- a/tests/unit/assets/cet/test_classifications.py
+++ b/tests/unit/assets/cet/test_classifications.py
@@ -564,12 +564,12 @@ class TestEdgeCases:
     @patch("sbir_analytics.assets.cet.classifications.Path")
     @patch("sbir_analytics.assets.cet.classifications.save_dataframe_parquet")
     @patch("builtins.open", new_callable=mock_open)
-    def test_award_classifications_save_failure(
+    def test_award_classifications_save_failure_propagates(
         self, mock_file, mock_save, mock_path_class, mock_taxonomy_loader
     ):
-        """Test asset handles save failure gracefully."""
+        """A helper failure means neither Parquet nor NDJSON could be written."""
         mock_taxonomy_loader.side_effect = Exception("Load failed")
-        mock_save.side_effect = Exception("Save failed")
+        mock_save.side_effect = OSError("Save failed")
 
         # Mock Path behaviors
         mock_path = Mock()
@@ -585,8 +585,8 @@ class TestEdgeCases:
         )
         mock_path_class.return_value = mock_path
 
-        # Should not raise, just log error
-        enriched_cet_award_classifications()
+        with pytest.raises(OSError, match="Save failed"):
+            enriched_cet_award_classifications()
 
     def test_quality_check_file_permission_error(self, tmp_path):
         """Test quality check handles file permission errors."""

--- a/tests/unit/assets/cet/test_company_neo4j_client.py
+++ b/tests/unit/assets/cet/test_company_neo4j_client.py
@@ -1,0 +1,73 @@
+"""Contract test for the CET Neo4j connection factory.
+
+Every other test of the CET load assets patches ``_get_neo4j_client`` away, so
+nothing exercised the real factory and a keyword mismatch against
+``Neo4jConfig`` stayed green in CI while making all five CET load assets
+unrunnable. This test calls the real factory.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from sbir_analytics.assets.cet.company import _get_neo4j_client
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def test_neo4j_client_factory_builds_a_valid_config():
+    """The factory must construct a ``Neo4jConfig`` that validates.
+
+    ``Neo4jConfig`` requires ``username``; passing ``user`` raised a pydantic
+    ``ValidationError`` before any network call, so the factory failed 100% of
+    the time regardless of whether Neo4j was reachable.
+    """
+
+    captured = {}
+
+    class _FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def run(self, *args, **kwargs):
+            return None
+
+    class _FakeClient:
+        def __init__(self, config):
+            captured["config"] = config
+
+        def session(self):
+            return _FakeSession()
+
+    with patch("sbir_analytics.assets.cet.company.Neo4jClient", _FakeClient):
+        client = _get_neo4j_client()
+
+    assert client is not None
+    config = captured["config"]
+    assert config.username, "Neo4jConfig.username must be populated by the factory"
+    assert config.uri
+    assert config.database
+
+
+def test_neo4j_client_factory_failure_is_a_connection_error_not_a_config_error():
+    """A failure here must come from connecting, never from building the config.
+
+    Pins the distinction the original bug erased: with the config malformed,
+    the factory raised before attempting any connection, so an operator saw a
+    validation error where they expected a connectivity one.
+    """
+
+    class _ExplodingClient:
+        def __init__(self, config):
+            raise ConnectionError("simulated connection refused")
+
+    with patch("sbir_analytics.assets.cet.company.Neo4jClient", _ExplodingClient):
+        with pytest.raises(RuntimeError, match="Neo4j connection failed") as excinfo:
+            _get_neo4j_client()
+
+    assert "simulated connection refused" in str(excinfo.value)
+    assert "validation error" not in str(excinfo.value).lower()

--- a/tests/unit/ml/test_pipeline_smoke.py
+++ b/tests/unit/ml/test_pipeline_smoke.py
@@ -104,7 +104,6 @@ def test_patent_classifier_smoke():
         assignee_col="assignee",
         cet_label_col="cet_labels",
         pipelines_factory=factory,
-        use_feature_extraction=False,
     )
 
     results = classifier.classify(

--- a/tests/unit/reporting/test_cet_vocabulary.py
+++ b/tests/unit/reporting/test_cet_vocabulary.py
@@ -1,5 +1,6 @@
 """Tests for CET-area agreement facts."""
 
+import logging
 from pathlib import Path
 
 from sbir_etl.reporting.procurement_transition.cet_vocabulary import (
@@ -56,3 +57,20 @@ def test_missing_taxonomy_degrades_to_empty():
         )
         is None
     )
+
+
+def test_structurally_invalid_taxonomy_degrades_and_warns(tmp_path, caplog):
+    """A non-mapping taxonomy is an authoring error, so it must not degrade silently.
+
+    The result is cached for the process lifetime, so a caller who misses the
+    warning gets no CET fact for the rest of the run with nothing to explain it.
+    """
+
+    taxonomy = tmp_path / "taxonomy.yaml"
+    taxonomy.write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING):
+        assert load_cet_vocabulary(str(taxonomy)) == {}
+
+    assert "degrading to no CET fact" in caplog.text
+    assert str(taxonomy) in caplog.text

--- a/tests/unit/scripts/test_config_boundaries.py
+++ b/tests/unit/scripts/test_config_boundaries.py
@@ -33,6 +33,29 @@ def test_direct_safe_load_import_is_rejected(tmp_path: Path) -> None:
     assert len(boundaries.scan_file(path, repository_root=tmp_path)) == 1
 
 
+def test_non_safe_load_readers_are_rejected(tmp_path: Path) -> None:
+    """``yaml.load(..., Loader=...)`` and friends bypass the primitive just as much.
+
+    Matching only ``safe_load`` left the pre-``safe_load`` idiom green, which is
+    the spelling most likely to be reached for from habit.
+    """
+
+    for source, expected in (
+        ("import yaml\npayload = yaml.load('k: v', Loader=yaml.SafeLoader)\n", "load"),
+        ("import yaml\npayload = yaml.full_load('k: v')\n", "full_load"),
+        ("import yaml\npayload = yaml.unsafe_load('k: v')\n", "unsafe_load"),
+        ("import yaml\npayload = list(yaml.safe_load_all('k: v'))\n", "safe_load_all"),
+        ("from yaml import load\npayload = load('k: v')\n", "load"),
+    ):
+        path = _write(tmp_path, "sbir_etl/example.py", source)
+
+        violations = boundaries.scan_file(path, repository_root=tmp_path)
+
+        assert len(violations) == 1, source
+        assert violations[0].function_name == expected
+        assert f"yaml.{expected}" in violations[0].format()
+
+
 def test_shared_reader_and_yaml_writes_are_allowed(tmp_path: Path) -> None:
     path = _write(
         tmp_path,

--- a/tests/unit/transition/test_transition_assets_unit.py
+++ b/tests/unit/transition/test_transition_assets_unit.py
@@ -220,6 +220,11 @@ def test_transition_scores_and_evidence(monkeypatch, tmp_path):
     # Run all outputs into a temp working directory
     monkeypatch.chdir(tmp_path)
 
+    def unavailable_parquet_engine(*args, **kwargs):
+        raise ImportError("Parquet engine unavailable")
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", unavailable_parquet_engine)
+
     from sbir_analytics.assets.transition import (
         transformed_transition_evidence,
         transformed_transition_scores,
@@ -283,7 +288,7 @@ def test_transition_scores_and_evidence(monkeypatch, tmp_path):
         validated_contracts_sample=contracts_df,
         enriched_sbir_awards=awards_df,
     )
-    scores_df, _ = _unwrap_output(scores_out)
+    scores_df, scores_metadata = _unwrap_output(scores_out)
 
     # Expect 2 candidates (A1↔C1 via UEI, A2↔C2 via fuzzy)
     assert isinstance(scores_df, pd.DataFrame)
@@ -291,6 +296,13 @@ def test_transition_scores_and_evidence(monkeypatch, tmp_path):
         set(scores_df.columns)
     )
     assert len(scores_df) == 2
+
+    scores_path_value = scores_metadata["output_path"]
+    if hasattr(scores_path_value, "text"):
+        scores_path_value = scores_path_value.text
+    scores_path = Path(scores_path_value)
+    assert scores_path == Path("data/processed/transitions.ndjson")
+    assert scores_path.exists()
 
     s1 = scores_df.loc[(scores_df["award_id"] == "A1") & (scores_df["contract_id"] == "C1")].iloc[0]
     assert s1["method"] == "uei"
@@ -319,6 +331,11 @@ def test_transition_scores_and_evidence(monkeypatch, tmp_path):
     entry = json.loads(lines[0])
     for key in ["award_id", "contract_id", "score", "method", "matched_keys", "contract_snapshot"]:
         assert key in entry
+
+    manifest = json.loads(
+        Path("reports/validation/transition_mvp.json").read_text(encoding="utf-8")
+    )
+    assert manifest["artifacts"]["transitions"] == str(scores_path)
 
 
 def test_transition_detections_pipeline_generates_transition(monkeypatch, tmp_path):
@@ -469,3 +486,32 @@ def test_transition_detections_returns_empty_without_candidates(monkeypatch, tmp
     if hasattr(rows_value, "value"):
         rows_value = rows_value.value
     assert rows_value == 0
+
+
+def test_transition_detections_reports_ndjson_fallback_path(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    config_path = _write_detection_config(tmp_path)
+    monkeypatch.setenv("SBIR_ETL__TRANSITION__DETECTION_CONFIG", str(config_path))
+
+    def unavailable_parquet_engine(*args, **kwargs):
+        raise OSError("Parquet engine unavailable")
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", unavailable_parquet_engine)
+
+    from sbir_analytics.assets.transition import transformed_transition_detections  # type: ignore
+
+    scores_df = pd.DataFrame(columns=["award_id", "contract_id", "score", "method", "computed_at"])
+    result = transformed_transition_detections(
+        context=build_asset_context(),
+        transformed_transition_scores=scores_df,
+    )
+
+    _, metadata = _unwrap_output(result)
+    output_path_value = metadata["output_path"]
+    if hasattr(output_path_value, "text"):
+        output_path_value = output_path_value.text
+    output_path = Path(output_path_value)
+
+    assert output_path.suffix == ".ndjson"
+    assert output_path.exists()
+    assert not output_path.with_suffix(".parquet").exists()

--- a/tests/unit/utils/test_file_io.py
+++ b/tests/unit/utils/test_file_io.py
@@ -33,7 +33,7 @@ def temp_dir():
 def test_save_dataframe_parquet_success(temp_dir, sample_dataframe):
     """Test successful Parquet save."""
     path = temp_dir / "test.parquet"
-    save_dataframe_parquet(sample_dataframe, path)
+    assert save_dataframe_parquet(sample_dataframe, path) == path
     assert path.exists()
 
     # Verify can read back
@@ -42,17 +42,46 @@ def test_save_dataframe_parquet_success(temp_dir, sample_dataframe):
     assert list(df.columns) == ["a", "b"]
 
 
-def test_save_dataframe_parquet_fallback_to_ndjson(temp_dir, sample_dataframe):
-    """Test fallback to NDJSON when Parquet fails."""
+def test_save_dataframe_parquet_fallback_to_ndjson(temp_dir, sample_dataframe, monkeypatch):
+    """The NDJSON fallback must report where it actually wrote.
+
+    The fallback is handled inside the helper rather than raised, so a caller
+    that keeps using the Parquet path it passed in ends up pointing at a file
+    this function deleted.
+    """
+
     path = temp_dir / "test.parquet"
 
-    # Mock failure by using invalid path (but this won't actually fail)
-    # Instead, test the fallback mechanism by disabling parquet
-    # For a real test, we'd need to mock the to_parquet call
+    def _explode(*args, **kwargs):
+        raise OSError("simulated parquet engine failure")
 
-    # Test that NDJSON fallback path is created correctly
-    ndjson_path = path.with_suffix(".ndjson")
-    assert ndjson_path == temp_dir / "test.ndjson"
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", _explode)
+
+    written = save_dataframe_parquet(sample_dataframe, path)
+
+    assert written == temp_dir / "test.ndjson"
+    assert written.exists()
+    assert not path.exists(), "stale Parquet must be removed so readers find the NDJSON"
+
+    records = [json.loads(line) for line in written.read_text(encoding="utf-8").splitlines()]
+    assert len(records) == 3
+    assert set(records[0]) == {"a", "b"}
+
+
+def test_save_dataframe_parquet_reraises_when_fallback_disabled(
+    temp_dir, sample_dataframe, monkeypatch
+):
+    """With the fallback disabled the caller owns the failure."""
+
+    def _explode(*args, **kwargs):
+        raise OSError("simulated parquet engine failure")
+
+    monkeypatch.setattr(pd.DataFrame, "to_parquet", _explode)
+
+    with pytest.raises(OSError, match="simulated parquet engine failure"):
+        save_dataframe_parquet(
+            sample_dataframe, temp_dir / "test.parquet", fallback_to_ndjson=False
+        )
 
 
 def test_write_json_atomic(temp_dir):


### PR DESCRIPTION
## Summary

This PR closes the review findings around CET configuration, Parquet fallback behavior, CI guard coverage, and stale developer documentation.

- Fix the CET Neo4j client factory to pass `username=` to `Neo4jConfig`.
- Make `save_dataframe_parquet` return the artifact path it actually wrote.
- Propagate NDJSON fallback paths through CET and transition asset metadata and the transition validation manifest.
- Remove duplicate manual fallback blocks and stale Parquet placeholders.
- Require genuine Parquet output in APIs and caches that cannot read NDJSON.
- Expand the YAML boundary guard and log CET taxonomy degradation.
- Remove the dead patent-training `use_feature_extraction` parameter.
- Align pre-commit and CI documentation with the current mypy and job scope.

The branch is rebased onto `main` at `9a61fa63`.

## Behavior

When a Parquet write fails, the shared helper writes an `.ndjson` sibling and removes any stale Parquet file. Fallback-aware assets now publish the returned path. Parquet-only persistence paths disable fallback so they do not report an unusable cache as successfully saved.

The transition evidence manifest now follows the same fallback path as the scoring asset.

## Versioning Impact

- [x] No release impact: internal correctness and documentation fixes
- [ ] PATCH
- [ ] MINOR
- [ ] MAJOR

## Verification

- `pytest -o addopts='' -q tests/unit -m 'not slow'`: **5,848 passed, 7 skipped, 2 deselected**
- Focused CET, transition, file-I/O, cache, enrichment, NAICS, BEA, and vendor-crosswalk tests: passing
- `ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml tests`: passing
- `mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml`: passing, 305 files
- Architecture, tier, file-size, config, removed-source-reference, and study-manifest guards: passing
- Regression coverage forces Parquet failures and verifies both Dagster metadata and the transition manifest point to the actual NDJSON artifact.
