### PR TITLE
Audit exact-name SBIR Form D proxy evidence

### DIFF
--- a/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json
+++ b/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json
@@ -1,0 +1,253 @@
+{
+  "caveats": [
+    "Exact-name candidate identities are not verified SBIR identities.",
+    "Exact-name identity recall is unknown.",
+    "The event is a filer-supplied Form D filing proxy, not a verified legal event.",
+    "Filing dates are evidence dates and are not transaction or exit dates.",
+    "Agency memberships overlap and must not be summed.",
+    "No count in this audit is an outcome, prevalence, or match rate."
+  ],
+  "code_commit": "3e76c3bf165693ebca056841127255a28ad497d6",
+  "complete": true,
+  "complete_sbir_exclusion": false,
+  "complete_sbir_identity": false,
+  "counts": {
+    "agency_membership_nonexclusive": {
+      "DHS": {
+        "proxy_bearing_ciks": 1,
+        "proxy_filings": 1
+      },
+      "DOC": {
+        "proxy_bearing_ciks": 3,
+        "proxy_filings": 6
+      },
+      "DOD": {
+        "proxy_bearing_ciks": 76,
+        "proxy_filings": 96
+      },
+      "DOE": {
+        "proxy_bearing_ciks": 23,
+        "proxy_filings": 31
+      },
+      "DOT": {
+        "proxy_bearing_ciks": 3,
+        "proxy_filings": 5
+      },
+      "ED": {
+        "proxy_bearing_ciks": 3,
+        "proxy_filings": 3
+      },
+      "EPA": {
+        "proxy_bearing_ciks": 2,
+        "proxy_filings": 2
+      },
+      "HHS": {
+        "proxy_bearing_ciks": 133,
+        "proxy_filings": 181
+      },
+      "NASA": {
+        "proxy_bearing_ciks": 21,
+        "proxy_filings": 28
+      },
+      "NSF": {
+        "proxy_bearing_ciks": 31,
+        "proxy_filings": 44
+      },
+      "USDA": {
+        "proxy_bearing_ciks": 7,
+        "proxy_filings": 12
+      }
+    },
+    "amendment_proxy_filings": 26,
+    "candidate_ciks": 4465,
+    "complete_filing_fiscal_year_window": {
+      "end_fy": 2024,
+      "proxy_bearing_ciks": 212,
+      "proxy_filings": 283,
+      "start_fy": 2010
+    },
+    "filing_fiscal_years": {
+      "2010": {
+        "proxy_bearing_ciks": 23,
+        "proxy_filings": 26
+      },
+      "2011": {
+        "proxy_bearing_ciks": 23,
+        "proxy_filings": 29
+      },
+      "2012": {
+        "proxy_bearing_ciks": 13,
+        "proxy_filings": 16
+      },
+      "2013": {
+        "proxy_bearing_ciks": 20,
+        "proxy_filings": 29
+      },
+      "2014": {
+        "proxy_bearing_ciks": 21,
+        "proxy_filings": 22
+      },
+      "2015": {
+        "proxy_bearing_ciks": 18,
+        "proxy_filings": 20
+      },
+      "2016": {
+        "proxy_bearing_ciks": 16,
+        "proxy_filings": 19
+      },
+      "2017": {
+        "proxy_bearing_ciks": 12,
+        "proxy_filings": 14
+      },
+      "2018": {
+        "proxy_bearing_ciks": 10,
+        "proxy_filings": 12
+      },
+      "2019": {
+        "proxy_bearing_ciks": 14,
+        "proxy_filings": 16
+      },
+      "2020": {
+        "proxy_bearing_ciks": 16,
+        "proxy_filings": 17
+      },
+      "2021": {
+        "proxy_bearing_ciks": 16,
+        "proxy_filings": 17
+      },
+      "2022": {
+        "proxy_bearing_ciks": 11,
+        "proxy_filings": 13
+      },
+      "2023": {
+        "proxy_bearing_ciks": 15,
+        "proxy_filings": 16
+      },
+      "2024": {
+        "proxy_bearing_ciks": 15,
+        "proxy_filings": 17
+      }
+    },
+    "full_source_join": {
+      "proxy_bearing_ciks": 222,
+      "proxy_filings": 295
+    },
+    "identity_evidence_classes": {
+      "ambiguous_name_only": {
+        "proxy_bearing_ciks": 26,
+        "proxy_filings": 33
+      },
+      "unique_within_materialized_name_map": {
+        "proxy_bearing_ciks": 186,
+        "proxy_filings": 250
+      }
+    },
+    "incomplete_boundary_fiscal_years": {
+      "2009": {
+        "proxy_bearing_ciks": 10,
+        "proxy_filings": 10
+      },
+      "2025": {
+        "proxy_bearing_ciks": 2,
+        "proxy_filings": 2
+      }
+    },
+    "submission_types": {
+      "D": 257,
+      "D/A": 26
+    }
+  },
+  "covariates_ready": false,
+  "exclusion_recall": "unknown",
+  "identity_status": "exact_name_candidate",
+  "inputs": {
+    "awards_snapshot": {
+      "path": "award_data.csv",
+      "row_count": 219500,
+      "sha256": "73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd",
+      "size_bytes": 394456822
+    },
+    "candidate_exclusions": {
+      "path": "sbir_cik_exclusion_candidates.identity-staging.jsonl",
+      "row_count": 4465,
+      "sha256": "94cb5bc0eae682675f6e0015cc2c21b48411aba6429b6ef5e4cccfe769af38d3",
+      "size_bytes": 2276095
+    },
+    "control_manifest": {
+      "path": "agency-private-capital-form-d-control-universe.manifest.json",
+      "sha256": "1777119114c4f7385dd09d6b60c603f2c5c59db765311255440513190d94b331",
+      "size_bytes": 247889
+    },
+    "proxy_coverage": {
+      "path": "form_d_business_combination_filing_proxy.coverage.1a8b017959109e8c14ce8469fd93b6ef3df5751b93678a4b092b8af7562c510b.jsonl",
+      "row_count": 311809,
+      "sha256": "1a8b017959109e8c14ce8469fd93b6ef3df5751b93678a4b092b8af7562c510b",
+      "size_bytes": 125345249
+    },
+    "proxy_events": {
+      "path": "form_d_business_combination_filing_proxy.events.8ad27fa2cc319971853f6aaed8b637c7267ca4803901fa62b3b30799da5086fb.jsonl",
+      "row_count": 14408,
+      "sha256": "8ad27fa2cc319971853f6aaed8b637c7267ca4803901fa62b3b30799da5086fb",
+      "size_bytes": 8356489
+    },
+    "proxy_manifest": {
+      "path": "agency-private-capital-form-d-business-combination-proxy.manifest.json",
+      "sha256": "0bad05474580a27200f38474f5ea629bf2ff827c68c53e5d89bc47e3640dd680",
+      "size_bytes": 5048
+    }
+  },
+  "invariants": {
+    "agency_tags_nonempty_and_sorted": true,
+    "candidate_ciks_have_complete_proxy_coverage": true,
+    "complete_fiscal_years_only": true,
+    "content_addressed_output": true,
+    "exact_cik_join_only": true,
+    "identity_classes_exhaustive_and_exclusive": true,
+    "input_hash_rows_bytes_verified": true,
+    "one_row_per_unique_accession": true,
+    "per_fiscal_year_filings_reconcile": true
+  },
+  "outcome_kind": "filing_proxy",
+  "outputs": {
+    "filing_evidence_audit": {
+      "path": "sbir_form_d_proxy_audit.aaa60a046a8a8d952dee06fd4a83a496eecb167f3ce2bff2d0e4ae69a5f4af91.jsonl",
+      "row_count": 283,
+      "sha256": "aaa60a046a8a8d952dee06fd4a83a496eecb167f3ce2bff2d0e4ae69a5f4af91",
+      "size_bytes": 244696
+    }
+  },
+  "ready_for_matching": false,
+  "schema_version": 1,
+  "source": {
+    "coverage_end_date": "2024-12-31",
+    "coverage_start_date": "2009-01-01",
+    "date_basis": "filing_date",
+    "event_type": "form_d_business_combination_filing_proxy",
+    "source": "sec_dera_form_d_quarterly_bulk",
+    "source_snapshot_id": "form_d_control_universe_manifest_sha256:1777119114c4f7385dd09d6b60c603f2c5c59db765311255440513190d94b331"
+  },
+  "verified_ma": false,
+  "window": {
+    "complete_filing_fiscal_years": [
+      2010,
+      2011,
+      2012,
+      2013,
+      2014,
+      2015,
+      2016,
+      2017,
+      2018,
+      2019,
+      2020,
+      2021,
+      2022,
+      2023,
+      2024
+    ],
+    "excluded_incomplete_boundary_fiscal_years": [
+      2009,
+      2025
+    ]
+  }
+}

