### PR TITLE
Make test infrastructure signals trustworthy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,8 @@ jobs:
             --cov=packages/sbir-analytics/sbir_analytics \
             --cov=packages/sbir-ml/sbir_ml \
             --cov=packages/sbir-graph/sbir_graph \
+            --cov-branch \
+            --cov-fail-under=70 \
             --cov-report=xml \
             --cov-report=term
 

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ doctor: ## Verify the local Python development environment
 .PHONY: test
 test: ## Run all tests
 	@$(call info,Running tests)
-	$(call run,uv run pytest -v --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph)
+	$(call run,uv run pytest -v --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-branch --cov-fail-under=70)
 
 .PHONY: test-unit
 test-unit: ## Run unit tests only
@@ -385,7 +385,7 @@ docker-test: env-check ## Run containerised CI tests (profile=ci)
 	 $(call info,Running containerised tests (profile: ci)); \
 	 $(call print-cmd,$(COMPOSE) --profile ci up --abort-on-container-exit --build); \
 	 STATUS=0; \
-	 if ! $(COMPOSE) --profile ci up --abort-on-container-exit --build; then STATUS=$$?; fi; \
+	 if $(COMPOSE) --profile ci up --abort-on-container-exit --build; then STATUS=0; else STATUS=$$?; fi; \
 	 $(call print-cmd,$(COMPOSE) --profile ci down --remove-orphans --volumes); \
 	 $(COMPOSE) --profile ci down --remove-orphans --volumes || true; \
 	 if [ $$STATUS -eq 0 ]; then \
@@ -402,7 +402,7 @@ docker-e2e: env-check ## Run full end-to-end test suite (profile=ci)
 	 $(call info,Running E2E tests (profile: ci)); \
 	 $(call print-cmd,$(COMPOSE) --profile ci up --build --abort-on-container-exit neo4j app); \
 	 STATUS=0; \
-	 if ! $(COMPOSE) --profile ci up --build --abort-on-container-exit neo4j app 2>&1; then STATUS=$$?; fi; \
+	 if $(COMPOSE) --profile ci up --build --abort-on-container-exit neo4j app 2>&1; then STATUS=0; else STATUS=$$?; fi; \
 	 if [ "$(QUIET)" != "1" ]; then printf "$(BLUE)➤$(RESET) E2E tests completed with exit code %s\n" "$$STATUS"; fi; \
 	 if [ $$STATUS -ne 0 ]; then \
 	   $(call failure,E2E tests failed with exit code $$STATUS); \
@@ -422,7 +422,7 @@ docker-e2e-clean: ## Tear down the E2E environment
 	 if [ "$(QUIET)" != "1" ]; then printf "$(BLUE)➤$(RESET) Cleaning up E2E test environment\n"; fi; \
 	 printf "$(GRAY)$ %s$(RESET)\n" "$(COMPOSE) --profile ci down --remove-orphans --volumes"; \
 	 STATUS=0; \
-	 if ! $(COMPOSE) --profile ci down --remove-orphans --volumes; then STATUS=$$?; fi; \
+	 if $(COMPOSE) --profile ci down --remove-orphans --volumes; then STATUS=0; else STATUS=$$?; fi; \
 	 if [ $$STATUS -eq 0 ]; then \
 	   if [ "$(QUIET)" != "1" ]; then printf "$(GREEN)✔$(RESET) %s\n" "E2E environment cleaned up successfully"; fi; \
 	 else \
@@ -439,16 +439,6 @@ docker-e2e-minimal: env-check ## Run the minimal (fast) E2E scenario
 docker-e2e-standard: env-check ## Run the standard E2E scenario
 	@$(call info,Running standard E2E scenario)
 	@E2E_TEST_SCENARIO=standard $(MAKE) docker-e2e
-
-.PHONY: docker-e2e-large
-docker-e2e-large: env-check ## Run the large dataset E2E scenario
-	@$(call info,Running large dataset E2E scenario)
-	@E2E_TEST_SCENARIO=large $(MAKE) docker-e2e
-
-.PHONY: docker-e2e-edge-cases
-docker-e2e-edge-cases: env-check ## Run the edge-case E2E scenario
-	@$(call info,Running edge-case E2E scenario)
-	@E2E_TEST_SCENARIO=edge-cases $(MAKE) docker-e2e
 
 .PHONY: docker-e2e-debug
 docker-e2e-debug: env-check ## Open an interactive shell in the CI test container

--- a/docs/development/docker.md
+++ b/docs/development/docker.md
@@ -63,6 +63,7 @@ Prefer these targets over hand-written Compose commands:
 | `make docker-exec SERVICE=dagster-webserver CMD=sh` | Run a command in a service |
 | `make docker-test` | Run containerized tests through the `ci` profile |
 | `make docker-e2e-minimal` | Run the minimal E2E scenario |
