### PR TITLE
Add possible-SBIR contamination review queue

### DIFF
--- a/docs/research/agency-private-capital-form-d-sbir-contamination-audit.manifest.json
+++ b/docs/research/agency-private-capital-form-d-sbir-contamination-audit.manifest.json
@@ -1,0 +1,85 @@
+{
+  "applied_exclusion_count": 0,
+  "candidate_only": true,
+  "code_commit": "bca87c5696c87290337464ec4f15c68e0619aea0",
+  "complete": true,
+  "complete_sbir_exclusion": false,
+  "counts": {
+    "candidate_ciks": 1568,
+    "candidate_pairs": 2588,
+    "eligible_sbir_normalized_names": 32603,
+    "exact_exclusion_ciks": 4465,
+    "provisional_control_ciks": 307344,
+    "routes": {
+      "state_supported": 982,
+      "strong_name": 230,
+      "zip_supported": 1464
+    },
+    "sbir_award_rows": 219500
+  },
+  "covariates_ready": false,
+  "exclusion_recall": "unknown",
+  "identity_only": true,
+  "inputs": {
+    "awards_csv": {
+      "path": "award_data.csv",
+      "row_count": 219500,
+      "sha256": "73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd",
+      "size_bytes": 394456822
+    },
+    "exact_exclusions": {
+      "path": "sbir_cik_exclusion_candidates.identity-staging.jsonl",
+      "row_count": 4465,
+      "sha256": "94cb5bc0eae682675f6e0015cc2c21b48411aba6429b6ef5e4cccfe769af38d3",
+      "size_bytes": 2276095
+    },
+    "provisional_controls": {
+      "path": "form_d_control_identity_universe.provisional.jsonl",
+      "row_count": 307344,
+      "sha256": "aaffebbda1ef3d2b1fe04e211b6973a027181d6840b03c12d4329a1649f31c75",
+      "size_bytes": 710168771
+    },
+    "source_manifest": {
+      "path": "agency-private-capital-form-d-control-universe.manifest.json",
+      "sha256": "1777119114c4f7385dd09d6b60c603f2c5c59db765311255440513190d94b331",
+      "size_bytes": 247889
+    }
+  },
+  "invariants": {
+    "all_candidates_unreviewed": true,
+    "candidate_ciks_disjoint_exact_exclusions": true,
+    "candidate_ciks_subset_provisional_controls": true,
+    "candidate_ids_unique": true,
+    "content_addressed_output": true,
+    "no_automatic_exclusions": true,
+    "source_inputs_hash_rows_bytes_verified": true
+  },
+  "outputs": {
+    "possible_sbir_contamination_candidates": {
+      "path": "form_d_possible_sbir_contamination_candidates.f7a10a24e7e55405508539466feb638debead67293e0724c39bb28315b9e09fd.jsonl",
+      "row_count": 2588,
+      "sha256": "f7a10a24e7e55405508539466feb638debead67293e0724c39bb28315b9e09fd",
+      "size_bytes": 2390117
+    }
+  },
+  "parameters": {
+    "candidate_contract_version": "form-d-sbir-exclusion-candidate-v1",
+    "geography_profile": "us-jurisdiction-strict-v1",
+    "minimum_normalized_name_length": 6,
+    "name_metrics": [
+      "ratio",
+      "token-sort",
+      "token-set"
+    ],
+    "name_normalizer": "organization-key-v1",
+    "prefix_length": 2,
+    "retrieval_is_exhaustive_within_declared_rules": true,
+    "thresholds": {
+      "state_supported_ratio": 0.85,
+      "strong_name_ratio": 0.95,
+      "zip_supported_ratio": 0.8
+    }
+  },
+  "ready_for_matching": false,
+  "schema_version": 1
+}

--- a/docs/research/agency-private-capital-form-d-sbir-contamination-audit.md
+++ b/docs/research/agency-private-capital-form-d-sbir-contamination-audit.md
@@ -1,0 +1,122 @@
+---
+Type: Research Report
+Owner: research@project
+Last-Reviewed: 2026-08-09
+Status: draft
+---
+
+# Form D possible-SBIR contamination candidate audit
+
+> **Exploratory and non-citable.** This artifact is an unreviewed identity-audit
+> queue. It is not a contamination estimate, does not change the provisional
+> controls, and reports no treated-versus-control outcome.
+
+## Materialization result
+
+The follow-on screen compared all historical issuer aliases and location
+evidence for the 307,344 provisional Form D control CIKs with the pinned SBIR
+award history. It emitted 2,588 candidate pairs spanning 1,568 control CIKs.
+Every candidate remains unreviewed and the producer applied **zero** additional
+exclusions.
+
+| Audit measure | Value |
+| --- | ---: |
+| Provisional control CIKs screened | 307,344 |
+| Upstream exact-exclusion CIKs verified | 4,465 |
+| Historical SBIR award rows | 219,500 |
+| Eligible normalized SBIR names | 32,603 |
+| Unreviewed candidate pairs | 2,588 |
+| Provisional control CIKs represented in the queue | 1,568 |
+| Strong-name route hits | 230 |
+| State-supported route hits | 982 |
+| ZIP-supported route hits | 1,464 |
+| Additional exclusions applied | 0 |
+
+Route counts overlap because a pair can satisfy more than one rule. They must
+not be summed or interpreted as distinct firms. The 32,603 eligible SBIR names
+exclude normalized keys shorter than six alphanumeric characters; the input
+snapshot itself remains unchanged.
+
+## Frozen candidate rules
+
+The producer uses `organization-key-v1` name normalization and
+`us-jurisdiction-strict-v1` state normalization. It evaluates every eligible
+historical alias, state, and ZIP observed for each issuer; there is no top-k
+cutoff.
+
+1. **Strong name:** same two-character normalized prefix and ratio similarity
+   at least 0.95.
+2. **State supported:** same strict U.S. state, same prefix, and ratio similarity
+   at least 0.85.
+3. **ZIP supported:** exact valid ZIP5 and ratio similarity at least 0.80; no
+   prefix agreement is required.
+
+Pairs are deduplicated at `(CIK, normalized SBIR name)`. Ratio, token-sort, and
+token-set similarities are retained as review evidence, but none can establish
+identity. A stable candidate ID binds the contract version, CIK, and normalized
+SBIR name.
+
+## Interpretation boundary
+
+This run contains no adjudication and therefore provides no precision, recall,
+or contamination-rate estimate. Shared ZIP codes and similar organization
+names can produce unrelated candidates. Missing geography does not count as
+agreement, and geographic agreement does not convert a fuzzy name into an
+identity decision.
+
+The machine-readable manifest consequently preserves:
+
+- `candidate_only=true`;
+- `applied_exclusion_count=0`;
+- `complete_sbir_exclusion=false`;
+- `exclusion_recall="unknown"`;
+- `identity_only=true`;
+- `covariates_ready=false`; and
+- `ready_for_matching=false`.
+
+The original 307,344-row provisional control product remains unchanged. No
+candidate in this queue may be removed from that product without a separate,
+versioned adjudication decision.
+
+## Product and provenance
+
+The full [tracked research manifest](agency-private-capital-form-d-sbir-contamination-audit.manifest.json)
+pins the upstream control-universe manifest, provisional controls, exact
+exclusion ledger, SBIR award snapshot, frozen policies and thresholds, producer
+commit, output hash, and invariant results.
+
+| Product | Rows | Bytes | SHA-256 |
+| --- | ---: | ---: | --- |
+| Possible-SBIR contamination candidates | 2,588 | 2,390,117 | `f7a10a24e7e55405508539466feb638debead67293e0724c39bb28315b9e09fd` |
+
+The source products remain gitignored. Their pinned hashes are:
+
+- provisional controls:
+  `aaffebbda1ef3d2b1fe04e211b6973a027181d6840b03c12d4329a1649f31c75`;
+- exact-exclusion ledger:
+  `94cb5bc0eae682675f6e0015cc2c21b48411aba6429b6ef5e4cccfe769af38d3`;
+- SBIR award CSV:
+  `73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd`;
+  and
+- upstream control-universe manifest:
+  `1777119114c4f7385dd09d6b60c603f2c5c59db765311255440513190d94b331`.
+
+Two independent real-data builds produced the same content-addressed candidate
+product. Reproduce after materializing the pinned control-universe inputs at
+their default processed-data paths:
+
+```bash
+uv run python scripts/data/build_form_d_sbir_exclusion_candidates.py \
+  --source-manifest \
+  docs/research/agency-private-capital-form-d-control-universe.manifest.json \
+  --awards-csv data/raw/sbir/award_data.csv
+```
+
+## Gate decision
+
+This screen turns a broad fuzzy search into a bounded review queue, but it does
+not close task 2.2. The next identity step must adjudicate candidate pairs and
+incorporate higher-recall authoritative CIK or alias evidence, then rebuild and
+validate the exclusion boundary. A validated SIC-to-NAICS-2 strategy and
+symmetric FPDS, patent, and verified-M&A coverage remain separate prerequisites
+for matching.