--- a/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.md
+++ b/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.md
@@ -1,0 +1,141 @@
+---
+Type: Research Report
+Owner: research@project
+Last-Reviewed: 2026-08-09
+Status: draft
+---
+
+# Exact-name SBIR candidate / Form D filing-proxy audit
+
+> **Exploratory and non-citable.** This is an identity-and-evidence audit, not
+> an outcome study or a treated-versus-control comparison. The evidence is a
+> filer-supplied Form D business-combination filing proxy. It does not verify a
+> merger, acquisition, transaction, exit, or successful commercialization.
+
+## Materialization result
+
+The audit linked the 4,465 exact-name candidate CIKs from the pinned Form D
+control-universe identity stage to the symmetric
+`form_d_business_combination_filing_proxy` evidence on canonical exact CIK.
+Within the complete federal filing fiscal years FY2010–FY2024, it retained 283
+unique Form D accessions across 212 exact Form D CIKs. These are filing and CIK
+counts, not rates. They do not establish that every candidate identity is an
+SBIR firm or that any filing corresponds to a completed business combination.
+
+| Filing fiscal year | Proxy filings | Distinct exact Form D CIKs |
+| ---: | ---: | ---: |
+| 2010 | 26 | 23 |
+| 2011 | 29 | 23 |
+| 2012 | 16 | 13 |
+| 2013 | 29 | 20 |
+| 2014 | 22 | 21 |
+| 2015 | 20 | 18 |
+| 2016 | 19 | 16 |
+| 2017 | 14 | 12 |
+| 2018 | 12 | 10 |
+| 2019 | 16 | 14 |
+| 2020 | 17 | 16 |
+| 2021 | 17 | 16 |
+| 2022 | 13 | 11 |
+| 2023 | 16 | 15 |
+| 2024 | 17 | 15 |
+| **Complete FY2010–FY2024 window** | **283** | **212** |
+
+Distinct-CIK counts are not additive across filing fiscal years because a CIK
+can have evidence in more than one year. Filing fiscal year is derived from the
+SEC filing date: October through December map to the following federal fiscal
+year. It is not a transaction, announcement, signing, closing, or exit year.
+
+The bounded source starts on 2009-01-01 and ends on 2024-12-31. Consequently,
+FY2009 and FY2025 are incomplete. Ten FY2009 filings across ten CIKs and two
+FY2025 filings across two CIKs were audited as boundary diagnostics but excluded
+from the product and headline counts. The full source-window join contains 295
+filings across 222 CIKs; that boundary-inclusive count is not the complete-FY
+result.
+
+## Identity sensitivity
+
+Each candidate CIK is classified from the already-materialized exact-name
+evidence. `unique_within_materialized_name_map` means that at least one matched
+normalized name mapped to one CIK in that materialization.
+`ambiguous_name_only` means every matched normalized name mapped to multiple
+candidate CIKs.
+
+| Exact-name evidence class | Proxy filings | Distinct exact Form D CIKs |
+| --- | ---: | ---: |
+| `unique_within_materialized_name_map` | 250 | 186 |
+| `ambiguous_name_only` | 33 | 26 |
+| **Complete FY2010–FY2024 window** | **283** | **212** |
+
+“Unique” here is not a verified real-world corporate identity. The upstream
+exact-name exclusion has unknown recall and can miss aliases, renames, spelling
+variation, acquisitions, or unresolved CIKs. This audit does not rerun or expand
+name matching.
+
+## Agency membership diagnostics
+
+Agency tags are reconstructed from the pinned SBIR award snapshot only for the
+normalized names already recorded in the candidate ledger. A CIK can carry
+multiple tags, so the rows below overlap and must not be summed.
+
+| Agency tag | Proxy filings | Distinct exact Form D CIKs |
+| --- | ---: | ---: |
+| NSF | 44 | 31 |
+| DOE | 31 | 23 |
+| HHS | 181 | 133 |
+| DoD | 96 | 76 |
+
+These are evidence-membership diagnostics, not agency outcome comparisons.
+They do not use award dates, post-award windows, matched controls, or mutually
+exclusive agency assignment.
+
+## Filing lineage
+
+The complete-FY product preserves 257 original `D` filings and 26 `D/A`
+amendments. Each amendment remains a separate filing-evidence row with its prior
+accession when supplied. The audit does not collapse related filings into an
+inferred transaction.
+
+Each output row retains the exact CIK and firm key, accession, filing date and
+fiscal year, submission type, amendment lineage, proxy/evidence labels, source
+snapshot, matched normalized names, evidence class, and sorted agency tags.
+One accession produces one row even when it has multiple names or agency tags.
+
+## Provenance and gate decision
+
+The [tracked materialization manifest](agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json)
+pins both upstream manifest byte hashes; the candidate, event, and coverage
+product hashes, sizes, and row counts; the SBIR award snapshot; the
+content-addressed audit product; aggregate reconciliations; and all fail-closed
+gates. The producer verifies exact canonical CIKs, unique accessions and event
+IDs, complete source coverage for every candidate CIK, expected proxy labels,
+and the 2009-01-01 through 2024-12-31 source interval before publishing.
+
+| Product | Rows | Bytes | SHA-256 |
+| --- | ---: | ---: | --- |
+| Complete-FY filing evidence audit | 283 | 244,696 | `aaa60a046a8a8d952dee06fd4a83a496eecb167f3ce2bff2d0e4ae69a5f4af91` |
+
+Two full materializations produced byte-identical product and manifest hashes;
+the tracked manifest SHA-256 is
+`9c23587c49a1ecddea15f1fc0af67b4016a905d253d46d3198c3f0642042e768`.
+
+This audit does not close the Phase 2 identity, covariate, or outcome gates.
+Its manifest retains `complete_sbir_identity=false`,
+`complete_sbir_exclusion=false`, `exclusion_recall="unknown"`,
+`covariates_ready=false`, `ready_for_matching=false`,
+`outcome_kind="filing_proxy"`, and `verified_ma=false`.
+
+Reproduce after materializing the pinned #582 and #584 products:
+
+```bash
+uv run python scripts/data/audit_sbir_form_d_business_combination_proxy.py \
+  --control-manifest docs/research/agency-private-capital-form-d-control-universe.manifest.json \
+  --candidate-jsonl data/processed/agency_private_capital/control_universe/sbir_cik_exclusion_candidates.identity-staging.jsonl \
+  --proxy-manifest docs/research/agency-private-capital-form-d-business-combination-proxy.manifest.json \
+  --event-jsonl data/processed/agency_private_capital/form_d_business_combination_events/form_d_business_combination_filing_proxy.events.8ad27fa2cc319971853f6aaed8b637c7267ca4803901fa62b3b30799da5086fb.jsonl \
+  --coverage-jsonl data/processed/agency_private_capital/form_d_business_combination_events/form_d_business_combination_filing_proxy.coverage.1a8b017959109e8c14ce8469fd93b6ef3df5751b93678a4b092b8af7562c510b.jsonl \
+  --awards-csv data/raw/sbir/award_data.csv \
+  --output-dir data/processed/agency_private_capital/sbir_form_d_proxy_audit \
+  --audit-manifest docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json \
+  --code-version 3e76c3bf165693ebca056841127255a28ad497d6
+```

