### PR TITLE
Make E2E tests reflect production workflows

### DIFF
--- a/docs/architecture/neo4j-epistemic-assertions-plan.md
+++ b/docs/architecture/neo4j-epistemic-assertions-plan.md
@@ -84,7 +84,7 @@ Important test gaps are:
 
 - `tests/unit/loaders/neo4j/test_transitions.py` and `test_transitions_nodes.py` use hand-built
   frames, not the active Dagster adapter.
-- `tests/e2e/transition/test_graph_queries.py` mocks result shapes rather than exercising Neo4j
+- `tests/unit/transition/test_graph_queries.py` mocks result shapes rather than exercising Neo4j
   projection semantics.
 - `tests/unit/transition/test_transition_scores_stability.py` removes dynamic timestamps before
   comparison; it does not prove stable record identity.
@@ -1252,7 +1252,7 @@ Likely files:
 - `tests/unit/loaders/neo4j/test_assertions.py`
 - `tests/unit/loaders/neo4j/test_contracts.py`
 - `tests/integration/neo4j/test_assertion_projection.py`
-- `tests/e2e/transition/test_graph_queries.py`
+- `tests/unit/transition/test_graph_queries.py`
 - `tests/unit/assets/test_dagster_definitions.py`
 - `tests/unit/api/test_repository.py`
 - `tests/unit/api/test_analytics_api.py`
@@ -1269,7 +1269,7 @@ uv run pytest tests/unit/scripts/test_architecture_boundaries.py \
   tests/unit/api/test_repository.py tests/unit/api/test_analytics_api.py \
   tests/unit/scripts/test_migrate_transition_assertion_projection.py -q
 uv run pytest -m integration tests/integration/neo4j/test_assertion_projection.py -q
-uv run pytest tests/e2e/transition/test_graph_queries.py -q
+uv run pytest tests/unit/transition/test_graph_queries.py -q
 uv run ruff check packages/sbir-graph packages/sbir-analytics/sbir_analytics/assets/transition_assertions
 make lint-boundaries
 make docs-check

--- a/docs/testing/e2e-testing.md
+++ b/docs/testing/e2e-testing.md
@@ -8,8 +8,10 @@
 
 **Status**: Active
 
-End-to-end tests live in `tests/e2e/`. They exercise pipeline behavior across component boundaries,
-including scenarios that require Neo4j. The scenario runner is `scripts/run_e2e_tests.py`.
+End-to-end tests live in `tests/e2e/`. They execute production Dagster jobs from persisted,
+deterministic fixtures and validate their emitted products and asset checks. Mock-only checks and
+direct composition of helpers belong in unit or integration suites. The scenario runner is
+`scripts/run_e2e_tests.py`.
 
 ## Preferred Docker workflow
 
