### PR TITLE
Define fail-closed PatentsView source contract

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/patent_source_contract.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/patent_source_contract.py
@@ -417,6 +417,12 @@ def _source_id(value: object, *, label: str) -> str:
     return source_id
 
 
+def _binary_flag(value: object, *, label: str) -> bool:
+    if value not in {"0", "1"}:
+        raise PatentSourceContractError(f"{label} must be 0 or 1")
+    return value == "1"
+
+
 def materialize_patent_grant_events(bundle: ValidatedPatentBundle) -> list[dict[str, Any]]:
     """Reduce a verified synthetic/small bundle to native patent-grant events.
 
@@ -443,7 +449,7 @@ def materialize_patent_grant_events(bundle: ValidatedPatentBundle) -> list[dict[
     application_rows = _read_verified_rows(bundle.files["application"])
     assignee_rows = _read_verified_rows(bundle.files["assignee"])
 
-    patents: dict[str, tuple[str, str | None]] = {}
+    patents: dict[str, tuple[str, str | None, bool]] = {}
     for row in patent_rows:
         patent_id = _source_id(row.get("patent_id"), label="patent patent_id")
         patent_date = _iso_date(row.get("patent_date"), label=f"patent {patent_id} date")
@@ -453,7 +459,11 @@ def materialize_patent_grant_events(bundle: ValidatedPatentBundle) -> list[dict[
             raise PatentSourceContractError(
                 f"patent {patent_id} date follows the bundle data_through_date"
             )
-        patent_value = (patent_date.isoformat(), _optional_text(row.get("patent_title")))
+        patent_value = (
+            patent_date.isoformat(),
+            _optional_text(row.get("patent_title")),
+            _binary_flag(row.get("withdrawn"), label=f"patent {patent_id} withdrawn"),
+        )
         prior_patent = patents.get(patent_id)
         if prior_patent is not None and prior_patent != patent_value:
             raise PatentSourceContractError(f"patent {patent_id} has conflicting rows")
@@ -494,7 +504,9 @@ def materialize_patent_grant_events(bundle: ValidatedPatentBundle) -> list[dict[
 
     events: list[dict[str, Any]] = []
     for (assignee_id, patent_id), (organization, assignee_type) in sorted(assignees.items()):
-        event_date, patent_title = patents[patent_id]
+        event_date, patent_title, withdrawn = patents[patent_id]
+        if withdrawn:
+            continue
         event = {
             "application_filing_date": applications.get(patent_id),
             "assignee_id": assignee_id,

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/patent_source_contract.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/patent_source_contract.py
@@ -1,0 +1,585 @@
+"""Fail-closed PatentsView source and candidate-bridge contracts.
+
+This module deliberately stops below the study-outcome layer. It validates a
+local three-table PVGPATDIS bundle, reduces it to assignee-native patent-grant
+events, and validates candidate-only CIK-to-assignee evidence. It does not
+download data, establish identity links, evaluate coverage, or report rates.
+"""
+
+import csv
+import hashlib
+import io
+import json
+import re
+import zipfile
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+
+
+SCHEMA_VERSION = 1
+BRIDGE_SCHEMA_VERSION = 1
+PRODUCT = "PVGPATDIS"
+EVENT_TYPE = "patent_grant"
+SOURCE_RELEASE_DOMAIN = "patentsview-source-release-v1"
+NORMALIZER_PROFILE = CompanyNameProfile.ORGANIZATION_KEY_V1
+EVIDENCE_METHOD = "exact_normalized_name"
+VALID_CANDIDATE_STATUSES = frozenset({"candidate", "ambiguous"})
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+CIK_RE = re.compile(r"[1-9][0-9]{0,9}")
+
+ROLE_MEMBERS = {
+    "application": "g_application.tsv",
+    "assignee": "g_assignee_disambiguated.tsv",
+    "patent": "g_patent.tsv",
+}
+
+REQUIRED_HEADERS = {
+    "application": (
+        "application_id",
+        "patent_id",
+        "patent_application_type",
+        "filing_date",
+        "series_code",
+        "rule_47_flag",
+    ),
+    "assignee": (
+        "patent_id",
+        "assignee_sequence",
+        "assignee_id",
+        "disambig_assignee_individual_name_first",
+        "disambig_assignee_individual_name_last",
+        "disambig_assignee_organization",
+        "assignee_type",
+        "location_id",
+    ),
+    "patent": (
+        "patent_id",
+        "patent_type",
+        "patent_date",
+        "patent_title",
+        "wipo_kind",
+        "num_claims",
+        "withdrawn",
+        "filename",
+    ),
+}
+
+EVENT_FIELDS = frozenset(
+    {
+        "application_filing_date",
+        "assignee_id",
+        "assignee_organization",
+        "assignee_type",
+        "event_date",
+        "event_type",
+        "patent_id",
+        "patent_title",
+        "schema_version",
+        "source_release_id",
+    }
+)
+
+BRIDGE_FIELDS = frozenset(
+    {
+        "assignee_id",
+        "bridge_schema_version",
+        "candidate_status",
+        "evidence_method",
+        "form_d_cik",
+        "normalized_name_key",
+        "normalizer_profile",
+        "source_release_id",
+    }
+)
+
+
+class PatentSourceContractError(ValueError):
+    """Raised when source evidence cannot satisfy the patent contract."""
+
+
+@dataclass(frozen=True)
+class ValidatedPatentFile:
+    """One content-pinned ZIP role in a validated source release."""
+
+    role: str
+    path: Path
+    archive_member: str
+    sha256: str
+    size_bytes: int
+    headers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ValidatedPatentBundle:
+    """A verified local PVGPATDIS release."""
+
+    source_release_id: str
+    release_date: date
+    data_through_date: date
+    source_url: str
+    license_url: str
+    files: Mapping[str, ValidatedPatentFile]
+
+
+def _required_text(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise PatentSourceContractError(f"{label} must be a nonblank string")
+    return value.strip()
+
+
+def _strict_int(value: object, *, label: str, positive: bool = False) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise PatentSourceContractError(f"{label} must be an integer")
+    if value < (1 if positive else 0):
+        qualifier = "positive" if positive else "non-negative"
+        raise PatentSourceContractError(f"{label} must be {qualifier}")
+    return value
+
+
+def _iso_date(value: object, *, label: str, optional: bool = False) -> date | None:
+    if optional and (value is None or (isinstance(value, str) and not value.strip())):
+        return None
+    text = _required_text(value, label=label)
+    try:
+        return date.fromisoformat(text)
+    except ValueError as exc:
+        raise PatentSourceContractError(f"{label} must be an ISO date") from exc
+
+
+def _https_url(value: object, *, label: str) -> str:
+    url = _required_text(value, label=label)
+    parsed = urlsplit(url)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise PatentSourceContractError(f"{label} must be an HTTPS URL")
+    return url
+
+
+def _sha256_path(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _safe_local_path(base_dir: Path, value: object, *, role: str) -> Path:
+    raw_path = _required_text(value, label=f"{role} local_path")
+    relative = Path(raw_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise PatentSourceContractError(f"{role} local_path must stay within base_dir")
+    base = base_dir.resolve()
+    resolved = (base / relative).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise PatentSourceContractError(f"{role} local_path escapes base_dir")
+    if not resolved.is_file():
+        raise PatentSourceContractError(f"{role} archive is missing: {resolved}")
+    return resolved
+
+
+def _declared_headers(value: object, *, role: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise PatentSourceContractError(f"{role} headers must be a nonempty list")
+    headers: list[str] = []
+    for header in value:
+        canonical_header = _required_text(header, label=f"{role} header")
+        if header != canonical_header:
+            raise PatentSourceContractError(
+                f"{role} declared headers must not contain surrounding whitespace"
+            )
+        headers.append(canonical_header)
+    normalized = [header.casefold() for header in headers]
+    if len(normalized) != len(set(normalized)):
+        raise PatentSourceContractError(f"{role} headers contain duplicates")
+    return tuple(headers)
+
+
+def _observed_headers(path: Path, *, role: str, member: str) -> tuple[str, ...]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            matches = [info for info in archive.infolist() if info.filename == member]
+            if len(matches) != 1:
+                raise PatentSourceContractError(
+                    f"{role} archive must contain declared member exactly once: {member}"
+                )
+            if matches[0].flag_bits & 0x1:
+                raise PatentSourceContractError(f"{role} archive member must not be encrypted")
+            with archive.open(matches[0]) as raw:
+                with io.TextIOWrapper(
+                    raw, encoding="utf-8-sig", errors="strict", newline=""
+                ) as text:
+                    reader = csv.reader(text, delimiter="\t", strict=True)
+                    try:
+                        raw_headers = next(reader)
+                    except StopIteration as exc:
+                        raise PatentSourceContractError(f"{role} archive member is empty") from exc
+    except (OSError, UnicodeDecodeError, csv.Error, zipfile.BadZipFile) as exc:
+        raise PatentSourceContractError(f"{role} archive is not a readable UTF-8 TSV ZIP") from exc
+
+    headers = tuple(raw_headers)
+    if any(not header for header in headers):
+        raise PatentSourceContractError(f"{role} archive has a blank header")
+    if any(header != header.strip() for header in headers):
+        raise PatentSourceContractError(
+            f"{role} archive headers must not contain surrounding whitespace"
+        )
+    normalized = [header.casefold() for header in headers]
+    if len(normalized) != len(set(normalized)):
+        raise PatentSourceContractError(f"{role} archive has duplicate headers")
+    missing = set(REQUIRED_HEADERS[role]) - set(headers)
+    if missing:
+        raise PatentSourceContractError(f"{role} archive is missing headers: {sorted(missing)}")
+    return headers
+
+
+def _canonical_release_payload(
+    *,
+    release_date: date,
+    data_through_date: date,
+    files: Mapping[str, ValidatedPatentFile],
+) -> bytes:
+    payload = {
+        "data_through_date": data_through_date.isoformat(),
+        "files": [
+            {
+                "archive_member": files[role].archive_member,
+                "headers": list(files[role].headers),
+                "role": role,
+                "sha256": files[role].sha256,
+                "size_bytes": files[role].size_bytes,
+            }
+            for role in sorted(files)
+        ],
+        "product": PRODUCT,
+        "release_date": release_date.isoformat(),
+        "schema_version": SCHEMA_VERSION,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _derive_release_id(
+    *,
+    release_date: date,
+    data_through_date: date,
+    files: Mapping[str, ValidatedPatentFile],
+) -> str:
+    release_payload = _canonical_release_payload(
+        release_date=release_date,
+        data_through_date=data_through_date,
+        files=files,
+    )
+    return hashlib.sha256(SOURCE_RELEASE_DOMAIN.encode() + b"\0" + release_payload).hexdigest()
+
+
+def validate_patent_source_bundle(
+    manifest: Mapping[str, Any], *, base_dir: Path
+) -> ValidatedPatentBundle:
+    """Verify a local three-ZIP PVGPATDIS bundle and derive its release ID.
+
+    ``local_path`` and optional operational fields such as ``downloaded_at`` are
+    intentionally excluded from the release-ID payload.
+    """
+
+    if not isinstance(manifest, Mapping):
+        raise PatentSourceContractError("manifest must be an object")
+    schema_version = _strict_int(manifest.get("schema_version"), label="schema_version")
+    if schema_version != SCHEMA_VERSION:
+        raise PatentSourceContractError("unsupported schema_version")
+    if manifest.get("product") != PRODUCT:
+        raise PatentSourceContractError(f"product must be {PRODUCT}")
+    release_date = _iso_date(manifest.get("release_date"), label="release_date")
+    data_through_date = _iso_date(manifest.get("data_through_date"), label="data_through_date")
+    if release_date is None or data_through_date is None:
+        raise AssertionError("required dates were not parsed")
+    if data_through_date > release_date:
+        raise PatentSourceContractError("data_through_date must not follow release_date")
+    source_url = _https_url(manifest.get("source_url"), label="source_url")
+    license_url = _https_url(manifest.get("license_url"), label="license_url")
+
+    raw_files = manifest.get("files")
+    if not isinstance(raw_files, list):
+        raise PatentSourceContractError("files must be a list")
+    if len(raw_files) != len(ROLE_MEMBERS):
+        raise PatentSourceContractError("files must contain exactly the three required roles")
+
+    files: dict[str, ValidatedPatentFile] = {}
+    for index, raw_file in enumerate(raw_files):
+        if not isinstance(raw_file, Mapping):
+            raise PatentSourceContractError(f"files[{index}] must be an object")
+        role = _required_text(raw_file.get("role"), label=f"files[{index}].role")
+        if role not in ROLE_MEMBERS:
+            raise PatentSourceContractError(f"unknown patent source role: {role}")
+        if role in files:
+            raise PatentSourceContractError(f"duplicate patent source role: {role}")
+        member = _required_text(raw_file.get("archive_member"), label=f"{role} archive_member")
+        if member != ROLE_MEMBERS[role]:
+            raise PatentSourceContractError(f"{role} archive_member must be {ROLE_MEMBERS[role]}")
+        declared_sha = _required_text(raw_file.get("sha256"), label=f"{role} sha256")
+        if not SHA256_RE.fullmatch(declared_sha):
+            raise PatentSourceContractError(f"{role} sha256 is invalid")
+        declared_size = _strict_int(
+            raw_file.get("size_bytes"), label=f"{role} size_bytes", positive=True
+        )
+        declared_headers = _declared_headers(raw_file.get("headers"), role=role)
+        path = _safe_local_path(base_dir, raw_file.get("local_path"), role=role)
+        observed_sha, observed_size = _sha256_path(path)
+        if observed_size != declared_size:
+            raise PatentSourceContractError(f"{role} archive size does not match its pin")
+        if observed_sha != declared_sha:
+            raise PatentSourceContractError(f"{role} archive SHA-256 does not match its pin")
+        headers = _observed_headers(path, role=role, member=member)
+        if headers != declared_headers:
+            raise PatentSourceContractError(f"{role} archive headers do not match their pin")
+        files[role] = ValidatedPatentFile(
+            role=role,
+            path=path,
+            archive_member=member,
+            sha256=observed_sha,
+            size_bytes=observed_size,
+            headers=headers,
+        )
+
+    if set(files) != set(ROLE_MEMBERS):
+        raise PatentSourceContractError("source bundle does not contain every required role")
+    source_release_id = _derive_release_id(
+        release_date=release_date,
+        data_through_date=data_through_date,
+        files=files,
+    )
+    declared_release_id = manifest.get("source_release_id")
+    if declared_release_id is not None and declared_release_id != source_release_id:
+        raise PatentSourceContractError("source_release_id does not match verified source content")
+    return ValidatedPatentBundle(
+        source_release_id=source_release_id,
+        release_date=release_date,
+        data_through_date=data_through_date,
+        source_url=source_url,
+        license_url=license_url,
+        files=dict(files),
+    )
+
+
+def _read_verified_rows(file: ValidatedPatentFile) -> list[dict[str, str]]:
+    try:
+        archive_bytes = file.path.read_bytes()
+        if len(archive_bytes) != file.size_bytes:
+            raise PatentSourceContractError(f"{file.role} archive size changed after validation")
+        if hashlib.sha256(archive_bytes).hexdigest() != file.sha256:
+            raise PatentSourceContractError(f"{file.role} archive SHA-256 changed after validation")
+        with zipfile.ZipFile(io.BytesIO(archive_bytes)) as archive:
+            matches = [info for info in archive.infolist() if info.filename == file.archive_member]
+            if len(matches) != 1:
+                raise PatentSourceContractError(
+                    f"{file.role} archive member changed after validation"
+                )
+            rows: list[dict[str, str]] = []
+            with archive.open(matches[0]) as raw:
+                with io.TextIOWrapper(
+                    raw, encoding="utf-8-sig", errors="strict", newline=""
+                ) as text:
+                    reader = csv.DictReader(text, delimiter="\t", strict=True)
+                    if tuple(reader.fieldnames or ()) != file.headers:
+                        raise PatentSourceContractError(
+                            f"{file.role} archive headers changed after validation"
+                        )
+                    for row in reader:
+                        if None in row or any(value is None for value in row.values()):
+                            raise PatentSourceContractError(
+                                f"{file.role} archive contains a malformed TSV row"
+                            )
+                        rows.append(dict(row))
+            return rows
+    except (OSError, UnicodeDecodeError, csv.Error, zipfile.BadZipFile) as exc:
+        raise PatentSourceContractError(
+            f"{file.role} archive changed or became unreadable after validation"
+        ) from exc
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _source_id(value: object, *, label: str) -> str:
+    source_id = _required_text(value, label=label)
+    if value != source_id:
+        raise PatentSourceContractError(f"{label} must not contain surrounding whitespace")
+    return source_id
+
+
+def materialize_patent_grant_events(bundle: ValidatedPatentBundle) -> list[dict[str, Any]]:
+    """Reduce a verified synthetic/small bundle to native patent-grant events.
+
+    This in-memory reducer proves the contract only; it is not a production bulk
+    materializer and makes no source-coverage claim.
+    """
+
+    if set(bundle.files) != set(ROLE_MEMBERS):
+        raise PatentSourceContractError("validated patent bundle must contain exactly three roles")
+    for role, file in bundle.files.items():
+        if file.role != role or file.archive_member != ROLE_MEMBERS[role]:
+            raise PatentSourceContractError(
+                f"validated patent bundle has invalid {role} role metadata"
+            )
+    expected_release_id = _derive_release_id(
+        release_date=bundle.release_date,
+        data_through_date=bundle.data_through_date,
+        files=bundle.files,
+    )
+    if bundle.source_release_id != expected_release_id:
+        raise PatentSourceContractError("validated patent bundle source_release_id is stale")
+
+    patent_rows = _read_verified_rows(bundle.files["patent"])
+    application_rows = _read_verified_rows(bundle.files["application"])
+    assignee_rows = _read_verified_rows(bundle.files["assignee"])
+
+    patents: dict[str, tuple[str, str | None]] = {}
+    for row in patent_rows:
+        patent_id = _source_id(row.get("patent_id"), label="patent patent_id")
+        patent_date = _iso_date(row.get("patent_date"), label=f"patent {patent_id} date")
+        if patent_date is None:
+            raise AssertionError("required patent date was not parsed")
+        if patent_date > bundle.data_through_date:
+            raise PatentSourceContractError(
+                f"patent {patent_id} date follows the bundle data_through_date"
+            )
+        patent_value = (patent_date.isoformat(), _optional_text(row.get("patent_title")))
+        prior_patent = patents.get(patent_id)
+        if prior_patent is not None and prior_patent != patent_value:
+            raise PatentSourceContractError(f"patent {patent_id} has conflicting rows")
+        patents[patent_id] = patent_value
+
+    applications: dict[str, str | None] = {}
+    for row in application_rows:
+        patent_id = _source_id(row.get("patent_id"), label="application patent_id")
+        if patent_id not in patents:
+            raise PatentSourceContractError(f"application references unknown patent {patent_id}")
+        filing_date = _iso_date(
+            row.get("filing_date"), label=f"application {patent_id} filing_date", optional=True
+        )
+        if filing_date is not None and filing_date > date.fromisoformat(patents[patent_id][0]):
+            raise PatentSourceContractError(
+                f"application {patent_id} filing_date follows its patent grant date"
+            )
+        application_value = filing_date.isoformat() if filing_date else None
+        if patent_id in applications and applications[patent_id] != application_value:
+            raise PatentSourceContractError(f"patent {patent_id} has conflicting applications")
+        applications[patent_id] = application_value
+
+    assignees: dict[tuple[str, str], tuple[str | None, str | None]] = {}
+    for row in assignee_rows:
+        patent_id = _source_id(row.get("patent_id"), label="assignee patent_id")
+        assignee_id = _source_id(row.get("assignee_id"), label=f"patent {patent_id} assignee_id")
+        if patent_id not in patents:
+            raise PatentSourceContractError(f"assignee references unknown patent {patent_id}")
+        key = (assignee_id, patent_id)
+        assignee_value = (
+            _optional_text(row.get("disambig_assignee_organization")),
+            _optional_text(row.get("assignee_type")),
+        )
+        prior_assignee = assignees.get(key)
+        if prior_assignee is not None and prior_assignee != assignee_value:
+            raise PatentSourceContractError(f"assignee/patent key {key!r} has conflicting rows")
+        assignees[key] = assignee_value
+
+    events: list[dict[str, Any]] = []
+    for (assignee_id, patent_id), (organization, assignee_type) in sorted(assignees.items()):
+        event_date, patent_title = patents[patent_id]
+        event = {
+            "application_filing_date": applications.get(patent_id),
+            "assignee_id": assignee_id,
+            "assignee_organization": organization,
+            "assignee_type": assignee_type,
+            "event_date": event_date,
+            "event_type": EVENT_TYPE,
+            "patent_id": patent_id,
+            "patent_title": patent_title,
+            "schema_version": SCHEMA_VERSION,
+            "source_release_id": bundle.source_release_id,
+        }
+        if set(event) != EVENT_FIELDS:
+            raise AssertionError("native patent event schema drifted")
+        events.append(event)
+    return events
+
+
+def _valid_cik(value: object) -> str:
+    cik = _required_text(value, label="form_d_cik")
+    if value != cik or not CIK_RE.fullmatch(cik):
+        raise PatentSourceContractError("form_d_cik must be an unpadded SEC CIK")
+    return cik
+
+
+def validate_patent_bridge_candidates(
+    rows: Iterable[Mapping[str, Any]], *, source_release_id: str
+) -> list[dict[str, Any]]:
+    """Validate exact-name bridge evidence without accepting an identity link."""
+
+    expected_release_id = _required_text(source_release_id, label="source_release_id")
+    if not SHA256_RE.fullmatch(expected_release_id):
+        raise PatentSourceContractError("source_release_id must be a lowercase SHA-256 digest")
+    candidates: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for index, raw_row in enumerate(rows):
+        if not isinstance(raw_row, Mapping):
+            raise PatentSourceContractError(f"bridge row {index} must be an object")
+        if set(raw_row) != BRIDGE_FIELDS:
+            raise PatentSourceContractError(
+                f"bridge row {index} must contain only the candidate contract fields"
+            )
+        version = _strict_int(raw_row.get("bridge_schema_version"), label="bridge_schema_version")
+        if version != BRIDGE_SCHEMA_VERSION:
+            raise PatentSourceContractError("unsupported bridge_schema_version")
+        if raw_row.get("source_release_id") != expected_release_id:
+            raise PatentSourceContractError("bridge source_release_id does not match the source")
+        cik = _valid_cik(raw_row.get("form_d_cik"))
+        assignee_id = _source_id(raw_row.get("assignee_id"), label="assignee_id")
+        if raw_row.get("normalizer_profile") != NORMALIZER_PROFILE.value:
+            raise PatentSourceContractError("bridge normalizer_profile is not pinned")
+        normalized_name = _required_text(
+            raw_row.get("normalized_name_key"), label="normalized_name_key"
+        )
+        if normalize_company_name(normalized_name, profile=NORMALIZER_PROFILE) != normalized_name:
+            raise PatentSourceContractError("normalized_name_key is not canonical")
+        if raw_row.get("evidence_method") != EVIDENCE_METHOD:
+            raise PatentSourceContractError("bridge evidence_method must be exact normalized name")
+        status = raw_row.get("candidate_status")
+        if not isinstance(status, str) or status not in VALID_CANDIDATE_STATUSES:
+            raise PatentSourceContractError("candidate_status must be candidate or ambiguous")
+        candidate = {
+            "assignee_id": assignee_id,
+            "bridge_schema_version": BRIDGE_SCHEMA_VERSION,
+            "candidate_status": status,
+            "evidence_method": EVIDENCE_METHOD,
+            "form_d_cik": cik,
+            "normalized_name_key": normalized_name,
+            "normalizer_profile": NORMALIZER_PROFILE.value,
+            "source_release_id": expected_release_id,
+        }
+        key = (normalized_name, cik, assignee_id)
+        prior = candidates.get(key)
+        if prior is not None and prior != candidate:
+            raise PatentSourceContractError(f"bridge candidate {key!r} has conflicting rows")
+        candidates[key] = candidate
+
+    identities_by_name: dict[str, tuple[set[str], set[str]]] = defaultdict(lambda: (set(), set()))
+    for normalized_name, cik, assignee_id in candidates:
+        ciks, assignees = identities_by_name[normalized_name]
+        ciks.add(cik)
+        assignees.add(assignee_id)
+    for key, candidate in candidates.items():
+        ciks, assignees = identities_by_name[key[0]]
+        if (len(ciks) > 1 or len(assignees) > 1) and candidate["candidate_status"] != "ambiguous":
+            raise PatentSourceContractError(
+                f"normalized name {key[0]!r} maps to multiple identities and must be ambiguous"
+            )
+    return [candidates[key] for key in sorted(candidates)]

--- a/specs/agency-private-capital-comparison/design.md
+++ b/specs/agency-private-capital-comparison/design.md
@@ -161,6 +161,17 @@ eligible controls                         configured-agency treated cohort
    M&A adapters remain separate follow-ons. The matched asset continues to mark
    the proxy unavailable until an eligible matched risk set and the symmetric
    event/coverage artifacts are supplied.
+
+   The patent follow-on starts one layer below study outcomes. A local
+   `PVGPATDIS` contract validates exactly three pinned roles
+   (`g_assignee_disambiguated`, `g_patent`, and `g_application`) and reduces
+   them to deterministic, assignee-native `patent_grant` events. The source
+   release ID is content-derived and independent of local paths, download
+   timestamps, and manifest ordering. A separate minimal bridge contract may
+   emit exact-name evidence only as `candidate` or `ambiguous`. It cannot emit
+   accepted links, firm coverage, availability, denominators, or rates. Bulk
+   acquisition, production-scale materialization, real bridge review, and the
+   five-year patent outcome adapter remain separate work.
 9. **`ThreatsToValidity`** — Emits the structured caveats record. Required
    entries:
    - SAFE/convertible undercount (Form D weak on these)

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -8,8 +8,10 @@
 > producer, not a valid matched comparison. The staged universe has incomplete
 > SBIR exclusion and no validated NAICS-2 covariate. A shared date-aware
 > event/coverage contract and a CIK-native Form D business-combination filing
-> proxy now exist, but FPDS, patent, and verified M&A outcome inputs remain
-> missing. Do not materialize or publish Phase 2
+> proxy now exist. A synthetic-only, fail-closed PatentsView source contract
+> also exists, but no real patent release, accepted identity bridge, coverage,
+> or outcome projection does. FPDS, patent-outcome, and verified-M&A inputs
+> remain missing. Do not materialize or publish Phase 2
 > before the Phase 1, identity, covariate, and outcome gates are satisfied.
 > Supports inventory questions **F3** (private-capital comparison), **B2** (commercialization outcomes), **B3** (transition rates) in [docs/research-questions.md](../../docs/research-questions.md).
 
@@ -82,6 +84,14 @@ The bounded broad-universe prerequisite is now maintained separately by
 for the closed 2009Q1–2024Q4 window and pins sources and products in deterministic
 manifests. The [official Form D](https://www.sec.gov/files/Form_D.pdf) and DERA
 files provide SIC and Form D industry group, not NAICS.
+
+The patent source boundary uses the USPTO PatentsView Granted Patent
+Disambiguated Data product (`PVGPATDIS`). The three-table contract follows the
+field names in the official
+[PatentsView export definitions](https://github.com/PatentsView/PatentsView-DB/blob/5ba17dea3ef9435065301a10dc7bd094ed8f586d/resources/create_export_views.sql).
+PatentsView is a research dataset rather than the official patent record, so a
+later real-data acquisition must pin the release and preserve that limitation;
+see the [USPTO PatentsView description](https://www.uspto.gov/ip-policy/economic-research/patentsview).
 
 ## Phasing
 
@@ -213,6 +223,18 @@ provisional identity staging only.
     unavailable, never zero. Implement remaining source contracts in separate
     follow-on PRs. Survival proxy and Phase-graduation rates do not apply to
     controls and remain N/A.
+
+    Patent staging SHALL begin with a separate, fail-closed PatentsView
+    granted-patent source contract. Before any study outcome is possible, the
+    contract SHALL verify one pinned `PVGPATDIS` release containing the
+    assignee, patent, and application ZIP roles by byte size, SHA-256, declared
+    archive member, and required headers. Its native event grain is
+    `(source_release_id, assignee_id, patent_id)` and SHALL contain no CIK,
+    cohort arm, index date, availability flag, denominator, or rate. A Form D
+    CIK-to-assignee name match SHALL remain `candidate` or `ambiguous`; this
+    contract SHALL NOT accept a link or turn missing patent evidence into zero.
+    Real acquisition, identity adjudication, coverage, and outcome projection
+    remain later gates.
 11. **SHALL** publish a threats-to-validity section before any headline
     finding. Required entries: SAFE/convertible undercount, late-stage Form
     D inclusion, unknown exact-name exclusion recall, alias/rename/acquisition
@@ -240,7 +262,9 @@ not sufficient to evaluate it.
 - NSF identification (ALN 47.041 / 47.084) — `sbir_etl/models/sbir_identification.py` (EXISTS)
 - Transition detection (≥85% precision) — `packages/sbir-ml/sbir_ml/transition/` (EXISTS)
 - Entity resolution cascade — UEI/DUNS/CAGE/fuzzy-name (EXISTS)
-- Phase 2 patent linkage — NOT WIRED; no PATLINK input is present in the scaffold
+- Phase 2 patent linkage — native synthetic source contract EXISTS; a real
+  release, accepted CIK-to-assignee bridge, coverage, and PATLINK outcome input
+  are NOT WIRED
 - CET classifier (EXISTS, used for Phase 1 stratification)
 - Official SEC DERA quarterly Form D bulk data, pinned 2009Q1–2024Q4 — staging
   producer EXISTS; higher-recall exclusion and validated NAICS-2 do not

--- a/specs/agency-private-capital-comparison/tasks.md
+++ b/specs/agency-private-capital-comparison/tasks.md
@@ -17,7 +17,9 @@
 > contract, but do not constitute an M&A-exit outcome or matched comparison. A
 > deterministic possible-contamination screen now queues fuzzy name/location
 > candidates for review without changing the provisional controls or the open
-> identity gate.
+> identity gate. A synthetic-only PatentsView contract now proves pinned source
+> validation and assignee-native grant reduction, but real patent acquisition,
+> identity adjudication, coverage, and outcome projection remain open.
 
 Tasks are grouped by phase. Phase 1 ships independently of PR #286. Phase 2 is
 gated on Phase 1 sign-off and its missing real-data input contracts.
@@ -146,7 +148,12 @@ on a pinned real-data run.
   unavailable, never zero. The pinned
   [real-data source-adapter audit](../../docs/research/agency-private-capital-form-d-business-combination-proxy.md)
   materialized 14,408 evidence filings across 10,224 CIKs and 311,809 explicit
-  coverage rows; those are source counts, not matched-cohort outcomes.
+  coverage rows; those are source counts, not matched-cohort outcomes. A
+  contract-only PatentsView follow-on now validates synthetic pinned assignee,
+  patent, and application archives, reduces them to assignee-native grant
+  events, and keeps CIK-to-assignee name evidence candidate-only. It performs
+  no real bulk acquisition or identity adjudication and cannot emit patent
+  coverage or a rate, so the patent portion of this task remains open.
 - [ ] 2.5 Complete the `ThreatsToValidity` gate — required entries: SAFE/convertible
   undercount, late-stage Form D inclusion, incomplete SBIR-CIK exclusion,
   SIC-to-NAICS-2 mapping validity, technical-merit vs. lawyer-access selection

--- a/tests/unit/agency_private_capital/test_patent_source_contract.py
+++ b/tests/unit/agency_private_capital/test_patent_source_contract.py
@@ -334,6 +334,17 @@ def test_native_grant_events_have_exact_schema_and_joint_assignees(tmp_path: Pat
     assert not any(forbidden & set(row) for row in events)
 
 
+def test_withdrawn_patent_cannot_materialize_a_grant_event(tmp_path: Path) -> None:
+    rows = _default_rows()
+    rows["patent"][0]["withdrawn"] = "1"
+    manifest, root = _source_fixture(tmp_path, rows=rows)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    events = contract.materialize_patent_grant_events(bundle)
+
+    assert {row["patent_id"] for row in events} == {"P2"}
+
+
 def test_missing_application_join_is_nullable(tmp_path: Path) -> None:
     rows = _default_rows()
     rows["application"] = rows["application"][:1]
@@ -411,6 +422,10 @@ def test_native_reducer_rejects_temporal_inconsistency(
         (
             lambda rows: rows["patent"][0].update(patent_id=" P1 "),
             "surrounding whitespace",
+        ),
+        (
+            lambda rows: rows["patent"][0].update(withdrawn="yes"),
+            "withdrawn must be 0 or 1",
         ),
     ],
 )

--- a/tests/unit/agency_private_capital/test_patent_source_contract.py
+++ b/tests/unit/agency_private_capital/test_patent_source_contract.py
@@ -1,0 +1,530 @@
+"""Tests for the fail-closed PatentsView source contract."""
+
+import copy
+import csv
+import hashlib
+import io
+import shutil
+import zipfile
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sbir_analytics.assets.agency_private_capital import patent_source_contract as contract
+
+
+def _tsv(headers: list[str], rows: list[dict[str, str]]) -> bytes:
+    text = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        text,
+        fieldnames=headers,
+        delimiter="\t",
+        extrasaction="ignore",
+        lineterminator="\n",
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return text.getvalue().encode()
+
+
+def _write_zip(
+    path: Path,
+    *,
+    member: str,
+    headers: list[str],
+    rows: list[dict[str, str]],
+    duplicate_member: bool = False,
+) -> None:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(member, _tsv(headers, rows))
+        if duplicate_member:
+            archive.writestr(member, _tsv(headers, rows))
+
+
+def _default_rows() -> dict[str, list[dict[str, str]]]:
+    return {
+        "application": [
+            {
+                "application_id": "APP-1",
+                "patent_id": "P1",
+                "patent_application_type": "utility",
+                "filing_date": "2019-01-10",
+                "series_code": "16",
+                "rule_47_flag": "0",
+            },
+            {
+                "application_id": "APP-2",
+                "patent_id": "P2",
+                "patent_application_type": "utility",
+                "filing_date": "",
+                "series_code": "16",
+                "rule_47_flag": "0",
+            },
+        ],
+        "assignee": [
+            {
+                "patent_id": "P1",
+                "assignee_sequence": "1",
+                "assignee_id": "A2",
+                "disambig_assignee_individual_name_first": "",
+                "disambig_assignee_individual_name_last": "",
+                "disambig_assignee_organization": "Beta Labs",
+                "assignee_type": "2",
+                "location_id": "L2",
+            },
+            {
+                "patent_id": "P1",
+                "assignee_sequence": "0",
+                "assignee_id": "A1",
+                "disambig_assignee_individual_name_first": "",
+                "disambig_assignee_individual_name_last": "",
+                "disambig_assignee_organization": "Alpha Systems",
+                "assignee_type": "2",
+                "location_id": "L1",
+            },
+            {
+                "patent_id": "P2",
+                "assignee_sequence": "0",
+                "assignee_id": "A3",
+                "disambig_assignee_individual_name_first": "Ada",
+                "disambig_assignee_individual_name_last": "Lovelace",
+                "disambig_assignee_organization": "",
+                "assignee_type": "1",
+                "location_id": "L3",
+            },
+        ],
+        "patent": [
+            {
+                "patent_id": "P1",
+                "patent_type": "utility",
+                "patent_date": "2020-01-15",
+                "patent_title": "First invention",
+                "wipo_kind": "B2",
+                "num_claims": "12",
+                "withdrawn": "0",
+                "filename": "ipg.xml",
+            },
+            {
+                "patent_id": "P2",
+                "patent_type": "utility",
+                "patent_date": "2021-02-20",
+                "patent_title": "Second invention",
+                "wipo_kind": "B2",
+                "num_claims": "4",
+                "withdrawn": "0",
+                "filename": "ipg.xml",
+            },
+        ],
+    }
+
+
+def _source_fixture(
+    tmp_path: Path,
+    *,
+    rows: dict[str, list[dict[str, str]]] | None = None,
+    headers: dict[str, list[str]] | None = None,
+    duplicate_member_role: str | None = None,
+) -> tuple[dict[str, Any], Path]:
+    root = tmp_path / "source"
+    root.mkdir(parents=True)
+    source_rows = rows or _default_rows()
+    source_headers = headers or {
+        role: list(contract.REQUIRED_HEADERS[role]) for role in contract.ROLE_MEMBERS
+    }
+    files: list[dict[str, Any]] = []
+    for role in ("patent", "application", "assignee"):
+        zip_name = f"{role}.zip"
+        zip_path = root / zip_name
+        _write_zip(
+            zip_path,
+            member=contract.ROLE_MEMBERS[role],
+            headers=source_headers[role],
+            rows=source_rows[role],
+            duplicate_member=role == duplicate_member_role,
+        )
+        data = zip_path.read_bytes()
+        files.append(
+            {
+                "archive_member": contract.ROLE_MEMBERS[role],
+                "headers": source_headers[role],
+                "local_path": zip_name,
+                "role": role,
+                "sha256": hashlib.sha256(data).hexdigest(),
+                "size_bytes": len(data),
+            }
+        )
+    manifest = {
+        "data_through_date": "2026-03-31",
+        "downloaded_at": "2026-08-09T12:00:00Z",
+        "files": files,
+        "license_url": "https://example.test/patentsview-license",
+        "product": "PVGPATDIS",
+        "release_date": "2026-06-30",
+        "schema_version": 1,
+        "source_url": "https://example.test/patentsview-source",
+    }
+    return manifest, root
+
+
+def _bridge_row(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "assignee_id": "A1",
+        "bridge_schema_version": 1,
+        "candidate_status": "candidate",
+        "evidence_method": "exact_normalized_name",
+        "form_d_cik": "12345",
+        "normalized_name_key": "ALPHA SYSTEMS",
+        "normalizer_profile": "organization-key-v1",
+        "source_release_id": "a" * 64,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_valid_bundle_release_id_ignores_order_paths_and_download_time(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    first = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    copied = root / "copied"
+    copied.mkdir()
+    second_manifest = copy.deepcopy(manifest)
+    second_manifest["files"].reverse()
+    second_manifest["downloaded_at"] = "2099-01-01T00:00:00Z"
+    second_manifest["verified"] = True
+    for file_row in second_manifest["files"]:
+        source = root / file_row["local_path"]
+        destination = copied / file_row["local_path"]
+        shutil.copyfile(source, destination)
+        file_row["local_path"] = f"copied/{destination.name}"
+
+    second = contract.validate_patent_source_bundle(second_manifest, base_dir=root)
+
+    assert first.source_release_id == second.source_release_id
+    assert set(first.files) == {"application", "assignee", "patent"}
+    pinned = copy.deepcopy(manifest)
+    pinned["source_release_id"] = first.source_release_id
+    assert contract.validate_patent_source_bundle(pinned, base_dir=root) == first
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda manifest: manifest["files"].pop(), "exactly"),
+        (
+            lambda manifest: manifest["files"].__setitem__(0, copy.deepcopy(manifest["files"][2])),
+            "duplicate",
+        ),
+        (lambda manifest: manifest["files"][0].update(role="inventor"), "unknown"),
+    ],
+)
+def test_required_roles_fail_closed(tmp_path: Path, mutation, message: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    mutation(manifest)
+    with pytest.raises(contract.PatentSourceContractError, match=message):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("schema_version", True, "schema_version"),
+        ("product", "OTHER", "product"),
+        ("release_date", "June 2026", "ISO date"),
+        ("data_through_date", "2027-01-01", "must not follow"),
+        ("source_url", "http://example.test/source", "HTTPS"),
+        ("license_url", "", "nonblank"),
+    ],
+)
+def test_manifest_metadata_fails_closed(
+    tmp_path: Path, field: str, value: Any, message: str
+) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    manifest[field] = value
+    with pytest.raises(contract.PatentSourceContractError, match=message):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("bad_path", ["../patent.zip", "/tmp/patent.zip"])
+def test_local_paths_cannot_escape_base_dir(tmp_path: Path, bad_path: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    manifest["files"][0]["local_path"] = bad_path
+    with pytest.raises(contract.PatentSourceContractError, match="base_dir"):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("field", ["sha256", "size_bytes", "archive_member", "headers"])
+def test_file_pins_are_recomputed(tmp_path: Path, field: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    file_row = manifest["files"][0]
+    if field == "sha256":
+        file_row[field] = "0" * 64
+    elif field == "size_bytes":
+        file_row[field] += 1
+    elif field == "archive_member":
+        file_row[field] = "other.tsv"
+    else:
+        file_row[field] = list(reversed(file_row[field]))
+    with pytest.raises(contract.PatentSourceContractError, match="(SHA|size|member|headers)"):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+def test_self_asserted_verification_cannot_bypass_corruption(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    manifest["verified"] = True
+    (root / manifest["files"][0]["local_path"]).write_bytes(b"not a zip")
+    with pytest.raises(contract.PatentSourceContractError, match="(size|SHA|readable)"):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+def test_materialization_rechecks_validated_archive_bytes(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+    bundle.files["patent"].path.write_bytes(b"changed after validation")
+
+    with pytest.raises(contract.PatentSourceContractError, match="changed after validation"):
+        contract.materialize_patent_grant_events(bundle)
+
+
+def test_missing_required_header_and_duplicate_member_fail(tmp_path: Path) -> None:
+    headers = {role: list(contract.REQUIRED_HEADERS[role]) for role in contract.ROLE_MEMBERS}
+    headers["patent"].remove("patent_date")
+    manifest, root = _source_fixture(tmp_path / "missing", headers=headers)
+    with pytest.raises(contract.PatentSourceContractError, match="missing headers"):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        manifest, root = _source_fixture(tmp_path / "duplicate", duplicate_member_role="patent")
+    with pytest.raises(contract.PatentSourceContractError, match="exactly once"):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("location", ["declared", "archive"])
+def test_header_pins_reject_surrounding_whitespace(tmp_path: Path, location: str) -> None:
+    headers = {role: list(contract.REQUIRED_HEADERS[role]) for role in contract.ROLE_MEMBERS}
+    headers["patent"][0] = " patent_id"
+    manifest, root = _source_fixture(tmp_path, headers=headers)
+    if location == "archive":
+        manifest["files"][0]["headers"] = list(contract.REQUIRED_HEADERS["patent"])
+
+    with pytest.raises(contract.PatentSourceContractError, match="whitespace"):
+        contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+
+def test_native_grant_events_have_exact_schema_and_joint_assignees(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    events = contract.materialize_patent_grant_events(bundle)
+
+    assert [(row["assignee_id"], row["patent_id"]) for row in events] == [
+        ("A1", "P1"),
+        ("A2", "P1"),
+        ("A3", "P2"),
+    ]
+    assert all(set(row) == contract.EVENT_FIELDS for row in events)
+    assert all(row["event_type"] == "patent_grant" for row in events)
+    assert all(row["source_release_id"] == bundle.source_release_id for row in events)
+    assert events[0]["event_date"] == "2020-01-15"
+    assert events[0]["application_filing_date"] == "2019-01-10"
+    assert events[2]["application_filing_date"] is None
+    assert events[2]["assignee_organization"] is None
+    forbidden = {"available", "arm", "denominator", "firm_key", "form_d_cik", "rate", "value"}
+    assert not any(forbidden & set(row) for row in events)
+
+
+def test_missing_application_join_is_nullable(tmp_path: Path) -> None:
+    rows = _default_rows()
+    rows["application"] = rows["application"][:1]
+    manifest, root = _source_fixture(tmp_path, rows=rows)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    events = contract.materialize_patent_grant_events(bundle)
+
+    assert (
+        next(row for row in events if row["patent_id"] == "P2")["application_filing_date"] is None
+    )
+
+
+def test_materialization_rejects_stale_bundle_identity(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    with pytest.raises(contract.PatentSourceContractError, match="source_release_id is stale"):
+        contract.materialize_patent_grant_events(replace(bundle, source_release_id="f" * 64))
+
+    incomplete_files = {role: file for role, file in bundle.files.items() if role != "application"}
+    with pytest.raises(contract.PatentSourceContractError, match="exactly three roles"):
+        contract.materialize_patent_grant_events(replace(bundle, files=incomplete_files))
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda rows: rows["patent"][0].update(patent_date="2026-04-01"),
+            "data_through_date",
+        ),
+        (
+            lambda rows: rows["application"][0].update(filing_date="2020-01-16"),
+            "follows its patent grant date",
+        ),
+    ],
+)
+def test_native_reducer_rejects_temporal_inconsistency(
+    tmp_path: Path, mutate, message: str
+) -> None:
+    rows = _default_rows()
+    mutate(rows)
+    manifest, root = _source_fixture(tmp_path, rows=rows)
+    manifest["data_through_date"] = "2026-03-31"
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    with pytest.raises(contract.PatentSourceContractError, match=message):
+        contract.materialize_patent_grant_events(bundle)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda rows: rows["patent"][0].update(patent_date="not-a-date"),
+            "ISO date",
+        ),
+        (
+            lambda rows: rows["application"][0].update(filing_date="2020-99-99"),
+            "ISO date",
+        ),
+        (
+            lambda rows: rows["assignee"][0].update(patent_id="UNKNOWN"),
+            "unknown patent",
+        ),
+        (
+            lambda rows: rows["application"][0].update(patent_id="UNKNOWN"),
+            "unknown patent",
+        ),
+        (
+            lambda rows: rows["assignee"][0].update(assignee_id=""),
+            "nonblank",
+        ),
+        (
+            lambda rows: rows["patent"][0].update(patent_id=" P1 "),
+            "surrounding whitespace",
+        ),
+    ],
+)
+def test_native_reducer_rejects_malformed_source_rows(tmp_path: Path, mutate, message: str) -> None:
+    rows = _default_rows()
+    mutate(rows)
+    manifest, root = _source_fixture(tmp_path, rows=rows)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+    with pytest.raises(contract.PatentSourceContractError, match=message):
+        contract.materialize_patent_grant_events(bundle)
+
+
+@pytest.mark.parametrize("role", ["patent", "application", "assignee"])
+def test_conflicting_duplicate_rows_fail_closed(tmp_path: Path, role: str) -> None:
+    rows = _default_rows()
+    duplicate = dict(rows[role][0])
+    if role == "patent":
+        duplicate["patent_title"] = "Conflicting title"
+    elif role == "application":
+        duplicate["filing_date"] = "2018-01-10"
+    else:
+        duplicate["disambig_assignee_organization"] = "Conflicting organization"
+    rows[role].append(duplicate)
+    manifest, root = _source_fixture(tmp_path, rows=rows)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+    with pytest.raises(contract.PatentSourceContractError, match="conflicting"):
+        contract.materialize_patent_grant_events(bundle)
+
+
+def test_identical_duplicate_rows_are_deduplicated(tmp_path: Path) -> None:
+    rows = _default_rows()
+    for role in rows:
+        rows[role].append(dict(rows[role][0]))
+    manifest, root = _source_fixture(tmp_path, rows=rows)
+    bundle = contract.validate_patent_source_bundle(manifest, base_dir=root)
+
+    events = contract.materialize_patent_grant_events(bundle)
+
+    assert len(events) == 3
+
+
+def test_bridge_candidates_are_minimal_sorted_and_candidate_only() -> None:
+    rows = [
+        _bridge_row(form_d_cik="999", assignee_id="Z9", normalized_name_key="ZETA SYSTEMS"),
+        _bridge_row(),
+    ]
+
+    candidates = contract.validate_patent_bridge_candidates(rows, source_release_id="a" * 64)
+
+    assert [row["normalized_name_key"] for row in candidates] == [
+        "ALPHA SYSTEMS",
+        "ZETA SYSTEMS",
+    ]
+    assert all(set(row) == contract.BRIDGE_FIELDS for row in candidates)
+    assert all(row["candidate_status"] in {"candidate", "ambiguous"} for row in candidates)
+    assert not any("accepted" in row.values() for row in candidates)
+
+
+def test_bridge_collisions_must_be_ambiguous() -> None:
+    rows = [
+        _bridge_row(),
+        _bridge_row(form_d_cik="67890", assignee_id="A2"),
+    ]
+    with pytest.raises(contract.PatentSourceContractError, match="must be ambiguous"):
+        contract.validate_patent_bridge_candidates(rows, source_release_id="a" * 64)
+
+    for row in rows:
+        row["candidate_status"] = "ambiguous"
+    candidates = contract.validate_patent_bridge_candidates(rows, source_release_id="a" * 64)
+    assert len(candidates) == 2
+    assert all(row["candidate_status"] == "ambiguous" for row in candidates)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"source_release_id": "b" * 64}, "source_release_id"),
+        ({"form_d_cik": "00123"}, "CIK"),
+        ({"assignee_id": ""}, "nonblank"),
+        ({"assignee_id": " A1 "}, "surrounding whitespace"),
+        ({"candidate_status": "accepted"}, "candidate or ambiguous"),
+        ({"candidate_status": []}, "candidate or ambiguous"),
+        ({"normalizer_profile": "other"}, "normalizer"),
+        ({"normalized_name_key": "Alpha Systems, Inc."}, "canonical"),
+        ({"evidence_method": "fuzzy"}, "exact normalized name"),
+        ({"bridge_schema_version": True}, "integer"),
+    ],
+)
+def test_bridge_invalid_rows_fail_closed(overrides: dict[str, Any], message: str) -> None:
+    with pytest.raises(contract.PatentSourceContractError, match=message):
+        contract.validate_patent_bridge_candidates(
+            [_bridge_row(**overrides)], source_release_id="a" * 64
+        )
+
+
+@pytest.mark.parametrize("cik", ["0", "00123", "12345678901", " 12345 ", "١٢٣٤٥"])
+def test_bridge_cik_requires_one_to_ten_ascii_digits(cik: str) -> None:
+    with pytest.raises(contract.PatentSourceContractError, match="unpadded SEC CIK"):
+        contract.validate_patent_bridge_candidates(
+            [_bridge_row(form_d_cik=cik)], source_release_id="a" * 64
+        )
+
+
+def test_bridge_rejects_extra_study_or_confidence_fields() -> None:
+    for field in ("available", "arm", "confidence", "rate"):
+        row = _bridge_row()
+        row[field] = True
+        with pytest.raises(contract.PatentSourceContractError, match="only"):
+            contract.validate_patent_bridge_candidates([row], source_release_id="a" * 64)
+
+
+def test_bridge_requires_content_addressed_source_release_id() -> None:
+    with pytest.raises(contract.PatentSourceContractError, match="lowercase SHA-256"):
+        contract.validate_patent_bridge_candidates(
+            [_bridge_row(source_release_id="not-a-digest")],
+            source_release_id="not-a-digest",
+        )


### PR DESCRIPTION
## Summary

- verify a local three-role `PVGPATDIS` bundle by exact ZIP member, ordered headers, byte size, and SHA-256
- derive a path- and ordering-independent source release ID and reduce verified rows to deterministic assignee-native patent-grant events
- validate exact-name CIK-to-assignee evidence as candidate or ambiguous only
- keep acquisition, accepted linkage, firm coverage, five-year outcomes, denominators, and rates explicitly unavailable

## Evidence boundary

This is a synthetic contract proof, not a real patent-outcome materialization. It does not claim PatentsView coverage, accept an identity link, or wire a patent rate into the matched comparison.

## Validation

- `55 passed` — PatentsView contract tests
- `119 passed` — agency-private-capital unit tests
- `5,943 passed, 7 skipped` — complete unit suite
- Ruff format/check and targeted MyPy
- docs, architecture, epistemic-tier, identity-boundary, file-size, repository-hygiene, and study-manifest checks
- `git diff --check`

## Stack

- Base: #585
- Follows the symmetric Form D proxy in #584 and the reproducible Form D universe in #582