--- a/scripts/data/audit_sbir_form_d_business_combination_proxy.py
+++ b/scripts/data/audit_sbir_form_d_business_combination_proxy.py
@@ -1,0 +1,864 @@
+#!/usr/bin/env python3
+"""Audit exact-name SBIR candidate CIKs against Form D filing-proxy evidence.
+
+This producer is an identity/evidence audit only. It joins already-materialized
+exact-name candidate CIKs to the symmetric Form D business-combination filing
+proxy and emits no cohort classification, denominator, rate, or legal-event
+claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import tempfile
+from collections import Counter, defaultdict
+from collections.abc import Iterator, Mapping
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+
+
+EVENT_TYPE = "form_d_business_combination_filing_proxy"
+EVIDENCE_KIND = "proxy"
+SOURCE = "sec_dera_form_d_quarterly_bulk"
+SOURCE_START_DATE = date(2009, 1, 1)
+SOURCE_END_DATE = date(2024, 12, 31)
+OUTPUT_SCHEMA_VERSION = 1
+NORMALIZER = CompanyNameProfile.ORGANIZATION_KEY_V1
+MATERIALIZED_START_FY = 2010
+MATERIALIZED_END_FY = 2024
+BOUNDARY_FISCAL_YEARS = frozenset({2009, 2025})
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+CIK_RE = re.compile(r"[1-9][0-9]{0,9}")
+
+AGENCY_TAG_BY_NAME = {
+    "Department of Agriculture": "USDA",
+    "Department of Commerce": "DOC",
+    "Department of Defense": "DOD",
+    "Department of Education": "ED",
+    "Department of Energy": "DOE",
+    "Department of Health and Human Services": "HHS",
+    "Department of Homeland Security": "DHS",
+    "Department of Transportation": "DOT",
+    "Department of the Interior": "DOI",
+    "Environmental Protection Agency": "EPA",
+    "National Aeronautics and Space Administration": "NASA",
+    "National Science Foundation": "NSF",
+    "Nuclear Regulatory Commission": "NRC",
+}
+HEADLINE_AGENCIES = ("NSF", "DOE", "HHS", "DOD")
+
+
+class AuditError(RuntimeError):
+    """Raised when an input contract or audit invariant fails closed."""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _positive_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise AuditError(f"{label} must be a positive integer")
+    return value
+
+
+def _non_negative_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise AuditError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _required_text(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AuditError(f"{label} must be non-empty text")
+    return value.strip()
+
+
+def _canonical_cik(value: object, *, label: str) -> str:
+    cik = _required_text(value, label=label)
+    if CIK_RE.fullmatch(cik) is None:
+        raise AuditError(f"{label} is not a canonical CIK")
+    return cik
+
+
+def _mapping(value: object, *, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise AuditError(f"{label} must be a JSON object")
+    return value
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise AuditError(f"duplicate JSON key {key!r}")
+        value[key] = item
+    return value
+
+
+def _reject_nonstandard_constant(value: str) -> None:
+    raise AuditError(f"non-standard JSON constant {value!r}")
+
+
+def _loads_json(value: str | bytes, *, label: str) -> Any:
+    try:
+        return json.loads(
+            value,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonstandard_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, AuditError) as exc:
+        raise AuditError(f"Invalid JSON in {label}: {exc}") from exc
+
+
+def _load_manifest(path: Path, *, label: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    if not path.is_file() or path.is_symlink():
+        raise AuditError(f"Required {label} is missing or not a regular file: {path}")
+    data = path.read_bytes()
+    value = _loads_json(data, label=f"{label} {path}")
+    if not isinstance(value, dict):
+        raise AuditError(f"{label} must contain a JSON object")
+    return value, {
+        "path": path.name,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "size_bytes": len(data),
+    }
+
+
+def _product_reference(value: object, *, label: str) -> dict[str, Any]:
+    product = _mapping(value, label=label)
+    path = _required_text(product.get("path"), label=f"{label}.path")
+    sha = _required_text(product.get("sha256"), label=f"{label}.sha256")
+    if SHA256_RE.fullmatch(sha) is None:
+        raise AuditError(f"{label}.sha256 is invalid")
+    return {
+        "path": path,
+        "row_count": _positive_int(product.get("row_count"), label=f"{label}.row_count"),
+        "sha256": sha,
+        "size_bytes": _positive_int(product.get("size_bytes"), label=f"{label}.size_bytes"),
+    }
+
+
+def _verify_product(path: Path, reference: Mapping[str, Any], *, label: str) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        raise AuditError(f"Required {label} is missing or not a regular file: {path}")
+    if path.name != reference["path"]:
+        raise AuditError(f"{label} filename does not match its manifest")
+    size = path.stat().st_size
+    if size != reference["size_bytes"]:
+        raise AuditError(f"{label} byte size does not match its manifest")
+    sha = _sha256(path)
+    if sha != reference["sha256"]:
+        raise AuditError(f"{label} SHA-256 does not match its manifest")
+    return {
+        "path": path.name,
+        "row_count": reference["row_count"],
+        "sha256": sha,
+        "size_bytes": size,
+    }
+
+
+def _iter_jsonl(path: Path, *, label: str) -> Iterator[tuple[int, Mapping[str, Any]]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                raise AuditError(f"{label} line {line_number} is blank")
+            value = _loads_json(line, label=f"{label} line {line_number}")
+            yield line_number, _mapping(value, label=f"{label} line {line_number}")
+
+
+def _validate_manifests(
+    control: Mapping[str, Any],
+    control_meta: Mapping[str, Any],
+    proxy: Mapping[str, Any],
+) -> tuple[
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, Any],
+    dict[str, int],
+]:
+    if control.get("complete") is not True or control.get("schema_version") != 1:
+        raise AuditError("Control manifest is not a complete schema-v1 materialization")
+    if control.get("complete_sbir_exclusion") is not False:
+        raise AuditError("Control manifest must preserve complete_sbir_exclusion=false")
+    if control.get("exclusion_recall") != "unknown":
+        raise AuditError("Control manifest must preserve exclusion_recall=unknown")
+    control_outputs = _mapping(control.get("outputs"), label="control outputs")
+    candidate_ref = _product_reference(
+        control_outputs.get("candidate_sbir_cik_exclusions"),
+        label="candidate-exclusion product",
+    )
+    exclusion = _mapping(control.get("exclusion"), label="control exclusion metadata")
+    awards_ref = _product_reference(exclusion.get("awards_csv"), label="control awards snapshot")
+    exact_match = _mapping(exclusion.get("exact_match"), label="control exact-match metadata")
+    identity_contract = {
+        "candidate_cik_count": _positive_int(
+            exact_match.get("candidate_cik_count"), label="candidate CIK count"
+        ),
+        "matched_normalized_name_count": _positive_int(
+            exact_match.get("matched_normalized_name_count"),
+            label="matched normalized-name count",
+        ),
+        "ambiguous_normalized_name_count": _non_negative_int(
+            exact_match.get("normalized_names_mapping_to_multiple_ciks"),
+            label="ambiguous normalized-name count",
+        ),
+    }
+    if exact_match.get("normalizer_version") != NORMALIZER.value:
+        raise AuditError("Control manifest exact-name metadata uses an unexpected normalizer")
+    if identity_contract["candidate_cik_count"] != candidate_ref["row_count"]:
+        raise AuditError("Control manifest candidate CIK counts do not reconcile")
+    broad_ref = _product_reference(
+        control_outputs.get("broad_issuer_universe"), label="broad issuer-universe product"
+    )
+
+    if proxy.get("complete") is not True or proxy.get("schema_version") != 1:
+        raise AuditError("Proxy manifest is not a complete schema-v1 materialization")
+    if proxy.get("event_type") != EVENT_TYPE:
+        raise AuditError("Proxy manifest has an unexpected event type")
+    proxy_inputs = _mapping(proxy.get("inputs"), label="proxy inputs")
+    proxy_input = _mapping(
+        proxy_inputs.get("source_manifest"),
+        label="proxy source-manifest input",
+    )
+    if proxy_input.get("path") != control_meta["path"]:
+        raise AuditError("Proxy manifest does not pin the supplied control-manifest filename")
+    if proxy_input.get("sha256") != control_meta["sha256"]:
+        raise AuditError("Proxy manifest does not pin the supplied control-manifest bytes")
+    if proxy_input.get("size_bytes") != control_meta["size_bytes"]:
+        raise AuditError("Proxy manifest control-manifest byte size is inconsistent")
+    proxy_issuer_ref = _product_reference(
+        proxy_inputs.get("issuer_universe"), label="proxy issuer-universe input"
+    )
+    if proxy_issuer_ref != broad_ref:
+        raise AuditError("Proxy manifest issuer-universe pin does not match the control manifest")
+    proxy_source = _mapping(proxy.get("source"), label="proxy source")
+    expected_source = {
+        "coverage_start_date": SOURCE_START_DATE.isoformat(),
+        "coverage_end_date": SOURCE_END_DATE.isoformat(),
+        "source_snapshot_date": SOURCE_END_DATE.isoformat(),
+        "source": SOURCE,
+        "source_complete": True,
+    }
+    for key, expected in expected_source.items():
+        if proxy_source.get(key) != expected:
+            raise AuditError(f"Proxy manifest has unexpected source field {key}")
+    source_snapshot_id = _required_text(
+        proxy_source.get("source_snapshot_id"), label="proxy source_snapshot_id"
+    )
+    expected_snapshot_id = f"form_d_control_universe_manifest_sha256:{control_meta['sha256']}"
+    if source_snapshot_id != expected_snapshot_id:
+        raise AuditError("Proxy source snapshot does not identify the supplied control manifest")
+    proxy_outputs = _mapping(proxy.get("outputs"), label="proxy outputs")
+    event_ref = _product_reference(proxy_outputs.get("events"), label="proxy-event product")
+    coverage_ref = _product_reference(proxy_outputs.get("coverage"), label="coverage product")
+    proxy_counters = _mapping(proxy.get("counters"), label="proxy counters")
+    if proxy_counters.get("event_rows") != event_ref["row_count"]:
+        raise AuditError("Proxy manifest event rows do not reconcile")
+    if proxy_counters.get("coverage_rows") != coverage_ref["row_count"]:
+        raise AuditError("Proxy manifest coverage rows do not reconcile")
+    return candidate_ref, event_ref, coverage_ref, awards_ref, identity_contract
+
+
+def _load_candidates(
+    path: Path,
+    *,
+    expected_rows: int,
+    identity_contract: Mapping[str, int],
+) -> dict[str, dict[str, Any]]:
+    candidates: dict[str, dict[str, Any]] = {}
+    ciks_by_name: dict[str, set[str]] = defaultdict(set)
+    claimed_counts_by_name: dict[str, set[int]] = defaultdict(set)
+    row_count = 0
+    for line_number, row in _iter_jsonl(path, label="candidate-exclusion product"):
+        row_count += 1
+        if row.get("schema_version") != 1 or row.get("candidate_exclusion") is not True:
+            raise AuditError(f"Candidate line {line_number} has an unexpected schema or status")
+        cik = _canonical_cik(row.get("cik"), label=f"Candidate line {line_number} CIK")
+        if row.get("firm_key") != f"form_d_cik:{cik}":
+            raise AuditError(f"Candidate line {line_number} has a noncanonical firm key")
+        if cik in candidates:
+            raise AuditError(f"Candidate CIK {cik} occurs more than once")
+        evidence = row.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise AuditError(f"Candidate line {line_number} has no identity evidence")
+        exact_evidence: list[Mapping[str, Any]] = []
+        for index, item in enumerate(evidence):
+            item_map = _mapping(item, label=f"Candidate line {line_number} evidence {index}")
+            if item_map.get("resolution_method") != "candidate_exact_normalized_name":
+                continue
+            if item_map.get("normalizer_version") != NORMALIZER.value:
+                raise AuditError(f"Candidate line {line_number} uses an unexpected normalizer")
+            normalized_name = _required_text(
+                item_map.get("normalized_name"),
+                label=f"Candidate line {line_number} normalized_name",
+            )
+            issuer_count = _positive_int(
+                item_map.get("issuer_cik_count_for_normalized_name"),
+                label=f"Candidate line {line_number} issuer-CIK count",
+            )
+            exact_evidence.append(
+                {"normalized_name": normalized_name, "issuer_cik_count": issuer_count}
+            )
+        if not exact_evidence:
+            raise AuditError(f"Candidate line {line_number} has no exact-name evidence route")
+        names = sorted({str(item["normalized_name"]) for item in exact_evidence})
+        for item in exact_evidence:
+            normalized_name = str(item["normalized_name"])
+            ciks_by_name[normalized_name].add(cik)
+            claimed_counts_by_name[normalized_name].add(int(item["issuer_cik_count"]))
+        candidates[cik] = {
+            "cik": cik,
+            "firm_key": f"form_d_cik:{cik}",
+            "matched_normalized_names": names,
+        }
+    if row_count != expected_rows:
+        raise AuditError("Candidate-exclusion JSONL row count does not match its manifest")
+    for name, ciks in ciks_by_name.items():
+        if claimed_counts_by_name[name] != {len(ciks)}:
+            raise AuditError(f"Exact-name evidence has an inconsistent issuer-CIK count for {name}")
+    ambiguous_names = sum(len(ciks) > 1 for ciks in ciks_by_name.values())
+    if len(candidates) != identity_contract["candidate_cik_count"]:
+        raise AuditError("Physical candidate CIK count does not reconcile")
+    if len(ciks_by_name) != identity_contract["matched_normalized_name_count"]:
+        raise AuditError("Physical normalized-name count does not reconcile")
+    if ambiguous_names != identity_contract["ambiguous_normalized_name_count"]:
+        raise AuditError("Physical ambiguous-name count does not reconcile")
+    for candidate in candidates.values():
+        candidate["mapping_class"] = (
+            "unique_within_materialized_name_map"
+            if any(len(ciks_by_name[name]) == 1 for name in candidate["matched_normalized_names"])
+            else "ambiguous_name_only"
+        )
+    return candidates
+
+
+def _load_agency_tags(
+    path: Path,
+    *,
+    expected_rows: int,
+    candidates: Mapping[str, Mapping[str, Any]],
+) -> dict[str, list[str]]:
+    relevant_names = {
+        name for candidate in candidates.values() for name in candidate["matched_normalized_names"]
+    }
+    tags_by_name: dict[str, set[str]] = defaultdict(set)
+    row_count = 0
+    with path.open(encoding="utf-8-sig", errors="strict", newline="") as handle:
+        reader = csv.DictReader(handle)
+        fields = {str(field).lower(): str(field) for field in (reader.fieldnames or [])}
+        company_column = fields.get("company") or fields.get("company_name")
+        agency_column = fields.get("agency")
+        if company_column is None or agency_column is None:
+            raise AuditError("Awards CSV must contain Company and Agency columns")
+        for row in reader:
+            row_count += 1
+            normalized = normalize_company_name(
+                str(row.get(company_column) or "").strip(), profile=NORMALIZER
+            )
+            if not normalized or normalized not in relevant_names:
+                continue
+            agency_name = str(row.get(agency_column) or "").strip()
+            tag = AGENCY_TAG_BY_NAME.get(agency_name)
+            if tag is None:
+                raise AuditError(f"Matched award name has an unknown agency label: {agency_name!r}")
+            tags_by_name[normalized].add(tag)
+    if row_count != expected_rows:
+        raise AuditError("Awards CSV row count does not match the control manifest")
+    missing_names = sorted(relevant_names - set(tags_by_name))
+    if missing_names:
+        raise AuditError("Exact-name evidence is absent from the pinned awards snapshot")
+    tags_by_cik: dict[str, list[str]] = {}
+    for cik, candidate in candidates.items():
+        tags = sorted(
+            {tag for name in candidate["matched_normalized_names"] for tag in tags_by_name[name]}
+        )
+        if not tags:
+            raise AuditError(f"Candidate CIK {cik} has no agency tag")
+        tags_by_cik[cik] = tags
+    return tags_by_cik
+
+
+def _validate_coverage(
+    path: Path,
+    *,
+    expected_rows: int,
+    candidates: Mapping[str, Mapping[str, Any]],
+    source_snapshot_id: str,
+) -> None:
+    firm_keys: set[str] = set()
+    row_count = 0
+    for line_number, row in _iter_jsonl(path, label="coverage product"):
+        row_count += 1
+        firm_key = _required_text(row.get("firm_key"), label=f"Coverage line {line_number} key")
+        if not firm_key.startswith("form_d_cik:"):
+            raise AuditError(f"Coverage line {line_number} has a noncanonical firm key")
+        cik = _canonical_cik(
+            firm_key.removeprefix("form_d_cik:"), label=f"Coverage line {line_number} CIK"
+        )
+        if firm_key != f"form_d_cik:{cik}" or firm_key in firm_keys:
+            raise AuditError(f"Coverage line {line_number} has a duplicate/noncanonical key")
+        firm_keys.add(firm_key)
+        expected = {
+            "schema_version": 1,
+            "metric": EVENT_TYPE,
+            "source": SOURCE,
+            "source_complete": True,
+            "coverage_start_date": SOURCE_START_DATE.isoformat(),
+            "coverage_end_date": SOURCE_END_DATE.isoformat(),
+            "source_snapshot_date": SOURCE_END_DATE.isoformat(),
+            "source_snapshot_id": source_snapshot_id,
+        }
+        if any(row.get(key) != value for key, value in expected.items()):
+            raise AuditError(f"Coverage line {line_number} violates the proxy coverage contract")
+    if row_count != expected_rows:
+        raise AuditError("Coverage JSONL row count does not match its manifest")
+    missing = sorted(
+        candidate["firm_key"]
+        for candidate in candidates.values()
+        if candidate["firm_key"] not in firm_keys
+    )
+    if missing:
+        raise AuditError("At least one exact-name candidate CIK lacks proxy coverage")
+
+
+def federal_fiscal_year(value: date) -> int:
+    """Return the U.S. federal fiscal year containing ``value``."""
+
+    return value.year + (1 if value.month >= 10 else 0)
+
+
+def _validated_event(
+    row: Mapping[str, Any], *, line_number: int, source_snapshot_id: str
+) -> tuple[str, str, date]:
+    if row.get("schema_version") != 1:
+        raise AuditError(f"Event line {line_number} has an unexpected schema version")
+    firm_key = _required_text(row.get("firm_key"), label=f"Event line {line_number} firm_key")
+    if not firm_key.startswith("form_d_cik:"):
+        raise AuditError(f"Event line {line_number} has a noncanonical firm key")
+    cik = _canonical_cik(
+        firm_key.removeprefix("form_d_cik:"), label=f"Event line {line_number} CIK"
+    )
+    if firm_key != f"form_d_cik:{cik}":
+        raise AuditError(f"Event line {line_number} has a noncanonical firm key")
+    accession = _required_text(
+        row.get("accession_number"), label=f"Event line {line_number} accession"
+    )
+    expected = {
+        "event_id": f"form_d_accession:{accession}",
+        "event_type": EVENT_TYPE,
+        "evidence_kind": EVIDENCE_KIND,
+        "source": SOURCE,
+        "source_snapshot_id": source_snapshot_id,
+        "date_basis": "filing_date",
+    }
+    if any(row.get(key) != value for key, value in expected.items()):
+        raise AuditError(f"Event line {line_number} violates the proxy event contract")
+    filing_date_text = _required_text(
+        row.get("filing_date"), label=f"Event line {line_number} filing_date"
+    )
+    if row.get("event_date") != filing_date_text:
+        raise AuditError(f"Event line {line_number} event_date is not its filing_date")
+    try:
+        filing_date = date.fromisoformat(filing_date_text)
+    except ValueError as exc:
+        raise AuditError(f"Event line {line_number} has an invalid filing_date") from exc
+    if filing_date.isoformat() != filing_date_text:
+        raise AuditError(f"Event line {line_number} filing_date is not exact ISO YYYY-MM-DD")
+    if not SOURCE_START_DATE <= filing_date <= SOURCE_END_DATE:
+        raise AuditError(f"Event line {line_number} falls outside source coverage")
+    source_quarter = _required_text(
+        row.get("source_quarter"), label=f"Event line {line_number} source_quarter"
+    )
+    expected_quarter = f"{filing_date.year}Q{((filing_date.month - 1) // 3) + 1}"
+    if source_quarter != expected_quarter:
+        raise AuditError(f"Event line {line_number} has an inconsistent source quarter")
+    submission_type = row.get("submission_type")
+    is_amendment = row.get("is_amendment")
+    if submission_type not in {"D", "D/A"} or not isinstance(is_amendment, bool):
+        raise AuditError(f"Event line {line_number} has invalid filing lineage")
+    if (submission_type == "D/A") is not is_amendment:
+        raise AuditError(f"Event line {line_number} submission/amendment fields disagree")
+    previous = row.get("previous_accession_number")
+    if previous is not None and not isinstance(previous, str):
+        raise AuditError(f"Event line {line_number} has invalid prior-accession lineage")
+    return cik, accession, filing_date
+
+
+def _audit_events(
+    path: Path,
+    *,
+    expected_rows: int,
+    candidates: Mapping[str, Mapping[str, Any]],
+    agency_tags: Mapping[str, list[str]],
+    source_snapshot_id: str,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    output_rows: list[dict[str, Any]] = []
+    seen_accessions: set[str] = set()
+    seen_event_ids: set[str] = set()
+    full_join_ciks: set[str] = set()
+    boundary_filings: Counter[int] = Counter()
+    boundary_ciks: dict[int, set[str]] = defaultdict(set)
+    row_count = 0
+    for line_number, row in _iter_jsonl(path, label="proxy-event product"):
+        row_count += 1
+        cik, accession, filing_date = _validated_event(
+            row, line_number=line_number, source_snapshot_id=source_snapshot_id
+        )
+        event_id = str(row["event_id"])
+        if accession in seen_accessions or event_id in seen_event_ids:
+            raise AuditError("Proxy-event accessions and event IDs must be globally unique")
+        seen_accessions.add(accession)
+        seen_event_ids.add(event_id)
+        candidate = candidates.get(cik)
+        if candidate is None:
+            continue
+        full_join_ciks.add(cik)
+        fiscal_year = federal_fiscal_year(filing_date)
+        if fiscal_year in BOUNDARY_FISCAL_YEARS:
+            boundary_filings[fiscal_year] += 1
+            boundary_ciks[fiscal_year].add(cik)
+            continue
+        if not MATERIALIZED_START_FY <= fiscal_year <= MATERIALIZED_END_FY:
+            raise AuditError(
+                "Joined event falls outside complete or declared boundary fiscal years"
+            )
+        previous = row.get("previous_accession_number")
+        output_rows.append(
+            {
+                "accession_number": accession,
+                "agency_tags": agency_tags[cik],
+                "audit_record_id": "sbir_form_d_proxy_audit:"
+                + hashlib.sha256(f"exact-cik|{accession}".encode()).hexdigest(),
+                "cik": cik,
+                "date_basis": "filing_date",
+                "event_date": filing_date.isoformat(),
+                "event_id": event_id,
+                "event_type": EVENT_TYPE,
+                "evidence_kind": EVIDENCE_KIND,
+                "filing_date": filing_date.isoformat(),
+                "filing_fiscal_year": fiscal_year,
+                "firm_key": candidate["firm_key"],
+                "identity_evidence_class": candidate["mapping_class"],
+                "is_amendment": row["is_amendment"],
+                "matched_normalized_names": candidate["matched_normalized_names"],
+                "previous_accession_number": previous.strip()
+                if isinstance(previous, str) and previous.strip()
+                else None,
+                "schema_version": OUTPUT_SCHEMA_VERSION,
+                "source": SOURCE,
+                "source_quarter": row["source_quarter"],
+                "source_snapshot_id": source_snapshot_id,
+                "submission_type": row["submission_type"],
+            }
+        )
+    if row_count != expected_rows:
+        raise AuditError("Proxy-event JSONL row count does not match its manifest")
+    output_rows.sort(key=lambda item: (item["filing_date"], item["accession_number"]))
+    diagnostics = {
+        "full_source_join": {
+            "proxy_filings": len(output_rows) + sum(boundary_filings.values()),
+            "proxy_bearing_ciks": len(full_join_ciks),
+        },
+        "incomplete_boundary_fiscal_years": {
+            str(fy): {
+                "proxy_filings": boundary_filings[fy],
+                "proxy_bearing_ciks": len(boundary_ciks[fy]),
+            }
+            for fy in sorted(BOUNDARY_FISCAL_YEARS)
+        },
+    }
+    return output_rows, diagnostics
+
+
+def _counts(rows: list[dict[str, Any]], diagnostics: Mapping[str, Any]) -> dict[str, Any]:
+    ciks = {str(row["cik"]) for row in rows}
+    fiscal_years: dict[str, dict[str, Any]] = {}
+    for fiscal_year in range(MATERIALIZED_START_FY, MATERIALIZED_END_FY + 1):
+        fy_rows = [row for row in rows if row["filing_fiscal_year"] == fiscal_year]
+        fiscal_years[str(fiscal_year)] = {
+            "proxy_filings": len(fy_rows),
+            "proxy_bearing_ciks": len({str(row["cik"]) for row in fy_rows}),
+        }
+    mapping_classes: dict[str, dict[str, Any]] = {}
+    for mapping_class in (
+        "unique_within_materialized_name_map",
+        "ambiguous_name_only",
+    ):
+        selected = [row for row in rows if row["identity_evidence_class"] == mapping_class]
+        mapping_classes[mapping_class] = {
+            "proxy_filings": len(selected),
+            "proxy_bearing_ciks": len({str(row["cik"]) for row in selected}),
+        }
+    agency_membership: dict[str, dict[str, Any]] = {}
+    for agency in sorted({tag for row in rows for tag in row["agency_tags"]}):
+        selected = [row for row in rows if agency in row["agency_tags"]]
+        agency_membership[agency] = {
+            "proxy_filings": len(selected),
+            "proxy_bearing_ciks": len({str(row["cik"]) for row in selected}),
+        }
+    return {
+        "candidate_ciks": None,
+        "complete_filing_fiscal_year_window": {
+            "end_fy": MATERIALIZED_END_FY,
+            "proxy_filings": len(rows),
+            "proxy_bearing_ciks": len(ciks),
+            "start_fy": MATERIALIZED_START_FY,
+        },
+        "filing_fiscal_years": fiscal_years,
+        "identity_evidence_classes": mapping_classes,
+        "agency_membership_nonexclusive": agency_membership,
+        "submission_types": dict(
+            sorted(Counter(str(row["submission_type"]) for row in rows).items())
+        ),
+        "amendment_proxy_filings": sum(bool(row["is_amendment"]) for row in rows),
+        **diagnostics,
+    }
+
+
+def _write_jsonl_product(
+    output_dir: Path,
+    rows: list[dict[str, Any]],
+    *,
+    forbidden_paths: set[Path],
+) -> tuple[dict[str, Any], Path, bool]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not output_dir.is_dir() or output_dir.is_symlink():
+        raise AuditError("Output directory must be a real directory")
+    digest = hashlib.sha256()
+    size_bytes = 0
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=output_dir, prefix=".sbir-form-d-proxy-audit.", delete=False
+        ) as handle:
+            temp_path = Path(handle.name)
+            for row in rows:
+                data = (
+                    json.dumps(row, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+                    + "\n"
+                ).encode("utf-8")
+                handle.write(data)
+                digest.update(data)
+                size_bytes += len(data)
+        sha = digest.hexdigest()
+        destination = output_dir / f"sbir_form_d_proxy_audit.{sha}.jsonl"
+        if destination.resolve() in forbidden_paths:
+            raise AuditError("Content-addressed output must not alias an input or manifest")
+        destination_preexisted = destination.exists()
+        if destination_preexisted and (not destination.is_file() or destination.is_symlink()):
+            raise AuditError("Content-addressed output target must be a regular file or absent")
+        os.replace(temp_path, destination)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+    return (
+        {
+            "path": destination.name,
+            "row_count": len(rows),
+            "sha256": sha,
+            "size_bytes": size_bytes,
+        },
+        destination,
+        destination_preexisted,
+    )
+
+
+def _atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and (path.is_symlink() or not path.is_file()):
+        raise AuditError("Audit manifest target must be a regular file or absent")
+    temp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as handle:
+            temp_path = Path(handle.name)
+            handle.write(data)
+        os.replace(temp_path, path)
+        temp_path = None
+    finally:
+        if temp_path is not None:
+            temp_path.unlink(missing_ok=True)
+
+
+def build(args: argparse.Namespace) -> dict[str, Any]:
+    """Validate pinned inputs, perform the exact-CIK join, and publish the audit."""
+
+    code_version = _required_text(args.code_version, label="code-version")
+    input_paths = [
+        Path(args.control_manifest),
+        Path(args.candidate_jsonl),
+        Path(args.proxy_manifest),
+        Path(args.event_jsonl),
+        Path(args.coverage_jsonl),
+        Path(args.awards_csv),
+    ]
+    audit_manifest_path = Path(args.audit_manifest)
+    if audit_manifest_path.resolve() in {path.resolve() for path in input_paths}:
+        raise AuditError("Audit manifest must not alias an input")
+
+    control, control_meta = _load_manifest(input_paths[0], label="control manifest")
+    proxy, proxy_meta = _load_manifest(input_paths[2], label="proxy manifest")
+    candidate_ref, event_ref, coverage_ref, awards_ref, identity_contract = _validate_manifests(
+        control, control_meta, proxy
+    )
+    candidate_meta = _verify_product(input_paths[1], candidate_ref, label="candidate product")
+    event_meta = _verify_product(input_paths[3], event_ref, label="event product")
+    coverage_meta = _verify_product(input_paths[4], coverage_ref, label="coverage product")
+    awards_meta = _verify_product(input_paths[5], awards_ref, label="awards snapshot")
+
+    candidates = _load_candidates(
+        input_paths[1],
+        expected_rows=candidate_ref["row_count"],
+        identity_contract=identity_contract,
+    )
+    agency_tags = _load_agency_tags(
+        input_paths[5], expected_rows=awards_ref["row_count"], candidates=candidates
+    )
+    proxy_source = _mapping(proxy["source"], label="proxy source")
+    source_snapshot_id = str(proxy_source["source_snapshot_id"])
+    _validate_coverage(
+        input_paths[4],
+        expected_rows=coverage_ref["row_count"],
+        candidates=candidates,
+        source_snapshot_id=source_snapshot_id,
+    )
+    rows, diagnostics = _audit_events(
+        input_paths[3],
+        expected_rows=event_ref["row_count"],
+        candidates=candidates,
+        agency_tags=agency_tags,
+        source_snapshot_id=source_snapshot_id,
+    )
+    counts = _counts(rows, diagnostics)
+    counts["candidate_ciks"] = len(candidates)
+    product, product_path, product_preexisted = _write_jsonl_product(
+        Path(args.output_dir),
+        rows,
+        forbidden_paths={path.resolve() for path in [*input_paths, audit_manifest_path]},
+    )
+
+    invariants = {
+        "agency_tags_nonempty_and_sorted": all(
+            row["agency_tags"] and row["agency_tags"] == sorted(set(row["agency_tags"]))
+            for row in rows
+        ),
+        "candidate_ciks_have_complete_proxy_coverage": True,
+        "complete_fiscal_years_only": all(
+            MATERIALIZED_START_FY <= row["filing_fiscal_year"] <= MATERIALIZED_END_FY
+            for row in rows
+        ),
+        "content_addressed_output": product["path"]
+        == f"sbir_form_d_proxy_audit.{product['sha256']}.jsonl",
+        "exact_cik_join_only": True,
+        "identity_classes_exhaustive_and_exclusive": sum(
+            item["proxy_filings"] for item in counts["identity_evidence_classes"].values()
+        )
+        == len(rows),
+        "input_hash_rows_bytes_verified": True,
+        "one_row_per_unique_accession": len({row["accession_number"] for row in rows}) == len(rows),
+        "per_fiscal_year_filings_reconcile": sum(
+            item["proxy_filings"] for item in counts["filing_fiscal_years"].values()
+        )
+        == len(rows),
+    }
+    try:
+        if not all(invariants.values()):
+            raise AuditError(f"Audit invariant failed: {invariants}")
+
+        manifest = {
+            "caveats": [
+                "Exact-name candidate identities are not verified SBIR identities.",
+                "Exact-name identity recall is unknown.",
+                "The event is a filer-supplied Form D filing proxy, not a verified legal event.",
+                "Filing dates are evidence dates and are not transaction or exit dates.",
+                "Agency memberships overlap and must not be summed.",
+                "No count in this audit is an outcome, prevalence, or match rate.",
+            ],
+            "code_commit": code_version,
+            "complete": True,
+            "complete_sbir_exclusion": False,
+            "complete_sbir_identity": False,
+            "counts": counts,
+            "covariates_ready": False,
+            "exclusion_recall": "unknown",
+            "identity_status": "exact_name_candidate",
+            "inputs": {
+                "awards_snapshot": awards_meta,
+                "candidate_exclusions": candidate_meta,
+                "control_manifest": control_meta,
+                "proxy_coverage": coverage_meta,
+                "proxy_events": event_meta,
+                "proxy_manifest": proxy_meta,
+            },
+            "invariants": invariants,
+            "outcome_kind": "filing_proxy",
+            "outputs": {"filing_evidence_audit": product},
+            "ready_for_matching": False,
+            "schema_version": OUTPUT_SCHEMA_VERSION,
+            "source": {
+                "coverage_end_date": SOURCE_END_DATE.isoformat(),
+                "coverage_start_date": SOURCE_START_DATE.isoformat(),
+                "date_basis": "filing_date",
+                "event_type": EVENT_TYPE,
+                "source": SOURCE,
+                "source_snapshot_id": source_snapshot_id,
+            },
+            "verified_ma": False,
+            "window": {
+                "complete_filing_fiscal_years": list(
+                    range(MATERIALIZED_START_FY, MATERIALIZED_END_FY + 1)
+                ),
+                "excluded_incomplete_boundary_fiscal_years": sorted(BOUNDARY_FISCAL_YEARS),
+            },
+        }
+        manifest_data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+        _atomic_write(audit_manifest_path, manifest_data)
+    except Exception:
+        if not product_preexisted:
+            product_path.unlink(missing_ok=True)
+        raise
+    return manifest
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--control-manifest", type=Path, required=True)
+    parser.add_argument("--candidate-jsonl", type=Path, required=True)
+    parser.add_argument("--proxy-manifest", type=Path, required=True)
+    parser.add_argument("--event-jsonl", type=Path, required=True)
+    parser.add_argument("--coverage-jsonl", type=Path, required=True)
+    parser.add_argument("--awards-csv", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--audit-manifest", type=Path, required=True)
+    parser.add_argument("--code-version", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        manifest = build(parse_args(argv))
+    except AuditError as exc:
+        print(f"error: {exc}")
+        return 1
+    print(json.dumps({"counts": manifest["counts"], "outputs": manifest["outputs"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
+++ b/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
@@ -1,0 +1,440 @@
+"""Tests for the exact-name SBIR/Form D filing-proxy audit."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[3] / "scripts/data/audit_sbir_form_d_business_combination_proxy.py"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "audit_sbir_form_d_business_combination_proxy", SCRIPT
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+audit = _load_module()
+
+
+def _jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def _meta(path: Path, row_count: int) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {
+        "path": path.name,
+        "row_count": row_count,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "size_bytes": len(data),
+    }
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _candidate(cik: str, name: str, issuer_count: int) -> dict[str, Any]:
+    return {
+        "candidate_exclusion": True,
+        "cik": cik,
+        "evidence": [
+            {
+                "issuer_cik_count_for_normalized_name": issuer_count,
+                "normalized_name": name,
+                "normalizer_version": "organization-key-v1",
+                "resolution_method": "candidate_exact_normalized_name",
+            }
+        ],
+        "firm_key": f"form_d_cik:{cik}",
+        "schema_version": 1,
+    }
+
+
+def _coverage(cik: str, snapshot_id: str) -> dict[str, Any]:
+    return {
+        "coverage_end_date": "2024-12-31",
+        "coverage_start_date": "2009-01-01",
+        "firm_key": f"form_d_cik:{cik}",
+        "metric": audit.EVENT_TYPE,
+        "schema_version": 1,
+        "source": audit.SOURCE,
+        "source_complete": True,
+        "source_snapshot_date": "2024-12-31",
+        "source_snapshot_id": snapshot_id,
+    }
+
+
+def _event(
+    cik: str,
+    accession: str,
+    filing_date: str,
+    snapshot_id: str,
+    *,
+    amendment: bool = False,
+) -> dict[str, Any]:
+    month = int(filing_date[5:7])
+    return {
+        "accession_number": accession,
+        "date_basis": "filing_date",
+        "event_date": filing_date,
+        "event_id": f"form_d_accession:{accession}",
+        "event_type": audit.EVENT_TYPE,
+        "evidence_kind": "proxy",
+        "filing_date": filing_date,
+        "firm_key": f"form_d_cik:{cik}",
+        "is_amendment": amendment,
+        "previous_accession_number": "prior-accession" if amendment else None,
+        "schema_version": 1,
+        "source": audit.SOURCE,
+        "source_quarter": f"{filing_date[:4]}Q{((month - 1) // 3) + 1}",
+        "source_snapshot_id": snapshot_id,
+        "submission_type": "D/A" if amendment else "D",
+    }
+
+
+def _fixture(tmp_path: Path) -> argparse.Namespace:
+    candidates_path = tmp_path / "candidates.jsonl"
+    awards_path = tmp_path / "awards.csv"
+    control_path = tmp_path / "control.json"
+    events_path = tmp_path / "events.jsonl"
+    coverage_path = tmp_path / "coverage.jsonl"
+    proxy_path = tmp_path / "proxy.json"
+    alpha = _candidate("123", "ALPHA LABS", 1)
+    alpha["evidence"].append(
+        {
+            "issuer_cik_count_for_normalized_name": 2,
+            "normalized_name": "BETA SYSTEMS",
+            "normalizer_version": "organization-key-v1",
+            "resolution_method": "candidate_exact_normalized_name",
+        }
+    )
+    _jsonl(candidates_path, [alpha, _candidate("456", "BETA SYSTEMS", 2)])
+    with awards_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["Company", "Agency"])
+        writer.writeheader()
+        writer.writerows(
+            [
+                {"Company": "Alpha Labs, Inc.", "Agency": "National Science Foundation"},
+                {"Company": "Alpha Labs", "Agency": "Department of Energy"},
+                {
+                    "Company": "Beta Systems LLC",
+                    "Agency": "Department of Health and Human Services",
+                },
+            ]
+        )
+    control = {
+        "complete": True,
+        "complete_sbir_exclusion": False,
+        "exclusion": {
+            "awards_csv": _meta(awards_path, 3),
+            "exact_match": {
+                "candidate_cik_count": 2,
+                "matched_normalized_name_count": 2,
+                "normalized_names_mapping_to_multiple_ciks": 1,
+                "normalizer_version": "organization-key-v1",
+            },
+        },
+        "exclusion_recall": "unknown",
+        "outputs": {
+            "broad_issuer_universe": {
+                "path": "issuer-universe.jsonl",
+                "row_count": 3,
+                "sha256": "a" * 64,
+                "size_bytes": 10,
+            },
+            "candidate_sbir_cik_exclusions": _meta(candidates_path, 2),
+        },
+        "schema_version": 1,
+    }
+    _write_json(control_path, control)
+    control_data = control_path.read_bytes()
+    snapshot_id = (
+        f"form_d_control_universe_manifest_sha256:{hashlib.sha256(control_data).hexdigest()}"
+    )
+    coverage_rows = [_coverage(cik, snapshot_id) for cik in ("123", "456", "999")]
+    event_rows = [
+        _event("123", "a", "2009-09-30", snapshot_id),
+        _event("123", "b", "2009-10-01", snapshot_id),
+        _event("456", "c", "2024-09-30", snapshot_id, amendment=True),
+        _event("456", "d", "2024-10-01", snapshot_id),
+        _event("999", "e", "2020-02-01", snapshot_id),
+    ]
+    _jsonl(coverage_path, coverage_rows)
+    _jsonl(events_path, event_rows)
+    proxy = {
+        "complete": True,
+        "event_type": audit.EVENT_TYPE,
+        "inputs": {
+            "issuer_universe": control["outputs"]["broad_issuer_universe"],
+            "source_manifest": {
+                "path": control_path.name,
+                "sha256": hashlib.sha256(control_data).hexdigest(),
+                "size_bytes": len(control_data),
+            },
+        },
+        "outputs": {
+            "coverage": _meta(coverage_path, len(coverage_rows)),
+            "events": _meta(events_path, len(event_rows)),
+        },
+        "counters": {
+            "coverage_rows": len(coverage_rows),
+            "event_rows": len(event_rows),
+        },
+        "schema_version": 1,
+        "source": {
+            "coverage_end_date": "2024-12-31",
+            "coverage_start_date": "2009-01-01",
+            "source": audit.SOURCE,
+            "source_complete": True,
+            "source_snapshot_date": "2024-12-31",
+            "source_snapshot_id": snapshot_id,
+        },
+    }
+    _write_json(proxy_path, proxy)
+    return argparse.Namespace(
+        control_manifest=control_path,
+        candidate_jsonl=candidates_path,
+        proxy_manifest=proxy_path,
+        event_jsonl=events_path,
+        coverage_jsonl=coverage_path,
+        awards_csv=awards_path,
+        output_dir=tmp_path / "output",
+        audit_manifest=tmp_path / "audit-manifest.json",
+        code_version="test-commit",
+    )
+
+
+def _repin_proxy(args: argparse.Namespace) -> None:
+    proxy = json.loads(args.proxy_manifest.read_text(encoding="utf-8"))
+    proxy["outputs"]["events"] = _meta(
+        args.event_jsonl,
+        len(args.event_jsonl.read_text(encoding="utf-8").splitlines()),
+    )
+    proxy["outputs"]["coverage"] = _meta(
+        args.coverage_jsonl,
+        len(args.coverage_jsonl.read_text(encoding="utf-8").splitlines()),
+    )
+    proxy["counters"]["event_rows"] = proxy["outputs"]["events"]["row_count"]
+    proxy["counters"]["coverage_rows"] = proxy["outputs"]["coverage"]["row_count"]
+    _write_json(args.proxy_manifest, proxy)
+
+
+def test_contract_constants_and_federal_fiscal_year_are_frozen() -> None:
+    assert audit.EVENT_TYPE == "form_d_business_combination_filing_proxy"
+    assert audit.MATERIALIZED_START_FY == 2010
+    assert audit.MATERIALIZED_END_FY == 2024
+    assert audit.BOUNDARY_FISCAL_YEARS == {2009, 2025}
+    assert audit.federal_fiscal_year(audit.date(2019, 9, 30)) == 2019
+    assert audit.federal_fiscal_year(audit.date(2019, 10, 1)) == 2020
+
+
+def test_build_uses_exact_cik_and_excludes_partial_fiscal_years(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    manifest = audit.build(args)
+
+    assert manifest["counts"]["candidate_ciks"] == 2
+    assert manifest["counts"]["complete_filing_fiscal_year_window"] == {
+        "end_fy": 2024,
+        "proxy_filings": 2,
+        "proxy_bearing_ciks": 2,
+        "start_fy": 2010,
+    }
+    assert manifest["counts"]["full_source_join"] == {
+        "proxy_filings": 4,
+        "proxy_bearing_ciks": 2,
+    }
+    assert manifest["counts"]["incomplete_boundary_fiscal_years"] == {
+        "2009": {"proxy_filings": 1, "proxy_bearing_ciks": 1},
+        "2025": {"proxy_filings": 1, "proxy_bearing_ciks": 1},
+    }
+    product = manifest["outputs"]["filing_evidence_audit"]
+    rows = [
+        json.loads(line)
+        for line in (args.output_dir / product["path"]).read_text(encoding="utf-8").splitlines()
+    ]
+    assert [row["accession_number"] for row in rows] == ["b", "c"]
+    assert rows[0]["agency_tags"] == ["DOE", "HHS", "NSF"]
+    assert rows[0]["identity_evidence_class"] == "unique_within_materialized_name_map"
+    assert rows[1]["identity_evidence_class"] == "ambiguous_name_only"
+    assert rows[1]["submission_type"] == "D/A"
+    assert rows[1]["previous_accession_number"] == "prior-accession"
+
+
+def test_build_is_byte_deterministic(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    first = audit.build(args)
+    first_manifest = args.audit_manifest.read_bytes()
+    first_product = (
+        args.output_dir / first["outputs"]["filing_evidence_audit"]["path"]
+    ).read_bytes()
+
+    args.output_dir = tmp_path / "second-output"
+    args.audit_manifest = tmp_path / "second-manifest.json"
+    second = audit.build(args)
+
+    assert args.audit_manifest.read_bytes() == first_manifest
+    assert (
+        args.output_dir / second["outputs"]["filing_evidence_audit"]["path"]
+    ).read_bytes() == first_product
+
+
+def test_tampered_candidate_product_fails_before_publication(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    args.candidate_jsonl.write_text(
+        args.candidate_jsonl.read_text(encoding="utf-8") + "{}\n", encoding="utf-8"
+    )
+
+    with pytest.raises(audit.AuditError, match="byte size"):
+        audit.build(args)
+
+    assert not args.audit_manifest.exists()
+    assert not args.output_dir.exists()
+
+
+def test_duplicate_event_accession_fails_closed(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    rows = [json.loads(line) for line in args.event_jsonl.read_text().splitlines()]
+    duplicate = dict(rows[1])
+    duplicate["firm_key"] = "form_d_cik:456"
+    rows.append(duplicate)
+    _jsonl(args.event_jsonl, rows)
+    _repin_proxy(args)
+
+    with pytest.raises(audit.AuditError, match="globally unique"):
+        audit.build(args)
+
+    assert not args.audit_manifest.exists()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("firm_key", "form_d_cik:000123", "canonical"),
+        ("event_type", "verified_ma", "event contract"),
+        ("filing_date", "2025-01-01", "event_date"),
+    ],
+)
+def test_malformed_event_contract_fails_closed(
+    tmp_path: Path, field: str, value: object, message: str
+) -> None:
+    args = _fixture(tmp_path)
+    rows = [json.loads(line) for line in args.event_jsonl.read_text().splitlines()]
+    rows[1][field] = value
+    _jsonl(args.event_jsonl, rows)
+    _repin_proxy(args)
+
+    with pytest.raises(audit.AuditError, match=message):
+        audit.build(args)
+
+
+def test_missing_candidate_coverage_fails_closed(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    rows = [json.loads(line) for line in args.coverage_jsonl.read_text().splitlines()]
+    _jsonl(args.coverage_jsonl, rows[:1])
+    _repin_proxy(args)
+
+    with pytest.raises(audit.AuditError, match="lacks proxy coverage"):
+        audit.build(args)
+
+
+def test_manifest_cannot_alias_an_input(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    args.audit_manifest = args.control_manifest
+
+    with pytest.raises(audit.AuditError, match="must not alias"):
+        audit.build(args)
+
+
+def test_existing_manifest_survives_validation_failure(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    args.audit_manifest.write_text("old manifest\n", encoding="utf-8")
+    args.event_jsonl.write_text("{}\n", encoding="utf-8")
+
+    with pytest.raises(audit.AuditError):
+        audit.build(args)
+
+    assert args.audit_manifest.read_text(encoding="utf-8") == "old manifest\n"
+
+
+def test_blank_code_version_fails_before_any_output_is_published(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    args.code_version = "   "
+
+    with pytest.raises(audit.AuditError, match="code-version"):
+        audit.build(args)
+
+    assert not args.output_dir.exists()
+    assert not args.audit_manifest.exists()
+
+
+def test_mapping_class_is_recomputed_from_complete_name_map(tmp_path: Path) -> None:
+    path = tmp_path / "candidates.jsonl"
+    rows = [_candidate("123", "SHARED NAME", 1), _candidate("456", "SHARED NAME", 1)]
+    _jsonl(path, rows)
+
+    with pytest.raises(audit.AuditError, match="inconsistent issuer-CIK count"):
+        audit._load_candidates(
+            path,
+            expected_rows=2,
+            identity_contract={
+                "candidate_cik_count": 2,
+                "matched_normalized_name_count": 1,
+                "ambiguous_normalized_name_count": 1,
+            },
+        )
+
+
+def test_duplicate_json_key_fails_strict_parsing(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.jsonl"
+    path.write_text('{"cik":"123","cik":"456"}\n', encoding="utf-8")
+
+    with pytest.raises(audit.AuditError, match="duplicate JSON key"):
+        list(audit._iter_jsonl(path, label="fixture"))
+
+
+def test_noncanonical_iso_filing_date_fails_closed(tmp_path: Path) -> None:
+    args = _fixture(tmp_path)
+    rows = [json.loads(line) for line in args.event_jsonl.read_text().splitlines()]
+    rows[1]["filing_date"] = "20091001"
+    rows[1]["event_date"] = "20091001"
+    _jsonl(args.event_jsonl, rows)
+    _repin_proxy(args)
+
+    with pytest.raises(audit.AuditError, match="exact ISO"):
+        audit.build(args)
+
+
+def test_manifest_publish_failure_rolls_back_new_product(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    args = _fixture(tmp_path)
+    prior_manifest = b'{"prior":true}\n'
+    args.audit_manifest.write_bytes(prior_manifest)
+
+    def fail_manifest_write(path: Path, data: bytes) -> None:
+        raise OSError("manifest publish failed")
+
+    monkeypatch.setattr(audit, "_atomic_write", fail_manifest_write)
+    with pytest.raises(OSError, match="manifest publish failed"):
+        audit.build(args)
+
+    assert args.audit_manifest.read_bytes() == prior_manifest
+    assert not list(args.output_dir.glob("*.jsonl"))

--- a/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
+++ b/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
@@ -15,6 +15,15 @@ import pytest
 
 
 SCRIPT = Path(__file__).parents[3] / "scripts/data/audit_sbir_form_d_business_combination_proxy.py"
+REPO_ROOT = Path(__file__).parents[3]
+TRACKED_MANIFEST = (
+    REPO_ROOT
+    / "docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json"
+)
+TRACKED_REPORT = (
+    REPO_ROOT
+    / "docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.md"
+)
 
 
 def _load_module() -> ModuleType:
@@ -438,3 +447,28 @@ def test_manifest_publish_failure_rolls_back_new_product(
 
     assert args.audit_manifest.read_bytes() == prior_manifest
     assert not list(args.output_dir.glob("*.jsonl"))
+
+
+def test_tracked_report_reconciles_to_materialization_manifest() -> None:
+    manifest = json.loads(TRACKED_MANIFEST.read_text(encoding="utf-8"))
+    report = TRACKED_REPORT.read_text(encoding="utf-8")
+    report_words = " ".join(report.split())
+    complete = manifest["counts"]["complete_filing_fiscal_year_window"]
+    product = manifest["outputs"]["filing_evidence_audit"]
+
+    assert complete == {
+        "end_fy": 2024,
+        "proxy_bearing_ciks": 212,
+        "proxy_filings": 283,
+        "start_fy": 2010,
+    }
+    assert "283 unique Form D accessions across 212 exact Form D CIKs" in report_words
+    assert product["row_count"] == 283
+    assert (
+        f"| Complete-FY filing evidence audit | 283 | 244,696 | `{product['sha256']}` |" in report
+    )
+    assert manifest["complete_sbir_identity"] is False
+    assert manifest["complete_sbir_exclusion"] is False
+    assert manifest["covariates_ready"] is False
+    assert manifest["ready_for_matching"] is False
+    assert manifest["verified_ma"] is False


### PR DESCRIPTION
## Summary

- add a fail-closed producer that joins the #582 exact-name SBIR candidate ledger to #584 Form D business-combination filing-proxy evidence on canonical exact CIK only
- publish a pinned, content-addressed 283-row complete-federal-FY audit product plus a tracked manifest and report
- retain identity sensitivity, overlapping agency membership, filing lineage, boundary-FY diagnostics, and all closed matching/outcome gates

## Real-data result

For complete filing FY2010–FY2024, the audit finds 283 unique proxy filings across 212 exact Form D CIKs. The identity-evidence partition is 250 filings / 186 CIKs with at least one unique-within-the-materialized-map route and 33 / 26 with ambiguous-name-only routes.

The full 2009-01-01 through 2024-12-31 source-window join is 295 / 222, but that includes 10 partial-FY2009 filings and 2 partial-FY2025 filings. Those records are diagnostics only and are excluded from the product and headline count.

## Epistemic boundary

This is an identity-and-evidence audit, not an M&A, acquisition, transaction, exit, post-award, outcome-rate, or treated-versus-control result. The upstream exact-name identities remain candidates with unknown recall. Agency tags overlap. The manifest retains `complete_sbir_identity=false`, `complete_sbir_exclusion=false`, `covariates_ready=false`, `ready_for_matching=false`, `outcome_kind=filing_proxy`, and `verified_ma=false`.

## Stack

Draft PR stacked directly on #584 (`agent/symmetric-outcome-contracts`). It intentionally does not depend on #585's unadjudicated fuzzy-contamination queue.

## Verification

- focused audit tests: 17 passed
- full unit suite: 5,883 passed, 7 skipped
- targeted Ruff check and format check: passed
- targeted MyPy: passed
- `make docs-check`: passed
- `make lint-boundaries`: passed
- two real-data materializations produced identical product and manifest hashes

The repository-wide Ruff scan still reports pre-existing findings in archived scripts and notebooks; the changed files are clean.
