### PR TITLE
Publish normalized-name Form D proxy observation ledger

### DIFF
--- a/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json
+++ b/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json
@@ -1,5 +1,8 @@
 {
   "caveats": [
+    "The name ledger is normalized-name grain, not verified firm grain.",
+    "Boundary-only proxy evidence is separate from complete-fiscal-year evidence.",
+    "No exact-name candidate link is outcome-unobserved, not a binary zero.",
     "Exact-name candidate identities are not verified SBIR identities.",
     "Exact-name identity recall is unknown.",
     "The event is a filer-supplied Form D filing proxy, not a verified legal event.",
@@ -7,7 +10,7 @@
     "Agency memberships overlap and must not be summed.",
     "No count in this audit is an outcome, prevalence, or match rate."
   ],
-  "code_commit": "3e76c3bf165693ebca056841127255a28ad497d6",
+  "code_commit": "3f6c962526be1c2d3a7c053b4fd442d632b6ce8e",
   "complete": true,
   "complete_sbir_exclusion": false,
   "complete_sbir_identity": false,
@@ -152,6 +155,31 @@
         "proxy_filings": 2
       }
     },
+    "normalized_name_observation": {
+      "exact_name_candidate_link_classes": {
+        "ambiguous_exact_name_candidate_link": 89,
+        "no_exact_name_candidate_link": 29864,
+        "unique_exact_name_candidate_link": 4334
+      },
+      "observation_statuses": {
+        "no_exact_name_candidate_link": 29864,
+        "no_proxy_observed_on_exact_name_candidate_link_in_bounded_source": 4191,
+        "proxy_observed_in_complete_fiscal_year_window_on_exact_name_candidate_link": 222,
+        "proxy_observed_only_in_incomplete_boundary_fiscal_years_on_exact_name_candidate_link": 10
+      },
+      "proxy_cik_to_name_grain_reconciliation": {
+        "bounded_source_proxy_bearing_candidate_ciks": 222,
+        "bounded_source_proxy_observed_linked_normalized_names": 232,
+        "complete_fy_proxy_bearing_candidate_ciks": 212,
+        "complete_fy_proxy_observed_linked_normalized_names": 222,
+        "incomplete_boundary_only_proxy_observed_linked_normalized_names": 10,
+        "name_grain_minus_cik_grain_observed_difference": 10,
+        "observed_normalized_names_linked_to_multiple_proxy_bearing_ciks": 3,
+        "proxy_bearing_cik_name_memberships": 235,
+        "proxy_bearing_ciks_linked_to_multiple_normalized_names": 12
+      },
+      "rows": 34287
+    },
     "submission_types": {
       "D": 257,
       "D/A": 26
@@ -159,6 +187,8 @@
   },
   "covariates_ready": false,
   "exclusion_recall": "unknown",
