### PR TITLE
feat(research): add fail-closed FY M&A signal counts

### DIFF
--- a/scripts/data/sbir_ma_signal_counts_by_fy.py
+++ b/scripts/data/sbir_ma_signal_counts_by_fy.py
@@ -1,0 +1,604 @@
+#!/usr/bin/env python3
+"""Count fingerprinted SBIR M&A signal records by federal fiscal year.
+
+This is a descriptive diagnostic over an existing ``sbir_ma_events.jsonl``
+artifact. It does not calculate acquisition, exit, or match rates.
+"""
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+from collections.abc import Sequence
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from stat import S_IMODE
+from typing import Any
+
+
+DEFAULT_INPUT = Path("data/sbir_ma_events.jsonl")
+DEFAULT_CSV_OUTPUT = Path("reports/sbir_ma_signal_counts_by_fy.csv")
+DEFAULT_MARKDOWN_OUTPUT = Path("reports/sbir_ma_signal_counts_by_fy.md")
+DEFAULT_START_FY = 2015
+DEFAULT_END_FY = 2024
+CONFIDENCE_TIERS = ("high", "medium", "low")
+ISO_DATE = re.compile(r"\d{4}-\d{2}-\d{2}\Z")
+CSV_COLUMNS = (
+    "fiscal_year",
+    "high_signal_name_keys",
+    "medium_signal_name_keys",
+    "high_medium_signal_name_keys",
+    "low_sensitivity_signal_name_keys",
+    "total_signal_name_keys",
+)
+DATE_CATEGORIES = ("in_window", "valid_out_of_window", "missing", "invalid")
+
+
+class InputValidationError(ValueError):
+    """Raised when the supplied JSONL artifact violates the input contract."""
+
+
+@dataclass(frozen=True)
+class SignalRecord:
+    """One record at the normalized company-name-key grain."""
+
+    company_key: str
+    confidence: str
+    event_date: date | None
+    date_status: str
+    date_identity: tuple[str, str]
+    source_line: int
+
+
+@dataclass(frozen=True)
+class SignalDataset:
+    """Validated, deduplicated input plus its byte-level provenance."""
+
+    source_path: Path
+    source_sha256: str
+    source_bytes: int
+    input_rows: int
+    duplicate_rows: int
+    records: tuple[SignalRecord, ...]
+
+
+@dataclass(frozen=True)
+class CountResult:
+    """FY rows and reconciled diagnostics for a validated dataset."""
+
+    rows: tuple[dict[str, int], ...]
+    missing_date_keys: int
+    invalid_date_keys: int
+    valid_out_of_window_keys: int
+    in_window_keys: int
+    distinct_tier_counts: dict[str, int]
+    date_status_by_tier: dict[str, dict[str, int]]
+
+
+def fiscal_year(value: date) -> int:
+    """Return the federal fiscal year for an observation date."""
+
+    return value.year + 1 if value.month >= 10 else value.year
+
+
+def normalize_company_name(value: str) -> str:
+    """Normalize only leading/trailing whitespace and letter case."""
+
+    return value.strip().casefold()
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise InputValidationError(f"duplicate JSON object key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonstandard_constant(value: str) -> None:
+    raise InputValidationError(f"non-standard JSON constant {value!r}")
+
+
+def _parse_event_date(
+    payload: dict[str, Any], line_number: int
+) -> tuple[date | None, str, tuple[str, str]]:
+    if "event_date" not in payload or payload["event_date"] is None:
+        return None, "missing", ("missing", "")
+
+    raw_value = payload["event_date"]
+    if not isinstance(raw_value, str):
+        raise InputValidationError(
+            f"line {line_number}: event_date must be a string, null, or absent"
+        )
+    if raw_value == "":
+        return None, "missing", ("missing", "")
+    if not ISO_DATE.fullmatch(raw_value):
+        return None, "invalid", ("invalid", raw_value)
+
+    try:
+        parsed = date.fromisoformat(raw_value)
+    except ValueError:
+        return None, "invalid", ("invalid", raw_value)
+    return parsed, "valid", ("valid", parsed.isoformat())
+
+
+def _parse_record(line: str, line_number: int) -> SignalRecord:
+    if not line.strip():
+        raise InputValidationError(f"line {line_number}: blank JSONL lines are not allowed")
+
+    try:
+        payload = json.loads(
+            line,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonstandard_constant,
+        )
+    except (json.JSONDecodeError, InputValidationError) as exc:
+        raise InputValidationError(f"line {line_number}: invalid JSON: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise InputValidationError(f"line {line_number}: each JSONL value must be an object")
+
+    company_name = payload.get("company_name")
+    if not isinstance(company_name, str) or not company_name.strip():
+        raise InputValidationError(f"line {line_number}: company_name must be a non-empty string")
+    company_key = normalize_company_name(company_name)
+
+    confidence = payload.get("confidence")
+    if confidence not in CONFIDENCE_TIERS:
+        allowed = ", ".join(CONFIDENCE_TIERS)
+        raise InputValidationError(
+            f"line {line_number}: confidence must be exactly one of: {allowed}"
+        )
+
+    parsed_date, date_status, date_identity = _parse_event_date(payload, line_number)
+    return SignalRecord(
+        company_key=company_key,
+        confidence=confidence,
+        event_date=parsed_date,
+        date_status=date_status,
+        date_identity=date_identity,
+        source_line=line_number,
+    )
+
+
+def load_signal_dataset(path: Path) -> SignalDataset:
+    """Read, strictly validate, and deduplicate a JSONL signal artifact."""
+
+    try:
+        raw = path.read_bytes()
+    except FileNotFoundError as exc:
+        raise InputValidationError(f"input does not exist: {path}") from exc
+    except OSError as exc:
+        raise InputValidationError(f"cannot read input {path}: {exc}") from exc
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise InputValidationError(f"input is not valid UTF-8: {path}") from exc
+
+    records_by_key: dict[str, SignalRecord] = {}
+    input_rows = 0
+    duplicate_rows = 0
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        input_rows += 1
+        record = _parse_record(line, line_number)
+        prior = records_by_key.get(record.company_key)
+        if prior is None:
+            records_by_key[record.company_key] = record
+            continue
+
+        if prior.confidence != record.confidence or prior.date_identity != record.date_identity:
+            raise InputValidationError(
+                "conflicting duplicate company key "
+                f"{record.company_key!r} at lines {prior.source_line} and {line_number}: "
+                "event_date and confidence must agree"
+            )
+        duplicate_rows += 1
+
+    if input_rows == 0:
+        raise InputValidationError(f"input contains zero JSONL records: {path}")
+
+    return SignalDataset(
+        source_path=path,
+        source_sha256=hashlib.sha256(raw).hexdigest(),
+        source_bytes=len(raw),
+        input_rows=input_rows,
+        duplicate_rows=duplicate_rows,
+        records=tuple(records_by_key.values()),
+    )
+
+
+def build_counts(dataset: SignalDataset, start_fy: int, end_fy: int) -> CountResult:
+    """Build FY rows and fail if any internal reconciliation is violated."""
+
+    if start_fy > end_fy:
+        raise ValueError("start fiscal year must not be after end fiscal year")
+
+    by_fy = {
+        fiscal_year_value: Counter(dict.fromkeys(CONFIDENCE_TIERS, 0))
+        for fiscal_year_value in range(start_fy, end_fy + 1)
+    }
+    date_status_counts: Counter[str] = Counter()
+    distinct_tier_counts: Counter[str] = Counter()
+    date_status_by_tier = {
+        tier: Counter(dict.fromkeys(DATE_CATEGORIES, 0)) for tier in CONFIDENCE_TIERS
+    }
+    valid_out_of_window_keys = 0
+
+    for record in dataset.records:
+        distinct_tier_counts[record.confidence] += 1
+        date_status_counts[record.date_status] += 1
+        if record.date_status != "valid":
+            date_status_by_tier[record.confidence][record.date_status] += 1
+            continue
+        if record.event_date is None:  # Defensive invariant for static and runtime checking.
+            raise RuntimeError("valid date status without a parsed event date")
+        record_fy = fiscal_year(record.event_date)
+        if record_fy not in by_fy:
+            valid_out_of_window_keys += 1
+            date_status_by_tier[record.confidence]["valid_out_of_window"] += 1
+            continue
+        by_fy[record_fy][record.confidence] += 1
+        date_status_by_tier[record.confidence]["in_window"] += 1
+
+    rows: list[dict[str, int]] = []
+    for fiscal_year_value, tiers in by_fy.items():
+        high = tiers["high"]
+        medium = tiers["medium"]
+        low = tiers["low"]
+        high_medium = high + medium
+        total = high_medium + low
+        row = {
+            "fiscal_year": fiscal_year_value,
+            "high_signal_name_keys": high,
+            "medium_signal_name_keys": medium,
+            "high_medium_signal_name_keys": high_medium,
+            "low_sensitivity_signal_name_keys": low,
+            "total_signal_name_keys": total,
+        }
+        if (
+            row["high_medium_signal_name_keys"]
+            != row["high_signal_name_keys"] + row["medium_signal_name_keys"]
+        ):
+            raise RuntimeError("high+medium reconciliation failed")
+        if (
+            row["total_signal_name_keys"]
+            != row["high_medium_signal_name_keys"] + row["low_sensitivity_signal_name_keys"]
+        ):
+            raise RuntimeError("total tier reconciliation failed")
+        rows.append(row)
+
+    in_window_keys = sum(row["total_signal_name_keys"] for row in rows)
+    missing_date_keys = date_status_counts["missing"]
+    invalid_date_keys = date_status_counts["invalid"]
+    if in_window_keys + valid_out_of_window_keys + missing_date_keys + invalid_date_keys != len(
+        dataset.records
+    ):
+        raise RuntimeError("date-status reconciliation failed")
+    if sum(distinct_tier_counts.values()) != len(dataset.records):
+        raise RuntimeError("distinct tier reconciliation failed")
+    for tier in CONFIDENCE_TIERS:
+        if sum(date_status_by_tier[tier].values()) != distinct_tier_counts[tier]:
+            raise RuntimeError(f"date-status reconciliation failed for {tier} tier")
+
+    return CountResult(
+        rows=tuple(rows),
+        missing_date_keys=missing_date_keys,
+        invalid_date_keys=invalid_date_keys,
+        valid_out_of_window_keys=valid_out_of_window_keys,
+        in_window_keys=in_window_keys,
+        distinct_tier_counts={tier: distinct_tier_counts[tier] for tier in CONFIDENCE_TIERS},
+        date_status_by_tier={
+            tier: {category: date_status_by_tier[tier][category] for category in DATE_CATEGORIES}
+            for tier in CONFIDENCE_TIERS
+        },
+    )
+
+
+def render_csv(result: CountResult) -> str:
+    """Render deterministic CSV bytes (after UTF-8 encoding)."""
+
+    output = io.StringIO(newline="")
+    writer = csv.DictWriter(output, fieldnames=CSV_COLUMNS, lineterminator="\n")
+    writer.writeheader()
+    writer.writerows(result.rows)
+    return output.getvalue()
+
+
+def render_markdown(
+    dataset: SignalDataset,
+    result: CountResult,
+    start_fy: int,
+    end_fy: int,
+) -> str:
+    """Render a deterministic narrative with source and interpretation boundaries."""
+
+    lines = [
+        f"# SBIR M&A signal records by federal fiscal year, FY{start_fy}–FY{end_fy}",
+        "",
+        "## Source provenance",
+        "",
+        f"- Input: `{dataset.source_path}`",
+        f"- SHA-256: `{dataset.source_sha256}`",
+        f"- Bytes: {dataset.source_bytes:,}",
+        f"- Input rows: {dataset.input_rows:,}",
+        f"- Distinct normalized company-name keys: {len(dataset.records):,}",
+        f"- Duplicate rows collapsed: {dataset.duplicate_rows:,}",
+        "",
+        "## Counts",
+        "",
+        "| Fiscal year | High | Medium | High + medium | Low sensitivity | Total |",
+        "|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in result.rows:
+        lines.append(
+            "| "
+            f"FY{row['fiscal_year']} | {row['high_signal_name_keys']:,} | "
+            f"{row['medium_signal_name_keys']:,} | "
+            f"{row['high_medium_signal_name_keys']:,} | "
+            f"{row['low_sensitivity_signal_name_keys']:,} | "
+            f"{row['total_signal_name_keys']:,} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Date diagnostics",
+            "",
+            f"- Distinct keys with valid in-window dates: {result.in_window_keys:,}",
+            f"- Distinct keys with missing dates: {result.missing_date_keys:,}",
+            f"- Distinct keys with invalid dates: {result.invalid_date_keys:,}",
+            "- Distinct keys with valid dates outside the selected window: "
+            f"{result.valid_out_of_window_keys:,}",
+            "",
+            "The four date categories above reconcile to the distinct normalized-key count. "
+            "Within every FY row, high + medium equals the combined column, and high + medium "
+            "+ low sensitivity equals total.",
+            "",
+            "| Tier | In window | Valid out of window | Missing date | Invalid date | Distinct keys |",
+            "|---|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for tier in CONFIDENCE_TIERS:
+        statuses = result.date_status_by_tier[tier]
+        lines.append(
+            f"| {tier.title()} | {statuses['in_window']:,} | "
+            f"{statuses['valid_out_of_window']:,} | {statuses['missing']:,} | "
+            f"{statuses['invalid']:,} | {result.distinct_tier_counts[tier]:,} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Method",
+            "",
+            "Federal fiscal year is assigned from the top-level `event_date`: October 1 through "
+            "December 31 map to the following FY; January 1 through September 30 map to the "
+            "calendar year. The field is treated only as a signal-observation date, not a "
+            "transaction or close date.",
+            "",
+            "Company keys use `company_name.strip().casefold()` only. The script does not normalize "
+            "punctuation, legal suffixes, or internal whitespace. Repeated keys are collapsed only "
+            "when their top-level date and exact `high`, `medium`, or `low` tier agree; conflicts "
+            "fail validation.",
+            "",
+            "The high, medium, and low boundaries are upstream classifications. High + medium is "
+            "shown as the primary descriptive subtotal. Low-confidence records are shown only as "
+            "a sensitivity tier. No award denominator is used.",
+            "",
+            "## Source limitations",
+            "",
+            "- The artifact contains SBIR-only detected name records. Its rows are not verified "
+            "firms, deals, acquisitions, or exits.",
+            "- The top-level date is a hybrid selected by the tracked producer: the earliest valid "
+            "Form D business-combination filing date versus the aggregate latest EFTS mention "
+            "date. It may not align with the signal supporting the winning confidence tier.",
+            "- SEC visibility is incomplete, including for private parties and evidence outside the "
+            "upstream scan.",
+            "- The script reports the tier values in this fingerprinted artifact. The final "
+            "published tier counts are not reproducible from the tracked producer because the "
+            "refinement/apply-back artifacts are absent; this report does not assert those totals.",
+            "- These are descriptive signal-record counts. They are not incidence estimates, "
+            "comparisons, or causal findings.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _paths_alias(first: Path, second: Path) -> bool:
+    if first.resolve(strict=False) == second.resolve(strict=False):
+        return True
+    if not first.exists() or not second.exists():
+        return False
+    try:
+        return first.samefile(second)
+    except OSError:
+        return False
+
+
+def _validate_report_paths(source: Path, csv_output: Path, markdown_output: Path) -> None:
+    labeled_paths = (
+        ("input", source),
+        ("CSV output", csv_output),
+        ("Markdown output", markdown_output),
+    )
+    for label, path in labeled_paths[1:]:
+        if path.is_symlink():
+            raise InputValidationError(f"{label} must not be a symbolic link: {path}")
+        if path.exists() and not path.is_file():
+            raise InputValidationError(f"{label} must be a regular file or not exist: {path}")
+
+    for index, (first_label, first_path) in enumerate(labeled_paths):
+        for second_label, second_path in labeled_paths[index + 1 :]:
+            if _paths_alias(first_path, second_path):
+                raise InputValidationError(
+                    f"{first_label} and {second_label} paths must be distinct: {first_path}"
+                )
+
+
+def _stage_text(destination: Path, content: str) -> Path:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    fd, raw_temp_path = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+    )
+    temp_path = Path(raw_temp_path)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        mode = S_IMODE(destination.stat().st_mode) if destination.exists() else 0o644
+        temp_path.chmod(mode)
+    except BaseException:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        temp_path.unlink(missing_ok=True)
+        raise
+    return temp_path
+
+
+def _backup_existing(destination: Path) -> Path | None:
+    if not destination.exists():
+        return None
+    fd, raw_backup_path = tempfile.mkstemp(
+        dir=destination.parent,
+        prefix=f".{destination.name}.",
+        suffix=".backup",
+    )
+    os.close(fd)
+    backup_path = Path(raw_backup_path)
+    try:
+        shutil.copy2(destination, backup_path)
+    except BaseException:
+        backup_path.unlink(missing_ok=True)
+        raise
+    return backup_path
+
+
+def _publish_staged_reports(staged: tuple[tuple[Path, Path], ...]) -> None:
+    backups: dict[Path, Path | None] = {}
+    try:
+        for _, destination in staged:
+            backups[destination] = _backup_existing(destination)
+    except BaseException:
+        for temp_path, _ in staged:
+            temp_path.unlink(missing_ok=True)
+        for backup_path in backups.values():
+            if backup_path is not None:
+                backup_path.unlink(missing_ok=True)
+        raise
+
+    replaced: list[Path] = []
+    try:
+        for temp_path, destination in staged:
+            os.replace(temp_path, destination)
+            replaced.append(destination)
+    except OSError as publish_error:
+        rollback_errors: list[str] = []
+        for destination in reversed(replaced):
+            backup_path = backups[destination]
+            try:
+                if backup_path is None:
+                    destination.unlink(missing_ok=True)
+                else:
+                    os.replace(backup_path, destination)
+                    backups[destination] = None
+            except OSError as rollback_error:
+                rollback_errors.append(f"{destination}: {rollback_error}")
+        if rollback_errors:
+            details = "; ".join(rollback_errors)
+            raise OSError(
+                f"report publication failed and rollback was incomplete: {details}"
+            ) from publish_error
+        raise
+    finally:
+        for temp_path, _ in staged:
+            temp_path.unlink(missing_ok=True)
+        for backup_path in backups.values():
+            if backup_path is not None:
+                backup_path.unlink(missing_ok=True)
+
+
+def write_reports(
+    dataset: SignalDataset,
+    result: CountResult,
+    csv_output: Path,
+    markdown_output: Path,
+    start_fy: int,
+    end_fy: int,
+) -> None:
+    """Publish a distinct, internally consistent report pair."""
+
+    _validate_report_paths(dataset.source_path, csv_output, markdown_output)
+    csv_text = render_csv(result)
+    markdown_text = render_markdown(dataset, result, start_fy, end_fy)
+    staged_paths: list[tuple[Path, Path]] = []
+    try:
+        staged_paths.append((_stage_text(csv_output, csv_text), csv_output))
+        staged_paths.append((_stage_text(markdown_output, markdown_text), markdown_output))
+    except BaseException:
+        for temp_path, _ in staged_paths:
+            temp_path.unlink(missing_ok=True)
+        raise
+    _publish_staged_reports(tuple(staged_paths))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Count fingerprinted SBIR M&A signal records by federal fiscal year."
+    )
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--csv-output", type=Path, default=DEFAULT_CSV_OUTPUT)
+    parser.add_argument("--markdown-output", type=Path, default=DEFAULT_MARKDOWN_OUTPUT)
+    parser.add_argument("--start-fy", type=int, default=DEFAULT_START_FY)
+    parser.add_argument("--end-fy", type=int, default=DEFAULT_END_FY)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.start_fy > args.end_fy:
+        print("error: --start-fy must not be after --end-fy", file=sys.stderr)
+        return 2
+
+    try:
+        dataset = load_signal_dataset(args.input)
+        result = build_counts(dataset, args.start_fy, args.end_fy)
+        write_reports(
+            dataset,
+            result,
+            args.csv_output,
+            args.markdown_output,
+            args.start_fy,
+            args.end_fy,
+        )
+    except InputValidationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"error: could not write reports: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Wrote {args.csv_output} and {args.markdown_output} "
+        f"from {len(dataset.records):,} distinct keys ({dataset.source_sha256})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/sbir_ma_match_rate_by_fy/design.md
+++ b/specs/sbir_ma_match_rate_by_fy/design.md
@@ -1,143 +1,115 @@
-# Design: SBIR M&A Match Rate by Fiscal Year
+# Design: SBIR M&A Signal Counts by Fiscal Year
 
-## Approach
+## Decision
 
-Read-only analysis on top of existing enrichment outputs. No new
-extraction, no schema changes. One script, one Dagster asset, and
-three report files (per-FY CSV, narrative MD, firm-level detail CSV)
-matching the outputs enumerated in `requirements.md`.
+Replace the invalid FY match-rate design with one standard-library diagnostic:
 
-## Inputs (existing JSONL + Dagster asset)
-
-The implemented enrichment pipeline emits JSONL artifacts and one
-DataFrame asset, not per-filing parquet. The canonical inputs are:
-
-- `data/sbir_ma_events.jsonl` — curated M&A events output from PR #286
-  (`scripts/archive/data/detect_sbir_ma_events.py`).
-- `data/sec_edgar_scan.jsonl` — resumable EFTS scan output.
-- `data/form_d_details.jsonl` — Form D filings with
-  `is_business_combination` flag and confidence tier.
-- Dagster asset `sec_edgar_enriched_companies` (DataFrame) — per-firm
-  enrichment surface including `mention_*` aggregates and CIK linkage;
-  use this rather than re-deriving from raw mentions.
-- SBIR awards: the canonical `enriched_sbir_awards` asset.
-
-If any later refactor introduces parquet equivalents, those become the
-preferred inputs; update this section accordingly. The acceptance
-criterion (AC1) is "reproducible from existing artifacts," not
-specifically parquet.
-
-## Pipeline
-
-```
-awardees(FY2015-2024) ──┐
-                        ├─→ join on company_key ─→ matches ─→ tier-rank
-ma_signals(FY2015-2024)─┘                              │
-                                                       ↓
-                                            dedupe (one row per firm)
-                                                       ↓
-                                            group by match_fy → CSV + MD
+```text
+fingerprinted curated JSONL
+  -> strict schema/date validation
+  -> normalized-name-key deduplication
+  -> signal-observation federal FY
+  -> deterministic CSV + Markdown counts
 ```
 
-### Step 1: Build awardee denominator
+There is no award denominator, cross-source reconstruction, Dagster asset,
+firm-level output, network access, or committed generated report.
+
+## Input contract
+
+`scripts/data/sbir_ma_signal_counts_by_fy.py` reads
+`data/sbir_ma_events.jsonl` by default. Every nonblank line must be a UTF-8 JSON
+object with:
+
+- nonempty string `company_name`;
+- exact `confidence` in `high`, `medium`, or `low`; and
+- optional top-level `event_date`, which is missing when absent, null, or the
+  empty string, valid only when it is an exact ISO `YYYY-MM-DD` date, and
+  otherwise invalid.
+
+Duplicate JSON keys, blank JSONL lines, nonstandard JSON constants, an empty
+file, invalid types, and unknown tiers fail closed. Extra historical fields are
+retained outside this calculation and do not affect the result.
+
+The script reads the source bytes once, computes SHA-256 and byte count from
+those bytes, decodes them as UTF-8, then validates the decoded rows.
+
+## Grain and deduplication
+
+The descriptive unit is a normalized company-name key:
 
 ```python
-awardees = (
-    awards
-    .filter(award_start_date >= 2014-10-01,
-            award_start_date <  2024-10-01)
-    .with_column(award_fy = fiscal_year(award_start_date))
-    .group_by(company_key)
-    .agg(primary_award_fy = min(award_fy))
-)
+company_key = company_name.strip().casefold()
 ```
 
-Federal FY: a date in [Oct 1 of year Y-1, Sep 30 of Y] is FY Y.
+No punctuation, suffix, alias, fuzzy, CIK, UEI, or DUNS normalization is
+introduced. Repeated normalized keys collapse only when their top-level date
+status/value and exact confidence tier agree. A conflicting date or tier fails
+the run and identifies both source lines.
 
-### Step 2: Collect dated M&A signals
+## Fiscal-year aggregation
 
-Union the dated signal sources, tag each with tier and signal type:
+For a valid observation date:
 
-| Source | Filter | Tier | Date column |
-|---|---|---|---|
-| `ma_events` | all rows | Low (1.01/2.01) | `filing_date` |
-| `mentions` | `classification = 'subsidiary'` | High | `filing_date` (upper bound) |
-| `mentions` | `classification = 'acquisition'` | Medium | `filing_date` |
-| `mentions` | `classification = 'ma_definitive'`, form_type in (SC TO-T, SC 14D9) | Low | `filing_date` |
-| `mentions` | `classification = 'ma_proxy'` | Low | `filing_date` |
-| `mentions` | `classification = 'ownership_active'` | Low | `filing_date` |
-| `form_d` | `is_business_combination = True` | High | `filing_date` |
-
-Restrict to filings dated within FY2015–2024.
-
-### Step 3: Tier ranking and dedupe
-
-Per firm, keep one row:
-- Highest tier wins (High > Medium > Low).
-- Within tier, earliest filing_date wins.
-- Carry list of contributing signals for the detail CSV.
-- For Exhibit-21-only matches, set `date_upper_bound = true`.
-
-### Step 4: Compute rates
-
-Per FY:
-- Denominator: distinct firms with `primary_award_fy = FY`.
-- Numerator (per requirements.md): distinct matched firms with at least
-  one qualifying M&A signal dated in FY2015–2024. A match is attributed
-  to the FY of its earliest qualifying signal.
-- Per AC6, firms whose `match_fy` precedes their `primary_award_fy`
-  are still counted in the numerator but flagged
-  `match_before_first_award = true` in the firm-level detail CSV and
-  surfaced as a caveat in the narrative.
-
-Two rate columns (note the inclusive-tier semantics in the names):
-- `match_rate_high_medium` = (high + medium tier matches) / denom.
-- `match_rate_total` = all-tier matches / denom.
-
-Aggregate FY2015–2024 row reports Wilson 95% CI.
-
-### Step 5: Item 2.01 sub-rate (methodological footnote)
-
-Filter `ma_events` to rows where `'2.01' in items_reported`. Compute
-the same numerator/denominator. Report as a single number with the
-caveat that single-signal Item 2.01 has ~30–40% estimated precision.
-
-## File layout
-
-```
-scripts/analysis/sbir_ma_match_rate_by_fy.py    # script (one file)
-packages/sbir-analytics/sbir_analytics/assets/sbir_ma_match_rate.py
-                                                # thin Dagster wrapper
-reports/sbir_ma_match_rate_by_fy.csv            # generated
-reports/sbir_ma_match_rate_by_fy.md             # generated
-reports/sbir_ma_matched_firms_fy2015_2024.csv   # generated
+```python
+signal_fy = event_date.year + 1 if event_date.month >= 10 else event_date.year
 ```
 
-The Dagster asset just calls the script and writes outputs to the
-`reports/` directory — no new IO managers, no new resources.
+Each selected FY row reports:
 
-## Open questions to resolve before implementation
+- `high_signal_name_keys`;
+- `medium_signal_name_keys`;
+- `high_medium_signal_name_keys`;
+- `low_sensitivity_signal_name_keys`; and
+- `total_signal_name_keys`.
 
-- **Q1: Company key.** Is `company_key` already canonical across
-  awards and SEC enrichment, or do we need to join through
-  `sbir_company_cik_map`? Verify before writing the join.
-- **Q2: Form D party.** Form D filings can be filed by the acquirer,
-  the target, or a holdco. Confirm the existing `form_d_filings`
-  parquet links the filing CIK back to the SBIR firm — and that
-  `is_business_combination = True` rows include both directions.
-- **Q3: Mentions parquet.** Confirm the column names for
-  `classification` and `form_type` in `sec_edgar_mentions.parquet`
-  match the model in `sbir_etl/models/sec_edgar.py`.
-- **Q4: Right-censoring.** A firm acquired in 2024 may not have its
-  10-K Exhibit 21 filed yet. Should the FY2024 row footnote this, or
-  exclude FY2024 from the headline aggregate?
+The selected window defaults to FY2015–FY2024. Every distinct key belongs to
+exactly one of four date categories: in-window, valid-out-of-window, missing,
+or invalid. Those categories reconcile overall and within each confidence
+tier. High plus medium and total counts reconcile within every FY row.
 
-These are confirmable in <30 min by reading the asset definitions;
-not blocking the spec, but blocking implementation.
+## Rendering and failure behavior
 
-## Non-goals
+The CLI defaults are:
 
-- Form 15 (deregistration) extraction — separate spec if needed.
-- Re-running EFTS to attribute item codes per-mention — out of scope.
-- Linking to acquirer ticker / market cap — out of scope.
-- ML-based deduplication of signals — current rules are sufficient.
+```text
+--input data/sbir_ma_events.jsonl
+--csv-output reports/sbir_ma_signal_counts_by_fy.csv
+--markdown-output reports/sbir_ma_signal_counts_by_fy.md
+--start-fy 2015
+--end-fy 2024
+```
+
+Both renderers are deterministic for the same source path, bytes, and FY
+arguments. Input and output paths must be distinct and report destinations may
+not be symbolic links. Validation and rendering complete before either output
+is opened. Both products are staged in their destination directories before
+publication; if the second replacement fails, the first is rolled back to its
+prior content (or removed when it did not previously exist). Missing or invalid
+input returns nonzero and creates neither output. Output write failures also
+return nonzero.
+
+The Markdown includes source path, SHA-256, bytes, row/key/deduplication counts,
+the FY table, overall and per-tier date diagnostics, the exact normalization and
+FY rules, and the interpretation boundary.
+
+## Interpretation boundary
+
+`event_date` is labeled `signal-observation date`. It is a hybrid of Form D
+filing and aggregate EFTS mention timing, not a transaction date. The reporter
+does not infer that counts are acquisitions or exits and does not interpret
+higher/lower observed counts as incidence. SEC coverage is incomplete, the
+input is SBIR-only, and low-confidence rows remain sensitivity evidence.
+
+The supplied tier values are treated as data, not independently reproduced.
+The tracked repository lacks the historical refinement/apply-back artifacts
+needed to reconstruct the final published tier totals.
+
+## Why the original rate design was rejected
+
+The former design grouped matched names by signal FY but grouped awardees by
+their first award FY, and even allowed a signal to precede the first award.
+Dividing those groupings compares unlike populations. A valid award-vintage
+rate requires a single cohort definition and fixed follow-up window, plus
+identity, censoring, and symmetric coverage rules. That is a separate research
+design, not a small extension of this count diagnostic.

--- a/specs/sbir_ma_match_rate_by_fy/requirements.md
+++ b/specs/sbir_ma_match_rate_by_fy/requirements.md
@@ -1,110 +1,102 @@
-# Requirements: SBIR M&A Match Rate by Fiscal Year
+# Requirements: SBIR M&A Signal Counts by Fiscal Year
 
-**Target epistemic tier:** `pipelines`
+**Target epistemic tier:** `exploratory`
 
-> **Status:** Gated backlog — analysis-only spec, not yet implemented. Start
-> only when FY match-rate reporting is requested.
-> Supports inventory question **F2** (M&A exit rate by vintage) in [docs/research-questions.md](../../docs/research-questions.md).
-
-**Research question anchor:** F2 — SBIR-awardee M&A match rate by fiscal year
-**Answers for:** entrepreneurial finance researchers, policy analysts
-**Complexity tier:** Descriptive (Tier 1)
-
----
-
-## Done when
-
-> An entrepreneurial finance researcher can state: "The FY2015–2024 aggregate high+medium M&A match rate for SBIR awardees is [X]% (95% Wilson CI: [Y–Z]%), based on [N] distinct firms. The FY-by-FY breakdown shows [trend]. Item-2.01-only sub-rate is [P]% (reported as methodological footnote, not the headline number)."
-
----
-
-## User Stories
-
-**As an entrepreneurial finance researcher comparing SBIR-firm exit outcomes to venture-backed norms,**
-I want the SBIR M&A match rate broken down by fiscal year and confidence tier, so that I can report how acquisition frequency has changed over time and compare it to published VC exit-rate benchmarks alongside the leverage-ratio and private-capital comparison analyses.
-
-**As a policy analyst preparing a brief on SBIR program outcomes,**
-I want a reproducible firm-level M&A attribution table with signal provenance and explicit caveats, so that I can cite defensible exit-rate numbers without overstating precision from low-confidence signals like Item-2.01-only filings or Exhibit-21-only attributions.
-
----
+> **Status (2026-08-09):** The original match-rate design is superseded. The
+> fail-closed signal-count reporter is implemented, but a real-data report is
+> blocked because `data/sbir_ma_events.jsonl` is unavailable.
+>
+> **Research question anchor:** F2 — M&A evidence by vintage, descriptive
+> diagnostic only.
 
 ## Question of record
 
-What is the SBIR-awardee → M&A-event match rate for FY2015–2024,
-attributable by fiscal year, using SEC filings as evidence?
+How many normalized SBIR company-name keys in a supplied, fingerprinted M&A
+signal artifact have observation dates in each federal fiscal year from FY2015
+through FY2024, by upstream confidence tier?
 
-The user's literal question is "8-K Item 2.01 match rate." That cannot
-be answered in isolation: Item 2.01 has ~30–40% precision alone (per
-`docs/research/sbir-ma-exit-analysis.md:40-42`) and is bucketed with
-Item 1.01 in the existing pipeline. We answer the underlying question
-by combining the full signal stack.
+This deliverable does **not** estimate an acquisition rate, exit rate, hazard,
+or treatment effect. The prior design grouped numerators by signal fiscal year
+and denominators by first-award fiscal year. Those are different populations,
+so their quotient is not a coherent incidence or cohort rate. A future rate
+must use the same award-vintage cohort in both numerator and denominator and
+define a fixed observation horizon and censoring policy.
 
-## Scope
+## Evidence boundary
 
-- **In:** SBIR awardees (any agency) with ≥1 award FY2015–2024,
-  matched against SEC filings indicating acquisition in the same window.
-- **In:** Per-FY breakdown of match counts and rates.
-- **In:** Signal-tier breakdown (high / medium / low confidence).
-- **Out:** New signal extraction — reuse existing `EdgarMAEvent` rows,
-  the `mention_*` aggregates on `CompanyEdgarProfile`, and Form D
-  enrichment outputs.
-- **Out:** Re-running EFTS or Form D fetches.
-- **Out:** Backfilling Form 15 (deregistration) — tracked separately.
-
-## Definitions
-
-- **Awardee universe (denominator):** distinct SBIR firms with award
-  start date in FY2015–2024 (federal FY: Oct 1 – Sep 30).
-- **Match (numerator):** awardee has ≥1 dated M&A signal where the
-  signal's filing date falls in FY2015–2024.
-- **Acquisition FY:** fiscal year of the earliest qualifying signal
-  per awardee (one match per firm).
-- **Confidence tier per match:** the highest tier among that firm's
-  qualifying signals, using the existing tier rules in
+- Input: `data/sbir_ma_events.jsonl`, produced historically by
   `scripts/archive/data/detect_sbir_ma_events.py`.
+- Grain: one normalized `company_name` key, using only `strip()` and
+  case-folding.
+- Observation date: top-level `event_date`.
+- Federal FY: October through December map to the following calendar year;
+  January through September map to the current calendar year.
+- Confidence: the exact `high`, `medium`, or `low` value present in the
+  supplied artifact. Low is sensitivity-only.
+- Window: FY2015–FY2024 by default.
 
-## Signals used and date attribution
+The top-level date is a hybrid signal-observation proxy. The historical
+producer selected the earlier valid date between an issuer's earliest Form D
+business-combination filing and its aggregate latest EFTS mention. It is not a
+transaction announcement, agreement, or closing date, and it can be unrelated
+to the signal supporting the row's winning confidence tier.
 
-| Signal | Tier | Date used |
-|---|---|---|
-| `subsidiary` (Exhibit 21) | High | First 10-K filing date listing firm — **upper bound only** |
-| Form D `is_business_combination` | High | Form D filing date |
-| `acquisition` (10-K/10-Q text) | Medium | Filing date of the confirming 10-K/10-Q |
-| `ma_definitive` 8-K (Item 1.01/2.01) | Low | 8-K filing date |
-| `ma_definitive` tender (SC TO-T, SC 14D9) | Low | Tender filing date |
-| `ma_proxy` (DEFM14A/PREM14A) | Low | Proxy filing date |
-| `ownership_active` (SC 13D) | Low | 13D filing date (pre-event marker) |
-
-Exhibit 21 alone cannot date a transaction. When Exhibit 21 is the
-only signal, the match is attributed to the FY of the earliest 10-K
-in which the firm appears — flagged as `date_upper_bound = true`.
+The artifact contains SBIR-only detected names. Its rows are not verified
+distinct firms, deals, acquisitions, or exits, and it provides no outcome
+coverage for a non-SBIR comparison cohort.
 
 ## Outputs
 
-1. `reports/sbir_ma_match_rate_by_fy.csv` — one row per FY, columns:
-   `fiscal_year, awardees_in_fy, matched_high, matched_medium,
-   matched_low, matched_total, match_rate_high_medium,
-   match_rate_total`. The `match_rate_high_medium` column is named
-   for what it contains (high + medium tier numerator) so it cannot
-   be misread as "high tier only."
-2. `reports/sbir_ma_match_rate_by_fy.md` — narrative summary with
-   methodology, caveats, and the FY2015–2024 aggregate.
-3. `reports/sbir_ma_matched_firms_fy2015_2024.csv` — firm-level
-   detail: `award_recipient, primary_award_fy, match_fy,
-   tier, signals, acquirer (if known), date_upper_bound`.
+When a valid input is supplied, the reporter writes:
+
+1. `reports/sbir_ma_signal_counts_by_fy.csv` — one row per selected FY with
+   high, medium, high-plus-medium, low-sensitivity, and total normalized-name
+   key counts.
+2. `reports/sbir_ma_signal_counts_by_fy.md` — the same table plus input
+   fingerprint, input/deduplication counts, date-status reconciliation, method,
+   and interpretation limits.
+
+Generated reports remain gitignored. The source artifact's SHA-256 and byte
+count are embedded in the Markdown output so a later materialization identifies
+the exact evidence supplied.
 
 ## Acceptance criteria
 
-- AC1: Numerator and denominator are reproducible from existing
-  parquet outputs (no new network calls required).
-- AC2: Per-FY denominator equals the count of distinct firms whose
-  earliest FY2015–2024 award is in that FY.
-- AC3: Each matched firm appears exactly once (deduped on firm key).
-- AC4: Aggregate FY2015–2024 high+medium match rate is reported with
-  a 95% Wilson confidence interval.
-- AC5: The Item-2.01-only sub-rate is reported as a methodological
-  footnote, not as the headline number.
-- AC6: Caveats section explicitly addresses: Exhibit-21 dating,
-  private acquirers (no SEC filings), SBIR firms acquired before any
-  award in the window, and right-censoring (recent acquisitions not
-  yet filed).
+- AC1: `2020-09-30` maps to FY2020 and `2020-10-01` maps to FY2021.
+- AC2: Missing, invalid, valid-out-of-window, and in-window dates are counted
+  separately and reconcile overall and within each tier.
+- AC3: Case- and edge-whitespace-equivalent company names count once when date
+  and tier agree; conflicting duplicates fail validation.
+- AC4: High plus medium and total tier columns reconcile in every FY row.
+- AC5: Input SHA-256, bytes, input rows, distinct keys, and collapsed duplicates
+  appear in deterministic output.
+- AC6: Missing, empty, malformed, non-UTF-8, or contract-violating input exits
+  nonzero before an all-zero report can be written.
+- AC7: Input and output paths cannot alias; both outputs are staged before
+  publication and a partial replacement is rolled back.
+- AC8: Outputs contain no rate, exit-rate, control, Wilson-interval, Item-2.01,
+  or causal-comparison fields or claims.
+- AC9: No network call, raw SEC reconstruction, Dagster asset, or firm-detail
+  duplicate is added.
+
+## Materialization gate
+
+The historical JSONL was gitignored and was not committed with PR #286. The
+2026-08-09 audit found neither it nor its upstream Form D/EFTS refinement
+artifacts in the development checkout, live checkout, or persistent runtime
+data. Only published aggregate tier totals remain; they cannot recover exact FY
+counts, missing dates, duplicate diagnostics, or an input fingerprint.
+
+The final published tier assignments also cannot be regenerated from the
+tracked producer alone because the refinement/apply-back artifacts are absent.
+The reporter therefore describes only the tiers in the exact supplied artifact
+and must not assert the historical published totals.
+
+## Deferred requirements for a genuine rate
+
+A separately reviewed design is required before reporting a rate. It must, at
+minimum, define a canonical firm identity, assign numerator events to the same
+award-vintage cohort used for the denominator, use a fixed follow-up horizon,
+handle left and right censoring, establish symmetric outcome coverage, and
+retain per-filing provenance. Item 2.01 cannot be isolated from the curated
+JSONL schema because its aggregate signal fields conflate filing items/types.

--- a/specs/sbir_ma_match_rate_by_fy/tasks.md
+++ b/specs/sbir_ma_match_rate_by_fy/tasks.md
@@ -1,71 +1,59 @@
-# Tasks: SBIR M&A Match Rate by Fiscal Year
+# Tasks: SBIR M&A Signal Counts by Fiscal Year
 
-> **Status (2026-07-02):** Not started. Analysis-only spec building on the completed M&A detection work (`scripts/archive/data/detect_sbir_ma_events.py`).
+> **Status (2026-08-09):** Implementation complete; real-data materialization
+> blocked by the unavailable historical input artifact. The former match-rate
+> and Dagster plan is superseded.
 
-Estimated total: 1–1.5 days. No new extraction; analysis only.
+## T0. Review the former design
 
-## T0. Resolve open questions (design.md §"Open questions")
+- [x] Verify the curated JSONL schema and date semantics.
+- [x] Audit the proposed numerator and denominator grain.
+- [x] Confirm whether Item 2.01 can be isolated from the curated schema.
+- [x] Search development, live, persistent-runtime, and historical PR artifacts
+  for the real input.
+  - Result: the proposed rate was incoherent, Item 2.01 is not recoverable, and
+    the gitignored real artifact and upstream refinement inputs are absent.
 
-- [ ] Confirm canonical join key between awards and SEC enrichment
-  (UEI/DUNS vs. normalized company name) for both `sbir_ma_events.jsonl`
-  and the `sec_edgar_enriched_companies` asset.
-- [ ] Confirm `data/form_d_details.jsonl` schema and SBIR-firm linkage
-  (CIK and/or normalized name).
-- [ ] Confirm `data/sec_edgar_scan.jsonl` mention columns and
-  classification labels.
-- [ ] Decide FY2024 right-censoring policy (footnote vs. exclude).
-  → verify: each question answered in design.md before T1.
+## T1. Implement the fail-closed count reporter
 
-## T1. Implement match-rate script
-
-- [ ] Create `scripts/analysis/sbir_ma_match_rate_by_fy.py`.
-- [ ] Build awardee denominator (FY2015–2024, distinct firms).
-- [ ] Union dated signal sources with tier + signal-type labels.
-- [ ] Tier-rank dedupe (one row per firm).
-- [ ] Compute per-FY counts and rates; Wilson CI on aggregate.
-- [ ] Compute Item-2.01-only sub-rate.
-- [ ] Write three output files to `reports/`.
-  → verify: run end-to-end on local parquets; rows match
-  `awardees_in_fy ≥ matched_total`; aggregate rate is in
-  plausible range (5–15% based on prior 8.1% all-time figure).
+- [x] Add `scripts/data/sbir_ma_signal_counts_by_fy.py`.
+- [x] Validate UTF-8 JSONL, company name, tier, and exact ISO dates.
+- [x] Fingerprint source bytes and deduplicate normalized name keys.
+- [x] Assign signal-observation FY and aggregate FY2015–FY2024 tier counts.
+- [x] Reconcile overall and per-tier date categories.
+- [x] Render deterministic CSV and Markdown with explicit evidence limits.
 
 ## T2. Unit tests
 
-- [ ] `tests/unit/scripts/test_ma_match_rate_by_fy.py`:
-  - Tier-rank dedupe with synthetic firm having High + Low signals.
-  - FY boundary cases (Sep 30 vs. Oct 1).
-  - Exhibit-21-only match flagged `date_upper_bound = true`.
-  - Wilson CI matches a known reference value.
-  - Item 2.01 sub-rate filters correctly when 1.01 also present.
-  → verify: `pytest tests/unit/scripts/test_ma_match_rate_by_fy.py -v`.
+- [x] Test September 30 / October 1 FY boundaries.
+- [x] Test missing, invalid, out-of-window, and tier reconciliation.
+- [x] Test case/edge-whitespace duplicate collapse and conflict failure.
+- [x] Test strict malformed/empty input rejection.
+- [x] Test deterministic output bytes and source fingerprinting.
+- [x] Test missing input creates no plausible empty report.
+- [x] Test path-alias rejection and staged-publication rollback.
+- [x] Test the output contract excludes rate/control/Item-2.01 claims.
 
-## T3. Dagster asset
+## T3. Materialize the real report
 
-- [ ] `packages/sbir-analytics/sbir_analytics/assets/sbir_ma_match_rate.py`.
-- [ ] Thin wrapper that invokes the script and registers
-  outputs as Dagster assets for the `reports/` files.
-- [ ] No new resources; reuse existing parquet IO managers.
-  → verify: `dagster asset materialize --select sbir_ma_match_rate_by_fy`
-  produces all three reports.
+- [ ] Supply a reviewed `data/sbir_ma_events.jsonl` artifact with a retained
+  fingerprint and documented tier lineage.
+- [ ] Run the reporter twice and verify byte-identical CSV/Markdown.
+- [ ] Review annual counts and all exclusion diagnostics before publication.
+  - **Blocked:** the historical source was gitignored and is unavailable; old
+    aggregate totals cannot reconstruct a fiscal-year series.
 
-## T4. Report and write-up
+## T4. Quality checks
 
-- [ ] Populate `reports/sbir_ma_match_rate_by_fy.md` with: methodology,
-  per-FY table, aggregate FY2015–2024 row with CI, Item 2.01 footnote,
-  caveats (Exhibit-21 dating, private acquirers, right-censoring,
-  pre-window acquisitions).
-- [ ] Cross-link from `docs/research-questions.md` A4.
-  → verify: numbers in MD match the CSV exactly; markdown lints clean.
+- [x] Run focused pytest, Ruff, MyPy, documentation checks, and `git diff
+  --check` on this implementation.
+- [x] Run the repository unit suite before publication.
 
-## T5. Quality sweep
+## Superseded scope
 
-- [ ] Run `quality-sweep` agent on changed files.
-- [ ] Run full test suite: `pytest tests/unit -v`.
-  → verify: zero ruff / mypy errors; all tests pass.
-
-## Out of scope (not in this spec)
-
-- Form 15 (deregistration) extraction.
-- Per-item-code attribution from EFTS (would require re-fetching).
-- Acquirer market-cap / sector enrichment.
-- Backfill of acquisitions before FY2015.
+The following former tasks are intentionally removed from this quick
+diagnostic: awardee denominators, FY match/exit rates, Wilson intervals,
+Item-2.01 sub-rates, raw EFTS/Form D re-union, firm-detail duplication, and a
+Dagster asset. Any genuine cohort rate requires a new reviewed design with a
+common cohort grain, fixed horizon, censoring, canonical identity, and
+symmetric outcome coverage.

--- a/tests/unit/scripts/test_sbir_ma_signal_counts_by_fy.py
+++ b/tests/unit/scripts/test_sbir_ma_signal_counts_by_fy.py
@@ -1,0 +1,372 @@
+import csv
+import importlib.util
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts/data/sbir_ma_signal_counts_by_fy.py"
+SPEC = importlib.util.spec_from_file_location("sbir_ma_signal_counts_by_fy", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> Path:
+    path.write_text(
+        "".join(f"{json.dumps(record, sort_keys=True)}\n" for record in records),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _dataset(tmp_path: Path, records: list[dict]):
+    return MODULE.load_signal_dataset(_write_jsonl(tmp_path / "events.jsonl", records))
+
+
+def test_federal_fy_boundary_and_tier_subtotals(tmp_path):
+    dataset = _dataset(
+        tmp_path,
+        [
+            {"company_name": "Sep Co", "event_date": "2023-09-30", "confidence": "high"},
+            {"company_name": "Oct Co", "event_date": "2023-10-01", "confidence": "medium"},
+            {"company_name": "Low Co", "event_date": "2023-10-01", "confidence": "low"},
+        ],
+    )
+
+    result = MODULE.build_counts(dataset, 2023, 2024)
+
+    assert result.rows == (
+        {
+            "fiscal_year": 2023,
+            "high_signal_name_keys": 1,
+            "medium_signal_name_keys": 0,
+            "high_medium_signal_name_keys": 1,
+            "low_sensitivity_signal_name_keys": 0,
+            "total_signal_name_keys": 1,
+        },
+        {
+            "fiscal_year": 2024,
+            "high_signal_name_keys": 0,
+            "medium_signal_name_keys": 1,
+            "high_medium_signal_name_keys": 1,
+            "low_sensitivity_signal_name_keys": 1,
+            "total_signal_name_keys": 2,
+        },
+    )
+    assert result.in_window_keys == 3
+
+
+def test_missing_invalid_and_out_of_window_dates_are_separate(tmp_path):
+    dataset = _dataset(
+        tmp_path,
+        [
+            {"company_name": "Missing", "confidence": "high"},
+            {"company_name": "Null", "event_date": None, "confidence": "medium"},
+            {"company_name": "Malformed", "event_date": "2023-02-30", "confidence": "low"},
+            {"company_name": "Not ISO", "event_date": "2023-2-03", "confidence": "high"},
+            {"company_name": "Old", "event_date": "2013-12-01", "confidence": "medium"},
+        ],
+    )
+
+    result = MODULE.build_counts(dataset, 2015, 2024)
+
+    assert result.missing_date_keys == 2
+    assert result.invalid_date_keys == 2
+    assert result.valid_out_of_window_keys == 1
+    assert result.in_window_keys == 0
+    assert (
+        result.missing_date_keys
+        + result.invalid_date_keys
+        + result.valid_out_of_window_keys
+        + result.in_window_keys
+        == len(dataset.records)
+    )
+
+
+def test_case_and_edge_whitespace_duplicates_collapse(tmp_path):
+    dataset = _dataset(
+        tmp_path,
+        [
+            {"company_name": "  Example Corp ", "event_date": "2022-01-02", "confidence": "high"},
+            {"company_name": "example corp", "event_date": "2022-01-02", "confidence": "high"},
+        ],
+    )
+
+    assert dataset.input_rows == 2
+    assert len(dataset.records) == 1
+    assert dataset.duplicate_rows == 1
+    assert dataset.records[0].company_key == "example corp"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("event_date", "2022-01-03"),
+        ("confidence", "medium"),
+    ],
+)
+def test_conflicting_duplicate_date_or_tier_fails(tmp_path, field, value):
+    records = [
+        {"company_name": "Example Corp", "event_date": "2022-01-02", "confidence": "high"},
+        {"company_name": " example corp ", "event_date": "2022-01-02", "confidence": "high"},
+    ]
+    records[1][field] = value
+    source = _write_jsonl(tmp_path / "events.jsonl", records)
+
+    with pytest.raises(MODULE.InputValidationError, match="conflicting duplicate"):
+        MODULE.load_signal_dataset(source)
+
+
+@pytest.mark.parametrize(
+    "content,error",
+    [
+        ('{"company_name": "A", "confidence": "HIGH"}\n', "confidence must be exactly"),
+        ('{"company_name": "A", "confidence": "high"\n', "invalid JSON"),
+        ('{"company_name": "A", "company_name": "B", "confidence": "high"}\n', "duplicate JSON"),
+        ('{"company_name": "A", "confidence": "high"}\n\n', "blank JSONL"),
+    ],
+)
+def test_strict_jsonl_validation(tmp_path, content, error):
+    source = tmp_path / "events.jsonl"
+    source.write_text(content, encoding="utf-8")
+
+    with pytest.raises(MODULE.InputValidationError, match=error):
+        MODULE.load_signal_dataset(source)
+
+
+def test_empty_input_fails_before_all_zero_report_can_be_built(tmp_path):
+    source = tmp_path / "events.jsonl"
+    source.write_bytes(b"")
+
+    with pytest.raises(MODULE.InputValidationError, match="zero JSONL records"):
+        MODULE.load_signal_dataset(source)
+
+
+def test_per_tier_and_date_status_reconciliation(tmp_path):
+    dataset = _dataset(
+        tmp_path,
+        [
+            {"company_name": "H", "event_date": "2021-06-01", "confidence": "high"},
+            {"company_name": "M", "event_date": "2021-06-01", "confidence": "medium"},
+            {"company_name": "L", "event_date": "2021-06-01", "confidence": "low"},
+            {"company_name": "No date", "confidence": "low"},
+        ],
+    )
+
+    result = MODULE.build_counts(dataset, 2021, 2021)
+    row = result.rows[0]
+
+    assert row["high_medium_signal_name_keys"] == (
+        row["high_signal_name_keys"] + row["medium_signal_name_keys"]
+    )
+    assert row["total_signal_name_keys"] == (
+        row["high_medium_signal_name_keys"] + row["low_sensitivity_signal_name_keys"]
+    )
+    assert result.distinct_tier_counts == {"high": 1, "medium": 1, "low": 2}
+    assert sum(result.distinct_tier_counts.values()) == len(dataset.records)
+    assert row["total_signal_name_keys"] + result.missing_date_keys == len(dataset.records)
+    for tier in MODULE.CONFIDENCE_TIERS:
+        assert sum(result.date_status_by_tier[tier].values()) == result.distinct_tier_counts[tier]
+
+
+def test_outputs_are_byte_identical_and_include_fingerprint(tmp_path):
+    source = _write_jsonl(
+        tmp_path / "events.jsonl",
+        [
+            {"company_name": "B", "event_date": "2020-10-01", "confidence": "medium"},
+            {"company_name": "A", "event_date": "2020-09-30", "confidence": "high"},
+        ],
+    )
+    first_csv = tmp_path / "first" / "counts.csv"
+    first_md = tmp_path / "first" / "counts.md"
+    second_csv = tmp_path / "second" / "counts.csv"
+    second_md = tmp_path / "second" / "counts.md"
+
+    assert (
+        MODULE.main(
+            [
+                "--input",
+                str(source),
+                "--csv-output",
+                str(first_csv),
+                "--markdown-output",
+                str(first_md),
+            ]
+        )
+        == 0
+    )
+    assert (
+        MODULE.main(
+            [
+                "--input",
+                str(source),
+                "--csv-output",
+                str(second_csv),
+                "--markdown-output",
+                str(second_md),
+            ]
+        )
+        == 0
+    )
+
+    assert first_csv.read_bytes() == second_csv.read_bytes()
+    assert first_md.read_bytes() == second_md.read_bytes()
+    dataset = MODULE.load_signal_dataset(source)
+    assert dataset.source_sha256.encode() in first_md.read_bytes()
+    assert f"- Bytes: {dataset.source_bytes:,}" in first_md.read_text(encoding="utf-8")
+
+
+def test_missing_input_returns_nonzero_without_writing_outputs(tmp_path, capsys):
+    csv_output = tmp_path / "reports" / "counts.csv"
+    markdown_output = tmp_path / "reports" / "counts.md"
+
+    return_code = MODULE.main(
+        [
+            "--input",
+            str(tmp_path / "absent.jsonl"),
+            "--csv-output",
+            str(csv_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    assert return_code != 0
+    assert not csv_output.exists()
+    assert not markdown_output.exists()
+    assert "input does not exist" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("alias_input", [False, True])
+def test_report_paths_must_not_alias_each_other_or_input(tmp_path, capsys, alias_input):
+    source = _write_jsonl(
+        tmp_path / "events.jsonl",
+        [{"company_name": "A", "event_date": "2020-01-01", "confidence": "high"}],
+    )
+    original_source = source.read_bytes()
+    csv_output = source if alias_input else tmp_path / "same-output"
+    markdown_output = tmp_path / "other-output" if alias_input else csv_output
+
+    return_code = MODULE.main(
+        [
+            "--input",
+            str(source),
+            "--csv-output",
+            str(csv_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    assert return_code != 0
+    assert source.read_bytes() == original_source
+    assert "paths must be distinct" in capsys.readouterr().err
+
+
+def test_second_stage_failure_preserves_existing_report_pair(tmp_path, capsys, monkeypatch):
+    source = _write_jsonl(
+        tmp_path / "events.jsonl",
+        [{"company_name": "A", "event_date": "2020-01-01", "confidence": "high"}],
+    )
+    csv_output = tmp_path / "counts.csv"
+    markdown_output = tmp_path / "counts.md"
+    csv_output.write_text("old csv\n", encoding="utf-8")
+    markdown_output.write_text("old markdown\n", encoding="utf-8")
+    original_stage_text = MODULE._stage_text
+    calls = 0
+
+    def fail_second_stage(destination, content):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("simulated second-stage failure")
+        return original_stage_text(destination, content)
+
+    monkeypatch.setattr(MODULE, "_stage_text", fail_second_stage)
+    return_code = MODULE.main(
+        [
+            "--input",
+            str(source),
+            "--csv-output",
+            str(csv_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    assert return_code != 0
+    assert csv_output.read_text(encoding="utf-8") == "old csv\n"
+    assert markdown_output.read_text(encoding="utf-8") == "old markdown\n"
+    assert list(tmp_path.glob("*.tmp")) == []
+    assert "simulated second-stage failure" in capsys.readouterr().err
+
+
+def test_second_publish_failure_rolls_back_existing_report_pair(tmp_path, capsys, monkeypatch):
+    source = _write_jsonl(
+        tmp_path / "events.jsonl",
+        [{"company_name": "A", "event_date": "2020-01-01", "confidence": "high"}],
+    )
+    csv_output = tmp_path / "counts.csv"
+    markdown_output = tmp_path / "counts.md"
+    csv_output.write_text("old csv\n", encoding="utf-8")
+    markdown_output.write_text("old markdown\n", encoding="utf-8")
+    original_replace = MODULE.os.replace
+    failed = False
+
+    def fail_markdown_publish(source_path, destination):
+        nonlocal failed
+        source_path = Path(source_path)
+        destination = Path(destination)
+        if not failed and source_path.suffix == ".tmp" and destination == markdown_output:
+            failed = True
+            raise OSError("simulated second-publish failure")
+        return original_replace(source_path, destination)
+
+    monkeypatch.setattr(MODULE.os, "replace", fail_markdown_publish)
+    return_code = MODULE.main(
+        [
+            "--input",
+            str(source),
+            "--csv-output",
+            str(csv_output),
+            "--markdown-output",
+            str(markdown_output),
+        ]
+    )
+
+    assert return_code != 0
+    assert csv_output.read_text(encoding="utf-8") == "old csv\n"
+    assert markdown_output.read_text(encoding="utf-8") == "old markdown\n"
+    assert list(tmp_path.glob("*.tmp")) == []
+    assert list(tmp_path.glob("*.backup")) == []
+    assert "simulated second-publish failure" in capsys.readouterr().err
+
+
+def test_csv_contract_and_markdown_avoid_rate_or_incidence_claims(tmp_path):
+    dataset = _dataset(
+        tmp_path,
+        [{"company_name": "A", "event_date": "2020-01-01", "confidence": "high"}],
+    )
+    result = MODULE.build_counts(dataset, 2020, 2020)
+
+    csv_text = MODULE.render_csv(result)
+    fields = next(csv.reader(StringIO(csv_text)))
+    markdown = MODULE.render_markdown(dataset, result, 2020, 2020).lower()
+
+    assert fields == list(MODULE.CSV_COLUMNS)
+    assert not any(
+        forbidden in field for field in fields for forbidden in ("rate", "exit", "control")
+    )
+    assert "match rate" not in markdown
+    assert "wilson" not in markdown
+    assert "item 2.01" not in markdown
+    assert " rose " not in markdown
+    assert " fell " not in markdown
+    assert "not verified firms, deals, acquisitions, or exits" in markdown
+    assert "signal-observation date, not a transaction or close date" in markdown
+    assert "no award denominator is used" in markdown


### PR DESCRIPTION
## Summary

- add a standard-library FY2015-FY2024 reporter for fingerprinted SBIR M&A signal records
- validate JSONL, dates, confidence tiers, normalized-name duplicates, and per-tier reconciliation
- emit deterministic CSV and Markdown counts with explicit signal-observation and SBIR-only boundaries
- reject input/output path aliases and stage both reports with rollback on partial publication
- replace the stale match-rate spec with the defensible count diagnostic and its real-data gate

## Why counts, not rates

The prior spec grouped its numerator by signal fiscal year and its denominator by first-award fiscal year. Those are different populations, so the quotient is not a coherent incidence or cohort rate. A real vintage rate needs the same cohort in numerator and denominator, a fixed observation horizon, censoring rules, canonical identity, and symmetric outcome coverage.

The source event date is also a hybrid filing/mention observation date, not a transaction or closing date. This PR therefore reports normalized company-name signal counts only.

## Materialization status

The historical data/sbir_ma_events.jsonl artifact and its refinement inputs were gitignored and are absent from development, live, persistent-runtime, and historical CI storage. Published aggregate totals cannot reconstruct exact FY counts, missing-date diagnostics, duplicates, or a source fingerprint.

Accordingly, this PR does not publish invented or zero-valued real figures. The CLI exits nonzero and writes nothing when the input is absent. Once a reviewed artifact is supplied, the generated report embeds its SHA-256 and byte count.

## Verification

- 18 focused tests passed
- full unit suite: 5,860 passed, 7 skipped
- Ruff check and format check passed
- MyPy passed
- architecture, epistemic-tier, configuration, file-size, manifest, and docs guards passed
- default missing-input run exits 1 and creates neither report
- git diff --check passed