### PR TITLE
Build bounded SBIR–Form D candidate enrichment

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -968,10 +968,11 @@ The relevant literature is Lerner [L10], Howell [L11], and Kortum & Lerner
 - **Form D fundraising profile**
   What is the Form D [L23] private-placement fundraising profile of SBIR
   awardees?
-  **Status:** Partial and non-citable. A reproducible audit now preserves 4,542
-  atomic awardee–CIK candidates, but legal-entity identity is still unreviewed
-  and no fundraising amounts have been recomputed from that candidate set.
-  *Deps: ER, SEC EDGAR · Report: [atomic SBIR–Form D identity audit](research/agency-private-capital-sbir-form-d-identity-crosswalk.md) · Spec: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/) (PR #286 merged), [../specs/sbir-form-d-identity-crosswalk/](../specs/sbir-form-d-identity-crosswalk/)*
+  **Status:** Partial and non-citable. A reproducible bounded audit now preserves
+  7,787 atomic awardee–CIK candidates: 4,542 exact and 3,245 fuzzy-only. Legal-entity
+  identity remains unreviewed, and no fundraising amounts have been recomputed from
+  that candidate set.
+  *Deps: ER, SEC EDGAR · Reports: [atomic SBIR–Form D identity audit](research/agency-private-capital-sbir-form-d-identity-crosswalk.md), [candidate-enrichment audit](research/agency-private-capital-sbir-form-d-candidate-enrichment.md) · Specs: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/) (PR #286 merged), [../specs/sbir-form-d-identity-crosswalk/](../specs/sbir-form-d-identity-crosswalk/), [../specs/sbir-form-d-candidate-enrichment/](../specs/sbir-form-d-candidate-enrichment/)*
 
 - **Debt vs. equity composition**
   In SBIR-firm Form D filings, how much of the money raised is debt versus
@@ -1033,9 +1034,10 @@ The relevant literature is Lerner [L10], Howell [L11], and Kortum & Lerner
   What is the private-to-SBIR leverage ratio (private capital raised ÷ SBIR
   funding) by agency, vintage, and firm size?
   The private-side mirror of NASEM's 4:1 DoD follow-on funding multiplier [L1].
-  **Status:** Exploratory and non-citable. The atomic crosswalk is candidate-only;
-  accepted identity, amount deduplication, and linkage-error sensitivity remain open.
-  *Deps: ER, ID, SEC EDGAR · Refs: [L1] · Report: [atomic SBIR–Form D identity audit](research/agency-private-capital-sbir-form-d-identity-crosswalk.md) · Spec: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/), [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/)*
+  **Status:** Exploratory and non-citable. The 7,787-pair bounded crosswalk is
+  candidate-only; accepted identity, amount deduplication, and linkage-error
+  sensitivity remain open.
+  *Deps: ER, ID, SEC EDGAR · Refs: [L1] · Reports: [atomic SBIR–Form D identity audit](research/agency-private-capital-sbir-form-d-identity-crosswalk.md), [candidate-enrichment audit](research/agency-private-capital-sbir-form-d-candidate-enrichment.md) · Specs: [../specs/archive/completed-features/form-d-pipeline/](../specs/archive/completed-features/form-d-pipeline/), [../specs/sbir-form-d-candidate-enrichment/](../specs/sbir-form-d-candidate-enrichment/), [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/)*
 
 - **Outcomes vs. private-capital baselines**
   For Phase II awardees of any agency, do follow-on funding and exit outcomes
@@ -1048,10 +1050,11 @@ The relevant literature is Lerner [L10], Howell [L11], and Kortum & Lerner
   unavailable in that run. A reproducible 2009Q1–2024Q4 Form D identity audit
   now materializes 311,809 issuer CIKs and 307,344
   provisional retained identities. A second audit atomizes exact-name matching
-  into 4,542 awardee–CIK candidates, but neither audit establishes accepted
-  identity or complete SBIR exclusion, and the source has no NAICS; the controls
-  are not match-ready.
-  *Deps: ER, SEC EDGAR · Refs: [L10], [L11], [L24] · Reports: [NSF Phase I baseline review](research/agency-private-capital-phase1-nsf.md), [Form D control-identity audit](research/agency-private-capital-form-d-control-universe.md), [atomic SBIR–Form D identity audit](research/agency-private-capital-sbir-form-d-identity-crosswalk.md) · Spec: [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/) (PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, with terminology changed from "VC" to "private capital")*
+  into 4,542 exact awardee–CIK candidates; a bounded follow-on expands that queue
+  to 7,787 pairs with frozen fuzzy routes and contact corroboration. None of these
+  audits establishes accepted identity or complete SBIR exclusion, and the source
+  has no NAICS; the controls are not match-ready.
+  *Deps: ER, SEC EDGAR · Refs: [L10], [L11], [L24] · Reports: [NSF Phase I baseline review](research/agency-private-capital-phase1-nsf.md), [Form D control-identity audit](research/agency-private-capital-form-d-control-universe.md), [atomic SBIR–Form D identity audit](research/agency-private-capital-sbir-form-d-identity-crosswalk.md), [candidate-enrichment audit](research/agency-private-capital-sbir-form-d-candidate-enrichment.md) · Spec: [../specs/agency-private-capital-comparison/](../specs/agency-private-capital-comparison/) (PR #321 merged, supersedes #311; agency-parameterized via the `agency_private_capital_baseline_comparison` asset in group `agency_private_capital`, with terminology changed from "VC" to "private capital")*
 
 - **Crowd-in vs. crowd-out**
   Does SBIR funding crowd in or crowd out subsequent private capital?

--- a/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.manifest.json
+++ b/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.manifest.json
@@ -1,0 +1,147 @@
+{
+  "artifact_role": "tracked_research_manifest",
+  "candidate_only": true,
+  "complete": true,
+  "complete_sbir_exclusion": false,
+  "counts": {
+    "candidate_ciks": 6033,
+    "candidate_firms": 5631,
+    "candidate_pairs": 7787,
+    "contact_supported_pairs": {
+      "city": 5079,
+      "phone10": 1733,
+      "state": 6942,
+      "street1": 641,
+      "zip5": 4522
+    },
+    "exact_pairs": 4542,
+    "firms_with_multiple_candidate_ciks": 787,
+    "form_d_ciks_with_multiple_candidate_firms": 779,
+    "fuzzy_only_pairs": 3245,
+    "max_candidate_ciks_per_firm": 27,
+    "max_candidate_firms_per_cik": 29,
+    "routes": {
+      "exact_normalized_name": 4542,
+      "state_supported": 1201,
+      "strong_name": 271,
+      "zip_supported": 1871
+    }
+  },
+  "covariates_ready": false,
+  "decision_contract": {
+    "decision": "candidate_unreviewed",
+    "same_legal_entity": "unknown"
+  },
+  "exclusion_eligible": false,
+  "exclusion_recall": "unknown",
+  "identity_accepted": false,
+  "identity_only": true,
+  "inputs": {
+    "broad_issuer_universe": {
+      "path": "form_d_issuer_universe.identity-staging.jsonl",
+      "row_count": 311809,
+      "sha256": "a7c2ba7c84cf10711a029fd9b2e9326bd1e9137af61146ee47385d8aa03b310b",
+      "size_bytes": 827044055
+    },
+    "control_manifest": {
+      "path": "form_d_control_universe.manifest.json",
+      "sha256": "3ce34a04b592131dbd0aefdb8692c21c5ab72e46f90f5f81a2aeffb9dbaeeaaf",
+      "size_bytes": 231122
+    },
+    "crosswalk_manifest": {
+      "path": "sbir_form_d_identity_crosswalk.manifest.json",
+      "sha256": "71944c74dd7d6db05545757db85b812c56aa03fdb5cf25febdb23f13e50744c3",
+      "size_bytes": 3998
+    },
+    "exact_candidate_edges": {
+      "path": "sbir_form_d_candidate_edges.v1.5677ffe3b96b8d103312a7cc99b1ef9d12d3a7ebf95032b5e24e4c53fbbc193a.jsonl",
+      "row_count": 4542,
+      "sha256": "5677ffe3b96b8d103312a7cc99b1ef9d12d3a7ebf95032b5e24e4c53fbbc193a",
+      "size_bytes": 6578060
+    },
+    "firm_identity_ledger": {
+      "path": "sbir_firm_identity_ledger.v1.272d566a665aca6262f073c75c585dcca4d9ed61ff52bb7f8197e95f50b80508.jsonl",
+      "row_count": 34426,
+      "sha256": "272d566a665aca6262f073c75c585dcca4d9ed61ff52bb7f8197e95f50b80508",
+      "size_bytes": 62253221
+    },
+    "sbir_awards_csv": {
+      "path": "award_data.csv",
+      "row_count": 219500,
+      "sha256": "73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd",
+      "size_bytes": 394456822
+    }
+  },
+  "invariants": {
+    "all_candidates_atomic_by_sbir_firm_and_cik": true,
+    "all_candidates_unreviewed": true,
+    "all_downstream_gates_closed": true,
+    "all_routes_have_traceable_evidence": true,
+    "broad_form_d_evidence_cik_local": true,
+    "contact_evidence_never_generates_pairs": true,
+    "exact_phase1_pairs_preserved": true,
+    "no_forbidden_output_fields": true,
+    "source_records_reconcile_to_phase1_ledger": true
+  },
+  "matching_eligible": false,
+  "outputs": {
+    "identity_candidates": {
+      "path": "sbir_form_d_identity_candidates.v2.67779f952df4abb114488bbfcee3f3898758662f6898898ae6abd952bc71a1c7.jsonl",
+      "row_count": 7787,
+      "sha256": "67779f952df4abb114488bbfcee3f3898758662f6898898ae6abd952bc71a1c7",
+      "size_bytes": 25768887
+    }
+  },
+  "parameters": {
+    "candidate_contract": "sbir-form-d-identity-candidate-v2",
+    "contact_normalizers": {
+      "city": "alphanumeric-key-v1",
+      "phone10": "us-phone10-v1",
+      "state": "us-jurisdiction-strict-v1",
+      "street1": "alphanumeric-key-v1",
+      "zip5": "strict-zip5-v1"
+    },
+    "fuzzy_minimum_alphanumeric_length": 6,
+    "name_metrics": [
+      "ratio",
+      "token-sort",
+      "token-set"
+    ],
+    "name_normalizer": "organization-key-v1",
+    "prefix_length": 2,
+    "retrieval_is_exhaustive_within_declared_rules": true,
+    "routes": {
+      "state_supported": {
+        "same_prefix": true,
+        "strict_state_intersection": true,
+        "threshold": 0.85
+      },
+      "strong_name": {
+        "same_prefix": true,
+        "threshold": 0.95
+      },
+      "zip_supported": {
+        "strict_zip5_intersection": true,
+        "threshold": 0.8
+      }
+    },
+    "similarity_backend": {
+      "name": "rapidfuzz",
+      "version": "3.14.3"
+    }
+  },
+  "producer": {
+    "code_commit": "c91f00ac55f95b4c0d0d468af8a82c2428f9be61",
+    "path": "scripts/data/build_sbir_form_d_identity_candidates.py",
+    "sha256": "692df6d0a3d271f69db3d7e0b146c5fecaba0d4979c13e8e0b27ddae5a255bea",
+    "size_bytes": 68867
+  },
+  "rate_eligible": false,
+  "ready_for_matching": false,
+  "schema_version": 1,
+  "source_validation": {
+    "form_d_filing_rows": 673656,
+    "form_d_issuer_rows": 311809,
+    "sbir_award_rows": 219500
+  }
+}

--- a/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.manifest.json
+++ b/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.manifest.json
@@ -131,10 +131,10 @@
     }
   },
   "producer": {
-    "code_commit": "c91f00ac55f95b4c0d0d468af8a82c2428f9be61",
+    "code_commit": "c787d2dfbc8a06dd8dc9c2635649179caf1a5c42",
     "path": "scripts/data/build_sbir_form_d_identity_candidates.py",
-    "sha256": "692df6d0a3d271f69db3d7e0b146c5fecaba0d4979c13e8e0b27ddae5a255bea",
-    "size_bytes": 68867
+    "sha256": "648f1437604142b8a1b333109d33f34cefa56dd6a2df4bce1887eba9a25cfcb4",
+    "size_bytes": 69215
   },
   "rate_eligible": false,
   "ready_for_matching": false,

--- a/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.md
+++ b/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.md
@@ -1,0 +1,127 @@
+---
+Type: Research Report
+Owner: research@project
+Last-Reviewed: 2026-08-10
+Status: draft
+---
+
+# SBIR ↔ Form D candidate-enrichment audit
+
+> **Exploratory and non-citable.** This release expands a deterministic identity-review
+> worklist. Exact and fuzzy name evidence generate candidates, not legal-entity decisions. It
+> contains no accepted identity links, defines no control population, and attaches no capital
+> amounts or outcomes.
+
+## Materialization result
+
+Producer commit `c91f00ac55f95b4c0d0d468af8a82c2428f9be61` materialized the pinned
+full-history inputs twice. The two release directories were byte-identical. Their runtime manifests
+both have SHA-256 `a2c293796b135094ce4bfa77f6aa2f704c153277394adffa7aebf121ca09744f`;
+their candidate JSONLs both have SHA-256
+`67779f952df4abb114488bbfcee3f3898758662f6898898ae6abd952bc71a1c7`.
+
+| Audit measure | Value |
+| --- | ---: |
+| SBIR award rows validated | 219,500 |
+| SBIR firm-ledger components | 34,426 |
+| Form D issuer CIKs / filing records validated | 311,809 / 673,656 |
+| Atomic candidate pairs | 7,787 |
+| Preserved exact pairs / fuzzy-only pairs | 4,542 / 3,245 |
+| Candidate SBIR firms / Form D CIKs | 5,631 / 6,033 |
+| Firms linked to multiple candidate CIKs | 787 (maximum 27) |
+| CIKs linked to multiple candidate firms | 779 (maximum 29) |
+| Candidate pairs with any contact intersection / none | 7,015 / 772 |
+| Quarantined-component pairs / firms | 36 / 30 |
+
+The large collision maxima are review signals, not permission to choose one CIK. The 36
+quarantined-component pairs remain in the review universe, visibly marked, but cannot become
+automatic identity decisions. The release also preserves 254 exact pairs whose names are too short
+for fuzzy generation.
+
+## Frozen candidate routes
+
+Fuzzy comparison applies only to unequal names with at least six alphanumeric characters on each
+side. Similarity is pinned to RapidFuzz `3.14.3`; a different or missing backend fails closed.
+
+- `strong_name`: equal two-character alphanumeric prefix and ratio at least `0.95`;
+- `state_supported`: equal prefix, equal strict U.S. state, and ratio at least `0.85`; and
+- `zip_supported`: equal strict ZIP5 and ratio at least `0.80`, without a prefix requirement.
+
+There is no fallback, top-k truncation, phonetic rule, person rule, or post-materialization
+threshold tuning. Route counts overlap because one pair can satisfy multiple declared rules.
+
+| Exact route combination | Pairs |
+| --- | ---: |
+| `exact_normalized_name` | 4,542 |
+| `strong_name` | 232 |
+| `strong_name` + `state_supported` | 26 |
+| `strong_name` + `state_supported` + `zip_supported` | 13 |
+| `state_supported` | 1,116 |
+| `state_supported` + `zip_supported` | 46 |
+| `zip_supported` | 1,812 |
+
+The marginal route totals are 271 `strong_name`, 1,201 `state_supported`, and 1,871
+`zip_supported`. For a later exclusive validation sample ordered exact → strong → state → ZIP,
+the corresponding strata contain 4,542, 271, 1,162, and 1,812 pairs.
+
+Every route has a deterministic witness. Fuzzy witnesses retain the qualifying SBIR raw names and
+source-record ordinals, Form D raw aliases and accessions, ratio/token-sort/token-set scores, and
+the required prefix, state, or ZIP evidence. Exact rows embed their Phase 1 edge unchanged.
+
+## Contact corroboration and provenance
+
+Street line 1, city, strict state, strict ZIP5, and normalized ten-digit U.S. phone are intersected
+only after a name route creates a pair. They never generate candidates. Each shared value names its
+supporting SBIR source records and Form D accessions, within one firm and one CIK.
+
+| Contact field | Pairs with an exact intersection |
+| --- | ---: |
+| Street line 1 | 641 |
+| City | 5,079 |
+| State | 6,942 |
+| ZIP5 | 4,522 |
+| Phone | 1,733 |
+
+The tracked
+[candidate manifest](agency-private-capital-sbir-form-d-candidate-enrichment.manifest.json) pins
+the PR1 crosswalk runtime manifest at SHA-256
+`71944c74dd7d6db05545757db85b812c56aa03fdb5cf25febdb23f13e50744c3`
+and its upstream control manifest at SHA-256
+`3ce34a04b592131dbd0aefdb8692c21c5ab72e46f90f5f81a2aeffb9dbaeeaaf`.
+The tracked copy adds only `artifact_role`, so its digest intentionally differs from the runtime
+manifest.
+
+| Artifact | Rows | Bytes | SHA-256 |
+| --- | ---: | ---: | --- |
+| SBIR `award_data.csv` | 219,500 | 394,456,822 | `73d646fc6883ed93b36d19518b0d9442a9ebae94c5b49ad5a7fcd6d3c2b872dd` |
+| PR1 firm identity ledger | 34,426 | 62,253,221 | `272d566a665aca6262f073c75c585dcca4d9ed61ff52bb7f8197e95f50b80508` |
+| PR1 exact candidate edges | 4,542 | 6,578,060 | `5677ffe3b96b8d103312a7cc99b1ef9d12d3a7ebf95032b5e24e4c53fbbc193a` |
+| PR2 enriched candidates | 7,787 | 25,768,887 | `67779f952df4abb114488bbfcee3f3898758662f6898898ae6abd952bc71a1c7` |
+
+Reproduce with the pinned runtime products and award snapshot present:
+
+```bash
+uv run python scripts/data/build_sbir_form_d_identity_candidates.py \
+  --crosswalk-manifest data/processed/agency_private_capital/identity_crosswalk/sbir_form_d_identity_crosswalk.manifest.json \
+  --crosswalk-manifest-sha256 71944c74dd7d6db05545757db85b812c56aa03fdb5cf25febdb23f13e50744c3 \
+  --control-manifest data/processed/agency_private_capital/control_universe/form_d_control_universe.manifest.json \
+  --control-manifest-sha256 3ce34a04b592131dbd0aefdb8692c21c5ab72e46f90f5f81a2aeffb9dbaeeaaf \
+  --awards-csv data/raw/sbir/award_data.csv \
+  --output-dir /tmp/sbir-form-d-candidate-enrichment-run-1 \
+  --code-version c91f00ac55f95b4c0d0d468af8a82c2428f9be61
+```
+
+Repeat with `run-2`, then compare the directories with `diff -rq`.
+
+## Gate decision and next validation step
+
+Every row remains `candidate_unreviewed`; `same_legal_entity` is `null`.
+`identity_accepted`, `exclusion_eligible`, `covariates_ready`, `matching_eligible`, and
+`rate_eligible` are false. `complete_sbir_exclusion` and `ready_for_matching` are false, and
+`exclusion_recall` remains `unknown`.
+
+The next phase must construct outcome-blind review packets, obtain independent labels, adjudicate
+disagreements, and estimate conservative precision separately for each exclusive route. Review of
+generated candidates can estimate route precision, but not recall for SBIR–Form D links that no
+route generated. Until that phase passes, this product cannot support filer/non-filer, capital
+amount, leverage, matching, outcome, or rate claims.