@@ -34,8 +36,9 @@ make docker-logs SERVICE=app
 make docker-e2e-clean
 ```
 
-The non-minimal scenario creates branch-aware HTML coverage under `/app/artifacts/htmlcov` in the test
-container. Use `make docker-e2e-debug` for an interactive shell in the same image.
+The non-minimal scenario creates branch-aware HTML coverage under `artifacts/htmlcov` (mounted as
+`/app/artifacts/htmlcov` in the test container). Use `make docker-e2e-debug` for an interactive shell
+in the same image. Override the host path with `E2E_ARTIFACT_DIR` when needed.
 
 ## Running the scenario runner directly
 
@@ -65,7 +68,7 @@ Supported scenarios are:
 
 | Scenario | Pytest selection |
 | --- | --- |
-| `minimal` | Excludes `slow`, `requires_api`, and `real_data` |
+| `minimal` | Selects the `smoke` job and excludes `requires_api` and `real_data` |
 | `standard` | Excludes `requires_api` and `real_data` |
 
 The descriptions and expected durations printed by the runner are planning estimates, not CI
@@ -74,12 +77,15 @@ installed it is also applied per test; the runner always enforces an overall sub
 
 ## Test structure
 
-Important shared helpers are intentionally small:
+The current hermetic scenarios are:
 
-- `tests/e2e/pipeline_validator.py` validates pipeline outputs and quality conditions.
-- `tests/e2e/validation_models.py` defines validation result models.
-- `tests/fixtures/enrichment_scenarios.json` contains enrichment scenarios.
-- `tests/e2e/transition/` covers the transition pipeline and graph queries.
+- `test_enrichment_job.py`: persisted freshness records and enriched awards through the production
+  USAspending freshness-selection job and asset check, with API construction prohibited.
+- `test_nsf_defense_lineage.py`: pinned CSV, JSON, and Parquet sources through the production
+  lineage job, release validation, static graph publication, and deterministic replay.
+
+Synthetic fiscal, multi-source enrichment, and transition chains live under `tests/integration/`.
+Mocked pipeline-validator and graph-query contracts live under `tests/unit/`.
 
 List the current tests rather than relying on a static count:
 

--- a/docs/testing/test-suite-inventory.md
+++ b/docs/testing/test-suite-inventory.md
@@ -21,12 +21,13 @@ The directories have distinct purposes:
 
 | Directory | Purpose | Normal execution |
 | --- | --- | --- |
-| `tests/integration/` | Interactions among current components or a declared service | Full CI on `main`; focused local runs |
-| `tests/e2e/` | Pipeline scenarios spanning major boundaries, often with Neo4j | Full CI on `main`; Docker E2E locally |
-| `tests/validation/` | Numerical/reference checks and small operator validation programs | Full CI where collectable; explicit local runs |
+| `tests/integration/` | Interactions among current components or a declared service | Full CI; conditional PR lane; focused local runs |
+| `tests/e2e/` | Production Dagster jobs over persisted deterministic fixtures | Every PR; full CI; Docker E2E locally |
+| `tests/validation/` | Small operator validation programs | Explicit operator runs only |
 
-Pull-request CI currently runs fast unit-test shards, not these entire directories. See
-[Test Execution and Scheduling](test-scheduling.md) for the event matrix.
+Pull-request CI runs fast unit-test shards, the complete hermetic E2E directory, and conditional
+integration tests for relevant paths. See [Test Execution and Scheduling](test-scheduling.md) for
+the event matrix.
 
 ## Prerequisite classes
 
@@ -49,10 +50,12 @@ suites. Run them explicitly as scripts when their prerequisites are available.
 - `tests/integration/test_company_categorization_client_injection.py` covers categorization client
   boundaries.
 - `tests/integration/test_patent_etl_integration.py` covers the patent ETL chain with fixtures.
-- `tests/e2e/test_pipeline_validator.py` covers shared pipeline validation models and behavior.
-- `tests/e2e/transition/` covers transition assets, quality metrics, detection, and graph queries.
-- `tests/validation/test_fiscal_reference_validation.py` contains local numerical checks plus
-  reference-data cases that may skip when their external prerequisites are absent.
+- `tests/integration/fiscal/` covers fiscal calculations and reference checks.
+- `tests/integration/transition/` covers transition analytics, detection, and quality metrics.
+- `tests/e2e/test_enrichment_job.py` executes USAspending freshness selection through Dagster.
+- `tests/e2e/test_nsf_defense_lineage.py` replays pinned sources through release and graph products.
+- `tests/unit/test_pipeline_validator.py` and `tests/unit/transition/test_graph_queries.py` cover
+  test-support validation and mocked query contracts.
 
 This list is navigational, not exhaustive; collection is authoritative.
 
@@ -70,6 +73,6 @@ can execute it. A skip is not a substitute for a removed implementation or an ob
 
 ## CI relationship
 
-On pushes to `main` and manual runs, `.github/workflows/ci.yml` starts Neo4j and runs the complete
-`tests/` tree except `requires_api` cases and the named known-failure deselections recorded directly
-in the workflow. GitHub Actions does not mount production data and does not run live pipeline work.
+On pushes to `main`, weekly schedules, and manual runs, `.github/workflows/ci.yml` starts Neo4j and
+runs the complete discoverable `tests/` tree except `requires_api` cases. GitHub Actions does not
+mount production data or run live pipeline work.

--- a/scripts/run_e2e_tests.py
+++ b/scripts/run_e2e_tests.py
@@ -9,8 +9,8 @@ Usage:
     python scripts/run_e2e_tests.py [--scenario SCENARIO] [--timeout TIMEOUT]
 
 Scenarios:
-    minimal     - Quick smoke tests (< 2 minutes)
-    standard    - Full E2E validation (5-8 minutes)
+    minimal     - Quick Dagster smoke test (< 30 seconds)
+    standard    - Hermetic production-job validation (< 1 minute)
 """
 
 import argparse
@@ -32,15 +32,15 @@ def get_test_config(scenario: str) -> dict[str, Any]:
         "minimal": {
             "description": "Quick smoke tests for basic functionality",
             "timeout": 120,
-            "test_markers": "not slow and not requires_api and not real_data",
-            "expected_duration": "< 2 minutes",
+            "test_markers": "smoke and not requires_api and not real_data",
+            "expected_duration": "< 30 seconds",
             "memory_limit": "2GB",
         },
         "standard": {
             "description": "Hermetic E2E validation with representative data",
             "timeout": 480,
             "test_markers": "not requires_api and not real_data",
-            "expected_duration": "5-8 minutes",
+            "expected_duration": "< 1 minute",
             "memory_limit": "4GB",
         },
     }
@@ -148,6 +148,7 @@ def run_e2e_tests(scenario: str, timeout: int) -> int:
 
     # Add coverage if not in minimal mode
     if scenario != "minimal":
+        coverage_dir = Path(os.getenv("E2E_ARTIFACT_DIR", "artifacts")) / "htmlcov"
         pytest_args.extend(
             [
                 "--cov=sbir_etl",
@@ -156,7 +157,7 @@ def run_e2e_tests(scenario: str, timeout: int) -> int:
                 "--cov=packages/sbir-graph/sbir_graph",
                 "--cov-branch",
                 "--cov-report=term-missing",
-                "--cov-report=html:/app/artifacts/htmlcov",
+                f"--cov-report=html:{coverage_dir}",
             ]
         )
 
@@ -207,8 +208,8 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Scenarios:
-  minimal     Quick smoke tests (< 2 minutes)
-  standard    Full E2E validation (5-8 minutes) [default]
+  minimal     Quick Dagster smoke test (< 30 seconds)
+  standard    Hermetic production-job validation (< 1 minute) [default]
 
 Examples:
   python scripts/run_e2e_tests.py

--- a/specs/archive/e2e-testing-enhancement/design.md
+++ b/specs/archive/e2e-testing-enhancement/design.md
@@ -84,7 +84,7 @@ graph TB
 #### 4. Pipeline Validator
 
 - **Purpose**: Comprehensive validation of pipeline outputs
-- **Location**: `tests/e2e/pipeline_validator.py`
+- **Location**: `tests/utils/pipeline_validator.py`
 - **Responsibilities**:
   - Validate data flow through all ETL stages
   - Check Neo4j graph structure and relationships

--- a/specs/archive/e2e-testing-enhancement/tasks.md
+++ b/specs/archive/e2e-testing-enhancement/tasks.md
@@ -40,13 +40,13 @@
 
 - [x] 4. Build Pipeline Validator
   - [x] 4.1 Implement stage-specific validation
-    - Create validation logic for extraction stage (record counts, schema compliance) in `tests/e2e/pipeline_validator.py`
+    - Create validation logic for extraction stage (record counts, schema compliance) in `tests/utils/pipeline_validator.py`
     - Implement enrichment validation (match rates, quality metrics)
     - Add Neo4j graph validation (node types, relationships, query validation)
     - _Requirements: 4.1, 4.2, 4.3, 4.4_
 
   - [x] 4.2 Create comprehensive validation reporting
-    - Implement ValidationResult and ValidationReport data models in `tests/e2e/validation_models.py`
+    - Implement ValidationResult and ValidationReport data models in `tests/utils/validation_models.py`
     - Add detailed validation reporting with specific failure diagnostics
     - Create validation report generation with recommendations for fixes
     - Implement JSON and Markdown report artifact generation

--- a/specs/archive/sbir-fiscal-returns-analysis/tasks.md
+++ b/specs/archive/sbir-fiscal-returns-analysis/tasks.md
@@ -166,4 +166,4 @@
     - Validate sensitivity analysis and uncertainty quantification methods
     - Test boundary conditions and edge cases
     - _Requirements: Economic validation_
-    - Implementation: `tests/validation/test_fiscal_reference_validation.py` (includes boundary conditions, reasonableness checks, numerical stability)
+    - Implementation: `tests/integration/fiscal/test_fiscal_reference_validation.py` (includes boundary conditions, reasonableness checks, numerical stability)

--- a/tests/e2e/test_enrichment_job.py
+++ b/tests/e2e/test_enrichment_job.py
@@ -1,26 +1,71 @@
-"""End-to-end smoke test for SBIR enrichment via Dagster job."""
+"""Hermetic end-to-end test for the USAspending freshness Dagster job."""
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+
+import pandas as pd
 import pytest
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow, pytest.mark.requires_api]
+from sbir_analytics.assets import usaspending_iterative_enrichment as enrichment_assets
+from sbir_etl.models.enrichment import EnrichmentFreshnessRecord, EnrichmentStatus
+from sbir_etl.utils.enrichment.freshness import FreshnessStore
+
+
+pytestmark = [pytest.mark.e2e, pytest.mark.smoke]
 
 
 def test_usaspending_enrichment_job_smoke(tmp_path, monkeypatch):
-    """Materialize the iterative enrichment job and assert it succeeds.
-
-    Requires dagster, sbir_analytics, and real data files to be available.
-    """
+    """Materialize persisted freshness inputs through stale-award selection."""
     defs = pytest.importorskip("sbir_analytics.definitions").defs
+    data_root = tmp_path / "data"
+    enriched_path = data_root / "processed" / "enriched" / "sbir_awards.parquet"
+    enriched_path.parent.mkdir(parents=True)
+    pd.DataFrame(
+        [
+            {"award_id": "AWARD-STALE", "UEI": "ABCDEFGHIJKL"},
+            {"award_id": "AWARD-FRESH", "UEI": "MNOPQRSTUVWX"},
+        ]
+    ).to_parquet(enriched_path, index=False)
 
-    # Run in temporary working directory to avoid polluting repo
-    monkeypatch.chdir(tmp_path)
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    now = datetime.now()
+    store.save_records(
+        [
+            EnrichmentFreshnessRecord(
+                award_id="AWARD-STALE",
+                source="usaspending",
+                last_attempt_at=now - timedelta(days=3),
+                last_success_at=now - timedelta(days=3),
+                status=EnrichmentStatus.SUCCESS,
+            ),
+            EnrichmentFreshnessRecord(
+                award_id="AWARD-FRESH",
+                source="usaspending",
+                last_attempt_at=now,
+                last_success_at=now,
+                status=EnrichmentStatus.SUCCESS,
+            ),
+        ]
+    )
 
-    # Get the resolved job from defs
-    job = defs.get_job_def("usaspending_iterative_enrichment_job")
+    monkeypatch.setenv("SBIR_ETL__PATHS__DATA_ROOT", str(data_root))
+    monkeypatch.setattr(enrichment_assets, "FreshnessStore", lambda: store)
 
-    # Execute the job
+    def reject_api_client(*_args, **_kwargs):
+        raise AssertionError("freshness-selection job attempted to construct an API client")
+
+    monkeypatch.setattr(enrichment_assets, "USAspendingAPIClient", reject_api_client)
+
+    job = defs.resolve_job_def("usaspending_iterative_enrichment_job")
     result = job.execute_in_process()
 
-    assert result.success, "Enrichment job failed"
+    assert result.success
+    ledger = result.output_for_node("usaspending_freshness_ledger")
+    stale = result.output_for_node("stale_usaspending_awards")
+    assert set(ledger["award_id"]) == {"AWARD-STALE", "AWARD-FRESH"}
+    assert stale["award_id"].tolist() == ["AWARD-STALE"]
+    evaluations = result.get_asset_check_evaluations()
+    assert len(evaluations) == 1
+    assert evaluations[0].check_name == "stale_awards_threshold_check"
+    assert evaluations[0].passed

--- a/tests/e2e/test_nsf_defense_lineage.py
+++ b/tests/e2e/test_nsf_defense_lineage.py
@@ -22,7 +22,7 @@ from sbir_analytics.assets.nsf_defense_lineage import (
 )
 
 
-pytestmark = [pytest.mark.integration, pytest.mark.e2e]
+pytestmark = pytest.mark.e2e
 
 
 def _write_source_fixtures(root: Path, analysis_date: date) -> dict[str, Path]:

--- a/tests/e2e/transition/__init__.py
+++ b/tests/e2e/transition/__init__.py
@@ -1,1 +1,0 @@
-"""Transition-specific E2E tests."""

--- a/tests/integration/enrichment/test_multi_source_enrichment.py
+++ b/tests/integration/enrichment/test_multi_source_enrichment.py
@@ -1,4 +1,4 @@
-"""End-to-end integration test for SBIR + USAspending + SAM.gov data enrichment.
+"""Component integration test for SBIR, USAspending, and SAM.gov enrichment.
 
 This test demonstrates the complete enrichment pipeline:
 1. Load SBIR awards data (primary dataset)
@@ -6,8 +6,8 @@ This test demonstrates the complete enrichment pipeline:
 3. Enrich with SAM.gov entity data (company details)
 4. Verify the complete enriched dataset
 
-This test uses sample fixtures by default but can use real data if marked with
-@pytest.mark.real_data or USE_REAL_SBIR_DATA=1 environment variable.
+The test composes in-memory fixtures and direct enrichment helpers without
+Dagster orchestration or external services.
 """
 
 import pandas as pd
@@ -16,7 +16,7 @@ import pytest
 from sbir_etl.enrichers.usaspending import enrich_sbir_with_usaspending
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.weekly]
+pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
@@ -356,20 +356,6 @@ class TestMultiSourceEnrichmentPipeline:
         print(f"NAICS Coverage Rate: {naics_coverage_rate:.1%}")
 
 
-class TestRealDataEnrichmentPipeline:
-    """Scheduled enrichment validation using restricted production-derived snapshots."""
-
-    @pytest.mark.real_data
-    @pytest.mark.skip(
-        reason=(
-            "requires approved SBIR, USAspending, and SAM.gov snapshots mounted by the "
-            "scheduled real-data workflow; those datasets are not available in local CI"
-        )
-    )
-    def test_enrichment_pipeline_with_approved_real_data_snapshots(self):
-        """Run the fixture-proven enrichment behavior against approved real-data snapshots."""
-
-
 class TestDataSourceIntegrity:
     """Test data source compatibility and schema alignment."""
 
@@ -419,27 +405,18 @@ __doc__ += """
 
 ### Quick Test (Sample Data)
 ```bash
