### PR TITLE
Prepare v0.5.0 release

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.4.0"
+  version: "0.5.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.4.0"
+version = "0.5.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.4.0"
+version = "0.5.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.4.0"
+version = "0.5.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.4.0"
+version = "0.5.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2834,7 +2834,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2985,7 +2985,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3004,7 +3004,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Summary

- bump `sbir-etl`, `sbir-analytics`, `sbir-graph`, and `sbir-ml` from `0.4.0` to `0.5.0`
- synchronize `sbir_etl.__version__`, `config/base.yaml` pipeline metadata, and all four workspace entries in `uv.lock`
- prepare the annotated `v0.5.0` tag and GitHub release

## Version decision

This is a pre-1.0 minor release. Since `v0.4.0`, the repository added a repaired, reproducible NSF private-capital Phase 1 analysis and a fail-closed fiscal-year M&A signal-count diagnostic. It also corrected the public Neo4j load-metrics contract. These substantial research and pipeline capabilities require a minor increment under the repository version policy.

## Compatibility notes

- Neo4j load summaries now report canonical graph-label write deltas and distinguish rows submitted from nodes written on idempotent runs.
- NSF Phase I-to-II graduation now uses an inclusive five-year horizon and connected-component identity aliases. The committed result remains exploratory and non-citable.
- The new M&A reporter publishes fiscal-year signal counts only from a present, validated, fingerprinted input and fails without writing outputs when source evidence is absent.

## Verification

- `uv lock`
- `uv run python scripts/ci/check_versioning.py --tag v0.5.0`
- CI-scoped Ruff and format checks
- MyPy: 305 source files
- architecture, tier, configuration, repository, manifest, and docs guards
- unit suite: 5,927 passed, 7 skipped
- `git diff --check`

After this PR merges, the merge commit will be tagged with an annotated `v0.5.0` tag and published as a GitHub release.