--- a/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.md
+++ b/docs/research/agency-private-capital-sbir-form-d-candidate-enrichment.md
@@ -14,9 +14,9 @@ Status: draft
 
 ## Materialization result
 
-Producer commit `c91f00ac55f95b4c0d0d468af8a82c2428f9be61` materialized the pinned
+Producer commit `c787d2dfbc8a06dd8dc9c2635649179caf1a5c42` materialized the pinned
 full-history inputs twice. The two release directories were byte-identical. Their runtime manifests
-both have SHA-256 `a2c293796b135094ce4bfa77f6aa2f704c153277394adffa7aebf121ca09744f`;
+both have SHA-256 `adf9dc5219861f8ca144da46ead0038577b28e9fb5d122492c403a6a4955de32`;
 their candidate JSONLs both have SHA-256
 `67779f952df4abb114488bbfcee3f3898758662f6898898ae6abd952bc71a1c7`.
 
@@ -108,7 +108,7 @@ uv run python scripts/data/build_sbir_form_d_identity_candidates.py \
   --control-manifest-sha256 3ce34a04b592131dbd0aefdb8692c21c5ab72e46f90f5f81a2aeffb9dbaeeaaf \
   --awards-csv data/raw/sbir/award_data.csv \
   --output-dir /tmp/sbir-form-d-candidate-enrichment-run-1 \