-# Run all E2E multi-source tests with sample fixtures
-pytest tests/e2e/test_multi_source_enrichment.py -v
+# Run all multi-source integration tests with sample fixtures
+pytest tests/integration/enrichment/test_multi_source_enrichment.py -v
 
 # Run with detailed output
-pytest tests/e2e/test_multi_source_enrichment.py -v -s
-```
-
-### Real Data Test (Slower)
-```bash
-# Run with real SBIR data
-USE_REAL_SBIR_DATA=1 pytest tests/e2e/test_multi_source_enrichment.py -m real_data
-
-# Or mark individual tests
-pytest tests/e2e/test_multi_source_enrichment.py::TestRealDataEnrichmentPipeline -m real_data --run-real-data
+pytest tests/integration/enrichment/test_multi_source_enrichment.py -v -s
 ```
 
 ### Integration Testing Strategy
 
 1. **Unit Level**: Test individual extractors (SBIR, USAspending, SAM.gov)
 2. **Integration Level**: Test pairwise enrichment (SBIR+USAspending, SBIR+SAM.gov)
-3. **E2E Level**: Test complete pipeline (SBIR+USAspending+SAM.gov)
+3. **Orchestration Level**: Exercise a production Dagster job from persisted fixtures
 
 ### Expected Enrichment Flow
 
@@ -487,5 +464,5 @@ pytest tests/e2e/test_multi_source_enrichment.py::TestRealDataEnrichmentPipeline
   - `data/raw/sam_gov/sam_entity_records.parquet`
   - USAspending database dump (S3 or local)
 
-**Slow Tests**: Use sample data by default. Real data tests are marked with @pytest.mark.real_data
+**Real data**: Operator validation requires a separately approved snapshot and runbook.
 """

--- a/tests/integration/fiscal/test_stateio_pipeline.py
+++ b/tests/integration/fiscal/test_stateio_pipeline.py
@@ -1,4 +1,4 @@
-"""End-to-end test for complete fiscal I-O pipeline.
+"""Component integration test for the fiscal I-O calculation chain.
 
 This test validates the entire flow from SBIR awards to economic impact
 and fiscal return calculations:
@@ -27,7 +27,7 @@ from sbir_etl.transformers.fiscal.taxes import FiscalTaxEstimator
 from sbir_etl.enrichers.fiscal_bea_mapper import NAICSToBEAMapper
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.weekly]
+pytestmark = [pytest.mark.integration, pytest.mark.fiscal]
 
 
 @pytest.fixture
@@ -767,19 +767,19 @@ __doc__ += """
 ### Quick Test
 ```bash
 # Run all fiscal pipeline tests
