### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.3.0"
+  version: "0.4.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.3.0"
+version = "0.4.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.3.0"
+version = "0.4.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.3.0"
+version = "0.4.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.3.0"
+version = "0.4.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2834,7 +2834,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2985,7 +2985,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3004,7 +3004,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Summary

- bump `sbir-etl`, `sbir-analytics`, `sbir-graph`, and `sbir-ml` from `0.3.0` to `0.4.0`
- synchronize `sbir_etl.__version__`, `config/base.yaml` pipeline metadata, and all four workspace entries in `uv.lock`
- prepare the annotated `v0.4.0` tag and GitHub release

## Version decision

This is a pre-1.0 minor release. Since `v0.3.0`, the repository added substantial source-download, identity, research-notebook, transition-study, deployment, and CI capabilities. It also changed compatibility surfaces around Dagster schedules, environment configuration, CET materialization failures and company identity, and the published private-capital baseline set.

## Compatibility notes

- CET award, patent, training, and company assets now fail on missing or invalid prerequisites instead of publishing placeholder artifacts.
- CET company graph loads require explicit normalized UEIs and match `Organization.uei`; generic company IDs and DUNS values are not relabeled as UEIs.
- the repository-wide all-assets job, daily schedule, and server toggle were retired; operators now use explicitly named jobs and the stopped-by-default weekly core refresh.
- the documented Neo4j environment contract now distinguishes direct loader settings, Compose selection, and retained script-only compatibility variables.
- the removed organization-specific private-capital baseline is no longer emitted; the generic baseline artifact now contains four records.

## Verification

- `uv lock --check`
- `uv run python scripts/ci/check_versioning.py --tag v0.4.0`
- targeted version, configuration, and client suite: 185 passed
- `git diff --check`

After this PR merges, the merge commit will be tagged with an annotated `v0.4.0` tag and published as a GitHub release.