+  "filer_nonfiler_ready": false,
+  "identity_recall": "unknown",
   "identity_status": "exact_name_candidate",
   "inputs": {
     "awards_snapshot": {
@@ -199,13 +229,44 @@
   "invariants": {
     "agency_tags_nonempty_and_sorted": true,
     "candidate_ciks_have_complete_proxy_coverage": true,
+    "compact_name_observation_schema": true,
     "complete_fiscal_years_only": true,
     "content_addressed_output": true,
     "exact_cik_join_only": true,
     "identity_classes_exhaustive_and_exclusive": true,
     "input_hash_rows_bytes_verified": true,
+    "linked_proxy_accessions_are_unique": true,
+    "name_observation_content_addressed": true,
+    "name_observation_rows_sorted_and_unique": true,
+    "name_observation_statuses_exhaustive": true,
+    "no_link_proxy_observations_are_unknown": true,
     "one_row_per_unique_accession": true,
-    "per_fiscal_year_filings_reconcile": true
+    "per_fiscal_year_filings_reconcile": true,
+    "proxy_observed_name_timing_partition_reconciles": true
+  },
+  "name_observation_contract": {
+    "exact_name_candidate_link_classes": [
+      "unique_exact_name_candidate_link",
+      "ambiguous_exact_name_candidate_link",
+      "no_exact_name_candidate_link"
+    ],
+    "fields": [
+      "boundary_proxy_accessions",
+      "candidate_ciks",
+      "complete_fy_proxy_accessions",
+      "exact_name_candidate_link_class",
+      "normalized_sbir_name",
+      "observation_status",
+      "raw_sbir_names"
+    ],
+    "grain": "normalized_historical_sbir_name",
+    "normalizer_version": "organization-key-v1",
+    "observation_statuses": [
+      "proxy_observed_in_complete_fiscal_year_window_on_exact_name_candidate_link",
+      "proxy_observed_only_in_incomplete_boundary_fiscal_years_on_exact_name_candidate_link",
+      "no_proxy_observed_on_exact_name_candidate_link_in_bounded_source",
+      "no_exact_name_candidate_link"
+    ]
   },
   "outcome_kind": "filing_proxy",
   "outputs": {
@@ -214,8 +275,16 @@
       "row_count": 283,
       "sha256": "aaa60a046a8a8d952dee06fd4a83a496eecb167f3ce2bff2d0e4ae69a5f4af91",
       "size_bytes": 244696
+    },
+    "normalized_name_observation": {
+      "path": "sbir_form_d_proxy_observation.97c12eb10fe38b21ac37d2d962e54218144d47b78950029ed1a7c29fac7dd171.jsonl",
+      "row_count": 34287,
+      "sha256": "97c12eb10fe38b21ac37d2d962e54218144d47b78950029ed1a7c29fac7dd171",
+      "size_bytes": 10239501
     }
   },
+  "post_award": false,
+  "rate_ready": false,
   "ready_for_matching": false,
   "schema_version": 1,
   "source": {
@@ -226,6 +295,7 @@
     "source": "sec_dera_form_d_quarterly_bulk",
     "source_snapshot_id": "form_d_control_universe_manifest_sha256:1777119114c4f7385dd09d6b60c603f2c5c59db765311255440513190d94b331"
   },
+  "verified_identity": false,
   "verified_ma": false,
   "window": {
     "complete_filing_fiscal_years": [

--- a/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.md
+++ b/docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.md
@@ -72,6 +72,39 @@ exact-name exclusion has unknown recall and can miss aliases, renames, spelling
 variation, acquisitions, or unresolved CIKs. This audit does not rerun or expand
 name matching.
 
+## Normalized-name observation ledger
+
+The audit also emits one row for each of the 34,287 normalized historical names
+in the pinned SBIR award snapshot. This ledger keeps missing identity separate
+from an observed zero and separates complete-fiscal-year evidence from evidence
+seen only in an incomplete boundary year.
+
+| Exclusive observation status | Normalized SBIR names |
+| --- | ---: |
+| Proxy observed in complete FY2010–FY2024 through an exact-name candidate link | 222 |
+| Proxy observed only in incomplete FY2009 or FY2025 through an exact-name candidate link | 10 |
+| Exact-name candidate link, but no proxy observed anywhere in the bounded source | 4,191 |
+| No exact-name candidate link; outcome observation remains unknown | 29,864 |
+| **All normalized historical SBIR names** | **34,287** |
+
+The first two rows must not be combined with CIK-grain counts. The full bounded
+source contains 222 proxy-bearing candidate CIKs but 235 CIK/name memberships
+across 232 distinct normalized names. Twelve proxy-bearing CIKs link to more
+than one normalized name, and three observed names link to more than one
+proxy-bearing CIK. Applying every observed CIK to every declared exact-name
+candidate link therefore produces ten more observed name rows than distinct
+CIKs; selecting one name per CIK would be arbitrary.
+
+Of the 4,423 names with at least one exact-name candidate link, 4,334 link to
+one candidate CIK and 89 link to multiple candidate CIKs. “One” is only unique
+within this materialized exact-name map, not verified real-world identity.
+
+Each compact ledger row contains the normalized and source names, all candidate
+CIKs, the link class, one of the four exclusive statuses, and separate complete-
+FY and boundary accession lists. For a linked name with no proxy, the accession
+lists are empty. For a name with no exact-name candidate link, they are null;
+that row is outcome-unobserved and cannot enter a non-filer denominator.
+
 ## Agency membership diagnostics
 
 Agency tags are reconstructed from the pinned SBIR award snapshot only for the
@@ -106,7 +139,7 @@ One accession produces one row even when it has multiple names or agency tags.
 The [tracked materialization manifest](agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json)
 pins both upstream manifest byte hashes; the candidate, event, and coverage
 product hashes, sizes, and row counts; the SBIR award snapshot; the
-content-addressed audit product; aggregate reconciliations; and all fail-closed
+content-addressed audit products; aggregate reconciliations; and all fail-closed
 gates. The producer verifies exact canonical CIKs, unique accessions and event
 IDs, complete source coverage for every candidate CIK, expected proxy labels,
 and the 2009-01-01 through 2024-12-31 source interval before publishing.
@@ -114,15 +147,18 @@ and the 2009-01-01 through 2024-12-31 source interval before publishing.
 | Product | Rows | Bytes | SHA-256 |
 | --- | ---: | ---: | --- |
 | Complete-FY filing evidence audit | 283 | 244,696 | `aaa60a046a8a8d952dee06fd4a83a496eecb167f3ce2bff2d0e4ae69a5f4af91` |
+| Normalized-name observation ledger | 34,287 | 10,239,501 | `97c12eb10fe38b21ac37d2d962e54218144d47b78950029ed1a7c29fac7dd171` |
 
 Two full materializations produced byte-identical product and manifest hashes;
 the tracked manifest SHA-256 is
-`9c23587c49a1ecddea15f1fc0af67b4016a905d253d46d3198c3f0642042e768`.
+`dcaf1e3b26e35873769d4c06eeba0ed4b521726fa75672ba1045f774fbff6f5c`.
 
 This audit does not close the Phase 2 identity, covariate, or outcome gates.
 Its manifest retains `complete_sbir_identity=false`,
 `complete_sbir_exclusion=false`, `exclusion_recall="unknown"`,
-`covariates_ready=false`, `ready_for_matching=false`,
+`verified_identity=false`, `identity_recall="unknown"`, `post_award=false`,
+`filer_nonfiler_ready=false`, `covariates_ready=false`,
+`ready_for_matching=false`, `rate_ready=false`,
 `outcome_kind="filing_proxy"`, and `verified_ma=false`.
 
 Reproduce after materializing the pinned #582 and #584 products:
@@ -137,5 +173,5 @@ uv run python scripts/data/audit_sbir_form_d_business_combination_proxy.py \
   --awards-csv data/raw/sbir/award_data.csv \
   --output-dir data/processed/agency_private_capital/sbir_form_d_proxy_audit \
   --audit-manifest docs/research/agency-private-capital-sbir-form-d-business-combination-proxy-audit.manifest.json \
-  --code-version 3e76c3bf165693ebca056841127255a28ad497d6
+  --code-version 3f6c962526be1c2d3a7c053b4fd442d632b6ce8e
 ```

--- a/scripts/data/audit_sbir_form_d_business_combination_proxy.py
+++ b/scripts/data/audit_sbir_form_d_business_combination_proxy.py
@@ -38,6 +38,32 @@ BOUNDARY_FISCAL_YEARS = frozenset({2009, 2025})
 SHA256_RE = re.compile(r"[0-9a-f]{64}")
 CIK_RE = re.compile(r"[1-9][0-9]{0,9}")
 
+NAME_STATUS_COMPLETE = "proxy_observed_in_complete_fiscal_year_window_on_exact_name_candidate_link"
+NAME_STATUS_BOUNDARY = (
+    "proxy_observed_only_in_incomplete_boundary_fiscal_years_on_exact_name_candidate_link"
+)
+NAME_STATUS_COVERED_ZERO = "no_proxy_observed_on_exact_name_candidate_link_in_bounded_source"
+NAME_STATUS_NO_LINK = "no_exact_name_candidate_link"
+NAME_OBSERVATION_STATUSES = (
+    NAME_STATUS_COMPLETE,
+    NAME_STATUS_BOUNDARY,
+    NAME_STATUS_COVERED_ZERO,
+    NAME_STATUS_NO_LINK,
+)
+NAME_LINK_UNIQUE = "unique_exact_name_candidate_link"
+NAME_LINK_AMBIGUOUS = "ambiguous_exact_name_candidate_link"
+NAME_LINK_NONE = "no_exact_name_candidate_link"
+NAME_LINK_CLASSES = (NAME_LINK_UNIQUE, NAME_LINK_AMBIGUOUS, NAME_LINK_NONE)
+NAME_OBSERVATION_FIELDS = {
+    "boundary_proxy_accessions",
+    "candidate_ciks",
+    "complete_fy_proxy_accessions",
+    "exact_name_candidate_link_class",
+    "normalized_sbir_name",
+    "observation_status",
+    "raw_sbir_names",
+}
+
 AGENCY_TAG_BY_NAME = {
     "Department of Agriculture": "USDA",
     "Department of Commerce": "DOC",
@@ -202,7 +228,8 @@ def _validate_manifests(
         label="candidate-exclusion product",
     )
     exclusion = _mapping(control.get("exclusion"), label="control exclusion metadata")
-    awards_ref = _product_reference(exclusion.get("awards_csv"), label="control awards snapshot")
+    awards_snapshot = _mapping(exclusion.get("awards_csv"), label="control awards snapshot")
+    awards_ref = _product_reference(awards_snapshot, label="control awards snapshot")
     exact_match = _mapping(exclusion.get("exact_match"), label="control exact-match metadata")
     identity_contract = {
         "candidate_cik_count": _positive_int(
@@ -215,6 +242,10 @@ def _validate_manifests(
         "ambiguous_normalized_name_count": _non_negative_int(
             exact_match.get("normalized_names_mapping_to_multiple_ciks"),
             label="ambiguous normalized-name count",
+        ),
+        "award_normalized_name_count": _positive_int(
+            awards_snapshot.get("unique_normalized_company_names"),
+            label="award normalized-name count",
         ),
     }
     if exact_match.get("normalizer_version") != NORMALIZER.value:
@@ -350,12 +381,14 @@ def _load_agency_tags(
     path: Path,
     *,
     expected_rows: int,
+    expected_normalized_names: int,
     candidates: Mapping[str, Mapping[str, Any]],
-) -> dict[str, list[str]]:
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     relevant_names = {
         name for candidate in candidates.values() for name in candidate["matched_normalized_names"]
     }
     tags_by_name: dict[str, set[str]] = defaultdict(set)
+    raw_names_by_name: dict[str, set[str]] = defaultdict(set)
     row_count = 0
     with path.open(encoding="utf-8-sig", errors="strict", newline="") as handle:
         reader = csv.DictReader(handle)
@@ -366,9 +399,10 @@ def _load_agency_tags(
             raise AuditError("Awards CSV must contain Company and Agency columns")
         for row in reader:
             row_count += 1
-            normalized = normalize_company_name(
-                str(row.get(company_column) or "").strip(), profile=NORMALIZER
-            )
+            raw_name = str(row.get(company_column) or "").strip()
+            normalized = normalize_company_name(raw_name, profile=NORMALIZER)
+            if normalized:
+                raw_names_by_name[normalized].add(raw_name)
             if not normalized or normalized not in relevant_names:
                 continue
             agency_name = str(row.get(agency_column) or "").strip()
@@ -378,6 +412,8 @@ def _load_agency_tags(
             tags_by_name[normalized].add(tag)
     if row_count != expected_rows:
         raise AuditError("Awards CSV row count does not match the control manifest")
+    if len(raw_names_by_name) != expected_normalized_names:
+        raise AuditError("Awards CSV normalized-name count does not match the control manifest")
     missing_names = sorted(relevant_names - set(tags_by_name))
     if missing_names:
         raise AuditError("Exact-name evidence is absent from the pinned awards snapshot")
@@ -389,7 +425,10 @@ def _load_agency_tags(
         if not tags:
             raise AuditError(f"Candidate CIK {cik} has no agency tag")
         tags_by_cik[cik] = tags
-    return tags_by_cik
+    return tags_by_cik, {
+        normalized_name: sorted(raw_names)
+        for normalized_name, raw_names in raw_names_by_name.items()
+    }
 
 
 def _validate_coverage(
@@ -505,8 +544,11 @@ def _audit_events(
     candidates: Mapping[str, Mapping[str, Any]],
     agency_tags: Mapping[str, list[str]],
     source_snapshot_id: str,
-) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, dict[str, list[str]]]]:
     output_rows: list[dict[str, Any]] = []
+    candidate_events: dict[str, dict[str, list[str]]] = defaultdict(
+        lambda: {"boundary": [], "complete_fy": []}
+    )
     seen_accessions: set[str] = set()
     seen_event_ids: set[str] = set()
     full_join_ciks: set[str] = set()
@@ -529,6 +571,7 @@ def _audit_events(
         full_join_ciks.add(cik)
         fiscal_year = federal_fiscal_year(filing_date)
         if fiscal_year in BOUNDARY_FISCAL_YEARS:
+            candidate_events[cik]["boundary"].append(accession)
             boundary_filings[fiscal_year] += 1
             boundary_ciks[fiscal_year].add(cik)
             continue
@@ -565,6 +608,7 @@ def _audit_events(
                 "submission_type": row["submission_type"],
             }
         )
+        candidate_events[cik]["complete_fy"].append(accession)
     if row_count != expected_rows:
         raise AuditError("Proxy-event JSONL row count does not match its manifest")
     output_rows.sort(key=lambda item: (item["filing_date"], item["accession_number"]))
@@ -581,7 +625,14 @@ def _audit_events(
             for fy in sorted(BOUNDARY_FISCAL_YEARS)
         },
     }
-    return output_rows, diagnostics
+    normalized_events = {
+        cik: {
+            "boundary": sorted(set(groups["boundary"])),
+            "complete_fy": sorted(set(groups["complete_fy"])),
+        }
+        for cik, groups in candidate_events.items()
+    }
+    return output_rows, diagnostics, normalized_events
 
 
 def _counts(rows: list[dict[str, Any]], diagnostics: Mapping[str, Any]) -> dict[str, Any]:
@@ -629,11 +680,118 @@ def _counts(rows: list[dict[str, Any]], diagnostics: Mapping[str, Any]) -> dict[
     }
 
 
+def _name_observation_rows(
+    candidates: Mapping[str, Mapping[str, Any]],
+    award_names: Mapping[str, list[str]],
+    candidate_events: Mapping[str, Mapping[str, list[str]]],
+) -> list[dict[str, Any]]:
+    ciks_by_name: dict[str, set[str]] = defaultdict(set)
+    for cik, candidate in candidates.items():
+        for normalized_name in candidate["matched_normalized_names"]:
+            ciks_by_name[str(normalized_name)].add(cik)
+
+    rows: list[dict[str, Any]] = []
+    for normalized_name, raw_names in sorted(award_names.items()):
+        candidate_ciks = sorted(ciks_by_name.get(normalized_name, set()))
+        if not candidate_ciks:
+            link_class = NAME_LINK_NONE
+            status = NAME_STATUS_NO_LINK
+            complete_accessions: list[str] | None = None
+            boundary_accessions: list[str] | None = None
+        else:
+            link_class = NAME_LINK_AMBIGUOUS if len(candidate_ciks) > 1 else NAME_LINK_UNIQUE
+            complete_accessions = sorted(
+                {
+                    accession
+                    for cik in candidate_ciks
+                    for accession in candidate_events.get(cik, {}).get("complete_fy", [])
+                }
+            )
+            boundary_accessions = sorted(
+                {
+                    accession
+                    for cik in candidate_ciks
+                    for accession in candidate_events.get(cik, {}).get("boundary", [])
+                }
+            )
+            if complete_accessions:
+                status = NAME_STATUS_COMPLETE
+            elif boundary_accessions:
+                status = NAME_STATUS_BOUNDARY
+            else:
+                status = NAME_STATUS_COVERED_ZERO
+        rows.append(
+            {
+                "boundary_proxy_accessions": boundary_accessions,
+                "candidate_ciks": candidate_ciks,
+                "complete_fy_proxy_accessions": complete_accessions,
+                "exact_name_candidate_link_class": link_class,
+                "normalized_sbir_name": normalized_name,
+                "observation_status": status,
+                "raw_sbir_names": raw_names,
+            }
+        )
+    return rows
+
+
+def _name_observation_counts(
+    rows: list[dict[str, Any]],
+    candidates: Mapping[str, Mapping[str, Any]],
+    candidate_events: Mapping[str, Mapping[str, list[str]]],
+) -> dict[str, Any]:
+    statuses = Counter(str(row["observation_status"]) for row in rows)
+    link_classes = Counter(str(row["exact_name_candidate_link_class"]) for row in rows)
+    proxy_ciks = {
+        cik
+        for cik, groups in candidate_events.items()
+        if groups.get("complete_fy") or groups.get("boundary")
+    }
+    complete_fy_ciks = {
+        cik for cik, groups in candidate_events.items() if groups.get("complete_fy")
+    }
+    observed_rows = [
+        row
+        for row in rows
+        if row["observation_status"] in {NAME_STATUS_COMPLETE, NAME_STATUS_BOUNDARY}
+    ]
+    return {
+        "exact_name_candidate_link_classes": {
+            label: link_classes.get(label, 0) for label in NAME_LINK_CLASSES
+        },
+        "observation_statuses": {
+            label: statuses.get(label, 0) for label in NAME_OBSERVATION_STATUSES
+        },
+        "proxy_cik_to_name_grain_reconciliation": {
+            "bounded_source_proxy_bearing_candidate_ciks": len(proxy_ciks),
+            "bounded_source_proxy_observed_linked_normalized_names": len(observed_rows),
+            "complete_fy_proxy_bearing_candidate_ciks": len(complete_fy_ciks),
+            "complete_fy_proxy_observed_linked_normalized_names": statuses.get(
+                NAME_STATUS_COMPLETE, 0
+            ),
+            "incomplete_boundary_only_proxy_observed_linked_normalized_names": statuses.get(
+                NAME_STATUS_BOUNDARY, 0
+            ),
+            "name_grain_minus_cik_grain_observed_difference": len(observed_rows) - len(proxy_ciks),
+            "observed_normalized_names_linked_to_multiple_proxy_bearing_ciks": sum(
+                len(proxy_ciks & set(row["candidate_ciks"])) > 1 for row in observed_rows
+            ),
+            "proxy_bearing_cik_name_memberships": sum(
+                len(candidates[cik]["matched_normalized_names"]) for cik in proxy_ciks
+            ),
+            "proxy_bearing_ciks_linked_to_multiple_normalized_names": sum(
+                len(candidates[cik]["matched_normalized_names"]) > 1 for cik in proxy_ciks
+            ),
+        },
+        "rows": len(rows),
+    }
+
+
 def _write_jsonl_product(
     output_dir: Path,
     rows: list[dict[str, Any]],
     *,
     forbidden_paths: set[Path],
+    product_name: str,
 ) -> tuple[dict[str, Any], Path, bool]:
     output_dir.mkdir(parents=True, exist_ok=True)
     if not output_dir.is_dir() or output_dir.is_symlink():
@@ -643,7 +801,7 @@ def _write_jsonl_product(
     temp_path: Path | None = None
     try:
         with tempfile.NamedTemporaryFile(
-            dir=output_dir, prefix=".sbir-form-d-proxy-audit.", delete=False
+            dir=output_dir, prefix=f".{product_name}.", delete=False
         ) as handle:
             temp_path = Path(handle.name)
             for row in rows:
@@ -655,7 +813,7 @@ def _write_jsonl_product(
                 digest.update(data)
                 size_bytes += len(data)
         sha = digest.hexdigest()
-        destination = output_dir / f"sbir_form_d_proxy_audit.{sha}.jsonl"
+        destination = output_dir / f"{product_name}.{sha}.jsonl"
         if destination.resolve() in forbidden_paths:
             raise AuditError("Content-addressed output must not alias an input or manifest")
         destination_preexisted = destination.exists()
@@ -727,8 +885,11 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         expected_rows=candidate_ref["row_count"],
         identity_contract=identity_contract,
     )
-    agency_tags = _load_agency_tags(
-        input_paths[5], expected_rows=awards_ref["row_count"], candidates=candidates
+    agency_tags, award_names = _load_agency_tags(
+        input_paths[5],
+        expected_rows=awards_ref["row_count"],
+        expected_normalized_names=identity_contract["award_normalized_name_count"],
+        candidates=candidates,
     )
     proxy_source = _mapping(proxy["source"], label="proxy source")
     source_snapshot_id = str(proxy_source["source_snapshot_id"])
@@ -738,7 +899,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         candidates=candidates,
         source_snapshot_id=source_snapshot_id,
     )
-    rows, diagnostics = _audit_events(
+    rows, diagnostics, candidate_events = _audit_events(
         input_paths[3],
         expected_rows=event_ref["row_count"],
         candidates=candidates,
@@ -747,11 +908,71 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
     )
     counts = _counts(rows, diagnostics)
     counts["candidate_ciks"] = len(candidates)
-    product, product_path, product_preexisted = _write_jsonl_product(
-        Path(args.output_dir),
-        rows,
-        forbidden_paths={path.resolve() for path in [*input_paths, audit_manifest_path]},
-    )
+    name_rows = _name_observation_rows(candidates, award_names, candidate_events)
+    name_counts = _name_observation_counts(name_rows, candidates, candidate_events)
+    counts["normalized_name_observation"] = name_counts
+
+    expected_product_paths = {path.resolve() for path in [*input_paths, audit_manifest_path]}
+    published_products: list[Path] = []
+    try:
+        product, product_path, product_preexisted = _write_jsonl_product(
+            Path(args.output_dir),
+            rows,
+            forbidden_paths=expected_product_paths,
+            product_name="sbir_form_d_proxy_audit",
+        )
+        if not product_preexisted:
+            published_products.append(product_path)
+        name_product, name_product_path, name_product_preexisted = _write_jsonl_product(
+            Path(args.output_dir),
+            name_rows,
+            forbidden_paths=expected_product_paths | {product_path.resolve()},
+            product_name="sbir_form_d_proxy_observation",
+        )
+        if not name_product_preexisted:
+            published_products.append(name_product_path)
+    except Exception:
+        for path in published_products:
+            path.unlink(missing_ok=True)
+        raise
+
+    name_statuses = name_counts["observation_statuses"]
+    name_invariants = {
+        "compact_name_observation_schema": all(
+            set(row) == NAME_OBSERVATION_FIELDS for row in name_rows
+        ),
+        "name_observation_content_addressed": name_product["path"]
+        == f"sbir_form_d_proxy_observation.{name_product['sha256']}.jsonl",
+        "name_observation_rows_sorted_and_unique": [
+            row["normalized_sbir_name"] for row in name_rows
+        ]
+        == sorted({row["normalized_sbir_name"] for row in name_rows}),
+        "name_observation_statuses_exhaustive": sum(name_statuses.values()) == len(name_rows),
+        "no_link_proxy_observations_are_unknown": all(
+            row["candidate_ciks"] == []
+            and row["complete_fy_proxy_accessions"] is None
+            and row["boundary_proxy_accessions"] is None
+            for row in name_rows
+            if row["observation_status"] == NAME_STATUS_NO_LINK
+        ),
+        "linked_proxy_accessions_are_unique": all(
+            row["complete_fy_proxy_accessions"] is not None
+            and row["boundary_proxy_accessions"] is not None
+            and len(row["complete_fy_proxy_accessions"])
+            == len(set(row["complete_fy_proxy_accessions"]))
+            and len(row["boundary_proxy_accessions"]) == len(set(row["boundary_proxy_accessions"]))
+            and not (
+                set(row["complete_fy_proxy_accessions"]) & set(row["boundary_proxy_accessions"])
+            )
+            for row in name_rows
+            if row["observation_status"] != NAME_STATUS_NO_LINK
+        ),
+        "proxy_observed_name_timing_partition_reconciles": name_statuses[NAME_STATUS_COMPLETE]
+        + name_statuses[NAME_STATUS_BOUNDARY]
+        == name_counts["proxy_cik_to_name_grain_reconciliation"][
+            "bounded_source_proxy_observed_linked_normalized_names"
+        ],
+    }
 
     invariants = {
         "agency_tags_nonempty_and_sorted": all(
@@ -776,6 +997,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             item["proxy_filings"] for item in counts["filing_fiscal_years"].values()
         )
         == len(rows),
+        **name_invariants,
     }
     try:
         if not all(invariants.values()):
@@ -783,6 +1005,9 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
 
         manifest = {
             "caveats": [
+                "The name ledger is normalized-name grain, not verified firm grain.",
+                "Boundary-only proxy evidence is separate from complete-fiscal-year evidence.",
+                "No exact-name candidate link is outcome-unobserved, not a binary zero.",
                 "Exact-name candidate identities are not verified SBIR identities.",
                 "Exact-name identity recall is unknown.",
                 "The event is a filer-supplied Form D filing proxy, not a verified legal event.",
@@ -797,6 +1022,8 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
             "counts": counts,
             "covariates_ready": False,
             "exclusion_recall": "unknown",
+            "filer_nonfiler_ready": False,
+            "identity_recall": "unknown",
             "identity_status": "exact_name_candidate",
             "inputs": {
                 "awards_snapshot": awards_meta,
@@ -807,8 +1034,20 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
                 "proxy_manifest": proxy_meta,
             },
             "invariants": invariants,
+            "name_observation_contract": {
+                "exact_name_candidate_link_classes": list(NAME_LINK_CLASSES),
+                "fields": sorted(NAME_OBSERVATION_FIELDS),
+                "grain": "normalized_historical_sbir_name",
+                "normalizer_version": NORMALIZER.value,
+                "observation_statuses": list(NAME_OBSERVATION_STATUSES),
+            },
             "outcome_kind": "filing_proxy",
-            "outputs": {"filing_evidence_audit": product},
+            "outputs": {
+                "filing_evidence_audit": product,
+                "normalized_name_observation": name_product,
+            },
+            "post_award": False,
+            "rate_ready": False,
             "ready_for_matching": False,
             "schema_version": OUTPUT_SCHEMA_VERSION,
             "source": {
@@ -819,6 +1058,7 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
                 "source": SOURCE,
                 "source_snapshot_id": source_snapshot_id,
             },
+            "verified_identity": False,
             "verified_ma": False,
             "window": {
                 "complete_filing_fiscal_years": list(
@@ -830,8 +1070,8 @@ def build(args: argparse.Namespace) -> dict[str, Any]:
         manifest_data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
         _atomic_write(audit_manifest_path, manifest_data)
     except Exception:
-        if not product_preexisted:
-            product_path.unlink(missing_ok=True)
+        for path in published_products:
+            path.unlink(missing_ok=True)
         raise
     return manifest
 

--- a/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
+++ b/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
@@ -550,7 +550,9 @@ def test_tracked_report_reconciles_to_materialization_manifest() -> None:
     report = TRACKED_REPORT.read_text(encoding="utf-8")
     report_words = " ".join(report.split())
     complete = manifest["counts"]["complete_filing_fiscal_year_window"]
+    name_observation = manifest["counts"]["normalized_name_observation"]
     product = manifest["outputs"]["filing_evidence_audit"]
+    name_product = manifest["outputs"]["normalized_name_observation"]
 
     assert complete == {
         "end_fy": 2024,
@@ -563,8 +565,56 @@ def test_tracked_report_reconciles_to_materialization_manifest() -> None:
     assert (
         f"| Complete-FY filing evidence audit | 283 | 244,696 | `{product['sha256']}` |" in report
     )
+    assert name_observation == {
+        "exact_name_candidate_link_classes": {
+            "ambiguous_exact_name_candidate_link": 89,
+            "no_exact_name_candidate_link": 29_864,
+            "unique_exact_name_candidate_link": 4_334,
+        },
+        "observation_statuses": {
+            "no_exact_name_candidate_link": 29_864,
+            "no_proxy_observed_on_exact_name_candidate_link_in_bounded_source": 4_191,
+            "proxy_observed_in_complete_fiscal_year_window_on_exact_name_candidate_link": 222,
+            "proxy_observed_only_in_incomplete_boundary_fiscal_years_on_exact_name_candidate_link": 10,
+        },
+        "proxy_cik_to_name_grain_reconciliation": {
+            "bounded_source_proxy_bearing_candidate_ciks": 222,
+            "bounded_source_proxy_observed_linked_normalized_names": 232,
+            "complete_fy_proxy_bearing_candidate_ciks": 212,
+            "complete_fy_proxy_observed_linked_normalized_names": 222,
+            "incomplete_boundary_only_proxy_observed_linked_normalized_names": 10,
+            "name_grain_minus_cik_grain_observed_difference": 10,
+            "observed_normalized_names_linked_to_multiple_proxy_bearing_ciks": 3,
+            "proxy_bearing_cik_name_memberships": 235,
+            "proxy_bearing_ciks_linked_to_multiple_normalized_names": 12,
+        },
+        "rows": 34_287,
+    }
+    assert name_product == {
+        "path": (
+            "sbir_form_d_proxy_observation."
+            "97c12eb10fe38b21ac37d2d962e54218144d47b78950029ed1a7c29fac7dd171.jsonl"
+        ),
+        "row_count": 34_287,
+        "sha256": "97c12eb10fe38b21ac37d2d962e54218144d47b78950029ed1a7c29fac7dd171",
+        "size_bytes": 10_239_501,
+    }
+    assert (
+        f"| Normalized-name observation ledger | 34,287 | 10,239,501 | `{name_product['sha256']}` |"
+    ) in report
+    assert manifest["code_commit"] == "3f6c962526be1c2d3a7c053b4fd442d632b6ce8e"
+    assert hashlib.sha256(TRACKED_MANIFEST.read_bytes()).hexdigest() == (
+        "dcaf1e3b26e35873769d4c06eeba0ed4b521726fa75672ba1045f774fbff6f5c"
+    )
     assert manifest["complete_sbir_identity"] is False
     assert manifest["complete_sbir_exclusion"] is False
+    assert manifest["exclusion_recall"] == "unknown"
+    assert manifest["verified_identity"] is False
+    assert manifest["identity_recall"] == "unknown"
+    assert manifest["post_award"] is False
+    assert manifest["filer_nonfiler_ready"] is False
     assert manifest["covariates_ready"] is False
     assert manifest["ready_for_matching"] is False
+    assert manifest["rate_ready"] is False
+    assert manifest["outcome_kind"] == "filing_proxy"
     assert manifest["verified_ma"] is False

--- a/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
+++ b/tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py
@@ -135,7 +135,14 @@ def _fixture(tmp_path: Path) -> argparse.Namespace:
             "resolution_method": "candidate_exact_normalized_name",
         }
     )
-    _jsonl(candidates_path, [alpha, _candidate("456", "BETA SYSTEMS", 2)])
+    _jsonl(
+        candidates_path,
+        [
+            alpha,
+            _candidate("456", "BETA SYSTEMS", 2),
+            _candidate("789", "DELTA RESEARCH", 1),
+        ],
+    )
     with awards_path.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=["Company", "Agency"])
         writer.writeheader()
@@ -147,16 +154,20 @@ def _fixture(tmp_path: Path) -> argparse.Namespace:
                     "Company": "Beta Systems LLC",
                     "Agency": "Department of Health and Human Services",
                 },
+                {"Company": "Delta Research LLC", "Agency": "Department of Defense"},
+                {"Company": "Gamma Works Inc.", "Agency": "Unmapped for unlinked name"},
             ]
         )
+    awards_ref = _meta(awards_path, 5)
+    awards_ref["unique_normalized_company_names"] = 4
     control = {
         "complete": True,
         "complete_sbir_exclusion": False,
         "exclusion": {
-            "awards_csv": _meta(awards_path, 3),
+            "awards_csv": awards_ref,
             "exact_match": {
-                "candidate_cik_count": 2,
-                "matched_normalized_name_count": 2,
+                "candidate_cik_count": 3,
+                "matched_normalized_name_count": 3,
                 "normalized_names_mapping_to_multiple_ciks": 1,
                 "normalizer_version": "organization-key-v1",
             },
@@ -165,11 +176,11 @@ def _fixture(tmp_path: Path) -> argparse.Namespace:
         "outputs": {
             "broad_issuer_universe": {
                 "path": "issuer-universe.jsonl",
-                "row_count": 3,
+                "row_count": 4,
                 "sha256": "a" * 64,
                 "size_bytes": 10,
             },
-            "candidate_sbir_cik_exclusions": _meta(candidates_path, 2),
+            "candidate_sbir_cik_exclusions": _meta(candidates_path, 3),
         },
         "schema_version": 1,
     }
@@ -178,7 +189,7 @@ def _fixture(tmp_path: Path) -> argparse.Namespace:
     snapshot_id = (
         f"form_d_control_universe_manifest_sha256:{hashlib.sha256(control_data).hexdigest()}"
     )
-    coverage_rows = [_coverage(cik, snapshot_id) for cik in ("123", "456", "999")]
+    coverage_rows = [_coverage(cik, snapshot_id) for cik in ("123", "456", "789", "999")]
     event_rows = [
         _event("123", "a", "2009-09-30", snapshot_id),
         _event("123", "b", "2009-10-01", snapshot_id),
@@ -259,7 +270,7 @@ def test_build_uses_exact_cik_and_excludes_partial_fiscal_years(tmp_path: Path) 
     args = _fixture(tmp_path)
     manifest = audit.build(args)
 
-    assert manifest["counts"]["candidate_ciks"] == 2
+    assert manifest["counts"]["candidate_ciks"] == 3
     assert manifest["counts"]["complete_filing_fiscal_year_window"] == {
         "end_fy": 2024,
         "proxy_filings": 2,
@@ -286,6 +297,42 @@ def test_build_uses_exact_cik_and_excludes_partial_fiscal_years(tmp_path: Path) 
     assert rows[1]["submission_type"] == "D/A"
     assert rows[1]["previous_accession_number"] == "prior-accession"
 
+    name_product = manifest["outputs"]["normalized_name_observation"]
+    name_rows = [
+        json.loads(line)
+        for line in (args.output_dir / name_product["path"])
+        .read_text(encoding="utf-8")
+        .splitlines()
+    ]
+    by_name = {row["normalized_sbir_name"]: row for row in name_rows}
+    assert list(by_name) == ["ALPHA LABS", "BETA SYSTEMS", "DELTA RESEARCH", "GAMMA WORKS"]
+    assert by_name["ALPHA LABS"] == {
+        "boundary_proxy_accessions": ["a"],
+        "candidate_ciks": ["123"],
+        "complete_fy_proxy_accessions": ["b"],
+        "exact_name_candidate_link_class": audit.NAME_LINK_UNIQUE,
+        "normalized_sbir_name": "ALPHA LABS",
+        "observation_status": audit.NAME_STATUS_COMPLETE,
+        "raw_sbir_names": ["Alpha Labs", "Alpha Labs, Inc."],
+    }
+    assert by_name["BETA SYSTEMS"]["candidate_ciks"] == ["123", "456"]
+    assert by_name["BETA SYSTEMS"]["complete_fy_proxy_accessions"] == ["b", "c"]
+    assert by_name["BETA SYSTEMS"]["boundary_proxy_accessions"] == ["a", "d"]
+    assert by_name["BETA SYSTEMS"]["exact_name_candidate_link_class"] == (audit.NAME_LINK_AMBIGUOUS)
+    assert by_name["DELTA RESEARCH"]["observation_status"] == audit.NAME_STATUS_COVERED_ZERO
+    assert by_name["DELTA RESEARCH"]["complete_fy_proxy_accessions"] == []
+    assert by_name["DELTA RESEARCH"]["boundary_proxy_accessions"] == []
+    assert by_name["GAMMA WORKS"]["observation_status"] == audit.NAME_STATUS_NO_LINK
+    assert by_name["GAMMA WORKS"]["candidate_ciks"] == []
+    assert by_name["GAMMA WORKS"]["complete_fy_proxy_accessions"] is None
+    assert by_name["GAMMA WORKS"]["boundary_proxy_accessions"] is None
+    assert manifest["counts"]["normalized_name_observation"]["observation_statuses"] == {
+        audit.NAME_STATUS_COMPLETE: 2,
+        audit.NAME_STATUS_BOUNDARY: 0,
+        audit.NAME_STATUS_COVERED_ZERO: 1,
+        audit.NAME_STATUS_NO_LINK: 1,
+    }
+
 
 def test_build_is_byte_deterministic(tmp_path: Path) -> None:
     args = _fixture(tmp_path)
@@ -293,6 +340,9 @@ def test_build_is_byte_deterministic(tmp_path: Path) -> None:
     first_manifest = args.audit_manifest.read_bytes()
     first_product = (
         args.output_dir / first["outputs"]["filing_evidence_audit"]["path"]
+    ).read_bytes()
+    first_name_product = (
+        args.output_dir / first["outputs"]["normalized_name_observation"]["path"]
     ).read_bytes()
 
     args.output_dir = tmp_path / "second-output"
@@ -303,6 +353,52 @@ def test_build_is_byte_deterministic(tmp_path: Path) -> None:
     assert (
         args.output_dir / second["outputs"]["filing_evidence_audit"]["path"]
     ).read_bytes() == first_product
+    assert (
+        args.output_dir / second["outputs"]["normalized_name_observation"]["path"]
+    ).read_bytes() == first_name_product
+
+
+def test_name_observation_fanout_and_boundary_status_are_explicit() -> None:
+    candidates = {
+        "1": {"matched_normalized_names": ["CURRENT NAME", "FORMER NAME"]},
+        "2": {"matched_normalized_names": ["CURRENT NAME"]},
+        "3": {"matched_normalized_names": ["BOUNDARY NAME"]},
+    }
+    award_names = {
+        "BOUNDARY NAME": ["Boundary Name LLC"],
+        "CURRENT NAME": ["Current Name Inc."],
+        "FORMER NAME": ["Former Name Inc."],
+        "UNLINKED NAME": ["Unlinked Name LLC"],
+    }
+    candidate_events = {
+        "1": {"boundary": [], "complete_fy": ["complete-a"]},
+        "2": {"boundary": [], "complete_fy": ["complete-b"]},
+        "3": {"boundary": ["boundary-a"], "complete_fy": []},
+    }
+
+    rows = audit._name_observation_rows(candidates, award_names, candidate_events)
+    counts = audit._name_observation_counts(rows, candidates, candidate_events)
+    by_name = {row["normalized_sbir_name"]: row for row in rows}
+
+    assert by_name["CURRENT NAME"]["candidate_ciks"] == ["1", "2"]
+    assert by_name["CURRENT NAME"]["complete_fy_proxy_accessions"] == [
+        "complete-a",
+        "complete-b",
+    ]
+    assert by_name["FORMER NAME"]["complete_fy_proxy_accessions"] == ["complete-a"]
+    assert by_name["BOUNDARY NAME"]["observation_status"] == audit.NAME_STATUS_BOUNDARY
+    assert by_name["UNLINKED NAME"]["observation_status"] == audit.NAME_STATUS_NO_LINK
+    assert counts["proxy_cik_to_name_grain_reconciliation"] == {
+        "bounded_source_proxy_bearing_candidate_ciks": 3,
+        "bounded_source_proxy_observed_linked_normalized_names": 3,
+        "complete_fy_proxy_bearing_candidate_ciks": 2,
+        "complete_fy_proxy_observed_linked_normalized_names": 2,
+        "incomplete_boundary_only_proxy_observed_linked_normalized_names": 1,
+        "name_grain_minus_cik_grain_observed_difference": 0,
+        "observed_normalized_names_linked_to_multiple_proxy_bearing_ciks": 1,
+        "proxy_bearing_cik_name_memberships": 4,
+        "proxy_bearing_ciks_linked_to_multiple_normalized_names": 1,
+    }
 
 
 def test_tampered_candidate_product_fails_before_publication(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- extend the exact-name SBIR/Form D filing-proxy audit with one compact row per normalized historical SBIR name
- keep four observation states exclusive so missing identity is never treated as a non-filer zero
- reconcile CIK-grain evidence to name-grain evidence and publish the real content-addressed product and manifest
- retain all identity, post-award, filer/non-filer, matching, rate, and verified-M&A gates as closed

## Stack

Draft stacked on #589 (`agent/exact-sbir-formd-proxy-audit`).

## Real materialization

- 34,287 normalized historical SBIR names
- 222 observed in complete FY2010–FY2024 through an exact-name candidate link
- 10 observed only in incomplete boundary fiscal years
- 4,191 exact-name-linked names with no proxy in the bounded source
- 29,864 names with no exact-name candidate link; these remain outcome-unknown
- 10,239,501-byte observation product, SHA-256 `97c12eb10fe38b21ac37d2d962e54218144d47b78950029ed1a7c29fac7dd171`
- two materializations produced byte-identical products and manifests

The 222 bounded-source proxy-bearing CIKs expand to 235 CIK/name memberships and 232 observed normalized names. The report preserves that fan-out rather than selecting an arbitrary name per CIK.

## Validation

- `pytest -q tests/unit/scripts/test_audit_sbir_form_d_business_combination_proxy.py` (18 passed)
- `pytest -q tests/unit` (5,889 passed, 7 skipped)
- Ruff check and format check
- mypy on the producer
- `make docs-check`
- `make lint-boundaries`
- `git diff --check`

## Interpretation boundary

This remains an exploratory filer-supplied filing proxy, not a verified M&A outcome, rate estimate, agency comparison, or matched filer/non-filer analysis.