-pytest tests/e2e/test_fiscal_stateio_pipeline.py -v
+pytest tests/integration/fiscal/test_stateio_pipeline.py -v
 
 # Run with verbose output
-pytest tests/e2e/test_fiscal_stateio_pipeline.py -v -s
+pytest tests/integration/fiscal/test_stateio_pipeline.py -v -s
 ```
 
 ### Test Individual Steps
 ```bash
 # Test specific step
-pytest tests/e2e/test_fiscal_stateio_pipeline.py::TestFiscalStateIOPipelineE2E::test_step1_enrich_with_usaspending -v
+pytest tests/integration/fiscal/test_stateio_pipeline.py::TestFiscalStateIOPipelineE2E::test_step1_enrich_with_usaspending -v
 
 # Test complete pipeline
-pytest tests/e2e/test_fiscal_stateio_pipeline.py::TestFiscalStateIOPipelineE2E::test_complete_pipeline_integration -v -s
+pytest tests/integration/fiscal/test_stateio_pipeline.py::TestFiscalStateIOPipelineE2E::test_complete_pipeline_integration -v -s
 ```
 
 ### Expected Output

--- a/tests/integration/reporting/test_weekly_report_render.py
+++ b/tests/integration/reporting/test_weekly_report_render.py
@@ -1,4 +1,4 @@
-"""End-to-end render of the weekly awards report from fixture awards.
+"""Integration render of the weekly awards report from fixture awards.
 
 Hermetic full-document pass over models -> rendering (the unit tests cover the
 small helpers piecemeal). Asserts the output contract a reader relies on: the
@@ -13,7 +13,7 @@ import pytest
 from sbir_etl.reporting.weekly.rendering import generate_markdown
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.timeout(60)]
+pytestmark = [pytest.mark.integration, pytest.mark.timeout(60)]
 
 AGENCIES = ["DOD", "HHS", "NSF", "DOE"]
 

--- a/tests/integration/transition/conftest.py
+++ b/tests/integration/transition/conftest.py
@@ -1,4 +1,4 @@
-"""Shared fixtures for transition E2E tests."""
+"""Shared fixtures for transition integration tests."""
 
 from __future__ import annotations
 

--- a/tests/integration/transition/test_cet_effectiveness.py
+++ b/tests/integration/transition/test_cet_effectiveness.py
@@ -7,7 +7,7 @@ import pytest
 from sbir_ml.transition.analysis.analytics import TransitionAnalytics
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.transition]
 
 
 def test_cet_effectiveness_computation(cet_effectiveness_dataset):

--- a/tests/integration/transition/test_detection_smoke.py
+++ b/tests/integration/transition/test_detection_smoke.py
@@ -1,4 +1,4 @@
-"""Lightweight end-to-end tests for the transition detection pipeline."""
+"""Integration tests for transition detection and analytics components."""
 
 from __future__ import annotations
 
@@ -8,7 +8,7 @@ import pytest
 from sbir_ml.transition.analysis.analytics import TransitionAnalytics
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.transition]
 
 
 def test_transition_detector_smoke(

--- a/tests/integration/transition/test_quality_metrics.py
+++ b/tests/integration/transition/test_quality_metrics.py
@@ -12,7 +12,7 @@ from sbir_ml.transition.performance.monitoring import (
 )
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+pytestmark = [pytest.mark.integration, pytest.mark.transition]
 
 
 def _build_evaluation_payload(num_detections: int = 200, tp_count: int = 150):

--- a/tests/unit/scripts/test_run_e2e_tests.py
+++ b/tests/unit/scripts/test_run_e2e_tests.py
@@ -19,7 +19,7 @@ def test_supported_scenarios_are_distinct_and_hermetic() -> None:
     minimal = MODULE.get_test_config("minimal")
     standard = MODULE.get_test_config("standard")
 
-    assert minimal["test_markers"] == "not slow and not requires_api and not real_data"
+    assert minimal["test_markers"] == "smoke and not requires_api and not real_data"
     assert standard["test_markers"] == "not requires_api and not real_data"
     assert minimal["test_markers"] != standard["test_markers"]
 
@@ -41,5 +41,6 @@ def test_standard_scenario_uses_current_interpreter_and_branch_coverage(monkeypa
     assert isinstance(args, list)
     assert args[:3] == [sys.executable, "-m", "pytest"]
     assert "--cov-branch" in args
+    assert "--cov-report=html:artifacts/htmlcov" in args
     marker_index = args.index("-m", 3)
     assert args[marker_index + 1] == "not requires_api and not real_data"

--- a/tests/unit/test_pipeline_validator.py
+++ b/tests/unit/test_pipeline_validator.py
@@ -1,4 +1,4 @@
-"""Tests for the E2E pipeline validator.
+"""Unit tests for the test-support pipeline validator.
 
 This module tests the pipeline validator functionality to ensure
 comprehensive validation of ETL pipeline stages.
@@ -7,19 +7,16 @@ comprehensive validation of ETL pipeline stages.
 from unittest.mock import Mock
 
 import pandas as pd
-import pytest
 
-
-pytestmark = pytest.mark.e2e
 
 from sbir_etl.models.quality import QualitySeverity
-from tests.e2e.pipeline_validator import (
+from tests.utils.pipeline_validator import (
     PipelineValidator,
     ValidationCheck,
     ValidationStage,
     ValidationStatus,
 )
-from tests.e2e.validation_models import (
+from tests.utils.validation_models import (
     RecommendationPriority,
     ValidationReport,
     ValidationScenario,
@@ -249,7 +246,7 @@ class TestValidationModels:
 
     def test_validation_result_properties(self):
         """Test ValidationResult property methods."""
-        from tests.e2e.pipeline_validator import StageValidationResult
+        from tests.utils.pipeline_validator import StageValidationResult
 
         # Create test stage results
         passed_stage = StageValidationResult(
@@ -294,7 +291,7 @@ class TestValidationModels:
 
     def test_test_report_generation(self):
         """Test ValidationReport generation with recommendations."""
-        from tests.e2e.pipeline_validator import StageValidationResult
+        from tests.utils.pipeline_validator import StageValidationResult
 
         # Create validation result with critical issue
         critical_check = ValidationCheck(
@@ -347,7 +344,7 @@ class TestValidationModels:
         import os
         import tempfile
 
-        from tests.e2e.pipeline_validator import StageValidationResult
+        from tests.utils.pipeline_validator import StageValidationResult
 
         # Create temporary directory for artifacts
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/tests/unit/test_test_suite_integrity.py
+++ b/tests/unit/test_test_suite_integrity.py
@@ -100,6 +100,19 @@ def test_test_modules_define_executable_tests_or_are_documented_scripts():
     )
 
 
+def test_e2e_modules_do_not_mock_pipeline_boundaries():
+    """Keep mocked component checks in unit/integration suites rather than E2E."""
+    violations = []
+    for path in sorted((REPOSITORY_ROOT / "tests/e2e").rglob("test_*.py")):
+        relative_path = _relative(path)
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative_path)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "unittest.mock":
+                violations.append(f"{relative_path}:{node.lineno}")
+
+    assert not violations, "E2E modules importing unittest.mock:\n" + "\n".join(violations)
+
+
 @pytest.mark.parametrize("path, reason", NON_PYTEST_VALIDATION_SCRIPTS.items())
 def test_documented_non_pytest_validation_scripts_remain_operator_programs(path: str, reason: str):
     """Keep zero-test exceptions narrow and documented rather than silently expanding them."""

--- a/tests/unit/test_test_suite_integrity.py
+++ b/tests/unit/test_test_suite_integrity.py
@@ -100,17 +100,30 @@ def test_test_modules_define_executable_tests_or_are_documented_scripts():
     )
 
 
-def test_e2e_modules_do_not_mock_pipeline_boundaries():
-    """Keep mocked component checks in unit/integration suites rather than E2E."""
+def test_e2e_modules_do_not_import_mock_helpers():
+    """Reserve mock helpers for lower layers; E2E may monkeypatch external I/O boundaries."""
     violations = []
     for path in sorted((REPOSITORY_ROOT / "tests/e2e").rglob("test_*.py")):
         relative_path = _relative(path)
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative_path)
         for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom) and node.module == "unittest.mock":
+            imports_mock_helpers = (
+                isinstance(node, ast.Import)
+                and any(alias.name in {"unittest.mock", "pytest_mock"} for alias in node.names)
+            ) or (
+                isinstance(node, ast.ImportFrom)
+                and (
+                    node.module in {"unittest.mock", "pytest_mock"}
+                    or (
+                        node.module == "unittest"
+                        and any(alias.name == "mock" for alias in node.names)
+                    )
+                )
+            )
+            if imports_mock_helpers:
                 violations.append(f"{relative_path}:{node.lineno}")
 
-    assert not violations, "E2E modules importing unittest.mock:\n" + "\n".join(violations)
+    assert not violations, "E2E modules importing mock helpers:\n" + "\n".join(violations)
 
 
 @pytest.mark.parametrize("path, reason", NON_PYTEST_VALIDATION_SCRIPTS.items())

--- a/tests/unit/transition/test_asset_registration.py
+++ b/tests/unit/transition/test_asset_registration.py
@@ -7,7 +7,7 @@ import pytest
 import sbir_analytics.assets.transition as transition_assets
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+pytestmark = pytest.mark.transition
 
 
 def test_transition_assets_registered():

--- a/tests/unit/transition/test_graph_queries.py
+++ b/tests/unit/transition/test_graph_queries.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 
-pytestmark = [pytest.mark.e2e, pytest.mark.slow]
+pytestmark = pytest.mark.transition
 
 
 def _build_mock_queries():

--- a/tests/utils/pipeline_validator.py
+++ b/tests/utils/pipeline_validator.py
@@ -1,4 +1,4 @@
-"""Pipeline validator for E2E testing.
+"""Test-support pipeline validator.
 
 This module provides comprehensive validation of the SBIR ETL pipeline stages,
 including extraction, enrichment, and Neo4j graph validation.

--- a/tests/utils/validation_models.py
+++ b/tests/utils/validation_models.py
@@ -1,4 +1,4 @@
-"""Data models for E2E validation reporting.
+"""Data models for test-support pipeline validation reporting.
 
 This module provides comprehensive data models for validation results,
 test reports, and recommendations for E2E testing.
@@ -9,7 +9,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from tests.e2e.pipeline_validator import (
+from tests.utils.pipeline_validator import (
     StageValidationResult,
     ValidationCheck,
     ValidationStage,


### PR DESCRIPTION
## Summary
- replace the API-dependent enrichment placeholder with a hermetic execution of the production Dagster enrichment job
- keep only real cross-component production workflows in tests/e2e and reclassify mocked, component, and utility tests
- align the E2E runner, integrity contracts, and testing documentation with the executable suite

## Validation
- 6200 passed, 20 skipped; 71.02% branch coverage
- standard E2E runner: 2 passed
- make docs-check
- ruff check and format verification

## Stack
- builds on #603
- #603 builds on #602

Draft until the stack is reviewed in order.