-  --code-version c91f00ac55f95b4c0d0d468af8a82c2428f9be61
+  --code-version c787d2dfbc8a06dd8dc9c2635649179caf1a5c42
 ```
 
 Repeat with `run-2`, then compare the directories with `diff -rq`.

--- a/scripts/data/build_sbir_form_d_identity_candidates.py
+++ b/scripts/data/build_sbir_form_d_identity_candidates.py
@@ -1,0 +1,1549 @@
+#!/usr/bin/env python3
+"""Build a bounded, candidate-only SBIR awardee to Form D issuer review ledger.
+
+The producer preserves every exact Phase 1 pair, adds only three frozen fuzzy
+name routes, and appends CIK-local address and phone corroboration. It never
+accepts legal-entity identity or opens an exclusion, matching, or rate gate.
+"""
+
+import argparse
+import ctypes
+import csv
+import hashlib
+import json
+import os
+import re
+import shutil
+import sys
+import tempfile
+import unicodedata
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import rapidfuzz
+from rapidfuzz import fuzz as rapidfuzz_fuzz
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from sbir_etl.identity import (
+    CompanyNameMetric,
+    CompanyNameProfile,
+    USJurisdictionProfile,
+    normalize_company_name,
+    normalize_us_jurisdiction,
+)
+
+
+EPISTEMIC_TIER = "pipelines"
+
+DEFAULT_CROSSWALK_MANIFEST = (
+    REPO_ROOT / "data/processed/agency_private_capital/identity_crosswalk/"
+    "sbir_form_d_identity_crosswalk.manifest.json"
+)
+DEFAULT_CONTROL_MANIFEST = (
+    REPO_ROOT / "data/processed/agency_private_capital/control_universe/"
+    "form_d_control_universe.manifest.json"
+)
+DEFAULT_AWARDS_CSV = REPO_ROOT / "data/raw/sbir/award_data.csv"
+DEFAULT_OUTPUT_DIR = REPO_ROOT / "data/processed/agency_private_capital/identity_candidates"
+
+MANIFEST_SCHEMA_VERSION = 1
+CANDIDATE_SCHEMA_VERSION = 2
+CANDIDATE_CONTRACT = "sbir-form-d-identity-candidate-v2"
+EDGE_ID_CONTRACT = "sbir-form-d-edge-id-v1"
+LEDGER_CONTRACT = "sbir-firm-identity-ledger-v1"
+EXACT_EDGE_CONTRACT = "sbir-form-d-candidate-edge-v1"
+FIRM_ID_CONTRACT = "sbir-firm-id-v1"
+NORMALIZER = CompanyNameProfile.ORGANIZATION_KEY_V1
+GEOGRAPHY_PROFILE = USJurisdictionProfile.STRICT_V1
+PREFIX_LENGTH = 2
+MINIMUM_FUZZY_NAME_LENGTH = 6
+STRONG_NAME_THRESHOLD = 0.95
+STATE_SUPPORTED_THRESHOLD = 0.85
+ZIP_SUPPORTED_THRESHOLD = 0.80
+SIMILARITY_BACKEND = "rapidfuzz"
+SIMILARITY_BACKEND_VERSION = "3.14.3"
+ROUTE_ORDER = ("exact_normalized_name", "strong_name", "state_supported", "zip_supported")
+CONTACT_FIELDS = ("street1", "city", "state", "zip5", "phone10")
+EXPECTED_IDENTITY_FIELDS = (
+    "issuer_name",
+    "street1",
+    "street2",
+    "city",
+    "state",
+    "zip_code",
+    "issuer_phone",
+    "jurisdiction_of_incorporation",
+    "year_of_incorporation",
+)
+FORBIDDEN_OUTPUT_KEYS = frozenset(
+    {
+        "amount",
+        "award_amount",
+        "award_value",
+        "company_website",
+        "confidence",
+        "confidence_label",
+        "confidence_tier",
+        "email",
+        "email_address",
+        "email_domain",
+        "offering_amount",
+        "people",
+        "person",
+        "person_name",
+        "persons",
+        "preferred_cik",
+        "related_person",
+        "related_persons",
+        "related_people",
+        "sale_amount",
+        "total_amount_sold",
+        "total_offering_amount",
+        "website",
+        "website_url",
+    }
+)
+SHA256_RE = re.compile(r"[0-9a-f]{64}")
+GIT_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+ZIP5_RE = re.compile(r"^\s*(\d{5})(?:-\d{4})?\s*$")
+PHONE_EXTENSION_RE = re.compile(r"\s+(?:ext(?:ension)?\.?|x)\s*\d+\s*$", re.IGNORECASE)
+
+
+class BuildError(RuntimeError):
+    """Raised when input evidence cannot support a deterministic release."""
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_path(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+            size += len(block)
+    return digest.hexdigest(), size
+
+
+def _non_negative_int(value: object, *, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise BuildError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _pinned_product(value: object, *, label: str) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise BuildError(f"Manifest does not pin {label}")
+    path = value.get("path")
+    sha256 = value.get("sha256")
+    if (
+        not isinstance(path, str)
+        or not path
+        or path in {".", ".."}
+        or Path(path).name != path
+        or Path(path).is_absolute()
+    ):
+        raise BuildError(f"Pinned {label} path must be one safe filename")
+    if not isinstance(sha256, str) or not SHA256_RE.fullmatch(sha256):
+        raise BuildError(f"Pinned {label} has an invalid SHA-256")
+    _non_negative_int(value.get("size_bytes"), label=f"Pinned {label} size_bytes")
+    _non_negative_int(value.get("row_count"), label=f"Pinned {label} row_count")
+    return dict(value)
+
+
+def _read_manifest(path: Path, *, expected_sha256: str, label: str) -> tuple[dict[str, Any], bytes]:
+    expected = expected_sha256.strip().lower()
+    if not SHA256_RE.fullmatch(expected):
+        raise BuildError(f"--{label}-manifest-sha256 must be 64 lowercase hexadecimal characters")
+    if not path.is_file():
+        raise BuildError(f"Required {label} manifest is missing: {path}")
+    data = path.read_bytes()
+    if _sha256_bytes(data) != expected:
+        raise BuildError(f"{label.title()} manifest SHA-256 does not match its external pin")
+    try:
+        manifest = json.loads(data)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BuildError(f"Invalid {label} manifest JSON: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise BuildError(f"{label.title()} manifest must be a JSON object")
+    return manifest, data
+
+
+def _required_false_gates(manifest: Mapping[str, Any], *, label: str) -> None:
+    expected: dict[str, object] = {
+        "complete_sbir_exclusion": False,
+        "covariates_ready": False,
+        "exclusion_recall": "unknown",
+        "identity_only": True,
+        "ready_for_matching": False,
+    }
+    for field, expected_value in expected.items():
+        actual = manifest.get(field)
+        valid = (
+            actual is expected_value
+            if isinstance(expected_value, bool)
+            else actual == expected_value
+        )
+        if not valid:
+            raise BuildError(f"{label} manifest has unexpected {field}")
+
+
+def _load_crosswalk_manifest(
+    path: Path, *, expected_sha256: str
+) -> tuple[dict[str, Any], bytes, dict[str, Any], dict[str, Any]]:
+    manifest, data = _read_manifest(path, expected_sha256=expected_sha256, label="crosswalk")
+    if manifest.get("schema_version") != 1 or manifest.get("complete") is not True:
+        raise BuildError("Crosswalk manifest is incomplete or unsupported")
+    _required_false_gates(manifest, label="Crosswalk")
+    for field, expected in {
+        "candidate_only": True,
+        "identity_accepted": False,
+        "exclusion_eligible": False,
+        "matching_eligible": False,
+        "rate_eligible": False,
+    }.items():
+        if manifest.get(field) is not expected:
+            raise BuildError(f"Crosswalk manifest has unexpected {field}")
+    if manifest.get("normalizer_version") != NORMALIZER.value:
+        raise BuildError("Crosswalk normalizer does not match the candidate producer")
+    decision = manifest.get("decision_contract")
+    if not isinstance(decision, Mapping) or decision.get("decision") != "candidate_unreviewed":
+        raise BuildError("Crosswalk manifest has an unsupported decision contract")
+    if decision.get("same_legal_entity") != "unknown":
+        raise BuildError("Crosswalk manifest does not keep identity unknown")
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise BuildError("Crosswalk manifest has no outputs object")
+    ledger = _pinned_product(outputs.get("firm_identity_ledger"), label="firm identity ledger")
+    edges = _pinned_product(outputs.get("candidate_edges"), label="exact candidate edges")
+    inputs = manifest.get("inputs")
+    if not isinstance(inputs, Mapping):
+        raise BuildError("Crosswalk manifest has no inputs object")
+    _pinned_product(inputs.get("broad_issuer_universe"), label="broad issuer universe")
+    _pinned_product(inputs.get("sbir_awards_csv"), label="SBIR awards CSV")
+    control_pin = inputs.get("control_manifest")
+    if not isinstance(control_pin, Mapping):
+        raise BuildError("Crosswalk manifest does not pin the control manifest")
+    control_sha = control_pin.get("sha256")
+    if not isinstance(control_sha, str) or not SHA256_RE.fullmatch(control_sha):
+        raise BuildError("Crosswalk control-manifest pin has an invalid SHA-256")
+    _non_negative_int(control_pin.get("size_bytes"), label="Crosswalk control manifest size")
+    return manifest, data, ledger, edges
+
+
+def _load_control_manifest(
+    path: Path,
+    *,
+    expected_sha256: str,
+    crosswalk: Mapping[str, Any],
+) -> tuple[dict[str, Any], bytes, dict[str, Any]]:
+    manifest, data = _read_manifest(path, expected_sha256=expected_sha256, label="control")
+    if manifest.get("schema_version") != 1 or manifest.get("complete") is not True:
+        raise BuildError("Control manifest is incomplete or unsupported")
+    _required_false_gates(manifest, label="Control")
+    control_pin = crosswalk["inputs"]["control_manifest"]
+    if _sha256_bytes(data) != control_pin["sha256"] or len(data) != control_pin["size_bytes"]:
+        raise BuildError("Control manifest does not match the crosswalk's upstream pin")
+    contract = manifest.get("identity_evidence_contract")
+    if not isinstance(contract, Mapping) or contract.get("fields") != list(
+        EXPECTED_IDENTITY_FIELDS
+    ):
+        raise BuildError("Control manifest has an unsupported identity evidence contract")
+    if (
+        contract.get("grain") != "form_d_filing_accession"
+        or contract.get("historical_aliases_retained") is not True
+        or contract.get("source_table") != "ISSUERS.tsv"
+    ):
+        raise BuildError("Control manifest has an unsupported identity evidence contract")
+    outputs = manifest.get("outputs")
+    if not isinstance(outputs, Mapping):
+        raise BuildError("Control manifest has no outputs object")
+    broad = _pinned_product(outputs.get("broad_issuer_universe"), label="broad issuer universe")
+    expected_broad = crosswalk["inputs"]["broad_issuer_universe"]
+    for field in ("row_count", "sha256", "size_bytes"):
+        if broad[field] != expected_broad[field]:
+            raise BuildError("Control broad-issuer pin does not match the crosswalk")
+    awards = manifest.get("exclusion", {}).get("awards_csv")
+    pinned_awards = _pinned_product(awards, label="SBIR awards CSV")
+    expected_awards = crosswalk["inputs"]["sbir_awards_csv"]
+    for field in ("row_count", "sha256", "size_bytes"):
+        if pinned_awards[field] != expected_awards[field]:
+            raise BuildError("Control award pin does not match the crosswalk")
+    return manifest, data, broad
+
+
+def _resolve_product(manifest_path: Path, product: Mapping[str, Any]) -> Path:
+    return manifest_path.parent / str(product["path"])
+
+
+def _load_jsonl(path: Path, product: Mapping[str, Any], *, label: str) -> list[dict[str, Any]]:
+    if not path.is_file():
+        raise BuildError(f"Pinned {label} is missing: {path}")
+    before = path.stat()
+    if before.st_size != product["size_bytes"]:
+        raise BuildError(f"Pinned {label} byte count does not match its manifest")
+    digest = hashlib.sha256()
+    size = 0
+    rows: list[dict[str, Any]] = []
+    with path.open("rb") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            digest.update(raw_line)
+            size += len(raw_line)
+            if not raw_line.strip():
+                raise BuildError(f"{label.title()} has a blank line at {line_number}")
+            try:
+                row = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise BuildError(f"Invalid {label} JSON at line {line_number}") from exc
+            if not isinstance(row, dict):
+                raise BuildError(f"{label.title()} line {line_number} must be an object")
+            rows.append(row)
+    after = path.stat()
+    if (
+        after.st_size != before.st_size
+        or after.st_mtime_ns != before.st_mtime_ns
+        or after.st_ino != before.st_ino
+    ):
+        raise BuildError(f"Pinned {label} changed while it was read")
+    if len(rows) != product["row_count"] or size != product["size_bytes"]:
+        raise BuildError(f"Pinned {label} rows or bytes do not match its manifest")
+    if digest.hexdigest() != product["sha256"]:
+        raise BuildError(f"Pinned {label} SHA-256 does not match its manifest")
+    return rows
+
+
+def _normalizer(value: object) -> str:
+    return normalize_company_name(value, profile=NORMALIZER)
+
+
+def _prefix(value: str) -> str:
+    return "".join(character for character in value if character.isalnum())[:PREFIX_LENGTH]
+
+
+def _fuzzy_eligible(value: str) -> bool:
+    return sum(character.isalnum() for character in value) >= MINIMUM_FUZZY_NAME_LENGTH
+
+
+def _validate_similarity_backend() -> None:
+    actual = rapidfuzz.__version__
+    if actual != SIMILARITY_BACKEND_VERSION:
+        raise BuildError(
+            "Candidate similarity requires "
+            f"{SIMILARITY_BACKEND}=={SIMILARITY_BACKEND_VERSION}; found {actual}"
+        )
+
+
+def _similarity(left: str, right: str, *, metric: CompanyNameMetric) -> float:
+    scorers = {
+        CompanyNameMetric.RATIO: rapidfuzz_fuzz.ratio,
+        CompanyNameMetric.TOKEN_SET: rapidfuzz_fuzz.token_set_ratio,
+        CompanyNameMetric.TOKEN_SORT: rapidfuzz_fuzz.token_sort_ratio,
+    }
+    return float(scorers[metric](left, right)) / 100.0
+
+
+def _normalize_zip5(value: object) -> str | None:
+    if value is None:
+        return None
+    match = ZIP5_RE.fullmatch(str(value))
+    return match.group(1) if match else None
+
+
+def _simple_key(value: object) -> str | None:
+    text = unicodedata.normalize("NFKD", str(value or "").strip().upper())
+    text = "".join(character for character in text if not unicodedata.combining(character))
+    key = " ".join(re.sub(r"[^A-Z0-9]+", " ", text).split())
+    return key or None
+
+
+def _normalize_phone10(value: object) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    text = PHONE_EXTENSION_RE.sub("", text)
+    digits = "".join(character for character in text if character.isdigit())
+    if len(digits) == 11 and digits.startswith("1"):
+        digits = digits[1:]
+    return digits if len(digits) == 10 else None
+
+
+def _edge_id(sbir_firm_id: str, cik: str) -> str:
+    material = "\0".join((EDGE_ID_CONTRACT, sbir_firm_id, cik))
+    return f"sbir_form_d_edge:{hashlib.sha256(material.encode()).hexdigest()}"
+
+
+def _column(fieldnames: Sequence[str], *aliases: str) -> str | None:
+    by_name = {field.strip().casefold(): field for field in fieldnames}
+    return next(
+        (by_name[alias.casefold()] for alias in aliases if alias.casefold() in by_name), None
+    )
+
+
+def _load_ledger(
+    path: Path, product: Mapping[str, Any]
+) -> tuple[dict[str, dict[str, Any]], dict[int, dict[str, Any]], dict[str, set[str]]]:
+    rows = _load_jsonl(path, product, label="firm identity ledger")
+    components: dict[str, dict[str, Any]] = {}
+    source_index: dict[int, dict[str, Any]] = {}
+    exact_name_index: dict[str, set[str]] = defaultdict(set)
+    previous_firm: str | None = None
+    for line_number, row in enumerate(rows, start=1):
+        firm_id = row.get("sbir_firm_id")
+        if not isinstance(firm_id, str) or not firm_id.startswith("sbir_firm:"):
+            raise BuildError(f"Ledger line {line_number} has an invalid firm ID")
+        if previous_firm is not None and firm_id <= previous_firm:
+            raise BuildError("Ledger firm IDs must be unique and ordered")
+        previous_firm = firm_id
+        if (
+            row.get("schema_version") != 1
+            or row.get("firm_id_contract") != FIRM_ID_CONTRACT
+            or row.get("ledger_contract") != LEDGER_CONTRACT
+        ):
+            raise BuildError(f"Ledger line {line_number} has an unsupported contract")
+        status = row.get("component_status")
+        if status not in {"identifier_consistent", "name_only", "quarantined_conflict"}:
+            raise BuildError(f"Ledger line {line_number} has an invalid component status")
+        names = row.get("normalized_names")
+        reasons = row.get("quarantine_reasons")
+        sources = row.get("source_records")
+        if (
+            not isinstance(names, list)
+            or not isinstance(reasons, list)
+            or not isinstance(sources, list)
+        ):
+            raise BuildError(f"Ledger line {line_number} has malformed evidence")
+        if row.get("source_record_count") != len(sources) or row.get("award_row_count") != len(
+            sources
+        ):
+            raise BuildError(f"Ledger line {line_number} has inconsistent source counts")
+        normalized_names: list[str] = []
+        firm_source_records: set[int] = set()
+        for name in names:
+            if not isinstance(name, str) or not name or _normalizer(name) != name:
+                raise BuildError(f"Ledger line {line_number} has an invalid normalized name")
+            normalized_names.append(name)
+            exact_name_index[name].add(firm_id)
+        for source in sources:
+            if not isinstance(source, Mapping):
+                raise BuildError(f"Ledger line {line_number} has a non-object source record")
+            source_record = source.get("source_record")
+            if (
+                isinstance(source_record, bool)
+                or not isinstance(source_record, int)
+                or source_record < 1
+            ):
+                raise BuildError(f"Ledger line {line_number} has an invalid source record")
+            if source_record in source_index:
+                raise BuildError(f"Ledger repeats SBIR source record {source_record}")
+            normalized_name = source.get("normalized_name")
+            if normalized_name is not None and normalized_name not in normalized_names:
+                raise BuildError(f"Ledger source record {source_record} has an unlisted name")
+            source_index[source_record] = {
+                "firm_id": firm_id,
+                "normalized_name": normalized_name,
+                "raw_name": source.get("raw_name"),
+            }
+            firm_source_records.add(source_record)
+        components[firm_id] = {
+            "component_status": status,
+            "normalized_names": sorted(normalized_names),
+            "quarantine_reasons": sorted(str(reason) for reason in reasons),
+            "source_records": firm_source_records,
+        }
+    return components, source_index, dict(exact_name_index)
+
+
+def _contains_forbidden_key(value: object) -> bool:
+    if isinstance(value, Mapping):
+        return any(
+            str(key).casefold() in FORBIDDEN_OUTPUT_KEYS or _contains_forbidden_key(child)
+            for key, child in value.items()
+        )
+    if isinstance(value, list):
+        return any(_contains_forbidden_key(child) for child in value)
+    return False
+
+
+def _validate_exact_lineage(
+    row: Mapping[str, Any],
+    *,
+    line_number: int,
+    firm_id: str,
+    component: Mapping[str, Any],
+    source_index: Mapping[int, Mapping[str, Any]],
+) -> None:
+    source_records = row.get("sbir_source_records")
+    accessions = row.get("form_d_source_accessions")
+    if (
+        not isinstance(source_records, list)
+        or not source_records
+        or any(
+            isinstance(source_record, bool)
+            or not isinstance(source_record, int)
+            or source_record < 1
+            for source_record in source_records
+        )
+        or source_records != sorted(set(source_records))
+        or not set(source_records) <= component["source_records"]
+    ):
+        raise BuildError(f"Exact edge line {line_number} has invalid SBIR lineage")
+    if (
+        not isinstance(accessions, list)
+        or not accessions
+        or any(not isinstance(accession, str) or not accession.strip() for accession in accessions)
+        or accessions != sorted(set(accessions))
+    ):
+        raise BuildError(f"Exact edge line {line_number} has invalid Form D lineage")
+
+    evidence_rows = row.get("name_evidence")
+    if not isinstance(evidence_rows, list) or not evidence_rows:
+        raise BuildError(f"Exact edge line {line_number} lacks nested name lineage")
+    nested_sources: set[int] = set()
+    nested_accessions: set[str] = set()
+    evidence_names: list[str] = []
+    for evidence in evidence_rows:
+        if not isinstance(evidence, Mapping):
+            raise BuildError(f"Exact edge line {line_number} has malformed name lineage")
+        normalized_name = evidence.get("normalized_name")
+        if (
+            not isinstance(normalized_name, str)
+            or normalized_name in evidence_names
+            or normalized_name not in component["normalized_names"]
+            or _normalizer(normalized_name) != normalized_name
+        ):
+            raise BuildError(f"Exact edge line {line_number} has invalid normalized-name lineage")
+        evidence_names.append(normalized_name)
+        form_d_rows = evidence.get("form_d")
+        sbir_rows = evidence.get("sbir")
+        if not isinstance(form_d_rows, list) or not form_d_rows:
+            raise BuildError(f"Exact edge line {line_number} lacks Form D name lineage")
+        if not isinstance(sbir_rows, list) or not sbir_rows:
+            raise BuildError(f"Exact edge line {line_number} lacks SBIR name lineage")
+        form_d_witnesses: list[tuple[str, str]] = []
+        for witness in form_d_rows:
+            if not isinstance(witness, Mapping):
+                raise BuildError(f"Exact edge line {line_number} has malformed Form D lineage")
+            accession = witness.get("accession_number")
+            raw_alias = witness.get("raw_alias")
+            if (
+                not isinstance(accession, str)
+                or accession not in accessions
+                or not isinstance(raw_alias, str)
+                or not raw_alias.strip()
+                or _normalizer(raw_alias) != normalized_name
+            ):
+                raise BuildError(f"Exact edge line {line_number} has invalid Form D name lineage")
+            nested_accessions.add(accession)
+            form_d_witnesses.append((accession, raw_alias))
+        if form_d_witnesses != sorted(set(form_d_witnesses)):
+            raise BuildError(f"Exact edge line {line_number} has unordered Form D lineage")
+        sbir_witnesses: list[tuple[int, str]] = []
+        for witness in sbir_rows:
+            if not isinstance(witness, Mapping):
+                raise BuildError(f"Exact edge line {line_number} has malformed SBIR lineage")
+            source_record = witness.get("source_record")
+            raw_name = witness.get("raw_name")
+            if (
+                isinstance(source_record, bool)
+                or not isinstance(source_record, int)
+                or source_record not in source_records
+                or not isinstance(raw_name, str)
+                or not raw_name.strip()
+            ):
+                raise BuildError(f"Exact edge line {line_number} has invalid SBIR name lineage")
+            frozen = source_index.get(source_record)
+            if (
+                frozen is None
+                or frozen["firm_id"] != firm_id
+                or frozen["normalized_name"] != normalized_name
+                or frozen["raw_name"] != raw_name
+            ):
+                raise BuildError(f"Exact edge line {line_number} has cross-firm SBIR lineage")
+            nested_sources.add(source_record)
+            sbir_witnesses.append((source_record, raw_name))
+        if sbir_witnesses != sorted(set(sbir_witnesses)):
+            raise BuildError(f"Exact edge line {line_number} has unordered SBIR lineage")
+    if evidence_names != sorted(evidence_names):
+        raise BuildError(f"Exact edge line {line_number} has unordered name lineage")
+    if nested_sources != set(source_records) or nested_accessions != set(accessions):
+        raise BuildError(f"Exact edge line {line_number} does not reconcile nested lineage")
+
+
+def _load_exact_edges(
+    path: Path,
+    product: Mapping[str, Any],
+    *,
+    components: Mapping[str, Mapping[str, Any]],
+    source_index: Mapping[int, Mapping[str, Any]],
+) -> tuple[dict[tuple[str, str], dict[str, Any]], dict[str, set[str]]]:
+    rows = _load_jsonl(path, product, label="exact candidate edges")
+    edges: dict[tuple[str, str], dict[str, Any]] = {}
+    exact_by_cik: dict[str, set[str]] = defaultdict(set)
+    previous_pair: tuple[str, str] | None = None
+    for line_number, row in enumerate(rows, start=1):
+        firm_id = row.get("sbir_firm_id")
+        cik = row.get("form_d_cik")
+        if not isinstance(firm_id, str) or firm_id not in components:
+            raise BuildError(f"Exact edge line {line_number} has an unknown firm")
+        if not isinstance(cik, str) or not cik.isdigit() or cik.startswith("0") or len(cik) > 10:
+            raise BuildError(f"Exact edge line {line_number} has an invalid CIK")
+        pair = (firm_id, cik)
+        if previous_pair is not None and pair <= previous_pair:
+            raise BuildError("Exact edge pairs must be unique and ordered")
+        previous_pair = pair
+        if (
+            row.get("schema_version") != 1
+            or row.get("edge_contract") != EXACT_EDGE_CONTRACT
+            or row.get("edge_id_contract") != EDGE_ID_CONTRACT
+            or row.get("edge_id") != _edge_id(firm_id, cik)
+            or row.get("match_method") != "exact_normalized_name"
+        ):
+            raise BuildError(f"Exact edge line {line_number} has an unsupported contract")
+        if row.get("component_status") != components[firm_id]["component_status"]:
+            raise BuildError(f"Exact edge line {line_number} disagrees with the firm ledger")
+        if (
+            row.get("normalizer_version") != NORMALIZER.value
+            or row.get("quarantine_reasons") != components[firm_id]["quarantine_reasons"]
+        ):
+            raise BuildError(f"Exact edge line {line_number} disagrees with firm provenance")
+        if (
+            row.get("decision") != "candidate_unreviewed"
+            or row.get("same_legal_entity") is not None
+        ):
+            raise BuildError(f"Exact edge line {line_number} contains an identity decision")
+        for gate in (
+            "identity_accepted",
+            "exclusion_eligible",
+            "matching_eligible",
+            "rate_eligible",
+        ):
+            if row.get(gate) is not False:
+                raise BuildError(f"Exact edge line {line_number} opens {gate}")
+        _validate_exact_lineage(
+            row,
+            line_number=line_number,
+            firm_id=firm_id,
+            component=components[firm_id],
+            source_index=source_index,
+        )
+        if _contains_forbidden_key(row):
+            raise BuildError(f"Exact edge line {line_number} contains a forbidden field")
+        edges[pair] = row
+        exact_by_cik[cik].add(firm_id)
+    return edges, dict(exact_by_cik)
+
+
+def _new_value_map() -> dict[str, dict[str, set[int]]]:
+    return {field: defaultdict(set) for field in CONTACT_FIELDS}
+
+
+def _load_award_profiles(
+    path: Path,
+    product: Mapping[str, Any],
+    *,
+    components: Mapping[str, Mapping[str, Any]],
+    source_index: Mapping[int, Mapping[str, Any]],
+) -> tuple[
+    dict[str, dict[str, Any]], dict[str, set[tuple[str, str]]], dict[str, set[tuple[str, str]]]
+]:
+    if not path.is_file():
+        raise BuildError(f"Pinned SBIR awards CSV is missing: {path}")
+    before = path.stat()
+    sha256, size = _sha256_path(path)
+    if size != product["size_bytes"] or sha256 != product["sha256"]:
+        raise BuildError("SBIR awards CSV bytes do not match the manifest pin")
+    profiles: dict[str, dict[str, Any]] = {
+        firm_id: {"contacts": _new_value_map(), "names": {}} for firm_id in components
+    }
+    reader: csv.DictReader[str] | None = None
+    row_count = 0
+    try:
+        with path.open(encoding="utf-8-sig", errors="strict", newline="") as handle:
+            reader = csv.DictReader(handle, strict=True)
+            fieldnames = reader.fieldnames or []
+            if any(not isinstance(field, str) or not field.strip() for field in fieldnames):
+                raise BuildError("SBIR awards CSV has a blank column name")
+            folded = [field.strip().casefold() for field in fieldnames]
+            if len(folded) != len(set(folded)):
+                raise BuildError("SBIR awards CSV has duplicate column names")
+            columns = {
+                "name": _column(fieldnames, "Company", "company_name"),
+                "street1": _column(fieldnames, "Address1", "address_1"),
+                "city": _column(fieldnames, "City"),
+                "state": _column(fieldnames, "State"),
+                "zip5": _column(fieldnames, "Zip", "zip_code"),
+                "contact_phone": _column(fieldnames, "Contact Phone", "contact_phone"),
+                "pi_phone": _column(fieldnames, "PI Phone", "pi_phone"),
+            }
+            missing = [name for name, column in columns.items() if column is None]
+            if missing:
+                raise BuildError("SBIR awards CSV lacks identity columns: " + ", ".join(missing))
+            for source_record, row in enumerate(reader, start=1):
+                row_count += 1
+                if None in row:
+                    raise BuildError(f"SBIR award record {source_record} has extra fields")
+                frozen = source_index.get(source_record)
+                if frozen is None:
+                    raise BuildError(f"SBIR award record {source_record} is absent from the ledger")
+                firm_id = str(frozen["firm_id"])
+                raw_name = str(row.get(columns["name"]) or "")
+                normalized_name = _normalizer(raw_name) or None
+                if (
+                    normalized_name != frozen["normalized_name"]
+                    or (raw_name if raw_name.strip() else None) != frozen["raw_name"]
+                ):
+                    raise BuildError(f"SBIR award record {source_record} disagrees with the ledger")
+                profile = profiles[firm_id]
+                name_profile = profile["names"].setdefault(
+                    normalized_name,
+                    {"raw_names": defaultdict(set), "contacts": _new_value_map()},
+                )
+                if raw_name.strip():
+                    name_profile["raw_names"][raw_name].add(source_record)
+                values = {
+                    "street1": _simple_key(row.get(columns["street1"])),
+                    "city": _simple_key(row.get(columns["city"])),
+                    "state": normalize_us_jurisdiction(
+                        row.get(columns["state"]), profile=GEOGRAPHY_PROFILE
+                    ),
+                    "zip5": _normalize_zip5(row.get(columns["zip5"])),
+                }
+                phones = {
+                    value
+                    for value in (
+                        _normalize_phone10(row.get(columns["contact_phone"])),
+                        _normalize_phone10(row.get(columns["pi_phone"])),
+                    )
+                    if value
+                }
+                for field, value in values.items():
+                    if value:
+                        profile["contacts"][field][value].add(source_record)
+                        name_profile["contacts"][field][value].add(source_record)
+                for phone in phones:
+                    profile["contacts"]["phone10"][phone].add(source_record)
+                    name_profile["contacts"]["phone10"][phone].add(source_record)
+    except (UnicodeDecodeError, csv.Error) as exc:
+        line_number = reader.line_num if reader is not None else 1
+        raise BuildError(
+            f"Invalid SBIR awards CSV near physical line {line_number}: {exc}"
+        ) from exc
+    after = path.stat()
+    if (
+        after.st_size != before.st_size
+        or after.st_mtime_ns != before.st_mtime_ns
+        or after.st_ino != before.st_ino
+    ):
+        raise BuildError("SBIR awards CSV changed while it was parsed")
+    if row_count != product["row_count"] or set(source_index) != set(range(1, row_count + 1)):
+        raise BuildError("SBIR award rows do not reconcile to the firm ledger")
+
+    prefix_index: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    zip_index: dict[str, set[tuple[str, str]]] = defaultdict(set)
+    for firm_id, profile in profiles.items():
+        for name, name_profile in profile["names"].items():
+            if not isinstance(name, str) or not _fuzzy_eligible(name):
+                continue
+            prefix = _prefix(name)
+            if len(prefix) == PREFIX_LENGTH:
+                prefix_index[prefix].add((firm_id, name))
+            for zip5 in name_profile["contacts"]["zip5"]:
+                zip_index[zip5].add((firm_id, name))
+    return profiles, dict(prefix_index), dict(zip_index)
+
+
+def _validated_aliases(value: object, *, label: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise BuildError(f"{label} must be a non-empty list")
+    aliases: list[str] = []
+    for alias in value:
+        if not isinstance(alias, str) or not alias.strip():
+            raise BuildError(f"{label} contains an invalid alias")
+        aliases.append(alias)
+    return aliases
+
+
+def _new_candidate(
+    firm_id: str,
+    cik: str,
+    component: Mapping[str, Any],
+    *,
+    exact_edge: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    routes: set[str] = {"exact_normalized_name"} if exact_edge is not None else set()
+    source_records = set(exact_edge["sbir_source_records"]) if exact_edge is not None else set()
+    accessions = set(exact_edge["form_d_source_accessions"]) if exact_edge is not None else set()
+    best: dict[str, Any] | None = None
+    route_evidence: dict[str, dict[str, Any]] = {}
+    if exact_edge is not None:
+        evidence = exact_edge.get("name_evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise BuildError("Exact edge lacks name evidence")
+        chosen_index, chosen = min(
+            enumerate(evidence),
+            key=lambda indexed: (str(indexed[1].get("normalized_name") or ""), indexed[0]),
+        )
+        best = {
+            "form_d": chosen["form_d"],
+            "form_d_normalized_alias": chosen["normalized_name"],
+            "ratio_similarity": 1.0,
+            "sbir": chosen["sbir"],
+            "sbir_normalized_name": chosen["normalized_name"],
+            "token_set_similarity": 1.0,
+            "token_sort_similarity": 1.0,
+        }
+        route_evidence["exact_normalized_name"] = {
+            "evidence_path": f"exact_source_edge.name_evidence[{chosen_index}]",
+            "normalized_name": chosen["normalized_name"],
+            "ratio_similarity": 1.0,
+        }
+    return {
+        "best_name_evidence": best,
+        "candidate_routes": routes,
+        "component_status": component["component_status"],
+        "contact_evidence": {field: [] for field in CONTACT_FIELDS},
+        "exact_source_edge": dict(exact_edge) if exact_edge is not None else None,
+        "form_d_cik": cik,
+        "form_d_source_accessions": accessions,
+        "quarantine_reasons": list(component["quarantine_reasons"]),
+        "route_evidence": route_evidence,
+        "sbir_firm_id": firm_id,
+        "sbir_source_records": source_records,
+    }
+
+
+def _name_evidence_rank(value: Mapping[str, Any]) -> tuple[float, str, str, str]:
+    return (
+        -float(value["ratio_similarity"]),
+        str(value["sbir_normalized_name"]),
+        str(value["form_d_normalized_alias"]),
+        json.dumps(value["form_d"], sort_keys=True, separators=(",", ":")),
+    )
+
+
+def _contact_intersections(
+    sbir_contacts: Mapping[str, Mapping[str, set[int]]],
+    form_d_contacts: Mapping[str, Mapping[str, set[str]]],
+) -> dict[str, list[dict[str, Any]]]:
+    result: dict[str, list[dict[str, Any]]] = {}
+    for field in CONTACT_FIELDS:
+        shared = sorted(set(sbir_contacts[field]) & set(form_d_contacts[field]))
+        result[field] = [
+            {
+                "form_d_accessions": sorted(form_d_contacts[field][value]),
+                "sbir_source_records": sorted(sbir_contacts[field][value]),
+                "value": value,
+            }
+            for value in shared
+        ]
+    return result
+
+
+def _fuzzy_route_evidence(
+    route: str,
+    *,
+    name_evidence: Mapping[str, Any],
+    prefix: str,
+    sbir_contacts: Mapping[str, Mapping[str, set[int]]],
+    form_d_contacts: Mapping[str, Mapping[str, set[str]]],
+) -> dict[str, Any]:
+    support: dict[str, Any] = {}
+    if route in {"strong_name", "state_supported"}:
+        support["prefix"] = prefix
+    if route in {"state_supported", "zip_supported"}:
+        field = "state" if route == "state_supported" else "zip5"
+        support[field] = _contact_intersections(sbir_contacts, form_d_contacts)[field]
+        if not support[field]:
+            raise BuildError(f"{route} lacks its required {field} witness")
+    return {"name_evidence": dict(name_evidence), "route_support": support}
+
+
+def _stream_candidates(
+    path: Path,
+    product: Mapping[str, Any],
+    *,
+    components: Mapping[str, Mapping[str, Any]],
+    exact_name_index: Mapping[str, set[str]],
+    exact_edges: Mapping[tuple[str, str], Mapping[str, Any]],
+    exact_by_cik: Mapping[str, set[str]],
+    profiles: Mapping[str, Mapping[str, Any]],
+    prefix_index: Mapping[str, set[tuple[str, str]]],
+    zip_index: Mapping[str, set[tuple[str, str]]],
+) -> tuple[dict[tuple[str, str], dict[str, Any]], dict[str, Any]]:
+    if not path.is_file():
+        raise BuildError(f"Pinned broad issuer universe is missing: {path}")
+    before = path.stat()
+    if before.st_size != product["size_bytes"]:
+        raise BuildError("Broad issuer universe byte count does not match its pin")
+    candidates = {
+        pair: _new_candidate(pair[0], pair[1], components[pair[0]], exact_edge=edge)
+        for pair, edge in exact_edges.items()
+    }
+    digest = hashlib.sha256()
+    size = 0
+    row_count = 0
+    filing_count = 0
+    previous_cik: str | None = None
+    exact_accessions = {
+        accession for edge in exact_edges.values() for accession in edge["form_d_source_accessions"]
+    }
+    seen_accessions: set[str] = set()
+    exact_accession_ciks: dict[str, str] = {}
+    accession_aliases: dict[str, set[str]] = {}
+    exact_reconstructed: set[tuple[str, str]] = set()
+    with path.open("rb") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            digest.update(raw_line)
+            size += len(raw_line)
+            if not raw_line.strip():
+                raise BuildError(f"Broad issuer universe has a blank line at {line_number}")
+            row_count += 1
+            try:
+                row = json.loads(raw_line)
+            except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+                raise BuildError(f"Invalid broad issuer JSON at line {line_number}") from exc
+            if not isinstance(row, Mapping):
+                raise BuildError(f"Broad issuer line {line_number} must be an object")
+            cik = row.get("cik")
+            if (
+                not isinstance(cik, str)
+                or not cik.isdigit()
+                or cik.startswith("0")
+                or len(cik) > 10
+            ):
+                raise BuildError(f"Broad issuer line {line_number} has an invalid CIK")
+            if previous_cik is not None and cik <= previous_cik:
+                raise BuildError("Broad issuer CIKs must be unique and ordered")
+            previous_cik = cik
+            if row.get("firm_key") != f"form_d_cik:{cik}" or row.get("schema_version") != 1:
+                raise BuildError(f"Broad issuer line {line_number} has an invalid contract")
+            filings = row.get("filings")
+            if (
+                not isinstance(filings, list)
+                or not filings
+                or row.get("filing_count") != len(filings)
+            ):
+                raise BuildError(f"Broad issuer line {line_number} has invalid filing evidence")
+            aggregate_aliases = set(
+                _validated_aliases(row.get("issuer_name_aliases"), label=f"Issuer {cik} aliases")
+            )
+            traceable_aliases: set[str] = set()
+            alias_sources: dict[str, dict[str, set[str]]] = defaultdict(lambda: defaultdict(set))
+            issuer_contacts: dict[str, dict[str, set[str]]] = {
+                field: defaultdict(set) for field in CONTACT_FIELDS
+            }
+            for filing in filings:
+                filing_count += 1
+                if not isinstance(filing, Mapping) or filing.get("cik") != cik:
+                    raise BuildError(f"Broad issuer {cik} pools evidence across CIKs")
+                missing = [field for field in EXPECTED_IDENTITY_FIELDS if field not in filing]
+                if missing:
+                    raise BuildError(
+                        f"Broad issuer {cik} lacks identity fields: {', '.join(missing)}"
+                    )
+                accession = filing.get("accession_number")
+                if not isinstance(accession, str) or not accession.strip():
+                    raise BuildError(f"Broad issuer {cik} has an invalid accession")
+                accession = accession.strip()
+                if accession in seen_accessions:
+                    raise BuildError(f"Broad issuer universe repeats accession {accession}")
+                seen_accessions.add(accession)
+                aliases = _validated_aliases(
+                    filing.get("issuer_name_aliases"), label=f"Filing {accession} aliases"
+                )
+                if accession in exact_accessions:
+                    exact_accession_ciks[accession] = cik
+                    accession_aliases[accession] = set(aliases)
+                issuer_name = filing.get("issuer_name")
+                if not isinstance(issuer_name, str) or issuer_name not in aliases:
+                    raise BuildError(f"Filing {accession} has an untraceable issuer name")
+                for raw_alias in aliases:
+                    traceable_aliases.add(raw_alias)
+                    normalized = _normalizer(raw_alias)
+                    if normalized:
+                        alias_sources[normalized][raw_alias].add(accession)
+                values = {
+                    "street1": _simple_key(filing.get("street1")),
+                    "city": _simple_key(filing.get("city")),
+                    "state": normalize_us_jurisdiction(
+                        filing.get("state"), profile=GEOGRAPHY_PROFILE
+                    ),
+                    "zip5": _normalize_zip5(filing.get("zip_code")),
+                    "phone10": _normalize_phone10(filing.get("issuer_phone")),
+                }
+                for field, value in values.items():
+                    if value:
+                        issuer_contacts[field][value].add(accession)
+            if aggregate_aliases != traceable_aliases:
+                raise BuildError(f"Broad issuer {cik} has untraceable aggregate aliases")
+
+            for alias in alias_sources:
+                for firm_id in exact_name_index.get(alias, set()):
+                    exact_reconstructed.add((firm_id, cik))
+
+            possible: set[tuple[str, str]] = set()
+            for alias in alias_sources:
+                prefix = _prefix(alias)
+                if len(prefix) == PREFIX_LENGTH:
+                    possible.update(prefix_index.get(prefix, set()))
+            for zip5 in issuer_contacts["zip5"]:
+                possible.update(zip_index.get(zip5, set()))
+
+            pairs_for_cik: set[tuple[str, str]] = {
+                (firm_id, cik) for firm_id in exact_by_cik.get(cik, set())
+            }
+            for firm_id, sbir_name in sorted(possible):
+                pair = (firm_id, cik)
+                if pair in exact_edges or not _fuzzy_eligible(sbir_name):
+                    continue
+                name_profile = profiles[firm_id]["names"].get(sbir_name)
+                if not isinstance(name_profile, Mapping):
+                    raise BuildError("Fuzzy index points at missing SBIR name evidence")
+                matched_states = set(name_profile["contacts"]["state"]) & set(
+                    issuer_contacts["state"]
+                )
+                matched_zip5s = set(name_profile["contacts"]["zip5"]) & set(issuer_contacts["zip5"])
+                sbir_prefix = _prefix(sbir_name)
+                for alias, raw_sources in sorted(alias_sources.items()):
+                    if alias == sbir_name or not _fuzzy_eligible(alias):
+                        continue
+                    ratio = _similarity(alias, sbir_name, metric=CompanyNameMetric.RATIO)
+                    same_prefix = (
+                        len(sbir_prefix) == PREFIX_LENGTH and _prefix(alias) == sbir_prefix
+                    )
+                    routes: set[str] = set()
+                    if same_prefix and ratio >= STRONG_NAME_THRESHOLD:
+                        routes.add("strong_name")
+                    if same_prefix and matched_states and ratio >= STATE_SUPPORTED_THRESHOLD:
+                        routes.add("state_supported")
+                    if matched_zip5s and ratio >= ZIP_SUPPORTED_THRESHOLD:
+                        routes.add("zip_supported")
+                    if not routes:
+                        continue
+                    candidate = candidates.setdefault(
+                        pair,
+                        _new_candidate(firm_id, cik, components[firm_id], exact_edge=None),
+                    )
+                    candidate["candidate_routes"].update(routes)
+                    form_d_rows = [
+                        {"accession_numbers": sorted(accessions), "raw_alias": raw_alias}
+                        for raw_alias, accessions in sorted(raw_sources.items())
+                    ]
+                    sbir_rows = [
+                        {"raw_name": raw_name, "source_records": sorted(source_records)}
+                        for raw_name, source_records in sorted(name_profile["raw_names"].items())
+                    ]
+                    evidence = {
+                        "form_d": form_d_rows,
+                        "form_d_normalized_alias": alias,
+                        "ratio_similarity": round(ratio, 6),
+                        "sbir": sbir_rows,
+                        "sbir_normalized_name": sbir_name,
+                        "token_set_similarity": round(
+                            _similarity(alias, sbir_name, metric=CompanyNameMetric.TOKEN_SET), 6
+                        ),
+                        "token_sort_similarity": round(
+                            _similarity(alias, sbir_name, metric=CompanyNameMetric.TOKEN_SORT), 6
+                        ),
+                    }
+                    if candidate["best_name_evidence"] is None or _name_evidence_rank(
+                        evidence
+                    ) < _name_evidence_rank(candidate["best_name_evidence"]):
+                        candidate["best_name_evidence"] = evidence
+                    for route in routes:
+                        witness = _fuzzy_route_evidence(
+                            route,
+                            name_evidence=evidence,
+                            prefix=sbir_prefix,
+                            sbir_contacts=name_profile["contacts"],
+                            form_d_contacts=issuer_contacts,
+                        )
+                        previous_witness = candidate["route_evidence"].get(route)
+                        if previous_witness is None or _name_evidence_rank(
+                            witness["name_evidence"]
+                        ) < _name_evidence_rank(previous_witness["name_evidence"]):
+                            candidate["route_evidence"][route] = witness
+                    for accessions in raw_sources.values():
+                        candidate["form_d_source_accessions"].update(accessions)
+                    for source_records in name_profile["raw_names"].values():
+                        candidate["sbir_source_records"].update(source_records)
+                    pairs_for_cik.add(pair)
+
+            for pair in sorted(pairs_for_cik):
+                candidate = candidates[pair]
+                contact = _contact_intersections(profiles[pair[0]]["contacts"], issuer_contacts)
+                candidate["contact_evidence"] = contact
+                for evidence_rows in contact.values():
+                    for evidence in evidence_rows:
+                        candidate["form_d_source_accessions"].update(evidence["form_d_accessions"])
+                        candidate["sbir_source_records"].update(evidence["sbir_source_records"])
+
+    after = path.stat()
+    if (
+        after.st_size != before.st_size
+        or after.st_mtime_ns != before.st_mtime_ns
+        or after.st_ino != before.st_ino
+    ):
+        raise BuildError("Broad issuer universe changed while it was parsed")
+    if row_count != product["row_count"] or size != product["size_bytes"]:
+        raise BuildError("Broad issuer rows or bytes do not match their pin")
+    if digest.hexdigest() != product["sha256"]:
+        raise BuildError("Broad issuer SHA-256 does not match its pin")
+    if exact_reconstructed != set(exact_edges):
+        missing_exact_count = len(set(exact_edges) - exact_reconstructed)
+        extra_exact_count = len(exact_reconstructed - set(exact_edges))
+        raise BuildError(
+            "Reconstructed exact pairs disagree with Phase 1: "
+            f"missing={missing_exact_count}, extra={extra_exact_count}"
+        )
+    for pair, edge in exact_edges.items():
+        for accession in edge["form_d_source_accessions"]:
+            if exact_accession_ciks.get(accession) != pair[1]:
+                raise BuildError(f"Exact edge {edge['edge_id']} has cross-CIK accession evidence")
+        for evidence in edge["name_evidence"]:
+            for witness in evidence["form_d"]:
+                accession = witness["accession_number"]
+                if witness["raw_alias"] not in accession_aliases.get(accession, set()):
+                    raise BuildError(
+                        f"Exact edge {edge['edge_id']} has untraceable Form D alias evidence"
+                    )
+    return candidates, {
+        "filing_rows_validated": filing_count,
+        "row_count": row_count,
+        "sha256": digest.hexdigest(),
+        "size_bytes": size,
+    }
+
+
+def _finalize_candidates(
+    candidates: Mapping[tuple[str, str], Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for (firm_id, cik), candidate in sorted(candidates.items()):
+        routes = candidate["candidate_routes"]
+        if not routes or candidate["best_name_evidence"] is None:
+            raise BuildError(f"Candidate {firm_id}/{cik} has no name route or evidence")
+        route_evidence = candidate["route_evidence"]
+        if set(route_evidence) != set(routes):
+            raise BuildError(f"Candidate {firm_id}/{cik} lacks route-specific evidence")
+        exact_edge = candidate["exact_source_edge"]
+        if (exact_edge is not None) != ("exact_normalized_name" in routes):
+            raise BuildError(f"Candidate {firm_id}/{cik} has inconsistent exact evidence")
+        row = {
+            "best_name_evidence": candidate["best_name_evidence"],
+            "candidate_contract": CANDIDATE_CONTRACT,
+            "candidate_only": True,
+            "candidate_routes": [route for route in ROUTE_ORDER if route in routes],
+            "component_status": candidate["component_status"],
+            "complete_sbir_exclusion": False,
+            "contact_evidence": candidate["contact_evidence"],
+            "covariates_ready": False,
+            "decision": "candidate_unreviewed",
+            "edge_id": _edge_id(firm_id, cik),
+            "edge_id_contract": EDGE_ID_CONTRACT,
+            "exact_source_edge": exact_edge,
+            "exclusion_eligible": False,
+            "exclusion_recall": "unknown",
+            "form_d_cik": cik,
+            "form_d_source_accessions": sorted(candidate["form_d_source_accessions"]),
+            "identity_accepted": False,
+            "matching_eligible": False,
+            "normalizer_version": NORMALIZER.value,
+            "quarantine_reasons": candidate["quarantine_reasons"],
+            "rate_eligible": False,
+            "route_evidence": {
+                route: route_evidence[route] for route in ROUTE_ORDER if route in routes
+            },
+            "same_legal_entity": None,
+            "sbir_firm_id": firm_id,
+            "sbir_source_records": sorted(candidate["sbir_source_records"]),
+            "schema_version": CANDIDATE_SCHEMA_VERSION,
+        }
+        if _contains_forbidden_key(row):
+            raise BuildError(f"Candidate {firm_id}/{cik} contains a forbidden field")
+        rows.append(row)
+    pairs = [(row["sbir_firm_id"], row["form_d_cik"]) for row in rows]
+    edge_ids = [row["edge_id"] for row in rows]
+    if len(pairs) != len(set(pairs)) or len(edge_ids) != len(set(edge_ids)):
+        raise BuildError("Candidate pairs or stable edge IDs are not unique")
+    return rows
+
+
+def _write_jsonl_product(
+    directory: Path, *, stem: str, rows: Sequence[Mapping[str, Any]]
+) -> dict[str, Any]:
+    temporary_path = directory / f".{stem}.jsonl"
+    digest = hashlib.sha256()
+    size = 0
+    with temporary_path.open("wb") as handle:
+        for row in rows:
+            data = (
+                json.dumps(row, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
+            ).encode("utf-8")
+            handle.write(data)
+            digest.update(data)
+            size += len(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+    sha256 = digest.hexdigest()
+    final_path = directory / f"{stem}.{sha256}.jsonl"
+    os.replace(temporary_path, final_path)
+    return {
+        "path": final_path.name,
+        "row_count": len(rows),
+        "sha256": sha256,
+        "size_bytes": size,
+    }
+
+
+def _write_manifest(directory: Path, manifest: Mapping[str, Any]) -> None:
+    path = directory / "sbir_form_d_identity_candidates.manifest.json"
+    data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    with path.open("wb") as handle:
+        handle.write(data)
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+def _atomic_exchange_directories(left: Path, right: Path) -> None:
+    """Atomically exchange two directories on supported deployment platforms."""
+
+    if sys.platform == "darwin":
+        function_name = "renameatx_np"
+        at_fdcwd = -2
+    elif sys.platform.startswith("linux"):
+        function_name = "renameat2"
+        at_fdcwd = -100
+    else:
+        raise BuildError(f"Atomic directory exchange is unsupported on {sys.platform}")
+    libc = ctypes.CDLL(None, use_errno=True)
+    exchange = getattr(libc, function_name, None)
+    if exchange is None:
+        raise BuildError(f"Atomic directory exchange function {function_name} is unavailable")
+    exchange.argtypes = [
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_int,
+        ctypes.c_char_p,
+        ctypes.c_uint,
+    ]
+    exchange.restype = ctypes.c_int
+    if exchange(at_fdcwd, os.fsencode(left), at_fdcwd, os.fsencode(right), 2) != 0:
+        error = ctypes.get_errno()
+        raise OSError(error, f"Atomic release exchange failed: {os.strerror(error)}")
+
+
+def _publish_release(staging: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if target.is_symlink() or (target.exists() and not target.is_dir()):
+        raise BuildError(f"Output target must be a directory, not a file or symlink: {target}")
+    if staging.parent.resolve() != target.parent.resolve():
+        raise BuildError("Release staging and target directories must be siblings")
+    if not target.exists():
+        os.replace(staging, target)
+        return
+    _atomic_exchange_directories(staging, target)
+    # After the atomic exchange, staging names the prior complete release. Its
+    # cleanup cannot expose a partial target and is safe to retry/remove later.
+    shutil.rmtree(staging, ignore_errors=True)
+
+
+def _ensure_output_disjoint(output_dir: Path, *, inputs: Iterable[Path]) -> None:
+    resolved_output = output_dir.resolve(strict=False)
+    for input_path in inputs:
+        resolved_input = input_path.resolve(strict=False)
+        if resolved_input == resolved_output or resolved_output in resolved_input.parents:
+            raise BuildError(f"Output directory would replace pinned input: {input_path}")
+
+
+def _input_record(
+    path: Path, *, sha256: str, size_bytes: int, row_count: int | None = None
+) -> dict[str, Any]:
+    record: dict[str, Any] = {
+        "path": path.name,
+        "sha256": sha256,
+        "size_bytes": size_bytes,
+    }
+    if row_count is not None:
+        record["row_count"] = row_count
+    return record
+
+
+def build(args: argparse.Namespace) -> dict[str, Any]:
+    code_version = str(args.code_version or "").strip()
+    if not GIT_COMMIT_RE.fullmatch(code_version):
+        raise BuildError("--code-version must be a full lowercase 40-character git commit")
+    _validate_similarity_backend()
+    crosswalk_manifest_path = Path(args.crosswalk_manifest)
+    control_manifest_path = Path(args.control_manifest)
+    awards_path = Path(args.awards_csv)
+    output_dir = Path(args.output_dir)
+    crosswalk, crosswalk_data, ledger_product, edge_product = _load_crosswalk_manifest(
+        crosswalk_manifest_path,
+        expected_sha256=args.crosswalk_manifest_sha256,
+    )
+    control, control_data, broad_product = _load_control_manifest(
+        control_manifest_path,
+        expected_sha256=args.control_manifest_sha256,
+        crosswalk=crosswalk,
+    )
+    ledger_path = _resolve_product(crosswalk_manifest_path, ledger_product)
+    edge_path = _resolve_product(crosswalk_manifest_path, edge_product)
+    broad_path = _resolve_product(control_manifest_path, broad_product)
+    award_product = crosswalk["inputs"]["sbir_awards_csv"]
+    _ensure_output_disjoint(
+        output_dir,
+        inputs=(
+            crosswalk_manifest_path,
+            control_manifest_path,
+            ledger_path,
+            edge_path,
+            broad_path,
+            awards_path,
+        ),
+    )
+    components, source_index, exact_name_index = _load_ledger(ledger_path, ledger_product)
+    if len(source_index) != crosswalk["counts"]["award_rows"]:
+        raise BuildError("Firm ledger source rows do not reconcile to the crosswalk manifest")
+    exact_edges, exact_by_cik = _load_exact_edges(
+        edge_path,
+        edge_product,
+        components=components,
+        source_index=source_index,
+    )
+    profiles, prefix_index, zip_index = _load_award_profiles(
+        awards_path,
+        award_product,
+        components=components,
+        source_index=source_index,
+    )
+    candidates, broad_metadata = _stream_candidates(
+        broad_path,
+        broad_product,
+        components=components,
+        exact_name_index=exact_name_index,
+        exact_edges=exact_edges,
+        exact_by_cik=exact_by_cik,
+        profiles=profiles,
+        prefix_index=prefix_index,
+        zip_index=zip_index,
+    )
+    rows = _finalize_candidates(candidates)
+    exact_pairs = set(exact_edges)
+    emitted_exact = {
+        (row["sbir_firm_id"], row["form_d_cik"])
+        for row in rows
+        if row["exact_source_edge"] is not None
+    }
+    if emitted_exact != exact_pairs:
+        raise BuildError("Enriched product does not preserve the exact Phase 1 pair set")
+
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(tempfile.mkdtemp(prefix=f".{output_dir.name}.staging-", dir=output_dir.parent))
+    try:
+        product_out = _write_jsonl_product(
+            staging,
+            stem="sbir_form_d_identity_candidates.v2",
+            rows=rows,
+        )
+        route_counts: Counter[str] = Counter()
+        contact_pair_counts: Counter[str] = Counter()
+        firms_to_ciks: dict[str, set[str]] = defaultdict(set)
+        ciks_to_firms: dict[str, set[str]] = defaultdict(set)
+        for row in rows:
+            route_counts.update(row["candidate_routes"])
+            for field, evidence in row["contact_evidence"].items():
+                if evidence:
+                    contact_pair_counts[field] += 1
+            firms_to_ciks[row["sbir_firm_id"]].add(row["form_d_cik"])
+            ciks_to_firms[row["form_d_cik"]].add(row["sbir_firm_id"])
+        producer_path = Path(__file__)
+        producer_sha, producer_size = _sha256_path(producer_path)
+        manifest = {
+            "candidate_only": True,
+            "complete": True,
+            "complete_sbir_exclusion": False,
+            "counts": {
+                "candidate_ciks": len(ciks_to_firms),
+                "candidate_firms": len(firms_to_ciks),
+                "candidate_pairs": len(rows),
+                "contact_supported_pairs": {
+                    field: contact_pair_counts.get(field, 0) for field in CONTACT_FIELDS
+                },
+                "exact_pairs": len(exact_pairs),
+                "firms_with_multiple_candidate_ciks": sum(
+                    len(ciks) > 1 for ciks in firms_to_ciks.values()
+                ),
+                "form_d_ciks_with_multiple_candidate_firms": sum(
+                    len(firms) > 1 for firms in ciks_to_firms.values()
+                ),
+                "fuzzy_only_pairs": len(rows) - len(exact_pairs),
+                "max_candidate_ciks_per_firm": max(map(len, firms_to_ciks.values()), default=0),
+                "max_candidate_firms_per_cik": max(map(len, ciks_to_firms.values()), default=0),
+                "routes": {route: route_counts.get(route, 0) for route in ROUTE_ORDER},
+            },
+            "covariates_ready": False,
+            "decision_contract": {
+                "decision": "candidate_unreviewed",
+                "same_legal_entity": "unknown",
+            },
+            "exclusion_eligible": False,
+            "exclusion_recall": "unknown",
+            "identity_accepted": False,
+            "identity_only": True,
+            "inputs": {
+                "broad_issuer_universe": _input_record(
+                    broad_path,
+                    sha256=broad_product["sha256"],
+                    size_bytes=broad_product["size_bytes"],
+                    row_count=broad_product["row_count"],
+                ),
+                "control_manifest": _input_record(
+                    control_manifest_path,
+                    sha256=_sha256_bytes(control_data),
+                    size_bytes=len(control_data),
+                ),
+                "crosswalk_manifest": _input_record(
+                    crosswalk_manifest_path,
+                    sha256=_sha256_bytes(crosswalk_data),
+                    size_bytes=len(crosswalk_data),
+                ),
+                "exact_candidate_edges": _input_record(
+                    edge_path,
+                    sha256=edge_product["sha256"],
+                    size_bytes=edge_product["size_bytes"],
+                    row_count=edge_product["row_count"],
+                ),
+                "firm_identity_ledger": _input_record(
+                    ledger_path,
+                    sha256=ledger_product["sha256"],
+                    size_bytes=ledger_product["size_bytes"],
+                    row_count=ledger_product["row_count"],
+                ),
+                "sbir_awards_csv": _input_record(
+                    awards_path,
+                    sha256=award_product["sha256"],
+                    size_bytes=award_product["size_bytes"],
+                    row_count=award_product["row_count"],
+                ),
+            },
+            "invariants": {
+                "all_candidates_atomic_by_sbir_firm_and_cik": True,
+                "all_candidates_unreviewed": all(
+                    row["decision"] == "candidate_unreviewed" for row in rows
+                ),
+                "all_downstream_gates_closed": all(
+                    not row[gate]
+                    for row in rows
+                    for gate in (
+                        "identity_accepted",
+                        "exclusion_eligible",
+                        "covariates_ready",
+                        "matching_eligible",
+                        "rate_eligible",
+                    )
+                ),
+                "all_routes_have_traceable_evidence": all(
+                    set(row["candidate_routes"]) == set(row["route_evidence"]) for row in rows
+                ),
+                "broad_form_d_evidence_cik_local": True,
+                "contact_evidence_never_generates_pairs": True,
+                "exact_phase1_pairs_preserved": emitted_exact == exact_pairs,
+                "no_forbidden_output_fields": not any(_contains_forbidden_key(row) for row in rows),
+                "source_records_reconcile_to_phase1_ledger": True,
+            },
+            "matching_eligible": False,
+            "outputs": {"identity_candidates": product_out},
+            "parameters": {
+                "candidate_contract": CANDIDATE_CONTRACT,
+                "contact_normalizers": {
+                    "city": "alphanumeric-key-v1",
+                    "phone10": "us-phone10-v1",
+                    "state": GEOGRAPHY_PROFILE.value,
+                    "street1": "alphanumeric-key-v1",
+                    "zip5": "strict-zip5-v1",
+                },
+                "fuzzy_minimum_alphanumeric_length": MINIMUM_FUZZY_NAME_LENGTH,
+                "name_metrics": [
+                    CompanyNameMetric.RATIO.value,
+                    CompanyNameMetric.TOKEN_SORT.value,
+                    CompanyNameMetric.TOKEN_SET.value,
+                ],
+                "name_normalizer": NORMALIZER.value,
+                "prefix_length": PREFIX_LENGTH,
+                "retrieval_is_exhaustive_within_declared_rules": True,
+                "similarity_backend": {
+                    "name": SIMILARITY_BACKEND,
+                    "version": SIMILARITY_BACKEND_VERSION,
+                },
+                "routes": {
+                    "state_supported": {
+                        "same_prefix": True,
+                        "strict_state_intersection": True,
+                        "threshold": STATE_SUPPORTED_THRESHOLD,
+                    },
+                    "strong_name": {
+                        "same_prefix": True,
+                        "threshold": STRONG_NAME_THRESHOLD,
+                    },
+                    "zip_supported": {
+                        "strict_zip5_intersection": True,
+                        "threshold": ZIP_SUPPORTED_THRESHOLD,
+                    },
+                },
+            },
+            "producer": {
+                "code_commit": code_version,
+                "path": str(producer_path.relative_to(REPO_ROOT)),
+                "sha256": producer_sha,
+                "size_bytes": producer_size,
+            },
+            "rate_eligible": False,
+            "ready_for_matching": False,
+            "schema_version": MANIFEST_SCHEMA_VERSION,
+            "source_validation": {
+                "form_d_filing_rows": broad_metadata["filing_rows_validated"],
+                "form_d_issuer_rows": broad_metadata["row_count"],
+                "sbir_award_rows": len(source_index),
+            },
+        }
+        _write_manifest(staging, manifest)
+        _publish_release(staging, output_dir)
+        return manifest
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--crosswalk-manifest", type=Path, default=DEFAULT_CROSSWALK_MANIFEST)
+    parser.add_argument("--crosswalk-manifest-sha256", required=True)
+    parser.add_argument("--control-manifest", type=Path, default=DEFAULT_CONTROL_MANIFEST)
+    parser.add_argument("--control-manifest-sha256", required=True)
+    parser.add_argument("--awards-csv", type=Path, default=DEFAULT_AWARDS_CSV)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    parser.add_argument("--code-version", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        manifest = build(parse_args(argv))
+    except BuildError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps({"counts": manifest["counts"], "outputs": manifest["outputs"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/build_sbir_form_d_identity_candidates.py
+++ b/scripts/data/build_sbir_form_d_identity_candidates.py
@@ -19,11 +19,9 @@ import tempfile
 import unicodedata
 from collections import Counter, defaultdict
 from collections.abc import Iterable, Mapping, Sequence
+from importlib.metadata import PackageNotFoundError, version as distribution_version
 from pathlib import Path
 from typing import Any
-
-import rapidfuzz
-from rapidfuzz import fuzz as rapidfuzz_fuzz
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -34,6 +32,7 @@ from sbir_etl.identity import (
     CompanyNameMetric,
     CompanyNameProfile,
     USJurisdictionProfile,
+    company_name_similarity,
     normalize_company_name,
     normalize_us_jurisdiction,
 )
@@ -68,6 +67,7 @@ STATE_SUPPORTED_THRESHOLD = 0.85
 ZIP_SUPPORTED_THRESHOLD = 0.80
 SIMILARITY_BACKEND = "rapidfuzz"
 SIMILARITY_BACKEND_VERSION = "3.14.3"
+SIMILARITY_BACKEND_SENTINEL = 0.8571428571428572
 ROUTE_ORDER = ("exact_normalized_name", "strong_name", "state_supported", "zip_supported")
 CONTACT_FIELDS = ("street1", "city", "state", "zip5", "phone10")
 EXPECTED_IDENTITY_FIELDS = (
@@ -333,21 +333,24 @@ def _fuzzy_eligible(value: str) -> bool:
 
 
 def _validate_similarity_backend() -> None:
-    actual = rapidfuzz.__version__
+    try:
+        actual = distribution_version(SIMILARITY_BACKEND)
+    except PackageNotFoundError as exc:
+        raise BuildError(
+            f"Candidate similarity requires {SIMILARITY_BACKEND}=={SIMILARITY_BACKEND_VERSION}"
+        ) from exc
     if actual != SIMILARITY_BACKEND_VERSION:
         raise BuildError(
             "Candidate similarity requires "
             f"{SIMILARITY_BACKEND}=={SIMILARITY_BACKEND_VERSION}; found {actual}"
         )
+    sentinel = company_name_similarity("ABCCCCC", "ABCBCCC", metric=CompanyNameMetric.RATIO)
+    if abs(sentinel - SIMILARITY_BACKEND_SENTINEL) > 1e-12:
+        raise BuildError("Shared company-name similarity is not using the pinned backend")
 
 
 def _similarity(left: str, right: str, *, metric: CompanyNameMetric) -> float:
-    scorers = {
-        CompanyNameMetric.RATIO: rapidfuzz_fuzz.ratio,
-        CompanyNameMetric.TOKEN_SET: rapidfuzz_fuzz.token_set_ratio,
-        CompanyNameMetric.TOKEN_SORT: rapidfuzz_fuzz.token_sort_ratio,
-    }
-    return float(scorers[metric](left, right)) / 100.0
+    return company_name_similarity(left, right, metric=metric)
 
 
 def _normalize_zip5(value: object) -> str | None:

--- a/specs/sbir-form-d-candidate-enrichment/design.md
+++ b/specs/sbir-form-d-candidate-enrichment/design.md
@@ -1,0 +1,85 @@
+# SBIR ↔ Form D Candidate Enrichment — Design
+
+## Data flow
+
+```text
+pinned Phase 1 runtime manifest ── ledger + exact atomic edges
+               │
+               ├── pinned SBIR award CSV ── source-record contact evidence
+               │
+pinned control runtime manifest ── broad Form D CIK/filing evidence
+               │
+               └── frozen exact/fuzzy name routes
+                              ↓
+             one enriched candidate per (sbir_firm_id, CIK)
+                              ↓
+            content-addressed JSONL + deterministic manifest
+```
+
+The module declares `EPISTEMIC_TIER = "pipelines"`. It generates and enriches a review universe;
+it does not score confidence or accept identity.
+
+## Inputs and validation
+
+The CLI accepts a Phase 1 crosswalk manifest plus required SHA-256, the upstream control manifest
+plus required SHA-256, the SBIR award CSV, an output directory, and a required full commit SHA.
+Product filenames resolve only beside their manifest and must be safe single filenames. The
+crosswalk's embedded upstream-manifest and award pins must equal the independently supplied pins.
+
+The ledger supplies stable firm IDs, component status, normalized names, and the exact mapping
+from CSV data-record ordinal to firm. The awards CSV is reparsed only to attach location and phone
+evidence to those already frozen components; it cannot change component membership. The exact-edge
+JSONL supplies the immutable exact pair set. The broad Form D JSONL is streamed once and validates
+unique ordered CIKs, CIK-local filings, globally unique accessions, traceable aliases, and the
+filing identity-field contract.
+
+## Blocking and routes
+
+For fuzzy-eligible SBIR names, two deterministic indexes avoid a Cartesian comparison:
+
+- two-character alphanumeric name prefix; and
+- strict ZIP5 observed on an award row carrying that normalized name.
+
+Each Form D alias draws possible SBIR names from its prefix block and each issuer ZIP draws names
+from its ZIP block. Unequal name pairs then apply exactly the three rules in the requirements.
+Route counts may overlap. There is no top-k truncation; retrieval is exhaustive within the frozen
+blocks and thresholds. Similarity calls go directly to the required RapidFuzz `3.14.3` backend;
+the producer rejects a different or missing backend instead of changing algorithms silently.
+
+Exact pairs are seeded from Phase 1 and are never inferred again. During the broad-issuer scan,
+exact equality is reconstructed solely to prove that the seeded set is complete and unchanged.
+Short exact names therefore survive even though short fuzzy names are ineligible.
+
+## Evidence model
+
+The candidate key and `edge_id` remain the Phase 1 pair-derived contract. Exact candidates embed
+their original Phase 1 edge unchanged. Fuzzy candidates record the best qualifying name comparison
+under a deterministic ratio/name/alias ordering while the route list is the union of every
+qualifying comparison for that pair. A separate route-evidence map records the best comparison for
+each emitted route; state and ZIP witnesses include their shared values and supporting lineage.
+The exact route points to its selected nested Phase 1 witness. Name evidence includes the
+supporting raw aliases, accessions, raw SBIR names, and source-record ordinals.
+
+After a pair exists through exact or fuzzy name evidence, the producer intersects normalized
+street line 1, city, strict state, strict ZIP5, and ten-digit U.S. phone histories. Each intersection
+records the value and supporting source records/accessions. These contact maps are computed inside
+one firm and one CIK; street, city, and phone indexes are never used for retrieval.
+
+## Outputs and failure behavior
+
+The release contains one content-addressed `sbir_form_d_identity_candidates.v2.<sha256>.jsonl` and
+`sbir_form_d_identity_candidates.manifest.json`. Rows and keys use canonical JSON ordering. The
+manifest records input products, frozen thresholds and normalizer contracts, pair/route/contact
+counts, ambiguity counts, producer bytes, and explicit false decision gates.
+
+The producer stages a complete sibling directory. First publication uses one atomic rename;
+replacement uses the native macOS or Linux atomic directory-exchange primitive and fails closed
+when that primitive is unavailable. Pin drift, unsafe paths, exact-pair mutation, source-record
+disagreement, untraceable or cross-CIK filing evidence, forbidden fields, duplicate pairs, or
+failed invariants abort publication. A failed exchange leaves the prior release byte for byte.
+
+## Consequences
+
+The result is deliberately broader than Phase 1 but remains only a finite review queue. Geography
+and contact agreement may help later reviewers; it has no calibrated meaning until the blinded
+adjudication phase evaluates predeclared rules on human labels.

--- a/specs/sbir-form-d-candidate-enrichment/design.md
+++ b/specs/sbir-form-d-candidate-enrichment/design.md
@@ -43,8 +43,9 @@ For fuzzy-eligible SBIR names, two deterministic indexes avoid a Cartesian compa
 Each Form D alias draws possible SBIR names from its prefix block and each issuer ZIP draws names
 from its ZIP block. Unequal name pairs then apply exactly the three rules in the requirements.
 Route counts may overlap. There is no top-k truncation; retrieval is exhaustive within the frozen
-blocks and thresholds. Similarity calls go directly to the required RapidFuzz `3.14.3` backend;
-the producer rejects a different or missing backend instead of changing algorithms silently.
+blocks and thresholds. Similarity calls use the shared `sbir_etl.identity` contract. The producer
+requires the RapidFuzz `3.14.3` distribution and checks a backend-specific sentinel before work, so
+a missing dependency, version drift, or fallback implementation fails closed.
 
 Exact pairs are seeded from Phase 1 and are never inferred again. During the broad-issuer scan,
 exact equality is reconstructed solely to prove that the seeded set is complete and unchanged.

--- a/specs/sbir-form-d-candidate-enrichment/requirements.md
+++ b/specs/sbir-form-d-candidate-enrichment/requirements.md
@@ -1,0 +1,104 @@
+# SBIR ↔ Form D Candidate Enrichment — Requirements
+
+- Research questions: F1, F2, F3
+**Target epistemic tier:** `pipelines`
+- Status: active
+- Out of scope: legal-entity decisions; confidence tiers; people, affiliates, acquisitions, and
+  successors; offering amounts; control exclusion; matching; outcomes; rates
+
+## Purpose
+
+The atomic crosswalk preserves exact-name awardee–CIK candidates but does not expose a bounded
+near-name review universe or comparable contact evidence. This phase preserves every exact pair,
+adds only three frozen fuzzy-name routes, and appends traceable address and phone corroborators. It
+produces candidates for a separate blinded validation phase and does not accept identity.
+
+## Requirements
+
+### 1. Pinned prerequisites
+
+1.1. The producer SHALL require external SHA-256 pins for both the Phase 1 crosswalk runtime
+manifest and its upstream Form D control-universe runtime manifest. It SHALL validate the pinned
+ledger, exact-edge, broad-issuer, and SBIR award products by safe path, hash, bytes, rows, schema,
+and closed downstream gates before publication.
+
+1.2. The Phase 1 exact-edge set SHALL be immutable input evidence. Every exact
+`(sbir_firm_id, form_d_cik)` pair, stable edge ID, and source provenance SHALL occur in the enriched
+product; no new exact pair may appear and no exact pair may disappear.
+
+### 2. Frozen candidate routes
+
+2.1. Fuzzy routes SHALL compare unequal names under
+`CompanyNameProfile.ORGANIZATION_KEY_V1`, require at least six alphanumeric characters on each
+side, and use RapidFuzz `3.14.3` ratio similarity with inclusive thresholds. The producer SHALL
+fail closed if that exact backend version is unavailable; it SHALL NOT fall back to a different
+similarity implementation.
+
+2.2. The only fuzzy routes SHALL be:
+
+- `strong_name`: equal two-alphanumeric-character prefix and ratio at least `0.95`;
+- `state_supported`: equal prefix, at least one equal state under
+  `USJurisdictionProfile.STRICT_V1`, and ratio at least `0.85`; and
+- `zip_supported`: at least one equal strict ZIP5 and ratio at least `0.80`, without a prefix
+  requirement.
+
+There SHALL be no fallback, top-k limit, phonetic route, person route, best-first shortcut, or
+threshold tuning after materialization.
+
+2.3. Missing or malformed prefix, state, or ZIP evidence SHALL fail that route closed. State and
+ZIP are retrieval predicates only; neither is an identity decision or confidence label.
+
+### 3. Atomic evidence
+
+3.1. Output SHALL contain exactly one row per `(sbir_firm_id, form_d_cik)`. Evidence from one CIK
+SHALL never be pooled onto another CIK. Shared names across firms and shared names across CIKs
+SHALL retain every implied atomic pair.
+
+3.2. Each candidate SHALL retain the stable Phase 1 edge ID contract, SBIR component and
+quarantine status, qualifying route set, deterministic best evidence for every qualifying route,
+overall best name evidence with ratio, token-sort, and token-set scores, SBIR source-record
+lineage, and Form D alias/accession lineage. State- and ZIP-supported route witnesses SHALL name
+the shared value and its supporting source records and accessions.
+
+3.3. Exact normalized street line 1, city, strict state, strict ZIP5, and normalized ten-digit U.S.
+phone intersections MAY enrich an already name-routed pair. Street, city, and phone SHALL never
+originate a candidate. Every contact value SHALL identify the supporting SBIR source records and
+Form D accessions.
+
+3.4. The product SHALL contain no people, email, website, award value, Form D offering or sale
+amount, confidence label, or preferred CIK.
+
+### 4. Decision and publication contract
+
+4.1. Every row SHALL remain `candidate_unreviewed`, set `same_legal_entity` to unknown, and keep
+identity acceptance, exclusion, covariate, matching, and rate eligibility false. Exclusion recall
+SHALL remain unknown.
+
+4.2. The JSONL SHALL be canonically ordered and content-addressed. A deterministic manifest SHALL
+pin inputs, rules, normalizers, producer bytes and commit, outputs, counts, and invariants without
+timestamps.
+
+4.3. The complete release SHALL publish by an atomic sibling-directory exchange when replacing an
+existing release; first publication SHALL use one atomic rename. The producer SHALL fail closed
+when the platform cannot provide the exchange primitive, leave the prior release intact when the
+exchange fails, reject output directories containing any pinned input, and require a full
+lowercase 40-character `--code-version`.
+
+4.4. Identical inputs and producer bytes SHALL yield byte-identical release directories.
+
+## Acceptance criteria
+
+- Inclusive `.95`, `.85`, and `.80` boundaries produce the declared routes only.
+- Short names can survive as preserved exact pairs but cannot create fuzzy pairs.
+- Contact-only agreement produces no candidate.
+- One shared name across multiple SBIR firms or CIKs preserves every atomic pair.
+- Every Phase 1 exact pair and its nested provenance is preserved exactly.
+- Every emitted route has a deterministic traceable witness, and backend drift fails closed.
+- Input drift, malformed lineage, cross-CIK evidence, and publication failure fail closed.
+- A second full-corpus build is byte-identical and every downstream gate remains closed.
+
+## Non-claims
+
+This product does not identify a legal entity, measure precision or recall, define a control,
+attach private-capital amounts, or support an outcome or rate. Those claims require the separately
+reviewed adjudication and sensitivity phases.

--- a/specs/sbir-form-d-candidate-enrichment/requirements.md
+++ b/specs/sbir-form-d-candidate-enrichment/requirements.md
@@ -2,7 +2,7 @@
 
 - Research questions: F1, F2, F3
 **Target epistemic tier:** `pipelines`
-- Status: active
+- Status: maintenance
 - Out of scope: legal-entity decisions; confidence tiers; people, affiliates, acquisitions, and
   successors; offering amounts; control exclusion; matching; outcomes; rates
 

--- a/specs/sbir-form-d-candidate-enrichment/tasks.md
+++ b/specs/sbir-form-d-candidate-enrichment/tasks.md
@@ -14,6 +14,6 @@
 - [x] 4. Run focused tests, Ruff, mypy, repository guards, and scope review.
   - Verify: all checks pass without opening identity or analytical gates.
 
-- [ ] 5. Materialize the pinned full corpus twice and publish the tracked manifest and audit.
+- [x] 5. Materialize the pinned full corpus twice and publish the tracked manifest and audit.
   - Verify: both releases are byte-identical and the report reconciles exact, fuzzy, route,
     contact, collision, and quarantine counts.

--- a/specs/sbir-form-d-candidate-enrichment/tasks.md
+++ b/specs/sbir-form-d-candidate-enrichment/tasks.md
@@ -1,0 +1,19 @@
+# SBIR ↔ Form D Candidate Enrichment — Tasks
+
+- [x] 1. Freeze the three fuzzy routes, contact-only prohibition, atomic grain, and non-claims.
+  - Verify: requirements contain the exact inclusive thresholds and every downstream gate.
+
+- [x] 2. Implement the pinned candidate-enrichment producer.
+  - Verify: exact Phase 1 pairs are preserved, fuzzy routes are exhaustive within their declared
+    blocks, and contact evidence cannot originate a pair.
+
+- [x] 3. Add focused deterministic and failure-path tests.
+  - Verify: thresholds, collisions, lineage, pin drift, forbidden fields, repeatability, and
+    rollback are covered.
+
+- [x] 4. Run focused tests, Ruff, mypy, repository guards, and scope review.
+  - Verify: all checks pass without opening identity or analytical gates.
+
+- [ ] 5. Materialize the pinned full corpus twice and publish the tracked manifest and audit.
+  - Verify: both releases are byte-identical and the report reconciles exact, fuzzy, route,
+    contact, collision, and quarantine counts.

--- a/specs/sbir-form-d-identity-crosswalk/tasks.md
+++ b/specs/sbir-form-d-identity-crosswalk/tasks.md
@@ -29,3 +29,10 @@
     component, collision, quarantine, and candidate-edge counts while every downstream gate stays
     closed.
   - Requirements: 1.1–4.4
+
+## Active follow-on
+
+The bounded fuzzy-name and contact-evidence review universe is specified in
+[`../sbir-form-d-candidate-enrichment/`](../sbir-form-d-candidate-enrichment/). It preserves these
+exact edges and remains candidate-only; identity acceptance belongs to the later adjudication
+phase.

--- a/specs/status.md
+++ b/specs/status.md
@@ -136,10 +136,11 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`procurement-transition-p1-remediation` — Active.** Award identity and path
   attribution landed. Cold-start bounds, source-normalization provenance, and
   ranking/auditability phases remain.
-- **`sbir-form-d-candidate-enrichment` — Active.** Bounded follow-on to the
-  atomic crosswalk. It preserves every exact awardee-CIK edge, adds only three
-  frozen fuzzy-name routes, and appends CIK-local contact corroboration for a
-  later blinded adjudication. Identity and every analytical gate remain closed.
+- **`sbir-form-d-candidate-enrichment` — Maintenance.** The bounded follow-on
+  is implemented and audited. It preserves every exact awardee-CIK edge, adds
+  only three frozen fuzzy-name routes, and appends CIK-local contact
+  corroboration for a later blinded adjudication. Identity and every analytical
+  gate remain closed.
 - **`sbir-form-d-identity-crosswalk` — Active.** Narrow M4 validation and repair
   for the private-capital identity seam. Its first phase freezes the expanded
   Form D identity evidence, builds a deterministic SBIR firm ledger, and emits

--- a/specs/status.md
+++ b/specs/status.md
@@ -136,6 +136,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`procurement-transition-p1-remediation` — Active.** Award identity and path
   attribution landed. Cold-start bounds, source-normalization provenance, and
   ranking/auditability phases remain.
+- **`sbir-form-d-candidate-enrichment` — Active.** Bounded follow-on to the
+  atomic crosswalk. It preserves every exact awardee-CIK edge, adds only three
+  frozen fuzzy-name routes, and appends CIK-local contact corroboration for a
+  later blinded adjudication. Identity and every analytical gate remain closed.
 - **`sbir-form-d-identity-crosswalk` — Active.** Narrow M4 validation and repair
   for the private-capital identity seam. Its first phase freezes the expanded
   Form D identity evidence, builds a deterministic SBIR firm ledger, and emits

--- a/tests/unit/scripts/test_build_sbir_form_d_identity_candidates.py
+++ b/tests/unit/scripts/test_build_sbir_form_d_identity_candidates.py
@@ -1,0 +1,930 @@
+"""Tests for the bounded SBIR ↔ Form D identity-candidate enrichment release."""
+
+import csv
+import hashlib
+import importlib.util
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).parents[3]
+CANDIDATE_SCRIPT = REPO_ROOT / "scripts/data/build_sbir_form_d_identity_candidates.py"
+CROSSWALK_SCRIPT = REPO_ROOT / "scripts/data/build_sbir_form_d_identity_crosswalk.py"
+CODE_VERSION = "a" * 40
+IDENTITY_FIELDS = [
+    "issuer_name",
+    "street1",
+    "street2",
+    "city",
+    "state",
+    "zip_code",
+    "issuer_phone",
+    "jurisdiction_of_incorporation",
+    "year_of_incorporation",
+]
+AWARD_FIELDS = [
+    "Company",
+    "UEI",
+    "Duns",
+    "Address1",
+    "City",
+    "State",
+    "Zip",
+    "Contact Phone",
+    "PI Phone",
+    "Award Amount",
+]
+
+
+def _load_script(name: str, path: Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    loaded = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+@pytest.fixture
+def module() -> Any:
+    return _load_script("build_sbir_form_d_identity_candidates", CANDIDATE_SCRIPT)
+
+
+@pytest.fixture
+def crosswalk_module() -> Any:
+    return _load_script("build_sbir_form_d_identity_crosswalk_for_candidates", CROSSWALK_SCRIPT)
+
+
+def _jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.write_bytes(
+        b"".join(
+            (json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n").encode() for row in rows
+        )
+    )
+
+
+def _product(path: Path, row_count: int) -> dict[str, Any]:
+    data = path.read_bytes()
+    return {
+        "path": path.name,
+        "row_count": row_count,
+        "sha256": hashlib.sha256(data).hexdigest(),
+        "size_bytes": len(data),
+    }
+
+
+def _award(
+    company: str,
+    *,
+    uei: str = "",
+    duns: str = "",
+    street1: str = "",
+    city: str = "",
+    state: str = "",
+    zip_code: str = "",
+    contact_phone: str = "",
+    pi_phone: str = "",
+    award_amount: str = "",
+) -> dict[str, str]:
+    return {
+        "Address1": street1,
+        "Award Amount": award_amount,
+        "City": city,
+        "Company": company,
+        "Contact Phone": contact_phone,
+        "Duns": duns,
+        "PI Phone": pi_phone,
+        "State": state,
+        "UEI": uei,
+        "Zip": zip_code,
+    }
+
+
+def _filing(
+    cik: str,
+    name: str,
+    *,
+    aliases: list[str] | None = None,
+    accession: str | None = None,
+    street1: str = "",
+    city: str = "",
+    state: str = "",
+    zip_code: str = "",
+    issuer_phone: str = "",
+    **extra: Any,
+) -> dict[str, Any]:
+    filing = {
+        "accession_number": accession or f"{int(cik):010d}-20-{int(cik):06d}",
+        "cik": cik,
+        "city": city,
+        "issuer_name": name,
+        "issuer_name_aliases": aliases if aliases is not None else [name],
+        "issuer_phone": issuer_phone,
+        "jurisdiction_of_incorporation": "DE",
+        "state": state,
+        "street1": street1,
+        "street2": "",
+        "year_of_incorporation": 2010,
+        "zip_code": zip_code,
+    }
+    filing.update(extra)
+    return filing
+
+
+def _issuer(
+    cik: str,
+    name: str,
+    *,
+    aliases: list[str] | None = None,
+    filings: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    filing_rows = filings or [_filing(cik, name, aliases=aliases)]
+    aggregate_aliases = sorted(
+        {alias for filing in filing_rows for alias in filing["issuer_name_aliases"]}
+    )
+    return {
+        "cik": cik,
+        "filing_count": len(filing_rows),
+        "filings": filing_rows,
+        "firm_key": f"form_d_cik:{cik}",
+        "issuer_name": name,
+        "issuer_name_aliases": aggregate_aliases,
+        "schema_version": 1,
+    }
+
+
+def _fixture(
+    tmp_path: Path,
+    crosswalk_module: Any,
+    *,
+    awards: list[dict[str, str]],
+    issuers: list[dict[str, Any]],
+    stem: str = "source",
+) -> dict[str, Any]:
+    root = tmp_path / stem
+    root.mkdir()
+    awards_path = root / "award_data.csv"
+    broad_path = root / "form_d_issuer_universe.identity-staging.jsonl"
+    control_manifest_path = root / "form_d_control_universe.manifest.json"
+    with awards_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=AWARD_FIELDS)
+        writer.writeheader()
+        writer.writerows(awards)
+    _jsonl(broad_path, sorted(issuers, key=lambda row: row["cik"]))
+
+    award_names = {
+        normalized
+        for award in awards
+        if (normalized := crosswalk_module._normalizer(award["Company"]))
+    }
+    matched_names: set[str] = set()
+    matched_ciks: set[str] = set()
+    for issuer in issuers:
+        for filing in issuer["filings"]:
+            for alias in filing["issuer_name_aliases"]:
+                normalized = crosswalk_module._normalizer(alias)
+                if normalized in award_names:
+                    matched_names.add(normalized)
+                    matched_ciks.add(issuer["cik"])
+
+    manifest = {
+        "complete": True,
+        "complete_sbir_exclusion": False,
+        "covariates_ready": False,
+        "exclusion": {
+            "awards_csv": _product(awards_path, len(awards)),
+            "exact_match": {
+                "candidate_cik_count": len(matched_ciks),
+                "matched_normalized_name_count": len(matched_names),
+                "normalizer_version": "organization-key-v1",
+            },
+        },
+        "exclusion_recall": "unknown",
+        "identity_evidence_contract": {
+            "fields": IDENTITY_FIELDS,
+            "grain": "form_d_filing_accession",
+            "historical_aliases_retained": True,
+            "source_table": "ISSUERS.tsv",
+        },
+        "identity_only": True,
+        "invariants": {"broad_ciks_unique": True},
+        "outputs": {"broad_issuer_universe": _product(broad_path, len(issuers))},
+        "parameters": {
+            "end_quarter": "2024Q4",
+            "quarter_count": 64,
+            "quarters": [
+                f"{year}Q{quarter}" for year in range(2009, 2025) for quarter in range(1, 5)
+            ],
+            "start_quarter": "2009Q1",
+        },
+        "ready_for_matching": False,
+        "schema_version": 1,
+        "source_counts": {"issuer_ciks": len(issuers)},
+    }
+    control_data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    control_manifest_path.write_bytes(control_data)
+    control_sha = hashlib.sha256(control_data).hexdigest()
+
+    crosswalk_output = root / "crosswalk"
+    crosswalk_module.build(
+        crosswalk_module.parse_args(
+            [
+                "--control-manifest",
+                str(control_manifest_path),
+                "--control-manifest-sha256",
+                control_sha,
+                "--awards-csv",
+                str(awards_path),
+                "--output-dir",
+                str(crosswalk_output),
+                "--code-version",
+                CODE_VERSION,
+            ]
+        )
+    )
+    crosswalk_manifest_path = crosswalk_output / "sbir_form_d_identity_crosswalk.manifest.json"
+    crosswalk_data = crosswalk_manifest_path.read_bytes()
+    return {
+        "awards": awards_path,
+        "broad": broad_path,
+        "candidate_output": root / "candidates",
+        "control_manifest": control_manifest_path,
+        "control_sha": control_sha,
+        "crosswalk_manifest": crosswalk_manifest_path,
+        "crosswalk_output": crosswalk_output,
+        "crosswalk_sha": hashlib.sha256(crosswalk_data).hexdigest(),
+        "root": root,
+    }
+
+
+def _args(paths: dict[str, Any], *, output: Path | None = None) -> list[str]:
+    return [
+        "--crosswalk-manifest",
+        str(paths["crosswalk_manifest"]),
+        "--crosswalk-manifest-sha256",
+        paths["crosswalk_sha"],
+        "--control-manifest",
+        str(paths["control_manifest"]),
+        "--control-manifest-sha256",
+        paths["control_sha"],
+        "--awards-csv",
+        str(paths["awards"]),
+        "--output-dir",
+        str(output or paths["candidate_output"]),
+        "--code-version",
+        CODE_VERSION,
+    ]
+
+
+def _build(module: Any, paths: dict[str, Any], *, output: Path | None = None) -> dict[str, Any]:
+    return module.build(module.parse_args(_args(paths, output=output)))
+
+
+def _rows(output: Path, product: dict[str, Any]) -> list[dict[str, Any]]:
+    data = (output / product["path"]).read_bytes()
+    assert hashlib.sha256(data).hexdigest() == product["sha256"]
+    assert len(data) == product["size_bytes"]
+    rows = [json.loads(line) for line in data.splitlines()]
+    assert len(rows) == product["row_count"]
+    return rows
+
+
+def _candidate_rows(module: Any, paths: dict[str, Any]) -> list[dict[str, Any]]:
+    manifest = _build(module, paths)
+    return _rows(paths["candidate_output"], manifest["outputs"]["identity_candidates"])
+
+
+def _crosswalk_manifest(paths: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(paths["crosswalk_manifest"].read_text())
+
+
+def _crosswalk_edges(paths: dict[str, Any]) -> list[dict[str, Any]]:
+    manifest = _crosswalk_manifest(paths)
+    return _rows(paths["crosswalk_output"], manifest["outputs"]["candidate_edges"])
+
+
+def _repin_crosswalk_product(paths: dict[str, Any], name: str, rows: list[dict[str, Any]]) -> None:
+    manifest = _crosswalk_manifest(paths)
+    path = paths["crosswalk_output"] / manifest["outputs"][name]["path"]
+    _jsonl(path, rows)
+    manifest["outputs"][name] = _product(path, len(rows))
+    data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    paths["crosswalk_manifest"].write_bytes(data)
+    paths["crosswalk_sha"] = hashlib.sha256(data).hexdigest()
+
+
+def _directory_bytes(path: Path) -> dict[str, bytes]:
+    return {
+        str(item.relative_to(path)): item.read_bytes()
+        for item in sorted(path.rglob("*"))
+        if item.is_file()
+    }
+
+
+def _all_keys(value: object) -> set[str]:
+    if isinstance(value, dict):
+        return {str(key) for key in value} | {
+            nested_key for child in value.values() for nested_key in _all_keys(child)
+        }
+    if isinstance(value, list):
+        return {nested_key for child in value for nested_key in _all_keys(child)}
+    return set()
+
+
+def test_inclusive_fuzzy_boundaries_and_route_overlap(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    strong_left = "AB" + "C" * 18
+    strong_right = "AB" + "C" * 17 + "D"
+    state_left = "CD" + "E" * 18
+    state_right = "CD" + "E" * 15 + "FFF"
+    zip_left = "GH" + "I" * 8
+    zip_right = "JK" + "I" * 8
+    overlap_left = "LM" + "N" * 18
+    overlap_right = "LM" + "N" * 17 + "O"
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[
+            _award(strong_left),
+            _award(state_left, state="CA"),
+            _award(zip_left, zip_code="12345"),
+            _award(overlap_left, state="NY", zip_code="10001"),
+        ],
+        issuers=[
+            _issuer("10", strong_right),
+            _issuer("20", state_right, filings=[_filing("20", state_right, state="California")]),
+            _issuer("30", zip_right, filings=[_filing("30", zip_right, zip_code="12345")]),
+            _issuer(
+                "40",
+                overlap_right,
+                filings=[_filing("40", overlap_right, state="NY", zip_code="10001")],
+            ),
+        ],
+    )
+
+    rows = _candidate_rows(module, paths)
+    by_name = {row["best_name_evidence"]["sbir_normalized_name"]: row for row in rows}
+
+    assert by_name[strong_left]["best_name_evidence"]["ratio_similarity"] == 0.95
+    assert by_name[strong_left]["candidate_routes"] == ["strong_name"]
+    assert set(by_name[strong_left]["route_evidence"]) == {"strong_name"}
+    assert by_name[strong_left]["route_evidence"]["strong_name"]["route_support"] == {
+        "prefix": "AB"
+    }
+    assert by_name[state_left]["best_name_evidence"]["ratio_similarity"] == 0.85
+    assert by_name[state_left]["candidate_routes"] == ["state_supported"]
+    assert by_name[state_left]["route_evidence"]["state_supported"]["route_support"]["state"]
+    assert by_name[zip_left]["best_name_evidence"]["ratio_similarity"] == 0.8
+    assert by_name[zip_left]["candidate_routes"] == ["zip_supported"]
+    assert by_name[zip_left]["route_evidence"]["zip_supported"]["route_support"]["zip5"]
+    assert by_name[overlap_left]["candidate_routes"] == [
+        "strong_name",
+        "state_supported",
+        "zip_supported",
+    ]
+    assert set(by_name[overlap_left]["route_evidence"]) == {
+        "strong_name",
+        "state_supported",
+        "zip_supported",
+    }
+
+
+def test_exact_short_name_is_preserved_without_a_fuzzy_route(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("AI")],
+        issuers=[_issuer("10", "AI")],
+    )
+    exact = _crosswalk_edges(paths)
+
+    rows = _candidate_rows(module, paths)
+
+    assert len(rows) == 1
+    assert rows[0]["candidate_routes"] == ["exact_normalized_name"]
+    assert rows[0]["exact_source_edge"] == exact[0]
+    assert rows[0]["route_evidence"] == {
+        "exact_normalized_name": {
+            "evidence_path": "exact_source_edge.name_evidence[0]",
+            "normalized_name": "AI",
+            "ratio_similarity": 1.0,
+        }
+    }
+    assert rows[0]["best_name_evidence"]["sbir"] == [{"raw_name": "AI", "source_record": 1}]
+    assert rows[0]["best_name_evidence"]["form_d"] == [
+        {"accession_number": "0000000010-20-000010", "raw_alias": "AI"}
+    ]
+
+
+def test_shared_exact_name_expands_across_every_firm_and_cik(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[
+            _award("Shared Labs", uei="UEI000000001", duns="000000001"),
+            _award("Shared Labs", uei="UEI000000002", duns="000000002"),
+            _award("Shared Labs"),
+        ],
+        issuers=[_issuer("10", "Shared Labs"), _issuer("20", "Shared Labs")],
+    )
+
+    rows = _candidate_rows(module, paths)
+    firms = {row["sbir_firm_id"] for row in rows}
+
+    assert len(firms) == 3
+    assert len(rows) == 6
+    assert {(row["sbir_firm_id"], row["form_d_cik"]) for row in rows} == {
+        (firm, cik) for firm in firms for cik in {"10", "20"}
+    }
+    assert all(row["candidate_routes"] == ["exact_normalized_name"] for row in rows)
+
+
+def test_exact_pairs_and_nested_historical_provenance_are_preserved_cik_locally(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    legacy = "Legacy Alpha Labs"
+    current = "Modern Alpha Labs"
+    issuers = []
+    expected_accessions: dict[str, set[str]] = {}
+    for cik in ("10", "20"):
+        old_accession = f"00000000{cik}-20-000001"
+        new_accession = f"00000000{cik}-20-000002"
+        expected_accessions[cik] = {old_accession, new_accession}
+        issuers.append(
+            _issuer(
+                cik,
+                current,
+                filings=[
+                    _filing(cik, legacy, accession=old_accession),
+                    _filing(
+                        cik,
+                        current,
+                        aliases=[current, legacy],
+                        accession=new_accession,
+                    ),
+                ],
+            )
+        )
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[
+            _award(legacy, uei="UEI000000001"),
+            _award(current, uei="UEI000000001"),
+        ],
+        issuers=issuers,
+    )
+    exact_by_pair = {
+        (edge["sbir_firm_id"], edge["form_d_cik"]): edge for edge in _crosswalk_edges(paths)
+    }
+
+    rows = _candidate_rows(module, paths)
+    enriched_by_pair = {(row["sbir_firm_id"], row["form_d_cik"]): row for row in rows}
+
+    assert set(enriched_by_pair) == set(exact_by_pair)
+    for pair, exact_edge in exact_by_pair.items():
+        enriched = enriched_by_pair[pair]
+        assert enriched["edge_id"] == exact_edge["edge_id"]
+        assert enriched["exact_source_edge"] == exact_edge
+        assert set(enriched["form_d_source_accessions"]) == expected_accessions[pair[1]]
+        nested_accessions = {
+            witness["accession_number"]
+            for evidence in enriched["exact_source_edge"]["name_evidence"]
+            for witness in evidence["form_d"]
+        }
+        assert nested_accessions == expected_accessions[pair[1]]
+
+
+def test_contact_evidence_enriches_name_pair_but_never_originates_one(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    routed_accession = "0000000010-20-000010"
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[
+            _award(
+                "Routed Research",
+                street1="1 Main Street",
+                city="Boston",
+                state="Massachusetts",
+                zip_code="02110-1234",
+                contact_phone="1 (617) 555-0100 ext. 9",
+            )
+        ],
+        issuers=[
+            _issuer(
+                "10",
+                "Routed Research",
+                filings=[
+                    _filing(
+                        "10",
+                        "Routed Research",
+                        accession=routed_accession,
+                        street1="1 MAIN STREET",
+                        city="BOSTON",
+                        state="MA",
+                        zip_code="02110",
+                        issuer_phone="617.555.0100",
+                    )
+                ],
+            ),
+            _issuer(
+                "20",
+                "Utterly Different Ventures",
+                filings=[
+                    _filing(
+                        "20",
+                        "Utterly Different Ventures",
+                        street1="1 Main Street",
+                        city="Boston",
+                        state="MA",
+                        zip_code="02110",
+                        issuer_phone="617-555-0100",
+                    )
+                ],
+            ),
+        ],
+    )
+
+    rows = _candidate_rows(module, paths)
+
+    assert len(rows) == 1
+    assert rows[0]["form_d_cik"] == "10"
+    expected_values = {
+        "street1": "1 MAIN STREET",
+        "city": "BOSTON",
+        "state": "MA",
+        "zip5": "02110",
+        "phone10": "6175550100",
+    }
+    for field, value in expected_values.items():
+        assert rows[0]["contact_evidence"][field] == [
+            {
+                "form_d_accessions": [routed_accession],
+                "sbir_source_records": [1],
+                "value": value,
+            }
+        ]
+
+
+def test_malformed_state_zip_and_phone_fail_closed(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    strong_left = "AB" + "C" * 18
+    strong_right = "AB" + "C" * 17 + "D"
+    state_left = "CD" + "E" * 18
+    state_right = "CD" + "E" * 15 + "FFF"
+    zip_left = "GH" + "I" * 8
+    zip_right = "JK" + "I" * 8
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[
+            _award(strong_left, state="ZZ", zip_code="1234", contact_phone="555"),
+            _award(state_left, state="ZZ"),
+            _award(zip_left, zip_code="ABCDE"),
+        ],
+        issuers=[
+            _issuer(
+                "10",
+                strong_right,
+                filings=[
+                    _filing(
+                        "10",
+                        strong_right,
+                        state="ZZ",
+                        zip_code="1234",
+                        issuer_phone="555",
+                    )
+                ],
+            ),
+            _issuer("20", state_right, filings=[_filing("20", state_right, state="ZZ")]),
+            _issuer("30", zip_right, filings=[_filing("30", zip_right, zip_code="ABCDE")]),
+        ],
+    )
+
+    rows = _candidate_rows(module, paths)
+
+    assert len(rows) == 1
+    assert rows[0]["best_name_evidence"]["sbir_normalized_name"] == strong_left
+    assert rows[0]["candidate_routes"] == ["strong_name"]
+    assert rows[0]["contact_evidence"]["state"] == []
+    assert rows[0]["contact_evidence"]["zip5"] == []
+    assert rows[0]["contact_evidence"]["phone10"] == []
+
+
+def test_exact_edge_pin_drift_fails_without_replacing_prior_release(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    manifest = _crosswalk_manifest(paths)
+    edge_path = paths["crosswalk_output"] / manifest["outputs"]["candidate_edges"]["path"]
+    edge_path.write_bytes(edge_path.read_bytes() + b"\n")
+    output = paths["candidate_output"]
+    output.mkdir()
+    sentinel = output / "prior.txt"
+    sentinel.write_bytes(b"prior release\n")
+
+    with pytest.raises(module.BuildError, match="byte count"):
+        _build(module, paths)
+
+    assert _directory_bytes(output) == {"prior.txt": b"prior release\n"}
+
+
+@pytest.mark.parametrize("change", ["mutation", "loss"])
+def test_repinned_exact_edge_mutation_or_loss_fails_reconstruction(
+    change: str, module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research"), _award("Beta Research")],
+        issuers=[_issuer("10", "Alpha Research"), _issuer("20", "Beta Research")],
+        stem=change,
+    )
+    edges = _crosswalk_edges(paths)
+    if change == "loss":
+        changed_edges = edges[:-1]
+    else:
+        changed_edges = deepcopy(edges)
+        changed_edges[0]["form_d_cik"] = "20"
+        changed_edges[0]["edge_id"] = module._edge_id(
+            changed_edges[0]["sbir_firm_id"], changed_edges[0]["form_d_cik"]
+        )
+        changed_edges.sort(key=lambda row: (row["sbir_firm_id"], row["form_d_cik"]))
+    _repin_crosswalk_product(paths, "candidate_edges", changed_edges)
+
+    with pytest.raises(module.BuildError, match="Reconstructed exact pairs disagree"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_identical_inputs_produce_byte_identical_release_directories(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    fuzzy_left = "AB" + "C" * 18
+    fuzzy_right = "AB" + "C" * 17 + "D"
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("AI"), _award(fuzzy_left)],
+        issuers=[_issuer("10", "AI"), _issuer("20", fuzzy_right)],
+    )
+    first_output = tmp_path / "first-release"
+    second_output = tmp_path / "second-release"
+
+    first = _build(module, paths, output=first_output)
+    second = _build(module, paths, output=second_output)
+
+    assert first == second
+    assert _directory_bytes(first_output) == _directory_bytes(second_output)
+    product = first["outputs"]["identity_candidates"]
+    assert product["sha256"] in product["path"]
+
+
+def test_forbidden_amount_fields_are_not_copied_from_inputs(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Amountless Labs", award_amount="987654321")],
+        issuers=[
+            _issuer(
+                "10",
+                "Amountless Labs",
+                filings=[
+                    _filing(
+                        "10",
+                        "Amountless Labs",
+                        total_amount_sold="111111111",
+                        total_offering_amount="999999999",
+                    )
+                ],
+            )
+        ],
+    )
+
+    rows = _candidate_rows(module, paths)
+    keys = {key.casefold() for key in _all_keys(rows)}
+
+    assert not keys & module.FORBIDDEN_OUTPUT_KEYS
+    assert "987654321" not in json.dumps(rows, sort_keys=True)
+    assert "999999999" not in json.dumps(rows, sort_keys=True)
+
+
+def test_code_version_requires_a_full_lowercase_commit_sha(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    missing = _args(paths)
+    index = missing.index("--code-version")
+    del missing[index : index + 2]
+    with pytest.raises(SystemExit):
+        module.parse_args(missing)
+
+    for invalid in ("a" * 39, "A" * 40, "not-a-commit"):
+        args = _args(paths)
+        args[args.index("--code-version") + 1] = invalid
+        with pytest.raises(module.BuildError, match="full lowercase 40-character git commit"):
+            module.build(module.parse_args(args))
+
+
+def test_similarity_backend_version_drift_fails_closed(
+    module: Any,
+    crosswalk_module: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    monkeypatch.setattr(module.rapidfuzz, "__version__", "3.14.2")
+
+    with pytest.raises(module.BuildError, match="rapidfuzz==3.14.3"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_unsafe_parent_product_path_fails_closed(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    manifest = _crosswalk_manifest(paths)
+    manifest["outputs"]["candidate_edges"]["path"] = ".."
+    data = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode()
+    paths["crosswalk_manifest"].write_bytes(data)
+    paths["crosswalk_sha"] = hashlib.sha256(data).hexdigest()
+
+    with pytest.raises(module.BuildError, match="safe filename"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_repinned_nested_cross_cik_lineage_fails_closed(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research"), _award("Beta Research")],
+        issuers=[_issuer("10", "Alpha Research"), _issuer("20", "Beta Research")],
+    )
+    edges = deepcopy(_crosswalk_edges(paths))
+    target = next(edge for edge in edges if edge["form_d_cik"] == "10")
+    foreign = next(edge for edge in edges if edge["form_d_cik"] == "20")
+    foreign_accession = foreign["form_d_source_accessions"][0]
+    target["form_d_source_accessions"] = [foreign_accession]
+    target["name_evidence"][0]["form_d"][0]["accession_number"] = foreign_accession
+    _repin_crosswalk_product(paths, "candidate_edges", edges)
+
+    with pytest.raises(module.BuildError, match="cross-CIK accession evidence"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_repinned_nested_cross_firm_lineage_fails_closed(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[
+            _award("Alpha Research", uei="UEI000000001"),
+            _award("Beta Research", uei="UEI000000002"),
+        ],
+        issuers=[_issuer("10", "Alpha Research"), _issuer("20", "Beta Research")],
+    )
+    edges = deepcopy(_crosswalk_edges(paths))
+    target = next(edge for edge in edges if edge["form_d_cik"] == "10")
+    foreign = next(edge for edge in edges if edge["form_d_cik"] == "20")
+    target["sbir_source_records"] = list(foreign["sbir_source_records"])
+    target["name_evidence"][0]["sbir"] = deepcopy(foreign["name_evidence"][0]["sbir"])
+    _repin_crosswalk_product(paths, "candidate_edges", edges)
+
+    with pytest.raises(module.BuildError, match="invalid SBIR lineage|cross-firm SBIR lineage"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_repinned_untraceable_nested_alias_fails_closed(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    edges = deepcopy(_crosswalk_edges(paths))
+    edges[0]["name_evidence"][0]["form_d"][0]["raw_alias"] = "Alpha Research, Inc."
+    _repin_crosswalk_product(paths, "candidate_edges", edges)
+
+    with pytest.raises(module.BuildError, match="untraceable Form D alias"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+@pytest.mark.parametrize("forbidden_key", ["confidence_label", "preferred_cik", "related_persons"])
+def test_forbidden_identity_decision_fields_in_exact_provenance_fail_closed(
+    forbidden_key: str, module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+        stem=forbidden_key,
+    )
+    edges = _crosswalk_edges(paths)
+    edges[0][forbidden_key] = "forbidden"
+    _repin_crosswalk_product(paths, "candidate_edges", edges)
+
+    with pytest.raises(module.BuildError, match="forbidden field"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_publication_failure_restores_the_complete_prior_release(
+    module: Any,
+    crosswalk_module: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    output = paths["candidate_output"]
+    (output / "nested").mkdir(parents=True)
+    (output / "prior.txt").write_bytes(b"prior release\n")
+    (output / "nested/state.bin").write_bytes(b"\x00prior\xff")
+    before = _directory_bytes(output)
+
+    def fail_release_swap(_staging: Path, _target: Path) -> None:
+        raise OSError("injected release swap failure")
+
+    monkeypatch.setattr(module, "_atomic_exchange_directories", fail_release_swap)
+
+    with pytest.raises(OSError, match="injected release swap failure"):
+        _build(module, paths)
+
+    assert _directory_bytes(output) == before
+    assert not list(output.parent.glob(f".{output.name}.staging-*"))
+
+
+def test_existing_release_is_atomically_replaced(
+    module: Any, crosswalk_module: Any, tmp_path: Path
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    output = paths["candidate_output"]
+    output.mkdir()
+    (output / "prior.txt").write_bytes(b"prior release\n")
+
+    manifest = _build(module, paths)
+
+    assert "prior.txt" not in _directory_bytes(output)
+    assert (output / "sbir_form_d_identity_candidates.manifest.json").is_file()
+    assert (output / manifest["outputs"]["identity_candidates"]["path"]).is_file()
+    assert not list(output.parent.glob(f".{output.name}.staging-*"))

--- a/tests/unit/scripts/test_build_sbir_form_d_identity_candidates.py
+++ b/tests/unit/scripts/test_build_sbir_form_d_identity_candidates.py
@@ -762,9 +762,29 @@ def test_similarity_backend_version_drift_fails_closed(
         awards=[_award("Alpha Research")],
         issuers=[_issuer("10", "Alpha Research")],
     )
-    monkeypatch.setattr(module.rapidfuzz, "__version__", "3.14.2")
+    monkeypatch.setattr(module, "distribution_version", lambda _name: "3.14.2")
 
     with pytest.raises(module.BuildError, match="rapidfuzz==3.14.3"):
+        _build(module, paths)
+
+    assert not paths["candidate_output"].exists()
+
+
+def test_similarity_backend_fallback_fails_closed(
+    module: Any,
+    crosswalk_module: Any,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = _fixture(
+        tmp_path,
+        crosswalk_module,
+        awards=[_award("Alpha Research")],
+        issuers=[_issuer("10", "Alpha Research")],
+    )
+    monkeypatch.setattr(module, "company_name_similarity", lambda *_args, **_kwargs: 0.5)
+
+    with pytest.raises(module.BuildError, match="not using the pinned backend"):
         _build(module, paths)
 
     assert not paths["candidate_output"].exists()


### PR DESCRIPTION
## What changed

- add a pinned, deterministic SBIR awardee ↔ Form D issuer candidate-enrichment producer
- preserve all 4,542 Phase 1 exact firm–CIK edges and add only three frozen fuzzy-name routes
- attach traceable CIK-local street, city, state, ZIP5, and phone corroboration after name routing
- enforce RapidFuzz 3.14.3 through the shared identity primitive, retain evidence for every emitted route, and publish via atomic directory exchange
- add focused failure-path tests, the completed spec, a tracked manifest, and a full-corpus audit

## Why

The exact-name crosswalk in #594 is intentionally narrow. This follow-on creates a finite,
reproducible review universe for outcome-blind identity validation without accepting organizational
identity, selecting a preferred CIK, excluding SBIR firms from controls, or attaching private
capital amounts or outcomes.

## Full-corpus result

- 7,787 atomic candidate pairs: 4,542 preserved exact and 3,245 fuzzy-only
- 5,631 SBIR firms and 6,033 Form D CIKs
- two byte-identical materializations
- candidate JSONL SHA-256: `67779f952df4abb114488bbfcee3f3898758662f6898898ae6abd952bc71a1c7`
- runtime manifest SHA-256: `adf9dc5219861f8ca144da46ead0038577b28e9fb5d122492c403a6a4955de32`

Every identity, exclusion, covariate, matching, and rate gate remains closed. Candidate review can
estimate route precision later, but it cannot establish recall for links no route generated.

## Validation

- `32 passed` across candidate-enrichment and identity-boundary tests after the CI repair
- `48 passed` across candidate enrichment, Phase 1 crosswalk, and Form D source producer tests
- `5,876 passed, 7 skipped` full unit suite
- Ruff check and format check
- mypy on the producer
- company-identity boundary guard
- `make lint-boundaries`
- `make docs-check`
- two corrected full-history materializations compared byte-for-byte

## Stack

Base: `agent/sbir-formd-atomic-crosswalk` (#594). Review and merge this PR after its base.