--- a/scripts/data/build_form_d_sbir_exclusion_candidates.py
+++ b/scripts/data/build_form_d_sbir_exclusion_candidates.py
@@ -1,0 +1,784 @@
+#!/usr/bin/env python3
+"""Build a review-only possible-SBIR contamination queue for Form D controls.
+
+The producer consumes the pinned provisional control identities from the
+maintained Form D universe and compares every retained issuer alias with every
+historical SBIR company-name key reachable through three frozen retrieval
+rules. Results are candidates for review, never automatic exclusions.
+"""
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, BinaryIO, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sbir_etl.identity import (
+    CompanyNameMetric,
+    CompanyNameProfile,
+    USJurisdictionProfile,
+    company_name_similarity,
+    normalize_company_name,
+    normalize_us_jurisdiction,
+)
+
+
+DEFAULT_SOURCE_MANIFEST = (
+    REPO_ROOT / "docs/research/agency-private-capital-form-d-control-universe.manifest.json"
+)
+DEFAULT_CONTROL_DIR = REPO_ROOT / "data/processed/agency_private_capital/control_universe"
+DEFAULT_PROVISIONAL_CONTROLS = (
+    DEFAULT_CONTROL_DIR / "form_d_control_identity_universe.provisional.jsonl"
+)
+DEFAULT_EXACT_EXCLUSIONS = (
+    DEFAULT_CONTROL_DIR / "sbir_cik_exclusion_candidates.identity-staging.jsonl"
+)
+DEFAULT_AWARDS_CSV = REPO_ROOT / "data/raw/sbir/award_data.csv"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "data/processed/agency_private_capital/sbir_contamination_audit"
+
+CONTRACT_VERSION = "form-d-sbir-exclusion-candidate-v1"
+NORMALIZER = CompanyNameProfile.ORGANIZATION_KEY_V1
+GEOGRAPHY_PROFILE = USJurisdictionProfile.STRICT_V1
+PREFIX_LENGTH = 2
+MINIMUM_NORMALIZED_NAME_LENGTH = 6
+STRONG_NAME_THRESHOLD = 0.95
+STATE_SUPPORTED_THRESHOLD = 0.85
+ZIP_SUPPORTED_THRESHOLD = 0.80
+ROUTE_ORDER = ("strong_name", "state_supported", "zip_supported")
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+ZIP5_RE = re.compile(r"^\s*(\d{5})(?:-\d{4})?\s*$")
+
+
+class BuildError(RuntimeError):
+    """Raised when an input or invariant would make the audit unreliable."""
+
+
+def normalize_zip5(value: object) -> str | None:
+    """Return a strict ZIP5 from ZIP5 or ZIP+4 source text."""
+
+    if value is None:
+        return None
+    match = ZIP5_RE.fullmatch(str(value))
+    return match.group(1) if match else None
+
+
+def candidate_id(cik: str, sbir_name_normalized: str) -> str:
+    """Return the stable candidate-pair identifier."""
+
+    payload = f"{CONTRACT_VERSION}\0{cik}\0{sbir_name_normalized}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_path(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _non_negative_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BuildError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _pinned_product(value: object, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise BuildError(f"Source manifest does not pin {label}")
+    path = value.get("path")
+    sha256 = value.get("sha256")
+    size_bytes = value.get("size_bytes")
+    row_count = value.get("row_count")
+    if not isinstance(path, str) or not path:
+        raise BuildError(f"Pinned {label} has no path")
+    if not isinstance(sha256, str) or not SHA256_RE.fullmatch(sha256):
+        raise BuildError(f"Pinned {label} has an invalid SHA-256")
+    _non_negative_int(size_bytes, label=f"Pinned {label} size_bytes")
+    _non_negative_int(row_count, label=f"Pinned {label} row_count")
+    return dict(value)
+
+
+def _load_source_manifest(path: Path) -> tuple[dict[str, Any], bytes]:
+    if not path.is_file():
+        raise BuildError(f"Required source manifest is missing: {path}")
+    try:
+        data = path.read_bytes()
+        manifest = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BuildError(f"Invalid source manifest JSON: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise BuildError("Source manifest must be a JSON object")
+    if manifest.get("complete") is not True:
+        raise BuildError("Source manifest is incomplete")
+    required_gates = {
+        "complete_sbir_exclusion": False,
+        "covariates_ready": False,
+        "exclusion_recall": "unknown",
+        "identity_only": True,
+        "ready_for_matching": False,
+    }
+    for field, expected in required_gates.items():
+        actual = manifest.get(field)
+        if isinstance(expected, bool):
+            valid = actual is expected
+        else:
+            valid = actual == expected
+        if not valid:
+            raise BuildError(f"Source manifest has unexpected {field}")
+    if manifest.get("schema_version") != 1 or isinstance(manifest.get("schema_version"), bool):
+        raise BuildError("Source manifest has an unsupported schema_version")
+    invariants = manifest.get("invariants")
+    if not isinstance(invariants, Mapping):
+        raise BuildError("Source manifest has no invariants object")
+    overlap_count = _non_negative_int(
+        invariants.get("control_exclusion_overlap_count"),
+        label="Source control_exclusion_overlap_count",
+    )
+    if overlap_count != 0:
+        raise BuildError("Source manifest does not establish disjoint controls and exclusions")
+    if invariants.get("control_ciks_unique") is not True:
+        raise BuildError("Source manifest does not establish unique provisional control CIKs")
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise BuildError("Source manifest has no outputs object")
+    controls = _pinned_product(
+        outputs.get("provisional_control_identity_universe"),
+        label="provisional controls",
+    )
+    exclusions = _pinned_product(
+        outputs.get("candidate_sbir_cik_exclusions"), label="exact exclusion ledger"
+    )
+    exclusion = manifest.get("exclusion")
+    if not isinstance(exclusion, Mapping):
+        raise BuildError("Source manifest has no exclusion object")
+    awards = exclusion.get("awards_csv")
+    awards_product = _pinned_product(awards, label="SBIR awards CSV")
+    if controls["row_count"] == 0:
+        raise BuildError("Source manifest pins an empty provisional control universe")
+    if awards_product["row_count"] == 0:
+        raise BuildError("Source manifest pins an empty SBIR awards CSV")
+    source_counts = manifest.get("source_counts")
+    if not isinstance(source_counts, Mapping):
+        raise BuildError("Source manifest has no source_counts object")
+    provisional_count = _non_negative_int(
+        source_counts.get("provisional_control_ciks"),
+        label="Source provisional_control_ciks",
+    )
+    if provisional_count != controls["row_count"]:
+        raise BuildError("Source provisional control count does not match its product pin")
+    excluded_broad_count = _non_negative_int(
+        source_counts.get("excluded_broad_ciks"),
+        label="Source excluded_broad_ciks",
+    )
+    if excluded_broad_count > exclusions["row_count"]:
+        raise BuildError("Source excluded broad CIK count exceeds the exact exclusion ledger")
+    explicit_cik_inputs = exclusion.get("explicit_cik_inputs")
+    if not isinstance(explicit_cik_inputs, list):
+        raise BuildError("Source manifest has no explicit-CIK input ledger")
+    if not explicit_cik_inputs and excluded_broad_count != exclusions["row_count"]:
+        raise BuildError("Source exact exclusion count does not match its product pin")
+    exact_match = exclusion.get("exact_match")
+    if not isinstance(exact_match, Mapping):
+        raise BuildError("Source manifest has no exact-match exclusion policy")
+    if exact_match.get("normalizer_version") != NORMALIZER.value:
+        raise BuildError("Source exclusion normalizer does not match the candidate audit")
+    return manifest, data
+
+
+def _validate_pin(path: Path, product: Mapping[str, Any], *, label: str) -> None:
+    if not path.is_file():
+        raise BuildError(f"Pinned {label} is missing: {path}")
+    if path.stat().st_size != product["size_bytes"]:
+        raise BuildError(f"Pinned {label} byte count does not match the source manifest")
+
+
+def _load_exact_exclusions(path: Path, product: Mapping[str, Any]) -> tuple[set[str], str, int]:
+    _validate_pin(path, product, label="exact exclusion ledger")
+    digest = hashlib.sha256()
+    ciks: set[str] = set()
+    rows = 0
+    size = 0
+    with path.open("rb") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            digest.update(raw_line)
+            size += len(raw_line)
+            if not raw_line.strip():
+                raise BuildError(f"Exact exclusion ledger has a blank line at {line_number}")
+            rows += 1
+            try:
+                row = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise BuildError(f"Invalid exact exclusion JSON at line {line_number}") from exc
+            if not isinstance(row, Mapping):
+                raise BuildError(f"Exact exclusion line {line_number} must be an object")
+            cik = row.get("cik")
+            if not isinstance(cik, str) or not cik.isdigit() or cik.startswith("0"):
+                raise BuildError(f"Exact exclusion line {line_number} has an invalid CIK")
+            if row.get("firm_key") != f"form_d_cik:{cik}":
+                raise BuildError(f"Exact exclusion line {line_number} has an invalid firm_key")
+            if cik in ciks:
+                raise BuildError(f"Exact exclusion ledger repeats CIK {cik}")
+            ciks.add(cik)
+    if rows != product["row_count"]:
+        raise BuildError("Exact exclusion ledger row count does not match its pin")
+    if size != product["size_bytes"]:
+        raise BuildError("Exact exclusion ledger byte count does not match its pin")
+    if digest.hexdigest() != product["sha256"]:
+        raise BuildError("Exact exclusion ledger SHA-256 does not match its pin")
+    return ciks, digest.hexdigest(), size
+
+
+def _normalized_name(value: object) -> str:
+    return normalize_company_name(value, profile=NORMALIZER)
+
+
+def _name_is_eligible(value: str) -> bool:
+    return sum(character.isalnum() for character in value) >= MINIMUM_NORMALIZED_NAME_LENGTH
+
+
+def _prefix(value: str) -> str:
+    return "".join(character for character in value if character.isalnum())[:PREFIX_LENGTH]
+
+
+def _parse_year(value: object) -> int | None:
+    text = str(value or "").strip()
+    return int(text) if re.fullmatch(r"(?:19|20)\d{2}", text) else None
+
+
+def _load_award_names(
+    path: Path, product: Mapping[str, Any]
+) -> tuple[dict[str, dict[str, Any]], dict[str, set[str]], dict[str, set[str]], dict[str, Any]]:
+    _validate_pin(path, product, label="SBIR awards CSV")
+    before = path.stat()
+    sha256, raw_size = _sha256_path(path)
+    if raw_size != product["size_bytes"]:
+        raise BuildError("SBIR awards CSV byte count does not match its pin")
+    if sha256 != product["sha256"]:
+        raise BuildError("SBIR awards CSV SHA-256 does not match its pin")
+    raw_rows = 0
+    profiles: dict[str, dict[str, Any]] = {}
+    try:
+        with path.open(encoding="utf-8-sig", errors="strict", newline="") as handle:
+            reader = csv.DictReader(handle, strict=True)
+            fieldnames = reader.fieldnames or []
+            if any(not isinstance(column, str) or not column.strip() for column in fieldnames):
+                raise BuildError("SBIR awards CSV has a blank column name")
+            normalized_columns = [column.strip().casefold() for column in fieldnames]
+            if len(normalized_columns) != len(set(normalized_columns)):
+                raise BuildError("SBIR awards CSV has duplicate column names")
+            columns = dict(zip(normalized_columns, fieldnames, strict=True))
+            name_column = columns.get("company") or columns.get("company_name")
+            state_column = columns.get("state")
+            zip_column = columns.get("zip") or columns.get("zip_code")
+            year_column = columns.get("award year") or columns.get("award_year")
+            if name_column is None:
+                raise BuildError("SBIR awards CSV has no Company/company_name column")
+            for row in reader:
+                raw_rows += 1
+                if None in row:
+                    raise BuildError(
+                        f"SBIR awards CSV record near line {reader.line_num} has extra fields"
+                    )
+                raw_name = str(row.get(name_column) or "").strip()
+                normalized = _normalized_name(raw_name)
+                if not normalized or not _name_is_eligible(normalized):
+                    continue
+                profile = profiles.setdefault(
+                    normalized,
+                    {
+                        "award_row_count": 0,
+                        "first_award_year": None,
+                        "last_award_year": None,
+                        "raw_names": set(),
+                        "states": set(),
+                        "zip5s": set(),
+                    },
+                )
+                profile["award_row_count"] += 1
+                profile["raw_names"].add(raw_name)
+                state = (
+                    normalize_us_jurisdiction(row.get(state_column), profile=GEOGRAPHY_PROFILE)
+                    if state_column
+                    else None
+                )
+                if state:
+                    profile["states"].add(state)
+                zip5 = normalize_zip5(row.get(zip_column)) if zip_column else None
+                if zip5:
+                    profile["zip5s"].add(zip5)
+                year = _parse_year(row.get(year_column)) if year_column else None
+                if year is not None:
+                    first = profile["first_award_year"]
+                    last = profile["last_award_year"]
+                    profile["first_award_year"] = year if first is None else min(first, year)
+                    profile["last_award_year"] = year if last is None else max(last, year)
+    except (UnicodeDecodeError, csv.Error) as exc:
+        line_number = reader.line_num if "reader" in locals() else 1
+        raise BuildError(f"Invalid SBIR awards CSV near line {line_number}: {exc}") from exc
+
+    after = path.stat()
+    if (
+        after.st_size != before.st_size
+        or after.st_mtime_ns != before.st_mtime_ns
+        or after.st_ino != before.st_ino
+    ):
+        raise BuildError("SBIR awards CSV changed while it was being parsed")
+
+    if raw_rows != product["row_count"]:
+        raise BuildError("SBIR awards CSV row count does not match its pin")
+
+    prefix_index: dict[str, set[str]] = defaultdict(set)
+    zip_index: dict[str, set[str]] = defaultdict(set)
+    for normalized, profile in profiles.items():
+        prefix_index[_prefix(normalized)].add(normalized)
+        for zip5 in profile["zip5s"]:
+            zip_index[zip5].add(normalized)
+    metadata = {
+        "eligible_normalized_names": len(profiles),
+        "row_count": raw_rows,
+        "sha256": sha256,
+        "size_bytes": raw_size,
+    }
+    return profiles, prefix_index, zip_index, metadata
+
+
+def _issuer_evidence(row: Mapping[str, Any], *, line_number: int) -> dict[str, Any]:
+    cik = row.get("cik")
+    if not isinstance(cik, str) or not cik.isdigit() or cik.startswith("0") or len(cik) > 10:
+        raise BuildError(f"Provisional control line {line_number} has an invalid CIK")
+    firm_key = f"form_d_cik:{cik}"
+    if row.get("firm_key") != firm_key:
+        raise BuildError(f"Provisional control line {line_number} has an invalid firm_key")
+    filings = row.get("filings")
+    if not isinstance(filings, list) or not filings:
+        raise BuildError(f"Provisional control line {line_number} has no filing evidence")
+    filing_count = row.get("filing_count")
+    if isinstance(filing_count, bool) or not isinstance(filing_count, int):
+        raise BuildError(f"Provisional control line {line_number} has an invalid filing_count")
+    if filing_count != len(filings):
+        raise BuildError(f"Provisional control line {line_number} filing_count does not match")
+
+    raw_aliases: set[str] = set()
+    states: set[str] = set()
+    zip5s: set[str] = set()
+
+    def add_name(value: object) -> None:
+        text = str(value or "").strip()
+        if text:
+            raw_aliases.add(text)
+
+    def add_state(value: object) -> None:
+        state = normalize_us_jurisdiction(value, profile=GEOGRAPHY_PROFILE)
+        if state:
+            states.add(state)
+
+    def add_zip(value: object) -> None:
+        zip5 = normalize_zip5(value)
+        if zip5:
+            zip5s.add(zip5)
+
+    add_name(row.get("issuer_name"))
+    aliases = row.get("issuer_name_aliases")
+    if not isinstance(aliases, list):
+        raise BuildError(f"Provisional control line {line_number} has invalid aliases")
+    for alias in aliases:
+        add_name(alias)
+    add_state(row.get("state"))
+    add_zip(row.get("zip_code"))
+    for filing in filings:
+        if not isinstance(filing, Mapping):
+            raise BuildError(f"Provisional control line {line_number} has a non-object filing")
+        if filing.get("cik") != cik:
+            raise BuildError(f"Provisional control line {line_number} has a filing CIK mismatch")
+        add_name(filing.get("issuer_name"))
+        filing_aliases = filing.get("issuer_name_aliases", [])
+        if not isinstance(filing_aliases, list):
+            raise BuildError(f"Provisional control line {line_number} has invalid filing aliases")
+        for alias in filing_aliases:
+            add_name(alias)
+        add_state(filing.get("state"))
+        add_zip(filing.get("zip_code"))
+
+    normalized_aliases: dict[str, set[str]] = defaultdict(set)
+    for alias in raw_aliases:
+        normalized = _normalized_name(alias)
+        if normalized and _name_is_eligible(normalized):
+            normalized_aliases[normalized].add(alias)
+    canonical = str(row.get("issuer_name") or "").strip()
+    canonical_evidence = {
+        "aliases": {key: sorted(values) for key, values in sorted(normalized_aliases.items())},
+        "cik": cik,
+        "states": sorted(states),
+        "zip5s": sorted(zip5s),
+    }
+    fingerprint = hashlib.sha256(
+        json.dumps(canonical_evidence, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    return {
+        "cik": cik,
+        "firm_key": firm_key,
+        "fingerprint": fingerprint,
+        "issuer_name": canonical,
+        "normalized_aliases": normalized_aliases,
+        "states": states,
+        "zip5s": zip5s,
+    }
+
+
+def _candidate_rows_for_issuer(
+    issuer: Mapping[str, Any],
+    *,
+    award_profiles: Mapping[str, Mapping[str, Any]],
+    prefix_index: Mapping[str, set[str]],
+    zip_index: Mapping[str, set[str]],
+) -> list[dict[str, Any]]:
+    normalized_aliases = issuer["normalized_aliases"]
+    possible_award_names: set[str] = set()
+    for alias in normalized_aliases:
+        possible_award_names.update(prefix_index.get(_prefix(alias), set()))
+    for zip5 in issuer["zip5s"]:
+        possible_award_names.update(zip_index.get(zip5, set()))
+
+    candidates: list[dict[str, Any]] = []
+    for sbir_normalized in sorted(possible_award_names):
+        award = award_profiles[sbir_normalized]
+        matched_states = sorted(issuer["states"] & award["states"])
+        matched_zip5s = sorted(issuer["zip5s"] & award["zip5s"])
+        evidence: list[tuple[float, str, str, set[str]]] = []
+        routes: set[str] = set()
+        sbir_prefix = _prefix(sbir_normalized)
+        for alias_normalized, raw_aliases in normalized_aliases.items():
+            ratio = company_name_similarity(
+                alias_normalized, sbir_normalized, metric=CompanyNameMetric.RATIO
+            )
+            alias_routes: set[str] = set()
+            same_prefix = _prefix(alias_normalized) == sbir_prefix
+            if same_prefix and ratio >= STRONG_NAME_THRESHOLD:
+                alias_routes.add("strong_name")
+            if same_prefix and matched_states and ratio >= STATE_SUPPORTED_THRESHOLD:
+                alias_routes.add("state_supported")
+            if matched_zip5s and ratio >= ZIP_SUPPORTED_THRESHOLD:
+                alias_routes.add("zip_supported")
+            routes.update(alias_routes)
+            for raw_alias in raw_aliases:
+                evidence.append((ratio, alias_normalized, raw_alias, alias_routes))
+        if not routes:
+            continue
+        routed_evidence = [item for item in evidence if item[3]]
+        if not routed_evidence:
+            raise AssertionError("candidate routes have no supporting alias evidence")
+        best_ratio, best_normalized, best_raw, _ = sorted(
+            routed_evidence, key=lambda item: (-item[0], item[1], item[2])
+        )[0]
+        token_sort = company_name_similarity(
+            best_normalized, sbir_normalized, metric=CompanyNameMetric.TOKEN_SORT
+        )
+        token_set = company_name_similarity(
+            best_normalized, sbir_normalized, metric=CompanyNameMetric.TOKEN_SET
+        )
+        sbir_raw_names = sorted(award["raw_names"])
+        candidates.append(
+            {
+                "adjudication_status": "unreviewed",
+                "candidate_id": candidate_id(str(issuer["cik"]), sbir_normalized),
+                "candidate_only": True,
+                "candidate_routes": [route for route in ROUTE_ORDER if route in routes],
+                "cik": issuer["cik"],
+                "firm_key": issuer["firm_key"],
+                "issuer_alias": best_raw,
+                "issuer_name": issuer["issuer_name"],
+                "issuer_name_normalized": best_normalized,
+                "issuer_states": sorted(issuer["states"]),
+                "issuer_zip5s": sorted(issuer["zip5s"]),
+                "matched_states": matched_states,
+                "matched_zip5s": matched_zip5s,
+                "ratio_similarity": round(best_ratio, 6),
+                "sbir_award_row_count": award["award_row_count"],
+                "sbir_company_name": sbir_raw_names[0],
+                "sbir_first_award_year": award["first_award_year"],
+                "sbir_last_award_year": award["last_award_year"],
+                "sbir_name_normalized": sbir_normalized,
+                "sbir_raw_names": sbir_raw_names,
+                "sbir_states": sorted(award["states"]),
+                "sbir_zip5s": sorted(award["zip5s"]),
+                "schema_version": 1,
+                "source_control_fingerprint": issuer["fingerprint"],
+                "token_set_similarity": round(token_set, 6),
+                "token_sort_similarity": round(token_sort, 6),
+            }
+        )
+    return candidates
+
+
+def _temporary_output(path: Path) -> tuple[BinaryIO, Path]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        mode="w+b", dir=path.parent, prefix=f".{path.name}.", delete=False
+    )
+    return cast(BinaryIO, handle), Path(handle.name)
+
+
+def _write_candidate_product(
+    output_dir: Path, rows: list[dict[str, Any]]
+) -> tuple[dict[str, Any], Path]:
+    staging_hint = output_dir / "form_d_possible_sbir_contamination_candidates.jsonl"
+    handle, temp_path = _temporary_output(staging_hint)
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        with handle:
+            for row in rows:
+                data = (
+                    json.dumps(row, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+                    + "\n"
+                ).encode("utf-8")
+                handle.write(data)
+                digest.update(data)
+                size += len(data)
+    except BaseException:
+        temp_path.unlink(missing_ok=True)
+        raise
+    sha256 = digest.hexdigest()
+    final_path = output_dir / f"form_d_possible_sbir_contamination_candidates.{sha256}.jsonl"
+    return {
+        "path": final_path.name,
+        "row_count": len(rows),
+        "sha256": sha256,
+        "size_bytes": size,
+    }, temp_path
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            cwd=REPO_ROOT,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def build(args: argparse.Namespace) -> dict[str, Any]:
+    source_manifest_path = Path(args.source_manifest)
+    controls_path = Path(args.provisional_controls)
+    exclusions_path = Path(args.exact_exclusions)
+    awards_path = Path(args.awards_csv)
+    output_dir = Path(args.output_dir)
+    source_manifest, source_manifest_data = _load_source_manifest(source_manifest_path)
+    outputs = source_manifest["outputs"]
+    controls_product = _pinned_product(
+        outputs["provisional_control_identity_universe"], label="provisional controls"
+    )
+    exclusions_product = _pinned_product(
+        outputs["candidate_sbir_cik_exclusions"], label="exact exclusion ledger"
+    )
+    awards_product = _pinned_product(
+        source_manifest["exclusion"]["awards_csv"], label="SBIR awards CSV"
+    )
+    _validate_pin(controls_path, controls_product, label="provisional controls")
+    exact_ciks, _, _ = _load_exact_exclusions(exclusions_path, exclusions_product)
+    award_profiles, prefix_index, zip_index, award_metadata = _load_award_names(
+        awards_path, awards_product
+    )
+
+    control_digest = hashlib.sha256()
+    control_size = 0
+    control_rows = 0
+    previous_cik: str | None = None
+    provisional_ciks: set[str] = set()
+    candidate_rows: list[dict[str, Any]] = []
+    with controls_path.open("rb") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            control_digest.update(raw_line)
+            control_size += len(raw_line)
+            if not raw_line.strip():
+                raise BuildError(f"Provisional controls have a blank line at {line_number}")
+            control_rows += 1
+            try:
+                row = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise BuildError(f"Invalid provisional control JSON at line {line_number}") from exc
+            if not isinstance(row, Mapping):
+                raise BuildError(f"Provisional control line {line_number} must be an object")
+            issuer = _issuer_evidence(row, line_number=line_number)
+            cik = str(issuer["cik"])
+            if previous_cik is not None and cik <= previous_cik:
+                raise BuildError("Provisional control CIKs must be unique and ordered")
+            previous_cik = cik
+            if cik in exact_ciks:
+                raise BuildError(f"Provisional controls overlap exact exclusion CIK {cik}")
+            provisional_ciks.add(cik)
+            candidate_rows.extend(
+                _candidate_rows_for_issuer(
+                    issuer,
+                    award_profiles=award_profiles,
+                    prefix_index=prefix_index,
+                    zip_index=zip_index,
+                )
+            )
+
+    if control_rows != controls_product["row_count"]:
+        raise BuildError("Provisional control row count does not match its pin")
+    if control_size != controls_product["size_bytes"]:
+        raise BuildError("Provisional control byte count does not match its pin")
+    if control_digest.hexdigest() != controls_product["sha256"]:
+        raise BuildError("Provisional control SHA-256 does not match its pin")
+
+    candidate_rows.sort(key=lambda row: (str(row["cik"]), str(row["sbir_name_normalized"])))
+    ids = [str(row["candidate_id"]) for row in candidate_rows]
+    if len(ids) != len(set(ids)):
+        raise BuildError("Possible-contamination queue contains duplicate candidate IDs")
+    candidate_ciks = {str(row["cik"]) for row in candidate_rows}
+    if not candidate_ciks <= provisional_ciks:
+        raise BuildError("Possible-contamination queue contains a non-control CIK")
+    if candidate_ciks & exact_ciks:
+        raise BuildError("Possible-contamination queue overlaps exact exclusions")
+
+    route_counts: Counter[str] = Counter()
+    for row in candidate_rows:
+        route_counts.update(row["candidate_routes"])
+    product, staged_product = _write_candidate_product(output_dir, candidate_rows)
+    product_temp: Path | None = staged_product
+    product_path = output_dir / product["path"]
+    manifest_path = output_dir / "form_d_sbir_exclusion_candidates.manifest.json"
+    source_manifest_sha = hashlib.sha256(source_manifest_data).hexdigest()
+    manifest = {
+        "applied_exclusion_count": 0,
+        "candidate_only": True,
+        "code_commit": args.code_version or _git_commit(),
+        "complete": True,
+        "complete_sbir_exclusion": False,
+        "counts": {
+            "candidate_ciks": len(candidate_ciks),
+            "candidate_pairs": len(candidate_rows),
+            "eligible_sbir_normalized_names": len(award_profiles),
+            "exact_exclusion_ciks": len(exact_ciks),
+            "provisional_control_ciks": len(provisional_ciks),
+            "routes": dict(sorted(route_counts.items())),
+            "sbir_award_rows": award_metadata["row_count"],
+        },
+        "covariates_ready": False,
+        "exclusion_recall": "unknown",
+        "identity_only": True,
+        "inputs": {
+            "awards_csv": {
+                "path": awards_path.name,
+                "row_count": award_metadata["row_count"],
+                "sha256": award_metadata["sha256"],
+                "size_bytes": award_metadata["size_bytes"],
+            },
+            "exact_exclusions": {
+                "path": exclusions_path.name,
+                "row_count": exclusions_product["row_count"],
+                "sha256": exclusions_product["sha256"],
+                "size_bytes": exclusions_product["size_bytes"],
+            },
+            "provisional_controls": {
+                "path": controls_path.name,
+                "row_count": controls_product["row_count"],
+                "sha256": controls_product["sha256"],
+                "size_bytes": controls_product["size_bytes"],
+            },
+            "source_manifest": {
+                "path": source_manifest_path.name,
+                "sha256": source_manifest_sha,
+                "size_bytes": len(source_manifest_data),
+            },
+        },
+        "invariants": {
+            "all_candidates_unreviewed": all(
+                row["adjudication_status"] == "unreviewed" for row in candidate_rows
+            ),
+            "candidate_ciks_disjoint_exact_exclusions": not bool(candidate_ciks & exact_ciks),
+            "candidate_ciks_subset_provisional_controls": candidate_ciks <= provisional_ciks,
+            "candidate_ids_unique": len(ids) == len(set(ids)),
+            "content_addressed_output": product["sha256"] in product["path"],
+            "no_automatic_exclusions": True,
+            "source_inputs_hash_rows_bytes_verified": True,
+        },
+        "outputs": {"possible_sbir_contamination_candidates": product},
+        "parameters": {
+            "candidate_contract_version": CONTRACT_VERSION,
+            "geography_profile": GEOGRAPHY_PROFILE.value,
+            "minimum_normalized_name_length": MINIMUM_NORMALIZED_NAME_LENGTH,
+            "name_metrics": [
+                CompanyNameMetric.RATIO.value,
+                CompanyNameMetric.TOKEN_SORT.value,
+                CompanyNameMetric.TOKEN_SET.value,
+            ],
+            "name_normalizer": NORMALIZER.value,
+            "prefix_length": PREFIX_LENGTH,
+            "retrieval_is_exhaustive_within_declared_rules": True,
+            "thresholds": {
+                "state_supported_ratio": STATE_SUPPORTED_THRESHOLD,
+                "strong_name_ratio": STRONG_NAME_THRESHOLD,
+                "zip_supported_ratio": ZIP_SUPPORTED_THRESHOLD,
+            },
+        },
+        "ready_for_matching": False,
+        "schema_version": 1,
+    }
+    manifest_data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_temp: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=manifest_path.parent, prefix=f".{manifest_path.name}.", delete=False
+        ) as handle:
+            manifest_temp = Path(handle.name)
+            handle.write(manifest_data)
+        if product_temp is None:
+            raise AssertionError("candidate product staging file is missing")
+        os.replace(product_temp, product_path)
+        product_temp = None
+        os.replace(manifest_temp, manifest_path)
+        manifest_temp = None
+    finally:
+        if product_temp is not None:
+            product_temp.unlink(missing_ok=True)
+        if manifest_temp is not None:
+            manifest_temp.unlink(missing_ok=True)
+    return manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-manifest", type=Path, default=DEFAULT_SOURCE_MANIFEST)
+    parser.add_argument("--provisional-controls", type=Path, default=DEFAULT_PROVISIONAL_CONTROLS)
+    parser.add_argument("--exact-exclusions", type=Path, default=DEFAULT_EXACT_EXCLUSIONS)
+    parser.add_argument("--awards-csv", type=Path, default=DEFAULT_AWARDS_CSV)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--code-version", help="Pinned producer commit for the manifest")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        manifest = build(parse_args(argv))
+    except BuildError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"counts": manifest["counts"], "outputs": manifest["outputs"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/agency-private-capital-comparison/design.md
+++ b/specs/agency-private-capital-comparison/design.md
@@ -129,6 +129,16 @@ eligible controls                         configured-agency treated cohort
    group, not NAICS. The producer performs no NAICS inference and states
    `covariates_ready=false`. Component 6 remains open until a higher-recall
    authoritative CIK/alias union and validated SIC-to-NAICS-2 strategy exist.
+
+   A separate possible-contamination audit screens the provisional retained CIKs
+   against every historical SBIR name and the Form D alias/location evidence.
+   Its frozen retrieval rules combine near-exact name similarity with state or
+   ZIP corroboration and emit a compact review queue. Those rows are candidates,
+   not identity decisions: the audit applies no automatic exclusion, preserves
+   the original controls, and keeps `complete_sbir_exclusion=false`,
+   `exclusion_recall="unknown"`, and `ready_for_matching=false`. Fuzzy evidence
+   can prioritize adjudication but cannot establish that a retained firm has no
+   SBIR exposure.
 7. **`CohortMatcher`** — Coarsened-exact matching on (vintage-year,
    validated NAICS-2, state). Reports cohort balance and unmatched residuals.
    No propensity scoring in v1. The existing asset must reject component 6's

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -177,6 +177,15 @@ provisional identity staging only.
    `complete_sbir_exclusion=false`; retained means only not exact-name-matched to
    observed SBIR history, not "never SBIR." Requirement 8 remains open until a
    higher-recall authoritative CIK/alias union is validated.
+
+   A follow-on possible-contamination screen SHALL remain candidate-only unless
+   an explicit adjudication record establishes the identity decision. Its
+   deterministic manifest SHALL pin the provisional controls, current exact
+   exclusions, SBIR award snapshot, name/geography policies, thresholds, and
+   output hashes. Missing geography SHALL NOT count as agreement, candidate
+   scores SHALL NOT automatically remove a CIK, and the screen SHALL preserve
+   `complete_sbir_exclusion=false`, `exclusion_recall="unknown"`,
+   `covariates_ready=false`, and `ready_for_matching=false`.
 9. **SHALL** match the agency and eligible control cohorts on vintage year,
    validated NAICS-2, and state using coarsened-exact matching; no propensity
    scoring in v1. DERA supplies SIC and Form D industry group, not NAICS. The

--- a/specs/agency-private-capital-comparison/tasks.md
+++ b/specs/agency-private-capital-comparison/tasks.md
@@ -14,7 +14,10 @@
 > and symmetric FPDS/patent/verified-M&A outcomes are wired and validated. A
 > shared date-aware event/coverage evaluator and a CIK-native Form D
 > business-combination filing proxy now establish the first symmetric source
-> contract, but do not constitute an M&A-exit outcome or matched comparison.
+> contract, but do not constitute an M&A-exit outcome or matched comparison. A
+> deterministic possible-contamination screen now queues fuzzy name/location
+> candidates for review without changing the provisional controls or the open
+> identity gate.
 
 Tasks are grouped by phase. Phase 1 ships independently of PR #286. Phase 2 is
 gated on Phase 1 sign-off and its missing real-data input contracts.
@@ -116,7 +119,11 @@ on a pinned real-data run.
   validated SIC-to-NAICS-2 strategy exist. The pinned
   [real-data identity audit](../../docs/research/agency-private-capital-form-d-control-universe.md)
   materialized 311,809 issuer CIKs and 307,344 provisional retained identities;
-  those are audit counts, not a matched cohort.
+  those are audit counts, not a matched cohort. The follow-on
+  [possible-contamination audit](../../docs/research/agency-private-capital-form-d-sbir-contamination-audit.md)
+  queued 2,588 unreviewed candidate pairs spanning 1,568 provisional control
+  CIKs and applied zero exclusions. Its recall remains unknown, so this task is
+  still open.
 - [ ] 2.3 Complete and validate `CohortMatcher` — coarsened-exact matching on (vintage,
   validated NAICS-2, state). Report balance and unmatched residuals. Document
   matching ratio (agency firm : k matched controls) in the output. The existing

--- a/tests/unit/scripts/test_build_form_d_sbir_exclusion_candidates.py
+++ b/tests/unit/scripts/test_build_form_d_sbir_exclusion_candidates.py
@@ -1,0 +1,585 @@
+"""Tests for the candidate-only Form D possible-SBIR contamination audit."""
+
+import csv
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[3] / "scripts/data/build_form_d_sbir_exclusion_candidates.py"
+
+
+@pytest.fixture
+def module():
+    spec = importlib.util.spec_from_file_location("build_form_d_sbir_exclusion_candidates", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+def _jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_bytes(
+        b"".join(
+            (json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n").encode() for row in rows
+        )
+    )
+
+
+def _product(path: Path, row_count: int) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {
+        "path": path.name,
+        "row_count": row_count,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "size_bytes": len(data),
+    }
+
+
+def _filing(
+    cik: str,
+    name: str,
+    *,
+    aliases: list[str] | None = None,
+    state: str = "CA",
+    zip_code: str = "94105",
+    accession: str = "0000000000-20-000001",
+) -> dict[str, Any]:
+    return {
+        "accession_number": accession,
+        "cik": cik,
+        "filing_date": "2020-01-15",
+        "issuer_name": name,
+        "issuer_name_aliases": aliases if aliases is not None else [name],
+        "source_quarter": "2020Q1",
+        "state": state,
+        "zip_code": zip_code,
+    }
+
+
+def _control(
+    cik: str,
+    name: str,
+    *,
+    aliases: list[str] | None = None,
+    filings: list[dict[str, Any]] | None = None,
+    state: str = "CA",
+) -> dict[str, Any]:
+    filing_rows = filings or [_filing(cik, name, aliases=aliases, state=state)]
+    return {
+        "cik": cik,
+        "filing_count": len(filing_rows),
+        "filings": filing_rows,
+        "firm_key": f"form_d_cik:{cik}",
+        "issuer_name": name,
+        "issuer_name_aliases": aliases if aliases is not None else [name],
+        "state": state,
+    }
+
+
+def _exclusion(cik: str = "900") -> dict[str, Any]:
+    return {
+        "candidate_exclusion": True,
+        "cik": cik,
+        "evidence": [{"resolution_method": "candidate_exact_normalized_name"}],
+        "evidence_count": 1,
+        "firm_key": f"form_d_cik:{cik}",
+        "resolution_methods": ["candidate_exact_normalized_name"],
+        "schema_version": 1,
+    }
+
+
+def _award(
+    company: str,
+    *,
+    state: str = "CA",
+    zip_code: str = "94105",
+    year: str = "2018",
+    uei: str = "IGNORED-UEI",
+    duns: str = "000000001",
+) -> dict[str, str]:
+    return {
+        "Company": company,
+        "State": state,
+        "Zip": zip_code,
+        "Award Year": year,
+        "UEI": uei,
+        "Duns": duns,
+    }
+
+
+def _fixture(
+    tmp_path: Path,
+    *,
+    controls: list[dict[str, Any]],
+    awards: list[dict[str, str]],
+    exclusions: list[dict[str, Any]] | None = None,
+    stem: str = "source",
+) -> dict[str, Path]:
+    root = tmp_path / stem
+    root.mkdir()
+    controls_path = root / "form_d_control_identity_universe.provisional.jsonl"
+    exclusions_path = root / "sbir_cik_exclusion_candidates.identity-staging.jsonl"
+    awards_path = root / "award_data.csv"
+    manifest_path = root / "agency-private-capital-form-d-control-universe.manifest.json"
+    output_dir = root / "output"
+    exact_exclusions = exclusions if exclusions is not None else [_exclusion()]
+    _jsonl(controls_path, controls)
+    _jsonl(exclusions_path, exact_exclusions)
+    with awards_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle, fieldnames=["Company", "State", "Zip", "Award Year", "UEI", "Duns"]
+        )
+        writer.writeheader()
+        writer.writerows(awards)
+    manifest = {
+        "complete": True,
+        "complete_sbir_exclusion": False,
+        "covariates_ready": False,
+        "exclusion": {
+            "awards_csv": _product(awards_path, len(awards)),
+            "exact_match": {"normalizer_version": "organization-key-v1"},
+            "explicit_cik_inputs": [],
+        },
+        "exclusion_recall": "unknown",
+        "identity_only": True,
+        "invariants": {
+            "control_ciks_unique": True,
+            "control_exclusion_overlap_count": 0,
+            "exclusion_ciks_unique": True,
+            "ready_for_matching_is_false": True,
+        },
+        "outputs": {
+            "candidate_sbir_cik_exclusions": _product(exclusions_path, len(exact_exclusions)),
+            "provisional_control_identity_universe": _product(controls_path, len(controls)),
+        },
+        "ready_for_matching": False,
+        "schema_version": 1,
+        "source_counts": {
+            "excluded_broad_ciks": len(exact_exclusions),
+            "provisional_control_ciks": len(controls),
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    return {
+        "awards": awards_path,
+        "controls": controls_path,
+        "exclusions": exclusions_path,
+        "manifest": manifest_path,
+        "output": output_dir,
+    }
+
+
+def _args(paths: dict[str, Path]) -> list[str]:
+    return [
+        "--source-manifest",
+        str(paths["manifest"]),
+        "--provisional-controls",
+        str(paths["controls"]),
+        "--exact-exclusions",
+        str(paths["exclusions"]),
+        "--awards-csv",
+        str(paths["awards"]),
+        "--output-dir",
+        str(paths["output"]),
+        "--code-version",
+        "test-commit",
+    ]
+
+
+def _build(module: Any, paths: dict[str, Path]) -> dict[str, Any]:
+    return module.build(module.parse_args(_args(paths)))
+
+
+def _candidate_product(manifest: dict[str, Any]) -> dict[str, Any]:
+    assert len(manifest["outputs"]) == 1
+    return next(iter(manifest["outputs"].values()))
+
+
+def _rows(paths: dict[str, Path], manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    product = _candidate_product(manifest)
+    data = (paths["output"] / product["path"]).read_bytes()
+    assert hashlib.sha256(data).hexdigest() == product["sha256"]
+    assert len(data) == product["size_bytes"]
+    rows = [json.loads(line) for line in data.splitlines()]
+    assert len(rows) == product["row_count"]
+    return rows
+
+
+def test_inclusive_route_boundaries_and_false_gates(module, tmp_path: Path) -> None:
+    controls = [
+        _control("1", "ALPHAABCDEFGHIJKLMNO", state="New York"),
+        _control("2", "GAMMAABCDEFGHIJKLMNO", state="California"),
+        _control(
+            "3",
+            "ALPHAABCDE",
+            filings=[_filing("3", "ALPHAABCDE", state="Nevada", zip_code="02139-1234")],
+            state="Nevada",
+        ),
+        _control("4", "GAMMAABCDEFGHIJKLMNO", state="Texas"),
+        _control(
+            "5",
+            "OMEGA MEDICAL DEVICE",
+            filings=[_filing("5", "OMEGA MEDICAL DEVICE", zip_code="10001")],
+        ),
+    ]
+    awards = [
+        _award("ALPHAABCDEFGHIJKLMNP", state="CA", zip_code="99999"),  # ratio = .95
+        _award("GAMMAABCDEFGHIJKLXYZ", state="CA", zip_code="99998"),  # ratio = .85
+        _award("ZLPHAXBCDE", state="MA", zip_code="02139"),  # ratio = .80
+        _award("GAMMAABCDEFGHIJKXYZQ", state="TX", zip_code="99997"),  # ratio = .80
+        _award("OMEGA MEDICAL SYSTEM", state="CA", zip_code="10001"),  # ratio = .75
+    ]
+    paths = _fixture(tmp_path, controls=controls, awards=awards)
+
+    manifest = _build(module, paths)
+    rows = _rows(paths, manifest)
+
+    assert [(row["cik"], row["candidate_routes"]) for row in rows] == [
+        ("1", ["strong_name"]),
+        ("2", ["state_supported"]),
+        ("3", ["zip_supported"]),
+    ]
+    assert all(row["firm_key"] == f"form_d_cik:{row['cik']}" for row in rows)
+    assert all(row["candidate_only"] is True for row in rows)
+    assert all(row["adjudication_status"] == "unreviewed" for row in rows)
+    assert manifest["complete"] is True
+    assert manifest["candidate_only"] is True
+    assert manifest["applied_exclusion_count"] == 0
+    assert manifest["complete_sbir_exclusion"] is False
+    assert manifest["exclusion_recall"] == "unknown"
+    assert manifest["covariates_ready"] is False
+    assert manifest["ready_for_matching"] is False
+    assert manifest["identity_only"] is True
+    assert manifest["parameters"]["minimum_normalized_name_length"] == 6
+    assert manifest["parameters"]["thresholds"] == {
+        "state_supported_ratio": 0.85,
+        "strong_name_ratio": 0.95,
+        "zip_supported_ratio": 0.8,
+    }
+
+
+def test_historical_aliases_and_filing_geography_are_exhaustive(module, tmp_path: Path) -> None:
+    controls = [
+        _control(
+            "10",
+            "UNRELATED HOLDINGS",
+            aliases=["UNRELATED HOLDINGS"],
+            filings=[
+                _filing(
+                    "10",
+                    "UNRELATED HOLDINGS",
+                    aliases=["UNRELATED HOLDINGS", "GAMMAABCDEFGHIJKLMNO"],
+                    state="California",
+                    zip_code="94105-4410",
+                )
+            ],
+        ),
+        _control(
+            "11",
+            "ANOTHER HOLDING",
+            filings=[
+                _filing(
+                    "11",
+                    "ANOTHER HOLDING",
+                    aliases=["ANOTHER HOLDING", "ALPHAABCDE"],
+                    state="Nevada",
+                    zip_code="02139-9999",
+                )
+            ],
+        ),
+    ]
+    awards = [
+        _award("GAMMAABCDEFGHIJKLXYZ", state="CA", zip_code="99999"),
+        _award("ZLPHAXBCDE", state="MA", zip_code="02139"),
+    ]
+    paths = _fixture(tmp_path, controls=controls, awards=awards)
+
+    rows = _rows(paths, _build(module, paths))
+
+    assert [(row["cik"], row["candidate_routes"]) for row in rows] == [
+        ("10", ["state_supported"]),
+        ("11", ["zip_supported"]),
+    ]
+    assert rows[0]["issuer_name_normalized"] == "GAMMAABCDEFGHIJKLMNO"
+    assert rows[1]["issuer_name_normalized"] == "ALPHAABCDE"
+
+
+def test_multiline_csv_record_is_one_award_and_all_routes_are_recorded(
+    module, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("12", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED\nSYSTEMS")],
+    )
+
+    manifest = _build(module, paths)
+    rows = _rows(paths, manifest)
+
+    assert manifest["counts"]["sbir_award_rows"] == 1
+    assert len(rows) == 1
+    assert rows[0]["candidate_routes"] == ["strong_name", "state_supported", "zip_supported"]
+
+
+def test_best_alias_must_support_a_declared_route(module, tmp_path: Path) -> None:
+    control = _control(
+        "13",
+        "UNRELATED HOLDINGS",
+        aliases=[
+            "GAMMAABCDEFGHIJKLMNO",  # state-supported at .85
+            "XAMMAABCDEFGHIJKLXYZ",  # higher similarity, but wrong retrieval prefix
+        ],
+    )
+    paths = _fixture(
+        tmp_path,
+        controls=[control],
+        awards=[_award("GAMMAABCDEFGHIJKLXYZ", state="CA", zip_code="99999")],
+    )
+
+    rows = _rows(paths, _build(module, paths))
+
+    assert len(rows) == 1
+    assert rows[0]["candidate_routes"] == ["state_supported"]
+    assert rows[0]["issuer_name_normalized"] == "GAMMAABCDEFGHIJKLMNO"
+    assert rows[0]["ratio_similarity"] == 0.85
+
+
+def test_candidate_dedup_best_evidence_and_reordering_determinism(module, tmp_path: Path) -> None:
+    filings = [
+        _filing(
+            "20",
+            "BETA QUANTUM LABORATORY",
+            aliases=["BETA QUANTUM LABORATORY", "BETA QUANTUM LAB"],
+            accession="0000000000-20-000002",
+        ),
+        _filing(
+            "20",
+            "BETA QUANTUM LAB",
+            aliases=["BETA QUANTUM LAB", "BETA QUANTUM LABORATORY"],
+            accession="0000000000-20-000003",
+        ),
+    ]
+    first = _control(
+        "20",
+        "BETA QUANTUM LABORATORY",
+        aliases=["BETA QUANTUM LABORATORY", "BETA QUANTUM LAB"],
+        filings=filings,
+    )
+    second = _control(
+        "20",
+        "BETA QUANTUM LABORATORY",
+        aliases=["BETA QUANTUM LAB", "BETA QUANTUM LABORATORY"],
+        filings=list(reversed(filings)),
+    )
+    awards = [
+        _award("BETA QUANTUM LABS", year="2019", uei="ONE", duns="1"),
+        _award("BETA QUANTUM LABS", year="2018", uei="TWO", duns="2"),
+    ]
+    paths_a = _fixture(tmp_path, controls=[first], awards=awards, stem="a")
+    paths_b = _fixture(tmp_path, controls=[second], awards=list(reversed(awards)), stem="b")
+
+    rows_a = _rows(paths_a, _build(module, paths_a))
+    rows_b = _rows(paths_b, _build(module, paths_b))
+
+    assert rows_a == rows_b
+    assert len(rows_a) == 1
+    row = rows_a[0]
+    expected_id = hashlib.sha256(
+        b"form-d-sbir-exclusion-candidate-v1\0" + b"20\0BETA QUANTUM LABS"
+    ).hexdigest()
+    assert row["candidate_id"] == expected_id
+    assert row["issuer_name_normalized"] == "BETA QUANTUM LAB"
+    assert set(row) >= {"ratio_similarity", "token_set_similarity", "token_sort_similarity"}
+    assert "uei" not in json.dumps(row).lower()
+    assert "duns" not in json.dumps(row).lower()
+
+
+def test_short_geographic_lookalikes_do_not_qualify(module, tmp_path: Path) -> None:
+    control = _control(
+        "30",
+        "ABCDE",
+        filings=[_filing("30", "ABCDE", state="CA", zip_code="90210")],
+    )
+    paths = _fixture(
+        tmp_path,
+        controls=[control],
+        awards=[_award("XBCDE", state="CA", zip_code="90210")],
+    )
+    assert _rows(paths, _build(module, paths)) == []
+
+
+@pytest.mark.parametrize("input_name", ["controls", "exclusions", "awards"])
+def test_pinned_input_mismatch_fails_closed(module, tmp_path: Path, input_name: str) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("40", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+    with paths[input_name].open("ab") as handle:
+        handle.write(b"corruption")
+
+    with pytest.raises(module.BuildError, match="(byte|row|SHA|hash|pin)"):
+        _build(module, paths)
+
+
+def test_source_manifest_internal_count_mismatch_fails_closed(module, tmp_path: Path) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("41", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+    manifest = json.loads(paths["manifest"].read_text())
+    manifest["source_counts"]["provisional_control_ciks"] = 2
+    paths["manifest"].write_text(json.dumps(manifest))
+
+    with pytest.raises(module.BuildError, match="control count"):
+        _build(module, paths)
+
+
+def test_source_manifest_exact_exclusion_count_mismatch_fails_closed(
+    module, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("410", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+    manifest = json.loads(paths["manifest"].read_text())
+    manifest["source_counts"]["excluded_broad_ciks"] = 0
+    paths["manifest"].write_text(json.dumps(manifest))
+
+    with pytest.raises(module.BuildError, match="exact exclusion count"):
+        _build(module, paths)
+
+
+def test_blank_awards_csv_header_fails_closed(module, tmp_path: Path) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("411", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+    paths["awards"].write_text(
+        "Company,State,Zip,Award Year,UEI,Duns,\n"
+        "ACME ADVANCED SYSTEM,CA,94105,2018,IGNORED-UEI,000000001,\n"
+    )
+    manifest = json.loads(paths["manifest"].read_text())
+    manifest["exclusion"]["awards_csv"] = _product(paths["awards"], 1)
+    paths["manifest"].write_text(json.dumps(manifest))
+
+    with pytest.raises(module.BuildError, match="blank column name"):
+        _build(module, paths)
+
+
+def test_boolean_source_gate_does_not_accept_integer_zero(module, tmp_path: Path) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("42", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+    manifest = json.loads(paths["manifest"].read_text())
+    manifest["ready_for_matching"] = 0
+    paths["manifest"].write_text(json.dumps(manifest))
+
+    with pytest.raises(module.BuildError, match="ready_for_matching"):
+        _build(module, paths)
+
+
+def test_exact_exclusion_overlap_is_rejected_and_never_emitted(module, tmp_path: Path) -> None:
+    control = _control("50", "ACME ADVANCED SYSTEMS")
+    paths = _fixture(
+        tmp_path,
+        controls=[control],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+        exclusions=[_exclusion("50")],
+    )
+
+    with pytest.raises(module.BuildError, match="(overlap|exclusion)"):
+        _build(module, paths)
+
+
+def test_invalid_control_firm_key_fails_closed(module, tmp_path: Path) -> None:
+    control = _control("60", "ACME ADVANCED SYSTEMS")
+    control["firm_key"] = "uei:NOT-A-CIK"
+    paths = _fixture(
+        tmp_path,
+        controls=[control],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+
+    with pytest.raises(module.BuildError, match="firm_key"):
+        _build(module, paths)
+
+
+def test_publication_failure_preserves_prior_manifest(module, tmp_path: Path, monkeypatch) -> None:
+    paths = _fixture(
+        tmp_path,
+        controls=[_control("70", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+    )
+    first = _build(module, paths)
+    manifest_path = next(paths["output"].glob("*.manifest.json"))
+    original_manifest = manifest_path.read_bytes()
+    original_product = _candidate_product(first)
+    original_product_path = paths["output"] / original_product["path"]
+    assert original_product_path.is_file()
+
+    real_replace = os.replace
+
+    def fail_product_publish(source: str | Path, destination: str | Path) -> None:
+        if Path(destination).suffix == ".jsonl":
+            raise OSError("injected product publication failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(module.os, "replace", fail_product_publish)
+    with pytest.raises(OSError, match="injected"):
+        _build(module, paths)
+
+    assert manifest_path.read_bytes() == original_manifest
+    assert (
+        hashlib.sha256(original_product_path.read_bytes()).hexdigest() == original_product["sha256"]
+    )
+
+
+def test_manifest_publication_failure_preserves_prior_generation(
+    module, tmp_path: Path, monkeypatch
+) -> None:
+    first_paths = _fixture(
+        tmp_path,
+        controls=[_control("80", "ACME ADVANCED SYSTEMS")],
+        awards=[_award("ACME ADVANCED SYSTEM")],
+        stem="first",
+    )
+    first = _build(module, first_paths)
+    manifest_path = next(first_paths["output"].glob("*.manifest.json"))
+    original_manifest = manifest_path.read_bytes()
+    original_product = _candidate_product(first)
+    original_product_path = first_paths["output"] / original_product["path"]
+
+    second_paths = _fixture(
+        tmp_path,
+        controls=[_control("81", "BETA ADVANCED SYSTEMS")],
+        awards=[_award("BETA ADVANCED SYSTEM")],
+        stem="second",
+    )
+    second_paths["output"] = first_paths["output"]
+    real_replace = os.replace
+
+    def fail_manifest_publish(source: str | Path, destination: str | Path) -> None:
+        if Path(destination).suffix == ".json":
+            raise OSError("injected manifest publication failure")
+        real_replace(source, destination)
+
+    monkeypatch.setattr(module.os, "replace", fail_manifest_publish)
+    with pytest.raises(OSError, match="injected"):
+        _build(module, second_paths)
+
+    assert manifest_path.read_bytes() == original_manifest
+    assert (
+        hashlib.sha256(original_product_path.read_bytes()).hexdigest() == original_product["sha256"]
+    )


### PR DESCRIPTION
## Summary

- add a deterministic, candidate-only screen over the pinned provisional Form D controls and full SBIR award history
- retrieve exhaustive candidates within three frozen name/state/ZIP rules, retain review evidence, and apply zero automatic exclusions
- publish a content-addressed 2,588-pair queue spanning 1,568 CIKs plus a pinned real-data audit manifest
- preserve complete_sbir_exclusion=false, exclusion_recall=unknown, covariates_ready=false, and ready_for_matching=false

## Real-data gate

- 307,344 provisional control CIKs screened
- 4,465 upstream exact exclusions verified and kept disjoint
- 219,500 logical award records parsed, including multiline CSV records
- 2,588 unreviewed pairs across 1,568 CIKs
- 0 additional exclusions applied
- committed-version reruns produced byte-identical product and manifest bytes

This is a review queue, not a contamination rate or a validated non-SBIR cohort. Task 2.2 remains open pending adjudication, higher-recall authoritative identity evidence, and validated matching covariates.

## Validation

- 17 focused producer tests passed
- full unit suite: 5,888 passed, 7 skipped
- Ruff format/check passed
- MyPy passed
- docs, architecture boundaries, epistemic tiers, and study manifests passed
- git diff --check passed

## Stack

Draft stacked on #584. It also depends transitively on #582 and #577.