### PR TITLE
Define fail-closed USAspending contract source

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/usaspending_contract_source.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/usaspending_contract_source.py
@@ -1,0 +1,753 @@
+"""Fail-closed USAspending prime-contract source contract.
+
+This module validates a local, content-pinned set of closed-fiscal-year
+``All_Contracts_Full`` archives and reduces synthetic/small fixtures to
+transaction-native contract actions. It deliberately does not download data,
+resolve firms, establish per-firm coverage, classify new awards, or emit study
+outcomes.
+"""
+
+import csv
+import hashlib
+import io
+import json
+import re
+import zipfile
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal, InvalidOperation
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+from sbir_etl.utils.identifiers import normalize_duns, normalize_uei
+
+
+SCHEMA_VERSION = 1
+PRODUCT = "All_Contracts_Full"
+EVENT_TYPE = "usaspending_prime_contract_action"
+SOURCE_RELEASE_DOMAIN = "usaspending-contract-source-release-v1"
+DOWNLOAD_HOST = "files.usaspending.gov"
+DOWNLOAD_PATH_PREFIX = "/award_data_archive/"
+
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+ARCHIVE_FILENAME_RE = re.compile(
+    r"FY(?P<fiscal_year>[0-9]{4})_All_Contracts_Full_(?P<updated>[0-9]{8})\.zip"
+)
+DECIMAL_RE = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?")
+ASCII_YEAR_RE = re.compile(r"[0-9]{4}")
+UEI_SOURCE_RE = re.compile(r"[A-Za-z0-9-]+")
+DUNS_SOURCE_RE = re.compile(r"[0-9-]+")
+
+REQUIRED_HEADERS = (
+    "contract_transaction_unique_key",
+    "contract_award_unique_key",
+    "modification_number",
+    "federal_action_obligation",
+    "action_date",
+    "action_date_fiscal_year",
+    "period_of_performance_start_date",
+    "recipient_uei",
+    "recipient_duns",
+    "award_or_idv_flag",
+    "award_type_code",
+    "idv_type_code",
+    "action_type_code",
+)
+
+EVENT_FIELDS = frozenset(
+    {
+        "action_date",
+        "action_type_code",
+        "award_or_idv_flag",
+        "award_type_code",
+        "contract_award_unique_key",
+        "contract_transaction_unique_key",
+        "event_type",
+        "federal_action_obligation",
+        "idv_type_code",
+        "modification_number",
+        "period_of_performance_start_date",
+        "recipient_duns",
+        "recipient_uei",
+        "schema_version",
+        "source_fiscal_year",
+        "source_release_id",
+    }
+)
+
+
+class USAspendingContractSourceError(ValueError):
+    """Raised when evidence cannot satisfy the USAspending source contract."""
+
+
+@dataclass(frozen=True)
+class ValidatedUSAspendingMember:
+    """One pinned CSV member in an Award Data Archive ZIP."""
+
+    member_name: str
+    size_bytes: int
+    crc32: int
+    headers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ValidatedUSAspendingArchive:
+    """One verified all-agency Contracts Full archive."""
+
+    fiscal_year: int
+    upstream_updated_date: date
+    filename: str
+    source_url: str
+    path: Path
+    sha256: str
+    size_bytes: int
+    members: tuple[ValidatedUSAspendingMember, ...]
+
+
+@dataclass(frozen=True)
+class ValidatedUSAspendingBundle:
+    """A verified contiguous set of closed-fiscal-year archives."""
+
+    source_release_id: str
+    source_snapshot_date: date
+    start_fiscal_year: int
+    end_fiscal_year: int
+    archives: Mapping[int, ValidatedUSAspendingArchive]
+
+
+def _required_text(value: object, *, label: str, exact: bool = False) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise USAspendingContractSourceError(f"{label} must be a nonblank string")
+    text = value.strip()
+    if exact and value != text:
+        raise USAspendingContractSourceError(f"{label} must not contain surrounding whitespace")
+    return text
+
+
+def _strict_int(
+    value: object,
+    *,
+    label: str,
+    positive: bool = False,
+    maximum: int | None = None,
+) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise USAspendingContractSourceError(f"{label} must be an integer")
+    if value < (1 if positive else 0):
+        qualifier = "positive" if positive else "non-negative"
+        raise USAspendingContractSourceError(f"{label} must be {qualifier}")
+    if maximum is not None and value > maximum:
+        raise USAspendingContractSourceError(f"{label} exceeds its maximum")
+    return value
+
+
+def _iso_date(value: object, *, label: str, optional: bool = False) -> date | None:
+    if optional and (value is None or value == ""):
+        return None
+    text = _required_text(value, label=label, exact=True)
+    try:
+        parsed = date.fromisoformat(text)
+    except ValueError as exc:
+        raise USAspendingContractSourceError(f"{label} must be an ISO date") from exc
+    if parsed.isoformat() != text:
+        raise USAspendingContractSourceError(f"{label} must be a canonical ISO date")
+    return parsed
+
+
+def _safe_local_path(base_dir: Path, value: object, *, fiscal_year: int) -> Path:
+    raw_path = _required_text(value, label=f"FY{fiscal_year} local_path", exact=True)
+    relative = Path(raw_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise USAspendingContractSourceError(
+            f"FY{fiscal_year} local_path must stay within base_dir"
+        )
+    base = base_dir.resolve()
+    resolved = (base / relative).resolve()
+    if resolved != base and base not in resolved.parents:
+        raise USAspendingContractSourceError(f"FY{fiscal_year} local_path escapes base_dir")
+    if not resolved.is_file():
+        raise USAspendingContractSourceError(f"FY{fiscal_year} archive is missing")
+    return resolved
+
+
+def _sha256_path(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _declared_headers(value: object, *, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise USAspendingContractSourceError(f"{label} headers must be a nonempty list")
+    headers = tuple(_required_text(item, label=f"{label} header", exact=True) for item in value)
+    folded = [header.casefold() for header in headers]
+    if len(folded) != len(set(folded)):
+        raise USAspendingContractSourceError(f"{label} headers contain duplicates")
+    missing = set(REQUIRED_HEADERS) - set(headers)
+    if missing:
+        raise USAspendingContractSourceError(
+            f"{label} is missing required headers: {sorted(missing)}"
+        )
+    return headers
+
+
+def _member_name(value: object, *, label: str) -> str:
+    name = _required_text(value, label=label, exact=True)
+    pure = PurePosixPath(name)
+    if pure.is_absolute() or pure.name != name or ".." in pure.parts:
+        raise USAspendingContractSourceError(f"{label} must be a flat archive member name")
+    if not name.lower().endswith(".csv"):
+        raise USAspendingContractSourceError(f"{label} must identify a CSV member")
+    return name
+
+
+def _read_member_headers(
+    archive: zipfile.ZipFile, info: zipfile.ZipInfo, *, label: str
+) -> tuple[str, ...]:
+    if info.flag_bits & 0x1:
+        raise USAspendingContractSourceError(f"{label} must not be encrypted")
+    try:
+        with archive.open(info) as raw:
+            with io.TextIOWrapper(raw, encoding="utf-8-sig", errors="strict", newline="") as text:
+                reader = csv.reader(text, strict=True)
+                try:
+                    raw_headers = next(reader)
+                except StopIteration as exc:
+                    raise USAspendingContractSourceError(f"{label} is empty") from exc
+    except (OSError, UnicodeDecodeError, csv.Error, zipfile.BadZipFile) as exc:
+        raise USAspendingContractSourceError(f"{label} is not a readable UTF-8 CSV") from exc
+    headers = tuple(raw_headers)
+    if any(not header for header in headers):
+        raise USAspendingContractSourceError(f"{label} has a blank header")
+    if any(header != header.strip() for header in headers):
+        raise USAspendingContractSourceError(
+            f"{label} headers must not contain surrounding whitespace"
+        )
+    folded = [header.casefold() for header in headers]
+    if len(folded) != len(set(folded)):
+        raise USAspendingContractSourceError(f"{label} has duplicate headers")
+    missing = set(REQUIRED_HEADERS) - set(headers)
+    if missing:
+        raise USAspendingContractSourceError(
+            f"{label} is missing required headers: {sorted(missing)}"
+        )
+    return headers
+
+
+def _archive_filename(value: object, *, fiscal_year: int, upstream_updated_date: date) -> str:
+    filename = _required_text(value, label=f"FY{fiscal_year} filename", exact=True)
+    match = ARCHIVE_FILENAME_RE.fullmatch(filename)
+    if match is None:
+        raise USAspendingContractSourceError(
+            f"FY{fiscal_year} filename must identify an all-agency Contracts Full archive"
+        )
+    if int(match["fiscal_year"]) != fiscal_year:
+        raise USAspendingContractSourceError(f"FY{fiscal_year} filename fiscal year disagrees")
+    if match["updated"] != upstream_updated_date.strftime("%Y%m%d"):
+        raise USAspendingContractSourceError(f"FY{fiscal_year} filename update date disagrees")
+    return filename
+
+
+def _source_url(value: object, *, fiscal_year: int, filename: str) -> str:
+    url = _required_text(value, label=f"FY{fiscal_year} source_url", exact=True)
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != DOWNLOAD_HOST
+        or parsed.path != f"{DOWNLOAD_PATH_PREFIX}{filename}"
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise USAspendingContractSourceError(
+            f"FY{fiscal_year} source_url must be the official archive URL"
+        )
+    return url
+
+
+def _validate_archive_members(
+    path: Path,
+    *,
+    fiscal_year: int,
+    declared_members: object,
+) -> tuple[ValidatedUSAspendingMember, ...]:
+    if not isinstance(declared_members, list) or not declared_members:
+        raise USAspendingContractSourceError(f"FY{fiscal_year} members must be a nonempty list")
+    declared: dict[str, tuple[int, int, tuple[str, ...]]] = {}
+    for index, row in enumerate(declared_members):
+        if not isinstance(row, Mapping):
+            raise USAspendingContractSourceError(
+                f"FY{fiscal_year} members[{index}] must be an object"
+            )
+        label = f"FY{fiscal_year} members[{index}]"
+        name = _member_name(row.get("member_name"), label=f"{label}.member_name")
+        if name in declared:
+            raise USAspendingContractSourceError(f"FY{fiscal_year} has duplicate declared members")
+        size = _strict_int(row.get("size_bytes"), label=f"{label}.size_bytes", positive=True)
+        crc = _strict_int(row.get("crc32"), label=f"{label}.crc32", maximum=0xFFFFFFFF)
+        headers = _declared_headers(row.get("headers"), label=label)
+        declared[name] = (size, crc, headers)
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            infos = archive.infolist()
+            if any(info.is_dir() for info in infos):
+                raise USAspendingContractSourceError(
+                    f"FY{fiscal_year} archive must contain only flat CSV members"
+                )
+            names = [info.filename for info in infos]
+            if len(names) != len(set(names)):
+                raise USAspendingContractSourceError(
+                    f"FY{fiscal_year} archive has duplicate member names"
+                )
+            if set(names) != set(declared):
+                raise USAspendingContractSourceError(
+                    f"FY{fiscal_year} archive members do not match their pins"
+                )
+            verified: list[ValidatedUSAspendingMember] = []
+            archive_headers: tuple[str, ...] | None = None
+            for info in sorted(infos, key=lambda item: item.filename):
+                _member_name(info.filename, label=f"FY{fiscal_year} archive member")
+                size, crc, declared_header = declared[info.filename]
+                if info.file_size != size or info.CRC != crc:
+                    raise USAspendingContractSourceError(
+                        f"FY{fiscal_year} member size or CRC does not match its pin"
+                    )
+                headers = _read_member_headers(
+                    archive,
+                    info,
+                    label=f"FY{fiscal_year} member {info.filename}",
+                )
+                if headers != declared_header:
+                    raise USAspendingContractSourceError(
+                        f"FY{fiscal_year} member headers do not match their pin"
+                    )
+                if archive_headers is not None and headers != archive_headers:
+                    raise USAspendingContractSourceError(
+                        f"FY{fiscal_year} archive members have different schemas"
+                    )
+                archive_headers = headers
+                verified.append(
+                    ValidatedUSAspendingMember(
+                        member_name=info.filename,
+                        size_bytes=info.file_size,
+                        crc32=info.CRC,
+                        headers=headers,
+                    )
+                )
+    except (OSError, zipfile.BadZipFile) as exc:
+        raise USAspendingContractSourceError(
+            f"FY{fiscal_year} archive is not a readable ZIP"
+        ) from exc
+    return tuple(verified)
+
+
+def _canonical_release_payload(
+    *,
+    source_snapshot_date: date,
+    start_fiscal_year: int,
+    end_fiscal_year: int,
+    archives: Mapping[int, ValidatedUSAspendingArchive],
+) -> bytes:
+    payload = {
+        "archives": [
+            {
+                "filename": archive.filename,
+                "fiscal_year": archive.fiscal_year,
+                "members": [
+                    {
+                        "crc32": member.crc32,
+                        "headers": list(member.headers),
+                        "member_name": member.member_name,
+                        "size_bytes": member.size_bytes,
+                    }
+                    for member in archive.members
+                ],
+                "sha256": archive.sha256,
+                "size_bytes": archive.size_bytes,
+                "source_url": archive.source_url,
+                "upstream_updated_date": archive.upstream_updated_date.isoformat(),
+            }
+            for _, archive in sorted(archives.items())
+        ],
+        "end_fiscal_year": end_fiscal_year,
+        "product": PRODUCT,
+        "schema_version": SCHEMA_VERSION,
+        "source_snapshot_date": source_snapshot_date.isoformat(),
+        "start_fiscal_year": start_fiscal_year,
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+
+
+def _derive_release_id(
+    *,
+    source_snapshot_date: date,
+    start_fiscal_year: int,
+    end_fiscal_year: int,
+    archives: Mapping[int, ValidatedUSAspendingArchive],
+) -> str:
+    payload = _canonical_release_payload(
+        source_snapshot_date=source_snapshot_date,
+        start_fiscal_year=start_fiscal_year,
+        end_fiscal_year=end_fiscal_year,
+        archives=archives,
+    )
+    return hashlib.sha256(SOURCE_RELEASE_DOMAIN.encode() + b"\0" + payload).hexdigest()
+
+
+def validate_usaspending_contract_source_bundle(
+    manifest: Mapping[str, Any], *, base_dir: Path
+) -> ValidatedUSAspendingBundle:
+    """Verify a local contiguous set of closed-year Contracts Full archives."""
+
+    if not isinstance(manifest, Mapping):
+        raise USAspendingContractSourceError("manifest must be an object")
+    version = _strict_int(manifest.get("schema_version"), label="schema_version")
+    if version != SCHEMA_VERSION:
+        raise USAspendingContractSourceError("unsupported schema_version")
+    if manifest.get("product") != PRODUCT:
+        raise USAspendingContractSourceError(f"product must be {PRODUCT}")
+    snapshot = _iso_date(manifest.get("source_snapshot_date"), label="source_snapshot_date")
+    if snapshot is None:
+        raise AssertionError("required snapshot date was not parsed")
+    start_fy = _strict_int(
+        manifest.get("start_fiscal_year"), label="start_fiscal_year", positive=True
+    )
+    end_fy = _strict_int(manifest.get("end_fiscal_year"), label="end_fiscal_year", positive=True)
+    if end_fy < start_fy:
+        raise USAspendingContractSourceError("end_fiscal_year must not precede start_fiscal_year")
+    latest_closed_fy = snapshot.year + (snapshot.month >= 10) - 1
+    if end_fy > latest_closed_fy:
+        raise USAspendingContractSourceError(f"FY{end_fy} is not closed as of source_snapshot_date")
+
+    raw_archives = manifest.get("archives")
+    if not isinstance(raw_archives, list):
+        raise USAspendingContractSourceError("archives must be a list")
+    expected_years = set(range(start_fy, end_fy + 1))
+    if len(raw_archives) != len(expected_years):
+        raise USAspendingContractSourceError(
+            "archives must contain exactly one entry for every fiscal year"
+        )
+
+    archives: dict[int, ValidatedUSAspendingArchive] = {}
+    for index, row in enumerate(raw_archives):
+        if not isinstance(row, Mapping):
+            raise USAspendingContractSourceError(f"archives[{index}] must be an object")
+        fiscal_year = _strict_int(row.get("fiscal_year"), label=f"archives[{index}].fiscal_year")
+        if fiscal_year not in expected_years:
+            raise USAspendingContractSourceError(
+                f"archive FY{fiscal_year} is outside the declared fiscal-year range"
+            )
+        if fiscal_year in archives:
+            raise USAspendingContractSourceError(f"duplicate archive fiscal year: {fiscal_year}")
+        updated = _iso_date(
+            row.get("upstream_updated_date"),
+            label=f"FY{fiscal_year} upstream_updated_date",
+        )
+        if updated is None:
+            raise AssertionError("required upstream date was not parsed")
+        if updated > snapshot:
+            raise USAspendingContractSourceError(
+                f"FY{fiscal_year} upstream_updated_date follows source_snapshot_date"
+            )
+        filename = _archive_filename(
+            row.get("filename"),
+            fiscal_year=fiscal_year,
+            upstream_updated_date=updated,
+        )
+        source_url = _source_url(row.get("source_url"), fiscal_year=fiscal_year, filename=filename)
+        path = _safe_local_path(base_dir, row.get("local_path"), fiscal_year=fiscal_year)
+        declared_sha = _required_text(
+            row.get("sha256"), label=f"FY{fiscal_year} sha256", exact=True
+        )
+        if not SHA256_RE.fullmatch(declared_sha):
+            raise USAspendingContractSourceError(f"FY{fiscal_year} sha256 is invalid")
+        declared_size = _strict_int(
+            row.get("size_bytes"), label=f"FY{fiscal_year} size_bytes", positive=True
+        )
+        observed_sha, observed_size = _sha256_path(path)
+        if observed_size != declared_size:
+            raise USAspendingContractSourceError(
+                f"FY{fiscal_year} archive size does not match its pin"
+            )
+        if observed_sha != declared_sha:
+            raise USAspendingContractSourceError(
+                f"FY{fiscal_year} archive SHA-256 does not match its pin"
+            )
+        members = _validate_archive_members(
+            path,
+            fiscal_year=fiscal_year,
+            declared_members=row.get("members"),
+        )
+        archives[fiscal_year] = ValidatedUSAspendingArchive(
+            fiscal_year=fiscal_year,
+            upstream_updated_date=updated,
+            filename=filename,
+            source_url=source_url,
+            path=path,
+            sha256=observed_sha,
+            size_bytes=observed_size,
+            members=members,
+        )
+
+    if set(archives) != expected_years:
+        raise USAspendingContractSourceError("archive fiscal years are not contiguous")
+    release_id = _derive_release_id(
+        source_snapshot_date=snapshot,
+        start_fiscal_year=start_fy,
+        end_fiscal_year=end_fy,
+        archives=archives,
+    )
+    declared_release_id = manifest.get("source_release_id")
+    if declared_release_id is not None and declared_release_id != release_id:
+        raise USAspendingContractSourceError(
+            "source_release_id does not match verified source content"
+        )
+    return ValidatedUSAspendingBundle(
+        source_release_id=release_id,
+        source_snapshot_date=snapshot,
+        start_fiscal_year=start_fy,
+        end_fiscal_year=end_fy,
+        archives=dict(archives),
+    )
+
+
+def _optional_text(value: object, *, label: str) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    if not text:
+        return None
+    if text != text.strip():
+        raise USAspendingContractSourceError(f"{label} must not contain surrounding whitespace")
+    return text
+
+
+def _source_id(value: object, *, label: str) -> str:
+    return _required_text(value, label=label, exact=True)
+
+
+def _source_fiscal_year(value: object, *, label: str) -> int:
+    text = _required_text(value, label=label, exact=True)
+    if not ASCII_YEAR_RE.fullmatch(text):
+        raise USAspendingContractSourceError(f"{label} must be a four-digit fiscal year")
+    return int(text)
+
+
+def _obligation(value: object, *, label: str) -> str | None:
+    if value is None or value == "":
+        return None
+    text = str(value)
+    if text != text.strip():
+        raise USAspendingContractSourceError(f"{label} must be a canonical decimal")
+    if not DECIMAL_RE.fullmatch(text):
+        raise USAspendingContractSourceError(f"{label} must be a canonical decimal")
+    try:
+        number = Decimal(text)
+    except InvalidOperation as exc:
+        raise USAspendingContractSourceError(f"{label} must be a canonical decimal") from exc
+    if not number.is_finite():
+        raise USAspendingContractSourceError(f"{label} must be finite")
+    return text
+
+
+def _identifier(value: object, *, label: str, kind: str) -> str | None:
+    text = _optional_text(value, label=label)
+    if text is None:
+        return None
+    source_pattern = UEI_SOURCE_RE if kind == "UEI" else DUNS_SOURCE_RE
+    if not source_pattern.fullmatch(text):
+        raise USAspendingContractSourceError(f"{label} is not a valid {kind}")
+    normalized = normalize_uei(text) if kind == "UEI" else normalize_duns(text)
+    if normalized is None:
+        raise USAspendingContractSourceError(f"{label} is not a valid {kind}")
+    return normalized
+
+
+def _iter_verified_rows(
+    archive_file: ValidatedUSAspendingArchive,
+) -> Iterator[tuple[str, dict[str, str]]]:
+    observed_sha, observed_size = _sha256_path(archive_file.path)
+    if observed_size != archive_file.size_bytes or observed_sha != archive_file.sha256:
+        raise USAspendingContractSourceError(
+            f"FY{archive_file.fiscal_year} archive changed after validation"
+        )
+    members = {member.member_name: member for member in archive_file.members}
+    try:
+        with zipfile.ZipFile(archive_file.path) as archive:
+            infos = archive.infolist()
+            if any(info.is_dir() for info in infos):
+                raise USAspendingContractSourceError(
+                    f"FY{archive_file.fiscal_year} members changed after validation"
+                )
+            names = [info.filename for info in infos]
+            if len(names) != len(set(names)) or set(names) != set(members):
+                raise USAspendingContractSourceError(
+                    f"FY{archive_file.fiscal_year} members changed after validation"
+                )
+            for info in sorted(infos, key=lambda item: item.filename):
+                member = members[info.filename]
+                if info.file_size != member.size_bytes or info.CRC != member.crc32:
+                    raise USAspendingContractSourceError(
+                        f"FY{archive_file.fiscal_year} member metadata changed after validation"
+                    )
+                with archive.open(info) as raw:
+                    with io.TextIOWrapper(
+                        raw,
+                        encoding="utf-8-sig",
+                        errors="strict",
+                        newline="",
+                    ) as text:
+                        reader = csv.DictReader(text, strict=True)
+                        if tuple(reader.fieldnames or ()) != member.headers:
+                            raise USAspendingContractSourceError(
+                                f"FY{archive_file.fiscal_year} headers changed after validation"
+                            )
+                        for row in reader:
+                            if None in row or any(value is None for value in row.values()):
+                                raise USAspendingContractSourceError(
+                                    f"FY{archive_file.fiscal_year} contains a malformed CSV row"
+                                )
+                            yield info.filename, dict(row)
+    except (OSError, UnicodeDecodeError, csv.Error, zipfile.BadZipFile) as exc:
+        raise USAspendingContractSourceError(
+            f"FY{archive_file.fiscal_year} archive changed or became unreadable"
+        ) from exc
+    final_sha, final_size = _sha256_path(archive_file.path)
+    if final_size != archive_file.size_bytes or final_sha != archive_file.sha256:
+        raise USAspendingContractSourceError(
+            f"FY{archive_file.fiscal_year} archive changed during materialization"
+        )
+
+
+def _validate_bundle_identity(bundle: ValidatedUSAspendingBundle) -> None:
+    expected_years = set(range(bundle.start_fiscal_year, bundle.end_fiscal_year + 1))
+    if set(bundle.archives) != expected_years:
+        raise USAspendingContractSourceError(
+            "validated USAspending bundle must contain its exact contiguous fiscal-year range"
+        )
+    for fiscal_year, archive in bundle.archives.items():
+        if archive.fiscal_year != fiscal_year:
+            raise USAspendingContractSourceError(
+                f"validated USAspending bundle has invalid FY{fiscal_year} metadata"
+            )
+    expected_release = _derive_release_id(
+        source_snapshot_date=bundle.source_snapshot_date,
+        start_fiscal_year=bundle.start_fiscal_year,
+        end_fiscal_year=bundle.end_fiscal_year,
+        archives=bundle.archives,
+    )
+    if bundle.source_release_id != expected_release:
+        raise USAspendingContractSourceError(
+            "validated USAspending bundle source_release_id is stale"
+        )
+
+
+def materialize_usaspending_contract_action_events(
+    bundle: ValidatedUSAspendingBundle,
+) -> list[dict[str, Any]]:
+    """Reduce a verified synthetic/small bundle to neutral contract actions."""
+
+    _validate_bundle_identity(bundle)
+    events: list[dict[str, Any]] = []
+    transaction_keys: set[str] = set()
+    for fiscal_year, archive in sorted(bundle.archives.items()):
+        for member_name, row in _iter_verified_rows(archive):
+            transaction_key = _source_id(
+                row.get("contract_transaction_unique_key"),
+                label=f"FY{fiscal_year} {member_name} transaction key",
+            )
+            if transaction_key in transaction_keys:
+                raise USAspendingContractSourceError(
+                    f"duplicate contract transaction key in release: {transaction_key}"
+                )
+            transaction_keys.add(transaction_key)
+            award_key = _source_id(
+                row.get("contract_award_unique_key"),
+                label=f"transaction {transaction_key} award key",
+            )
+            action_date = _iso_date(
+                row.get("action_date"), label=f"transaction {transaction_key} action_date"
+            )
+            if action_date is None:
+                raise AssertionError("required action date was not parsed")
+            derived_fy = action_date.year + (action_date.month >= 10)
+            declared_fy = _source_fiscal_year(
+                row.get("action_date_fiscal_year"),
+                label=f"transaction {transaction_key} action_date_fiscal_year",
+            )
+            if derived_fy != fiscal_year or declared_fy != fiscal_year:
+                raise USAspendingContractSourceError(
+                    f"transaction {transaction_key} action date fiscal year disagrees with FY{fiscal_year}"
+                )
+            award_flag = _source_id(
+                row.get("award_or_idv_flag"),
+                label=f"transaction {transaction_key} award_or_idv_flag",
+            )
+            if award_flag not in {"AWARD", "IDV"}:
+                raise USAspendingContractSourceError(
+                    f"transaction {transaction_key} award_or_idv_flag must be AWARD or IDV"
+                )
+            performance_start = _iso_date(
+                row.get("period_of_performance_start_date"),
+                label=f"transaction {transaction_key} period_of_performance_start_date",
+                optional=True,
+            )
+            event = {
+                "action_date": action_date.isoformat(),
+                "action_type_code": _optional_text(
+                    row.get("action_type_code"),
+                    label=f"transaction {transaction_key} action_type_code",
+                ),
+                "award_or_idv_flag": award_flag,
+                "award_type_code": _optional_text(
+                    row.get("award_type_code"),
+                    label=f"transaction {transaction_key} award_type_code",
+                ),
+                "contract_award_unique_key": award_key,
+                "contract_transaction_unique_key": transaction_key,
+                "event_type": EVENT_TYPE,
+                "federal_action_obligation": _obligation(
+                    row.get("federal_action_obligation"),
+                    label=f"transaction {transaction_key} federal_action_obligation",
+                ),
+                "idv_type_code": _optional_text(
+                    row.get("idv_type_code"),
+                    label=f"transaction {transaction_key} idv_type_code",
+                ),
+                "modification_number": _optional_text(
+                    row.get("modification_number"),
+                    label=f"transaction {transaction_key} modification_number",
+                ),
+                "period_of_performance_start_date": (
+                    performance_start.isoformat() if performance_start else None
+                ),
+                "recipient_duns": _identifier(
+                    row.get("recipient_duns"),
+                    label=f"transaction {transaction_key} recipient_duns",
+                    kind="DUNS",
+                ),
+                "recipient_uei": _identifier(
+                    row.get("recipient_uei"),
+                    label=f"transaction {transaction_key} recipient_uei",
+                    kind="UEI",
+                ),
+                "schema_version": SCHEMA_VERSION,
+                "source_fiscal_year": fiscal_year,
+                "source_release_id": bundle.source_release_id,
+            }
+            if set(event) != EVENT_FIELDS:
+                raise AssertionError("native USAspending action schema drifted")
+            events.append(event)
+    return sorted(
+        events,
+        key=lambda event: (
+            event["source_fiscal_year"],
+            event["contract_transaction_unique_key"],
+        ),
+    )

--- a/specs/agency-private-capital-comparison/design.md
+++ b/specs/agency-private-capital-comparison/design.md
@@ -172,6 +172,17 @@ eligible controls                         configured-agency treated cohort
    accepted links, firm coverage, availability, denominators, or rates. Bulk
    acquisition, production-scale materialization, real bridge review, and the
    five-year patent outcome adapter remain separate work.
+
+   The federal-contract follow-on also stops at the native source layer. A
+   local USAspending contract verifies a contiguous set of closed-year,
+   all-agency `All_Contracts_Full` archives and emits deterministic
+   `usaspending_prime_contract_action` rows at source transaction grain. It
+   preserves signed obligations, modifications, AWARD-versus-IDV distinctions,
+   and UEI/DUNS source identifiers without interpreting an action as a new
+   award or transition. Content pins freeze the observed release, not upstream
+   history or firm coverage. Real acquisition, a symmetric CIK-to-UEI/DUNS
+   identity bridge, per-firm coverage, new-award semantics, and the five-year
+   federal-contract outcome adapter remain separate work.
 9. **`ThreatsToValidity`** — Emits the structured caveats record. Required
    entries:
    - SAFE/convertible undercount (Form D weak on these)

--- a/specs/agency-private-capital-comparison/requirements.md
+++ b/specs/agency-private-capital-comparison/requirements.md
@@ -9,9 +9,10 @@
 > SBIR exclusion and no validated NAICS-2 covariate. A shared date-aware
 > event/coverage contract and a CIK-native Form D business-combination filing
 > proxy now exist. A synthetic-only, fail-closed PatentsView source contract
-> also exists, but no real patent release, accepted identity bridge, coverage,
-> or outcome projection does. FPDS, patent-outcome, and verified-M&A inputs
-> remain missing. Do not materialize or publish Phase 2
+> and an arm-neutral USAspending contract-action source contract also exist,
+> but no real patent or federal-contract release, accepted identity bridge,
+> firm coverage, or outcome projection does. FPDS-outcome, patent-outcome, and
+> verified-M&A inputs remain missing. Do not materialize or publish Phase 2
 > before the Phase 1, identity, covariate, and outcome gates are satisfied.
 > Supports inventory questions **F3** (private-capital comparison), **B2** (commercialization outcomes), **B3** (transition rates) in [docs/research-questions.md](../../docs/research-questions.md).
 
@@ -92,6 +93,16 @@ field names in the official
 PatentsView is a research dataset rather than the official patent record, so a
 later real-data acquisition must pin the release and preserve that limitation;
 see the [USPTO PatentsView description](https://www.uspto.gov/ip-policy/economic-research/patentsview).
+
+The federal-contract source boundary uses USAspending all-agency
+`All_Contracts_Full` Award Data Archives. The official monthly-files API
+returns the current versions of generated archives, so closed fiscal-year files
+remain mutable upstream and each observed local release must be content-pinned;
+see the [USAspending monthly-files contract](https://github.com/fedspendingtransparency/usaspending-api/blob/master/usaspending_api/api_contracts/contracts/v2/bulk_download/list_monthly_files.md).
+USAspending transaction history distinguishes action date, action type,
+modification, and amount. A source action is therefore not automatically a new
+contract or commercialization transition; see the
+[USAspending transactions contract](https://github.com/fedspendingtransparency/usaspending-api/blob/master/usaspending_api/api_contracts/contracts/v2/transactions.md).
 
 ## Phasing
 
@@ -235,6 +246,22 @@ provisional identity staging only.
     contract SHALL NOT accept a link or turn missing patent evidence into zero.
     Real acquisition, identity adjudication, coverage, and outcome projection
     remain later gates.
+
+    Federal-contract staging SHALL likewise begin with an arm-neutral,
+    fail-closed USAspending source contract. It SHALL verify a contiguous set of
+    closed-fiscal-year all-agency `All_Contracts_Full` archives by archive hash,
+    byte size, official filename and URL, and exact CSV member size, CRC, and
+    ordered headers. Its native grain is
+    `(source_release_id, contract_transaction_unique_key)` and its neutral event
+    type is `usaspending_prime_contract_action`. It SHALL preserve action date,
+    action fiscal year, award grouping key, modification, signed obligation,
+    AWARD-versus-IDV flag, and native UEI/DUNS identifiers without emitting a
+    CIK, firm key, cohort arm, transition classification, availability flag,
+    denominator, or rate. The archive fiscal-year window is source-level
+    temporal provenance only; it is not firm coverage and cannot make missing
+    CIK-to-UEI/DUNS identity evidence an observed zero. Real acquisition,
+    identity adjudication, coverage, new-award classification, and outcome
+    projection remain later gates.
 11. **SHALL** publish a threats-to-validity section before any headline
     finding. Required entries: SAFE/convertible undercount, late-stage Form
     D inclusion, unknown exact-name exclusion recall, alias/rename/acquisition
@@ -262,6 +289,9 @@ not sufficient to evaluate it.
 - NSF identification (ALN 47.041 / 47.084) — `sbir_etl/models/sbir_identification.py` (EXISTS)
 - Transition detection (≥85% precision) — `packages/sbir-ml/sbir_ml/transition/` (EXISTS)
 - Entity resolution cascade — UEI/DUNS/CAGE/fuzzy-name (EXISTS)
+- Phase 2 federal-contract linkage — native synthetic USAspending action source
+  contract EXISTS; a real closed-year release, accepted CIK-to-UEI/DUNS bridge,
+  firm coverage, and FPDS outcome input are NOT WIRED
 - Phase 2 patent linkage — native synthetic source contract EXISTS; a real
   release, accepted CIK-to-assignee bridge, coverage, and PATLINK outcome input
   are NOT WIRED
@@ -276,7 +306,8 @@ not sufficient to evaluate it.
 - Shared date-aware event/coverage evaluator — EXISTS
 - Symmetric CIK-native Form D business-combination filing proxy — EXISTS;
   matched-risk-set integration remains gated
-- Symmetric FPDS, patent, and verified M&A outcome inputs — MISSING
+- Symmetric FPDS, patent, and verified M&A outcome inputs — MISSING; their
+  native synthetic source contracts do not satisfy identity or coverage gates
 
 ## Out of Scope
 

--- a/specs/agency-private-capital-comparison/tasks.md
+++ b/specs/agency-private-capital-comparison/tasks.md
@@ -19,7 +19,11 @@
 > candidates for review without changing the provisional controls or the open
 > identity gate. A synthetic-only PatentsView contract now proves pinned source
 > validation and assignee-native grant reduction, but real patent acquisition,
-> identity adjudication, coverage, and outcome projection remain open.
+> identity adjudication, coverage, and outcome projection remain open. A
+> synthetic-only USAspending contract now proves arm-neutral, content-pinned
+> contract-action staging, but real acquisition, CIK-to-UEI/DUNS linkage,
+> per-firm coverage, new-award semantics, and FPDS outcome projection remain
+> open.
 
 Tasks are grouped by phase. Phase 1 ships independently of PR #286. Phase 2 is
 gated on Phase 1 sign-off and its missing real-data input contracts.
@@ -153,7 +157,13 @@ on a pinned real-data run.
   patent, and application archives, reduces them to assignee-native grant
   events, and keeps CIK-to-assignee name evidence candidate-only. It performs
   no real bulk acquisition or identity adjudication and cannot emit patent
-  coverage or a rate, so the patent portion of this task remains open.
+  coverage or a rate, so the patent portion of this task remains open. A
+  parallel contract-only USAspending follow-on validates synthetic contiguous
+  closed-year `All_Contracts_Full` archives and emits arm-neutral prime-contract
+  actions at transaction grain. It does not acquire a real archive set, bridge
+  Form D CIKs to UEI/DUNS identifiers, establish firm coverage, classify new
+  awards, or emit an FPDS rate, so the federal-contract portion also remains
+  open.
 - [ ] 2.5 Complete the `ThreatsToValidity` gate — required entries: SAFE/convertible
   undercount, late-stage Form D inclusion, incomplete SBIR-CIK exclusion,
   SIC-to-NAICS-2 mapping validity, technical-merit vs. lawyer-access selection

--- a/tests/unit/agency_private_capital/test_usaspending_contract_source.py
+++ b/tests/unit/agency_private_capital/test_usaspending_contract_source.py
@@ -1,0 +1,561 @@
+"""Tests for the fail-closed USAspending contract-action source contract."""
+
+import copy
+import csv
+import hashlib
+import io
+import shutil
+import zipfile
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from sbir_analytics.assets.agency_private_capital import usaspending_contract_source as contract
+
+
+HEADERS = [*contract.REQUIRED_HEADERS, "recipient_name"]
+
+
+def _row(fiscal_year: int, transaction: str, **overrides: str) -> dict[str, str]:
+    action_year = fiscal_year - 1
+    row = dict.fromkeys(HEADERS, "")
+    row.update(
+        {
+            "action_date": f"{action_year}-10-01",
+            "action_date_fiscal_year": str(fiscal_year),
+            "action_type_code": "A",
+            "award_or_idv_flag": "AWARD",
+            "award_type_code": "A",
+            "contract_award_unique_key": f"AWARD-{fiscal_year}",
+            "contract_transaction_unique_key": transaction,
+            "federal_action_obligation": "100.00",
+            "idv_type_code": "",
+            "modification_number": "0",
+            "period_of_performance_start_date": f"{action_year}-10-01",
+            "recipient_duns": "000000001",
+            "recipient_name": "MUST NOT LEAK LLC",
+            "recipient_uei": "ABC123456789",
+        }
+    )
+    row.update(overrides)
+    return row
+
+
+def _write_archive(
+    path: Path,
+    members: list[tuple[str, list[dict[str, str]], list[str]]],
+    *,
+    duplicate_first_member: bool = False,
+    force_zip64: bool = False,
+) -> list[dict[str, Any]]:
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as archive:
+        for index, (member_name, rows, headers) in enumerate(members):
+            text = io.StringIO(newline="")
+            writer = csv.DictWriter(
+                text,
+                fieldnames=headers,
+                extrasaction="ignore",
+                lineterminator="\n",
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+            payload = text.getvalue().encode()
+            if force_zip64 and index == 0:
+                with archive.open(member_name, "w", force_zip64=True) as raw:
+                    raw.write(payload)
+            else:
+                archive.writestr(member_name, payload)
+        if duplicate_first_member:
+            member_name, rows, headers = members[0]
+            text = io.StringIO(newline="")
+            writer = csv.DictWriter(
+                text,
+                fieldnames=headers,
+                extrasaction="ignore",
+                lineterminator="\n",
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+            archive.writestr(member_name, text.getvalue())
+
+    with zipfile.ZipFile(path) as archive:
+        infos = sorted(archive.infolist(), key=lambda item: item.filename)
+    headers_by_name = {name: headers for name, _, headers in members}
+    return [
+        {
+            "crc32": info.CRC,
+            "headers": headers_by_name[info.filename],
+            "member_name": info.filename,
+            "size_bytes": info.file_size,
+        }
+        for info in infos
+    ]
+
+
+def _source_fixture(
+    tmp_path: Path,
+    *,
+    fiscal_years: tuple[int, ...] = (2024, 2025),
+    snapshot_date: str = "2026-08-09",
+    rows_by_year: dict[int, list[dict[str, str]]] | None = None,
+    headers: list[str] | None = None,
+    duplicate_member_year: int | None = None,
+    force_zip64_year: int | None = None,
+) -> tuple[dict[str, Any], Path]:
+    root = tmp_path / "source"
+    root.mkdir(parents=True)
+    selected_headers = headers or HEADERS
+    archives: list[dict[str, Any]] = []
+    for fiscal_year in fiscal_years:
+        filename = f"FY{fiscal_year}_All_Contracts_Full_20260806.zip"
+        path = root / filename
+        rows = (
+            rows_by_year[fiscal_year]
+            if rows_by_year is not None
+            else [_row(fiscal_year, f"TX-{fiscal_year}")]
+        )
+        if fiscal_year == fiscal_years[0]:
+            split = max(1, len(rows) - 1)
+            member_rows = [rows[:split], rows[split:]] if len(rows) > 1 else [rows]
+        else:
+            member_rows = [rows]
+        members = [
+            (f"{filename.removesuffix('.zip')}_{index}.csv", part, selected_headers)
+            for index, part in enumerate(member_rows, start=1)
+        ]
+        pinned_members = _write_archive(
+            path,
+            members,
+            duplicate_first_member=fiscal_year == duplicate_member_year,
+            force_zip64=fiscal_year == force_zip64_year,
+        )
+        payload = path.read_bytes()
+        archives.append(
+            {
+                "downloaded_at": "2026-08-09T12:00:00Z",
+                "filename": filename,
+                "fiscal_year": fiscal_year,
+                "local_path": filename,
+                "members": pinned_members,
+                "sha256": hashlib.sha256(payload).hexdigest(),
+                "size_bytes": len(payload),
+                "source_url": f"https://files.usaspending.gov/award_data_archive/{filename}",
+                "upstream_updated_date": "2026-08-06",
+            }
+        )
+    manifest = {
+        "archives": archives,
+        "downloaded_at": "2026-08-09T12:00:00Z",
+        "end_fiscal_year": max(fiscal_years),
+        "product": "All_Contracts_Full",
+        "schema_version": 1,
+        "source_snapshot_date": snapshot_date,
+        "start_fiscal_year": min(fiscal_years),
+    }
+    return manifest, root
+
+
+def _archive_row(manifest: dict[str, Any], fiscal_year: int) -> dict[str, Any]:
+    return next(row for row in manifest["archives"] if row["fiscal_year"] == fiscal_year)
+
+
+def test_valid_bundle_is_content_addressed_and_order_independent(tmp_path: Path) -> None:
+    rows = {
+        2024: [
+            _row(2024, "TX-A", federal_action_obligation="100.000000000000000001"),
+            _row(
+                2024,
+                "TX-B",
+                contract_award_unique_key="AWARD-2024",
+                modification_number="1",
+                action_date="2024-09-30",
+                federal_action_obligation="-25.00",
+                recipient_uei="",
+                recipient_duns="",
+            ),
+        ],
+        2025: [
+            _row(
+                2025,
+                "TX-C",
+                award_or_idv_flag="IDV",
+                award_type_code="",
+                idv_type_code="B",
+                federal_action_obligation="-0.00",
+                recipient_uei="ABC-123456789",
+                recipient_duns="000-000-001",
+            )
+        ],
+    }
+    manifest, root = _source_fixture(tmp_path, rows_by_year=rows)
+    first = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+    copied = root / "copied"
+    copied.mkdir()
+    reordered = copy.deepcopy(manifest)
+    reordered["archives"].reverse()
+    reordered["downloaded_at"] = "2099-01-01T00:00:00Z"
+    for archive_row in reordered["archives"]:
+        archive_row["members"].reverse()
+        source = root / archive_row["local_path"]
+        destination = copied / source.name
+        shutil.copyfile(source, destination)
+        archive_row["local_path"] = f"copied/{destination.name}"
+        archive_row["downloaded_at"] = "2099-01-01T00:00:00Z"
+    second = contract.validate_usaspending_contract_source_bundle(reordered, base_dir=root)
+
+    assert first.source_release_id == second.source_release_id
+    assert set(first.archives) == {2024, 2025}
+    pinned = copy.deepcopy(manifest)
+    pinned["source_release_id"] = first.source_release_id
+    assert contract.validate_usaspending_contract_source_bundle(pinned, base_dir=root) == first
+
+    events = contract.materialize_usaspending_contract_action_events(first)
+    assert [event["contract_transaction_unique_key"] for event in events] == [
+        "TX-A",
+        "TX-B",
+        "TX-C",
+    ]
+    assert [event["contract_award_unique_key"] for event in events[:2]] == [
+        "AWARD-2024",
+        "AWARD-2024",
+    ]
+    assert [event["federal_action_obligation"] for event in events] == [
+        "100.000000000000000001",
+        "-25.00",
+        "-0.00",
+    ]
+    assert events[1]["recipient_uei"] is None
+    assert events[1]["recipient_duns"] is None
+    assert events[2]["recipient_uei"] == "ABC123456789"
+    assert events[2]["recipient_duns"] == "000000001"
+    assert events[2]["award_or_idv_flag"] == "IDV"
+    assert all(set(event) == contract.EVENT_FIELDS for event in events)
+    assert all(event["event_type"] == "usaspending_prime_contract_action" for event in events)
+    forbidden = {
+        "arm",
+        "available",
+        "denominator",
+        "event_date",
+        "firm_key",
+        "form_d_cik",
+        "index_date",
+        "is_new_award",
+        "rate",
+        "recipient_name",
+        "transition",
+        "value",
+    }
+    assert not any(forbidden & set(event) for event in events)
+
+
+def test_release_id_changes_with_semantic_metadata_bytes_and_headers(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path / "baseline")
+    baseline = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+    updated = copy.deepcopy(manifest)
+    archive_row = updated["archives"][0]
+    archive_row["upstream_updated_date"] = "2026-08-07"
+    archive_row["filename"] = archive_row["filename"].replace("20260806", "20260807")
+    archive_row["source_url"] = archive_row["source_url"].replace("20260806", "20260807")
+    changed_metadata = contract.validate_usaspending_contract_source_bundle(updated, base_dir=root)
+
+    changed_rows = {
+        2024: [_row(2024, "TX-2024", federal_action_obligation="101.00")],
+        2025: [_row(2025, "TX-2025")],
+    }
+    changed_manifest, changed_root = _source_fixture(tmp_path / "bytes", rows_by_year=changed_rows)
+    changed_bytes = contract.validate_usaspending_contract_source_bundle(
+        changed_manifest, base_dir=changed_root
+    )
+
+    extended_headers = [*HEADERS, "future_source_field"]
+    header_manifest, header_root = _source_fixture(tmp_path / "headers", headers=extended_headers)
+    changed_headers = contract.validate_usaspending_contract_source_bundle(
+        header_manifest, base_dir=header_root
+    )
+
+    assert (
+        len(
+            {
+                baseline.source_release_id,
+                changed_metadata.source_release_id,
+                changed_bytes.source_release_id,
+                changed_headers.source_release_id,
+            }
+        )
+        == 4
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda manifest: manifest.update(schema_version=True), "schema_version"),
+        (lambda manifest: manifest.update(product="Contracts_Full"), "product"),
+        (lambda manifest: manifest.update(source_snapshot_date="August 2026"), "ISO date"),
+        (lambda manifest: manifest.update(source_snapshot_date="20260809"), "canonical ISO date"),
+        (lambda manifest: manifest["archives"].pop(), "exactly one"),
+        (
+            lambda manifest: manifest["archives"].__setitem__(
+                1, copy.deepcopy(manifest["archives"][0])
+            ),
+            "duplicate",
+        ),
+        (lambda manifest: manifest.update(start_fiscal_year=2026), "must not precede"),
+    ],
+)
+def test_manifest_shape_fails_closed(tmp_path: Path, mutate, message: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    mutate(manifest)
+    with pytest.raises(contract.USAspendingContractSourceError, match=message):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+def test_open_fiscal_year_fails_closed(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(
+        tmp_path, fiscal_years=(2025, 2026), snapshot_date="2026-08-09"
+    )
+    with pytest.raises(contract.USAspendingContractSourceError, match="not closed"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize(
+    ("replacement", "message"),
+    [
+        ("FY2024_DoD_Contracts_Full_20260806.zip", "all-agency"),
+        ("FY2024_All_Assistance_Full_20260806.zip", "all-agency"),
+        ("FY2024_All_Contracts_Delta_20260806.zip", "all-agency"),
+        ("FY2025_All_Contracts_Full_20260806.zip", "fiscal year"),
+        ("FY2024_All_Contracts_Full_20260807.zip", "update date"),
+    ],
+)
+def test_archive_filename_contract_fails_closed(
+    tmp_path: Path, replacement: str, message: str
+) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    _archive_row(manifest, 2024)["filename"] = replacement
+    with pytest.raises(contract.USAspendingContractSourceError, match=message):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize(
+    "source_url",
+    [
+        "http://files.usaspending.gov/award_data_archive/file.zip",
+        "https://example.test/award_data_archive/file.zip",
+        "https://files.usaspending.gov/other/file.zip",
+        "https://user@files.usaspending.gov/award_data_archive/{filename}",
+        "https://files.usaspending.gov:443/award_data_archive/{filename}",
+        "https://files.usaspending.gov/award_data_archive/../award_data_archive/{filename}",
+        "https://files.usaspending.gov/award_data_archive//{filename}",
+    ],
+)
+def test_archive_source_url_must_be_official(tmp_path: Path, source_url: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    archive_row = _archive_row(manifest, 2024)
+    archive_row["source_url"] = source_url.format(filename=archive_row["filename"])
+    with pytest.raises(contract.USAspendingContractSourceError, match="official archive URL"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+def test_zip64_and_multiple_csv_members_are_supported(tmp_path: Path) -> None:
+    rows = {
+        2024: [_row(2024, "TX-A"), _row(2024, "TX-B")],
+        2025: [_row(2025, "TX-C")],
+    }
+    manifest, root = _source_fixture(
+        tmp_path,
+        rows_by_year=rows,
+        force_zip64_year=2024,
+    )
+    archive_row = _archive_row(manifest, 2024)
+    with zipfile.ZipFile(root / archive_row["local_path"]) as archive:
+        assert len(archive.infolist()) == 2
+        assert archive.infolist()[0].extract_version >= 45
+
+    bundle = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+    assert [
+        event["contract_transaction_unique_key"]
+        for event in contract.materialize_usaspending_contract_action_events(bundle)
+    ] == ["TX-A", "TX-B", "TX-C"]
+
+
+def test_upstream_update_cannot_follow_snapshot(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    archive_row = _archive_row(manifest, 2024)
+    archive_row["upstream_updated_date"] = "2026-08-10"
+    archive_row["filename"] = archive_row["filename"].replace("20260806", "20260810")
+    archive_row["source_url"] = archive_row["source_url"].replace("20260806", "20260810")
+    with pytest.raises(contract.USAspendingContractSourceError, match="follows"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("bad_path", ["../archive.zip", "/tmp/archive.zip"])
+def test_local_paths_cannot_escape_base_dir(tmp_path: Path, bad_path: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    _archive_row(manifest, 2024)["local_path"] = bad_path
+    with pytest.raises(contract.USAspendingContractSourceError, match="base_dir"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("field", ["sha256", "size_bytes"])
+def test_archive_file_pins_are_recomputed(tmp_path: Path, field: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    archive_row = _archive_row(manifest, 2024)
+    archive_row[field] = "0" * 64 if field == "sha256" else archive_row[field] + 1
+    with pytest.raises(contract.USAspendingContractSourceError, match="(SHA-256|size)"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("field", ["member_name", "size_bytes", "crc32", "headers"])
+def test_member_pins_are_recomputed(tmp_path: Path, field: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    member = _archive_row(manifest, 2024)["members"][0]
+    if field == "member_name":
+        member[field] = "other.csv"
+    elif field in {"size_bytes", "crc32"}:
+        member[field] += 1
+    else:
+        member[field] = list(reversed(member[field]))
+    with pytest.raises(contract.USAspendingContractSourceError, match="(members|size|CRC|headers)"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+def test_required_headers_and_duplicate_members_fail_closed(tmp_path: Path) -> None:
+    missing = [header for header in HEADERS if header != "action_type_code"]
+    manifest, root = _source_fixture(tmp_path / "missing", headers=missing)
+    with pytest.raises(contract.USAspendingContractSourceError, match="missing required headers"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+    with pytest.warns(UserWarning, match="Duplicate name"):
+        manifest, root = _source_fixture(tmp_path / "duplicate", duplicate_member_year=2024)
+    with pytest.raises(contract.USAspendingContractSourceError, match="duplicate"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+@pytest.mark.parametrize("extra_member", ["notes.txt", "folder/"])
+def test_extra_non_csv_or_directory_members_fail_closed(tmp_path: Path, extra_member: str) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    archive_row = _archive_row(manifest, 2024)
+    path = root / archive_row["local_path"]
+    with zipfile.ZipFile(path, "a") as archive:
+        archive.writestr(extra_member, "not contract data")
+    payload = path.read_bytes()
+    archive_row["sha256"] = hashlib.sha256(payload).hexdigest()
+    archive_row["size_bytes"] = len(payload)
+
+    with pytest.raises(contract.USAspendingContractSourceError, match="(members|flat CSV)"):
+        contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+
+def test_materialization_rechecks_archive_and_bundle_identity(tmp_path: Path) -> None:
+    manifest, root = _source_fixture(tmp_path)
+    bundle = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+
+    with pytest.raises(contract.USAspendingContractSourceError, match="stale"):
+        contract.materialize_usaspending_contract_action_events(
+            replace(bundle, source_release_id="f" * 64)
+        )
+
+    incomplete = dict(bundle.archives)
+    incomplete.pop(2024)
+    with pytest.raises(contract.USAspendingContractSourceError, match="contiguous"):
+        contract.materialize_usaspending_contract_action_events(
+            replace(bundle, archives=incomplete)
+        )
+
+    bundle.archives[2024].path.write_bytes(b"changed after validation")
+    with pytest.raises(contract.USAspendingContractSourceError, match="changed after validation"):
+        contract.materialize_usaspending_contract_action_events(bundle)
+
+
+def test_duplicate_transaction_keys_fail_even_when_rows_are_identical(tmp_path: Path) -> None:
+    duplicate = _row(2024, "TX-DUPLICATE")
+    rows = {
+        2024: [duplicate, dict(duplicate)],
+        2025: [_row(2025, "TX-2025")],
+    }
+    manifest, root = _source_fixture(tmp_path, rows_by_year=rows)
+    bundle = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+    with pytest.raises(contract.USAspendingContractSourceError, match="duplicate contract"):
+        contract.materialize_usaspending_contract_action_events(bundle)
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"contract_transaction_unique_key": ""}, "nonblank"),
+        ({"contract_transaction_unique_key": " TX "}, "whitespace"),
+        ({"contract_award_unique_key": ""}, "nonblank"),
+        ({"action_date": "not-a-date"}, "ISO date"),
+        ({"action_date": "20231001"}, "canonical ISO date"),
+        ({"action_date": "2024-10-01"}, "disagrees"),
+        ({"action_date_fiscal_year": "2025"}, "disagrees"),
+        ({"action_date_fiscal_year": "٢٠٢٤"}, "four-digit"),
+        ({"award_or_idv_flag": "CONTRACT"}, "AWARD or IDV"),
+        ({"period_of_performance_start_date": "bad-date"}, "ISO date"),
+        ({"period_of_performance_start_date": "20231001"}, "canonical ISO date"),
+        ({"period_of_performance_start_date": " "}, "nonblank"),
+        ({"action_type_code": " A "}, "surrounding whitespace"),
+        ({"modification_number": " 1 "}, "surrounding whitespace"),
+        ({"federal_action_obligation": "NaN"}, "canonical decimal"),
+        ({"federal_action_obligation": "+1"}, "canonical decimal"),
+        ({"federal_action_obligation": "01.00"}, "canonical decimal"),
+        ({"federal_action_obligation": " 1.00 "}, "canonical decimal"),
+        ({"federal_action_obligation": " "}, "canonical decimal"),
+        ({"recipient_uei": "BAD"}, "valid UEI"),
+        ({"recipient_uei": "ABCDEFGHIJK١"}, "valid UEI"),
+        ({"recipient_uei": "ABC!123456789"}, "valid UEI"),
+        ({"recipient_duns": "123"}, "valid DUNS"),
+        ({"recipient_duns": "٠٠٠٠٠٠٠٠١"}, "valid DUNS"),
+        ({"recipient_duns": "ABC000000001"}, "valid DUNS"),
+    ],
+)
+def test_malformed_source_rows_fail_closed(
+    tmp_path: Path, overrides: dict[str, str], message: str
+) -> None:
+    rows = {
+        2024: [_row(2024, "TX-BAD", **overrides)],
+        2025: [_row(2025, "TX-2025")],
+    }
+    manifest, root = _source_fixture(tmp_path, rows_by_year=rows)
+    bundle = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+    with pytest.raises(contract.USAspendingContractSourceError, match=message):
+        contract.materialize_usaspending_contract_action_events(bundle)
+
+
+def test_nullable_optional_source_values_remain_null(tmp_path: Path) -> None:
+    rows = {
+        2024: [
+            _row(
+                2024,
+                "TX-NULL",
+                action_type_code="",
+                award_type_code="",
+                federal_action_obligation="",
+                idv_type_code="",
+                modification_number="",
+                period_of_performance_start_date="",
+                recipient_duns="",
+                recipient_uei="",
+            )
+        ],
+        2025: [_row(2025, "TX-2025")],
+    }
+    manifest, root = _source_fixture(tmp_path, rows_by_year=rows)
+    bundle = contract.validate_usaspending_contract_source_bundle(manifest, base_dir=root)
+    event = contract.materialize_usaspending_contract_action_events(bundle)[0]
+    nullable = {
+        "action_type_code",
+        "award_type_code",
+        "federal_action_obligation",
+        "idv_type_code",
+        "modification_number",
+        "period_of_performance_start_date",
+        "recipient_duns",
+        "recipient_uei",
+    }
+    assert all(event[field] is None for field in nullable)


### PR DESCRIPTION
## Summary

- verify a contiguous set of closed-fiscal-year, all-agency `All_Contracts_Full` archives by official filename/URL, archive hash and size, and exact CSV member size, CRC, and ordered headers
- derive an ordering- and path-independent release ID and reduce verified rows to deterministic transaction-native `usaspending_prime_contract_action` events
- preserve action dates, fiscal years, award grouping keys, modifications, signed obligations, AWARD-versus-IDV flags, and normalized native UEI/DUNS identifiers
- retain the existing SBIR-vendor-filtered Award Archive extractor guard unchanged

## Evidence boundary

This is a synthetic source-contract proof, not a real federal-contract outcome materialization. A contract action is not classified as a new award or transition. This PR does not acquire a real archive set, link CIKs to UEI/DUNS identifiers, establish firm coverage, turn missing evidence into zero, or emit a denominator or rate.

## Validation

- `63 passed` — USAspending source-contract tests
- `8 passed` — unchanged Award Archive extractor tests
- `6,006 passed, 7 skipped` — complete unit suite
- Ruff format/check and targeted MyPy
- docs, architecture, epistemic-tier, file-size, repository-hygiene, and study-manifest checks
- `git diff --check`

## Stack

- Base: #586
- Follows the PatentsView source contract in #586, contamination review in #585, symmetric Form D proxy in #584, and Form D universe in #582