+| `make docker-e2e-standard` | Run the hermetic E2E scenario |
 | `make docker-e2e-clean` | Remove the E2E environment and volumes |
 | `make neo4j-up` / `make neo4j-down` | Start or stop local Neo4j |
 | `make validate-config` | Validate the root compose and environment files |

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -24,8 +24,6 @@ Then run a scenario through the Compose `ci` profile:
 ```bash
 make docker-e2e-minimal
 make docker-e2e-standard
-make docker-e2e-large
-make docker-e2e-edge-cases
 ```
 
 `make docker-e2e` uses `E2E_TEST_SCENARIO` directly and leaves containers running for inspection:
@@ -36,7 +34,7 @@ make docker-logs SERVICE=app
 make docker-e2e-clean
 ```
 
-The non-minimal scenarios create HTML coverage under `/app/artifacts/htmlcov` in the test
+The non-minimal scenario creates branch-aware HTML coverage under `/app/artifacts/htmlcov` in the test
 container. Use `make docker-e2e-debug` for an interactive shell in the same image.
 
 ## Running the scenario runner directly
@@ -67,10 +65,8 @@ Supported scenarios are:
 
 | Scenario | Pytest selection |
 | --- | --- |
-| `minimal` | Excludes `slow` and `large_dataset` |
-| `standard` | Excludes `large_dataset` |
-| `large` | Runs all E2E markers |
-| `edge-cases` | Selects `edge_case` |
+| `minimal` | Excludes `slow`, `requires_api`, and `real_data` |
+| `standard` | Excludes `requires_api` and `real_data` |
 
 The descriptions and expected durations printed by the runner are planning estimates, not CI
 service-level guarantees. The `--timeout` value defaults to 600 seconds. When `pytest-timeout` is

--- a/docs/testing/test-scheduling.md
+++ b/docs/testing/test-scheduling.md
@@ -46,9 +46,10 @@ Do not use the retired `pytest-shard`, `--shard-id`, or zero-based shard numberi
 ## Pushes to `main` and manual runs
 
 Pushes to `main` and `workflow_dispatch` run the full `tests/` tree with a Neo4j service and
-coverage. The workflow excludes `requires_api` tests and documents a small number of explicit test
-deselections that represent known pre-existing failures. Read the workflow before changing those
-exceptions; delete a deselection when its underlying test is repaired.
+branch coverage. The combined first-party coverage report must remain at or above 70%. The workflow
+excludes `requires_api` tests and documents a small number of explicit test deselections that
+represent known pre-existing failures. Read the workflow before changing those exceptions; delete
+a deselection when its underlying test is repaired.
 
 Fast PR shards do not replace the full post-merge gate. This split keeps pull-request feedback short
 while still exercising integration, functional, E2E, golden, slow, and validation tests on `main`.

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -11,8 +11,6 @@ Usage:
 Scenarios:
     minimal     - Quick smoke tests (< 2 minutes)
     standard    - Full E2E validation (5-8 minutes)
-    large       - Performance testing (8-10 minutes)
-    edge-cases  - Robustness testing (3-5 minutes)
 """
 
 import argparse
@@ -34,33 +32,19 @@ def get_test_config(scenario: str) -> dict[str, Any]:
         "minimal": {
             "description": "Quick smoke tests for basic functionality",
             "timeout": 120,
-            "test_markers": "not slow and not large_dataset",
+            "test_markers": "not slow and not requires_api and not real_data",
             "expected_duration": "< 2 minutes",
             "memory_limit": "2GB",
         },
         "standard": {
-            "description": "Full E2E validation with representative data",
+            "description": "Hermetic E2E validation with representative data",
             "timeout": 480,
-            "test_markers": "not large_dataset",
+            "test_markers": "not requires_api and not real_data",
             "expected_duration": "5-8 minutes",
             "memory_limit": "4GB",
         },
-        "large": {
-            "description": "Performance testing with larger datasets",
-            "timeout": 600,
-            "test_markers": "",
-            "expected_duration": "8-10 minutes",
-            "memory_limit": "6GB",
-        },
-        "edge-cases": {
-            "description": "Robustness testing with edge cases",
-            "timeout": 300,
-            "test_markers": "edge_case",
-            "expected_duration": "3-5 minutes",
-            "memory_limit": "3GB",
-        },
     }
-    return configs.get(scenario, configs["standard"])
+    return configs[scenario]
 
 
 def check_environment() -> bool:
@@ -137,7 +121,7 @@ def run_e2e_tests(scenario: str, timeout: int) -> int:
 
     # Build pytest command
     pytest_args = [
-        "python",
+        sys.executable,
         "-m",
         "pytest",
         "tests/e2e/",
@@ -170,6 +154,7 @@ def run_e2e_tests(scenario: str, timeout: int) -> int:
                 "--cov=packages/sbir-analytics/sbir_analytics",
                 "--cov=packages/sbir-ml/sbir_ml",
                 "--cov=packages/sbir-graph/sbir_graph",
+                "--cov-branch",
                 "--cov-report=term-missing",
                 "--cov-report=html:/app/artifacts/htmlcov",
             ]
@@ -224,19 +209,16 @@ def main():
 Scenarios:
   minimal     Quick smoke tests (< 2 minutes)
   standard    Full E2E validation (5-8 minutes) [default]
-  large       Performance testing (8-10 minutes)
-  edge-cases  Robustness testing (3-5 minutes)
 
 Examples:
   python scripts/run_e2e_tests.py
   python scripts/run_e2e_tests.py --scenario minimal
-  python scripts/run_e2e_tests.py --scenario large --timeout 900
         """,
     )
 
     parser.add_argument(
         "--scenario",
-        choices=["minimal", "standard", "large", "edge-cases"],
+        choices=["minimal", "standard"],
         default=os.getenv("E2E_TEST_SCENARIO", "standard"),
         help="Test scenario to run (default: standard)",
     )

--- a/tests/unit/phase_iii_census/test_import_isolation.py
+++ b/tests/unit/phase_iii_census/test_import_isolation.py
@@ -66,6 +66,12 @@ assert assets.verify_materialization_gate()["materialization_allowed"] is True
 """
     env = os.environ.copy()
     env["PYTHONPATH"] = str(install_root)
+    # pytest-cov instruments subprocesses through these environment variables.
+    # This subprocess imports a copied installation tree, which must not be
+    # counted as a second copy of the repository in the coverage report.
+    for key in tuple(env):
+        if key.startswith("COV_CORE_"):
+            env.pop(key)
 
     result = subprocess.run(
         [sys.executable, "-c", script, str(install_root)],

--- a/tests/unit/scripts/test_run_e2e_tests.py
+++ b/tests/unit/scripts/test_run_e2e_tests.py
@@ -1,0 +1,45 @@
+"""Regression tests for the local E2E scenario runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).parents[3] / "scripts" / "run_e2e_tests.py"
+SPEC = importlib.util.spec_from_file_location("run_e2e_tests", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+def test_supported_scenarios_are_distinct_and_hermetic() -> None:
+    minimal = MODULE.get_test_config("minimal")
+    standard = MODULE.get_test_config("standard")
+
+    assert minimal["test_markers"] == "not slow and not requires_api and not real_data"
+    assert standard["test_markers"] == "not requires_api and not real_data"
+    assert minimal["test_markers"] != standard["test_markers"]
+
+
+def test_standard_scenario_uses_current_interpreter_and_branch_coverage(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return subprocess.CompletedProcess(args, 0)
+
+    monkeypatch.setattr(MODULE, "_is_pytest_timeout_available", lambda: False)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert MODULE.run_e2e_tests("standard", 60) == 0
+
+    args = captured["args"]
+    assert isinstance(args, list)
+    assert args[:3] == [sys.executable, "-m", "pytest"]
+    assert "--cov-branch" in args
+    marker_index = args.index("-m", 3)
+    assert args[marker_index + 1] == "not requires_api and not real_data"


### PR DESCRIPTION
## Summary

- stop pytest-cov from counting the Phase III shallow-install source copy as a second repository
- measure branch coverage and enforce a 70% combined first-party baseline
- preserve Docker Compose failure exit codes in the local test targets
- retire the empty `large` and `edge-cases` E2E scenarios and make supported scenarios hermetic
- add regression tests for E2E runner selection and invocation

## Root cause

The import-isolation test inherited pytest-cov subprocess variables, so its copied `sbir_etl` tree inflated the denominator and reduced reported coverage from about 73% line coverage to 46%. The Compose targets used `if ! command; then STATUS=$?`, which captured the status of `!` rather than the failing command. Two scenario names referenced markers used by no tests.

## Impact

Coverage now reports the canonical source tree, includes branches, and fails below 70%. Local Docker test failures propagate correctly. E2E scenario names now correspond to distinct, non-empty selections that exclude external API and real-data tests.

## Validation

- `6154 passed, 50 skipped` with branch coverage at 71%
- `uv run pytest -n 0 tests/unit/scripts/test_run_e2e_tests.py tests/unit/phase_iii_census/test_import_isolation.py -q`
- `uv run python scripts/run_e2e_tests.py --scenario minimal --timeout 120` (`33 passed`)
- CI-equivalent Ruff checks and formatting (`909 files`)
- MyPy (`305 source files`)
- `make docs-check`
