### PR TITLE
Cover operated analytics and enrichment paths

### DIFF
--- a/tests/unit/assets/cet/test_analytics.py
+++ b/tests/unit/assets/cet/test_analytics.py
@@ -1,0 +1,143 @@
+"""Hermetic execution tests for the operated CET analytics assets."""
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sbir_analytics.assets.cet.analytics import (
+    transformed_cet_analytics,
+    transformed_cet_analytics_aggregates,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _write_ndjson(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{json.dumps(row)}\n" for row in rows), encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict | list:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_analytics_uses_ndjson_fallback_and_emits_successful_metrics(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    processed_dir = tmp_path / "data/processed"
+    _write_ndjson(
+        processed_dir / "cet_award_classifications.ndjson",
+        [
+            {"award_id": "A-1", "primary_cet": "quantum", "primary_score": 0.9},
+            {"award_id": "A-2", "primary_cet": "biotech", "primary_score": 0.8},
+        ],
+    )
+    _write_ndjson(
+        processed_dir / "cet_company_profiles.ndjson",
+        [
+            {"company_id": "C-1", "specialization_score": 0.25},
+            {"company_id": "C-2", "specialization_score": 0.75},
+            {"company_id": "C-3", "specialization_score": None},
+        ],
+    )
+    (processed_dir / "cet_award_classifications.parquet").write_text("broken")
+    (processed_dir / "cet_company_profiles.parquet").write_text("broken")
+
+    def fail_parquet_read(*_args, **_kwargs):
+        raise OSError("synthetic parquet failure")
+
+    monkeypatch.setattr(pd, "read_parquet", fail_parquet_read)
+
+    result = transformed_cet_analytics()
+
+    assert result.value["coverage_rate"] == pytest.approx(1.0)
+    assert result.value["num_awards"] == 2
+    assert result.value["num_classified"] == 2
+    assert result.value["company_specialization_avg"] == pytest.approx(0.5)
+
+    checks_path = tmp_path / result.value["checks_path"]
+    checks = _read_json(checks_path)
+    assert checks["ok"] is True
+    assert checks["award_coverage_rate"] == pytest.approx(1.0)
+    assert checks["alerts"]["alert_count"] == 0
+    assert _read_json(tmp_path / result.value["alerts_path"]) == checks["alerts"]
+
+
+def test_analytics_empty_input_emits_zero_metrics_and_failed_coverage_check(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    result = transformed_cet_analytics()
+
+    assert result.value["coverage_rate"] == 0.0
+    assert result.value["num_awards"] == 0
+    assert result.value["num_classified"] == 0
+    assert result.value["company_specialization_avg"] is None
+
+    checks = _read_json(tmp_path / result.value["checks_path"])
+    assert checks["award_coverage_rate"] == 0.0
+    assert checks["alerts"]["failure_count"] == 1
+    assert checks["alerts"]["alerts"][0]["metric_name"] == "cet_award_coverage_rate"
+
+
+def test_analytics_aggregates_write_dashboards_and_regression_alert(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    processed_dir = tmp_path / "data/processed"
+    _write_ndjson(
+        processed_dir / "cet_award_classifications.ndjson",
+        [
+            {"award_id": "A-1", "primary_cet": "quantum", "classified_at": "2024-01-01"},
+            {"award_id": "A-2", "primary_cet": None, "classified_at": "2024-06-01"},
+            {"award_id": "A-3", "primary_cet": "biotech", "classified_at": "2025-01-01"},
+            {"award_id": "A-4", "primary_cet": None, "classified_at": "2025-06-01"},
+            {"award_id": "A-5", "primary_cet": "space", "classified_at": "not-a-date"},
+        ],
+    )
+    _write_ndjson(
+        processed_dir / "cet_company_profiles.ndjson",
+        [
+            {"company_id": "C-1", "specialization_score": 0.1},
+            {"company_id": "C-2", "specialization_score": 0.3},
+            {"company_id": "C-3", "specialization_score": 0.6},
+            {"company_id": "C-4", "specialization_score": 0.9},
+        ],
+    )
+    baseline_path = tmp_path / "reports/benchmarks/baseline.json"
+    baseline_path.parent.mkdir(parents=True)
+    baseline_path.write_text(json.dumps({"cet": {"coverage_min": 0.75}}), encoding="utf-8")
+
+    result = transformed_cet_analytics_aggregates()
+
+    assert result.value["latest_year"] == 2025
+    assert result.value["latest_coverage_rate"] == pytest.approx(0.5)
+    assert result.value["total_awards"] == 5
+    assert result.value["total_classified"] == 3
+    assert result.value["specialization_avg"] == pytest.approx(0.475)
+
+    coverage_rows = _read_json(tmp_path / result.value["coverage_dashboard_json"])
+    coverage_by_year = {row["__year"]: row for row in coverage_rows}
+    assert coverage_by_year["2025"]["coverage_rate"] == pytest.approx(0.5)
+    assert coverage_by_year["unknown"]["classified"] == 1
+
+    specialization_rows = _read_json(tmp_path / result.value["specialization_dashboard_json"])
+    assert sum(row["count"] for row in specialization_rows) == 4
+
+    alerts = _read_json(tmp_path / result.value["alerts_path"])
+    assert alerts["failure_count"] == 1
+    assert alerts["alerts"][0]["metric_name"] == "cet_award_latest_year_coverage"
+
+
+def test_analytics_aggregates_empty_input_returns_empty_metadata(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    result = transformed_cet_analytics_aggregates()
+
+    assert result.value["latest_year"] is None
+    assert result.value["latest_coverage_rate"] is None
+    assert result.value["total_awards"] == 0
+    assert result.value["total_classified"] == 0
+    assert result.value["specialization_avg"] is None
+    assert not (tmp_path / result.value["coverage_dashboard_json"]).exists()
+    assert not (tmp_path / result.value["specialization_dashboard_json"]).exists()
+    assert _read_json(tmp_path / result.value["alerts_path"])["alert_count"] == 0

--- a/tests/unit/assets/cet/test_validation.py
+++ b/tests/unit/assets/cet/test_validation.py
@@ -1,0 +1,195 @@
+"""Hermetic execution tests for the operated CET validation assets."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sbir_analytics.assets.cet.validation import (
+    raw_cet_human_sampling,
+    validated_cet_drift_detection,
+    validated_cet_iaa_report,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _write_ndjson(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("".join(f"{json.dumps(row)}\n" for row in rows), encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict | list:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_human_sampling_balances_labels_and_tops_up_deterministically(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SBIR_ETL__CET__SAMPLE_SIZE", "4")
+    monkeypatch.setenv("SBIR_ETL__CET__SAMPLE_SEED", "7")
+    input_path = tmp_path / "data/processed/cet_award_classifications.ndjson"
+    _write_ndjson(
+        input_path,
+        [
+            {"award_id": "A-1", "primary_cet": "quantum", "primary_score": 0.9},
+            {"award_id": "A-2", "primary_cet": "quantum", "primary_score": 0.8},
+            {"award_id": "A-3", "primary_cet": "biotech", "primary_score": 0.7},
+            {"award_id": "A-4", "primary_cet": "biotech", "primary_score": 0.6},
+            {"award_id": "A-5", "primary_cet": "space", "primary_score": 0.5},
+            {"award_id": "A-6", "primary_cet": "space", "primary_score": 0.4},
+        ],
+    )
+
+    result = raw_cet_human_sampling()
+
+    sample_path = tmp_path / result.value
+    sampled = [json.loads(line) for line in sample_path.read_text().splitlines()]
+    assert len(sampled) == 4
+    assert len({row["award_id"] for row in sampled}) == 4
+    assert {row["primary_cet"] for row in sampled} == {"quantum", "biotech", "space"}
+
+    checks = _read_json(tmp_path / "data/processed/cet_human_sample.checks.json")
+    assert checks == {
+        "ok": True,
+        "total_rows": 6,
+        "sampled_rows": 4,
+        "balanced_by_primary": True,
+        "seed": 7,
+        "source": "data/processed/cet_award_classifications.ndjson",
+    }
+
+
+def test_human_sampling_empty_input_writes_empty_artifact_and_checks(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "data/processed").mkdir(parents=True)
+
+    result = raw_cet_human_sampling()
+
+    assert (tmp_path / result.value).read_text(encoding="utf-8") == ""
+    checks = _read_json(tmp_path / "data/processed/cet_human_sample.checks.json")
+    assert checks["reason"] == "no_input"
+    assert checks["total_rows"] == 0
+    assert checks["sampled_rows"] == 0
+
+
+def test_human_sampling_propagates_malformed_ndjson(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    input_path = tmp_path / "data/processed/cet_award_classifications.ndjson"
+    input_path.parent.mkdir(parents=True)
+    input_path.write_text('{"award_id": "A-1"}\nnot-json\n', encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        raw_cet_human_sampling()
+
+    assert not (tmp_path / "data/processed/cet_human_sample.ndjson").exists()
+    assert not (tmp_path / "data/processed/cet_human_sample.checks.json").exists()
+
+
+def test_iaa_report_computes_pairwise_kappa_and_exact_set_agreement(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _write_ndjson(
+        tmp_path / "data/processed/annotations/review.ndjson",
+        [
+            {"award_id": "A-1", "annotator": "alice", "labels": ["quantum", "ai"]},
+            {"award_id": "A-1", "annotator": "bob", "labels": ["ai", "quantum"]},
+            {"award_id": "A-2", "annotator": "alice", "labels": ["biotech"]},
+            {"award_id": "A-2", "annotator": "bob", "labels": ["biotech"]},
+            {"award_id": "A-3", "annotator": "alice", "labels": ["space"]},
+            {"award_id": "A-3", "annotator": "bob", "labels": ["cyber"]},
+        ],
+    )
+
+    result = validated_cet_iaa_report()
+
+    payload = _read_json(tmp_path / result.value)
+    assert payload["ok"] is True
+    assert payload["pairs"] == 1
+    assert payload["kappa"]["alice__vs__bob"] == pytest.approx(0.25)
+    assert payload["percent_agreement"] == pytest.approx(2 / 3)
+
+
+def test_iaa_report_skips_malformed_files_and_reports_no_annotations(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    annotations_dir = tmp_path / "data/processed/annotations"
+    annotations_dir.mkdir(parents=True)
+    (annotations_dir / "broken.jsonl").write_text("not-json\n", encoding="utf-8")
+    (annotations_dir / "ignored.txt").write_text("also-not-json\n", encoding="utf-8")
+
+    result = validated_cet_iaa_report()
+
+    payload = _read_json(tmp_path / result.value)
+    assert payload["reason"] == "no_annotations"
+    assert payload["pairs"] == 0
+    assert payload["percent_agreement"] is None
+
+
+def test_drift_detection_empty_input_writes_no_input_report(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SBIR_ETL__CET__DRIFT__SCORE_JS_THRESHOLD", "0.25")
+    monkeypatch.setenv("SBIR_ETL__CET__DRIFT__LABEL_JS_THRESHOLD", "0.125")
+
+    result = validated_cet_drift_detection()
+
+    assert result.value["reason"] == "no_input"
+    assert result.value["score_js_divergence"] is None
+    assert result.value["label_js_divergence"] is None
+    assert result.value["score_threshold"] == pytest.approx(0.25)
+    assert result.value["label_threshold"] == pytest.approx(0.125)
+    report = _read_json(tmp_path / "reports/benchmarks/cet_drift_report.json")
+    assert report["reason"] == "no_input"
+
+
+def test_drift_detection_without_baseline_writes_candidate(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    _write_ndjson(
+        tmp_path / "data/processed/cet_award_classifications.ndjson",
+        [
+            {"award_id": "A-1", "primary_cet": "quantum", "primary_score": "5"},
+            {"award_id": "A-2", "primary_cet": None, "primary_score": 95},
+        ],
+    )
+
+    result = validated_cet_drift_detection()
+
+    assert result.value["reason"] == "baseline_missing"
+    candidate_path = tmp_path / result.value["candidate_path"]
+    candidate = _read_json(candidate_path)
+    assert candidate["label_pmf"] == {"quantum": 0.5, "__none__": 0.5}
+    assert candidate["score_pmf"]["0-10"] == pytest.approx(0.5)
+    assert candidate["score_pmf"]["90-100"] == pytest.approx(0.5)
+    assert not (tmp_path / "reports/alerts/cet_drift_alerts.json").exists()
+
+
+def test_drift_detection_emits_failure_for_large_label_shift(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("SBIR_ETL__CET__DRIFT__SCORE_JS_THRESHOLD", "0.15")
+    monkeypatch.setenv("SBIR_ETL__CET__DRIFT__LABEL_JS_THRESHOLD", "0.10")
+    _write_ndjson(
+        tmp_path / "data/processed/cet_award_classifications.ndjson",
+        [
+            {"award_id": "A-1", "primary_cet": "quantum", "primary_score": 5},
+            {"award_id": "A-2", "primary_cet": "quantum", "primary_score": 5},
+        ],
+    )
+    baseline_path = tmp_path / "reports/benchmarks/cet_baseline_distributions.json"
+    baseline_path.parent.mkdir(parents=True)
+    baseline_path.write_text(
+        json.dumps(
+            {
+                "label_pmf": {"biotech": 1.0},
+                "score_pmf": {"0-10": 1.0},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = validated_cet_drift_detection()
+
+    assert result.value["label_js_divergence"] == pytest.approx(1.0)
+    assert result.value["score_js_divergence"] == pytest.approx(0.0)
+    alerts = _read_json(tmp_path / "reports/alerts/cet_drift_alerts.json")
+    assert alerts["alert_count"] == 1
+    assert alerts["failure_count"] == 1
+    assert alerts["alerts"][0]["severity"] == "FAILURE"
+    assert alerts["alerts"][0]["alert_type"] == "label_distribution_drift"

--- a/tests/unit/reporting/weekly/test_enrichment.py
+++ b/tests/unit/reporting/weekly/test_enrichment.py
@@ -1,0 +1,478 @@
+"""Hermetic tests for weekly report enrichment orchestration."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.press_wire import PressRelease
+from sbir_etl.reporting.weekly import enrichment
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_lookup_pi_external_data_reuses_company_results_and_deduplicates(monkeypatch):
+    patents = object()
+    publications = object()
+    orcid = object()
+    federal_awards = object()
+    patent_lookup = Mock(return_value=patents)
+    publication_lookup = Mock(return_value=publications)
+    orcid_lookup = Mock(return_value=orcid)
+    company_lookup = Mock(side_effect=AssertionError("company lookup should be reused"))
+    monkeypatch.setattr(enrichment, "_lib_lookup_pi_patents_with_fallback", patent_lookup)
+    monkeypatch.setattr(enrichment, "_lib_lookup_pi_publications_with_fallback", publication_lookup)
+    monkeypatch.setattr(enrichment, "_lib_lookup_pi_orcid_with_fallback", orcid_lookup)
+    monkeypatch.setattr(enrichment, "_lib_lookup_company_federal_awards", company_lookup)
+
+    awards = [
+        {
+            "PI Name": " Jane Doe ",
+            "Company": "Acme Labs",
+            "Company UEI": "UEI-1",
+            "_normalized_company": "acme labs",
+        },
+        {
+            "PI Name": "Jane Doe",
+            "Company": "Duplicate Company Context",
+            "_normalized_company": "duplicate",
+        },
+        {"PI Name": "   ", "Company": "Ignored"},
+    ]
+
+    result = enrichment.lookup_pi_external_data(
+        awards, company_federal_awards={"acme labs": federal_awards}
+    )
+
+    assert result == {
+        "JANE DOE": {
+            "patents": patents,
+            "publications": publications,
+            "orcid": orcid,
+            "federal_awards": federal_awards,
+        }
+    }
+    patent_lookup.assert_called_once_with(
+        "Jane Doe", "Acme Labs", lens_rate_limiter=enrichment._lens_limiter
+    )
+    publication_lookup.assert_called_once_with(
+        "Jane Doe",
+        rate_limiter=enrichment._semantic_scholar_limiter,
+        orcid_rate_limiter=enrichment._orcid_limiter,
+    )
+    orcid_lookup.assert_called_once_with(
+        "Jane Doe",
+        rate_limiter=enrichment._orcid_limiter,
+        semantic_scholar_rate_limiter=enrichment._semantic_scholar_limiter,
+    )
+    company_lookup.assert_not_called()
+
+
+def test_lookup_pi_external_data_queries_company_and_isolates_pi_errors(monkeypatch, capsys):
+    def patent_lookup(name, _company, **_kwargs):
+        if name == "Broken PI":
+            raise RuntimeError("patent service unavailable")
+        return f"patents:{name}"
+
+    monkeypatch.setattr(enrichment, "_lib_lookup_pi_patents_with_fallback", patent_lookup)
+    monkeypatch.setattr(
+        enrichment,
+        "_lib_lookup_pi_publications_with_fallback",
+        lambda name, **_kwargs: f"publications:{name}",
+    )
+    monkeypatch.setattr(
+        enrichment,
+        "_lib_lookup_pi_orcid_with_fallback",
+        lambda name, **_kwargs: f"orcid:{name}",
+    )
+    company_lookup = Mock(return_value="federal-history")
+    monkeypatch.setattr(enrichment, "_lib_lookup_company_federal_awards", company_lookup)
+
+    result = enrichment.lookup_pi_external_data(
+        [
+            {"PI Name": "Good PI", "Company": "Good Co", "UEI": "LEGACY-UEI"},
+            {"PI Name": "Broken PI", "Company": "Broken Co"},
+        ]
+    )
+
+    assert result == {
+        "GOOD PI": {
+            "patents": "patents:Good PI",
+            "publications": "publications:Good PI",
+            "orcid": "orcid:Good PI",
+            "federal_awards": "federal-history",
+        }
+    }
+    company_lookup.assert_called_once_with(
+        "Good Co", "LEGACY-UEI", rate_limiter=enrichment._usaspending_limiter
+    )
+    assert (
+        "PI external data error for Broken PI: patent service unavailable"
+        in capsys.readouterr().err
+    )
+
+
+def test_lookup_usaspending_recipients_keeps_hits_and_isolates_failures(monkeypatch, capsys):
+    profile = object()
+
+    def lookup(name, _uei, **_kwargs):
+        if name == "Broken Co":
+            raise RuntimeError("recipient API down")
+        if name == "No Match Co":
+            return None
+        return profile
+
+    lookup_mock = Mock(side_effect=lookup)
+    monkeypatch.setattr(enrichment, "_lib_lookup_usaspending_recipient_with_fallback", lookup_mock)
+
+    result = enrichment.lookup_usaspending_recipients(
+        [
+            {"Company": " Acme Co ", "Company UEI": "UEI-1"},
+            {"Company": "Acme Co", "Company UEI": "ignored duplicate"},
+            {"Company": "No Match Co"},
+            {"Company": "Broken Co"},
+            {"Company": "  "},
+        ]
+    )
+
+    assert result == {"ACME CO": profile}
+    assert lookup_mock.call_count == 3
+    stderr = capsys.readouterr().err
+    assert (
+        "Warning: USAspending recipient lookup failed for BROKEN CO: recipient API down" in stderr
+    )
+    assert "Found 1/3 recipient profiles" in stderr
+
+
+def test_lookup_usaspending_recipients_stops_after_stage_deadline(monkeypatch, capsys):
+    monkeypatch.setattr(
+        enrichment,
+        "_lib_lookup_usaspending_recipient_with_fallback",
+        Mock(return_value=object()),
+    )
+    monkeypatch.setattr(enrichment, "_past_deadline", lambda _deadline: True)
+
+    result = enrichment.lookup_usaspending_recipients([{"Company": "Acme Co"}])
+
+    assert result == {}
+    assert "USAspending recipient stage timeout" in capsys.readouterr().err
+
+
+def test_lookup_sam_entities_skips_without_api_key(monkeypatch, capsys):
+    lookup = Mock(side_effect=AssertionError("SAM lookup should not run without a key"))
+    monkeypatch.delenv("SAM_GOV_API_KEY", raising=False)
+    monkeypatch.setattr(enrichment, "_lib_lookup_sam_entity_with_fallback", lookup)
+
+    assert enrichment.lookup_sam_entities([{"Company": "Acme Co"}]) == {}
+    lookup.assert_not_called()
+    assert "SAM_GOV_API_KEY not set" in capsys.readouterr().err
+
+
+def test_lookup_sam_entities_passes_identifiers_and_collects_records(monkeypatch):
+    record = object()
+    lookup = Mock(return_value=record)
+    monkeypatch.setenv("SAM_GOV_API_KEY", "test-key")
+    monkeypatch.setattr(enrichment, "_lib_lookup_sam_entity_with_fallback", lookup)
+
+    result = enrichment.lookup_sam_entities(
+        [{"Company": "Acme Co", "UEI": "LEGACY-UEI", "CAGE": "1ABC2"}]
+    )
+
+    assert result == {"ACME CO": record}
+    lookup.assert_called_once_with(
+        "Acme Co",
+        "LEGACY-UEI",
+        "1ABC2",
+        rate_limiter=enrichment._sam_gov_limiter,
+        fallback_rate_limiter=enrichment._usaspending_limiter,
+    )
+
+
+def test_lookup_opencorporates_uses_jurisdiction_and_isolates_errors(monkeypatch, capsys):
+    record = object()
+    calls = []
+
+    class FakeOpenCorporatesClient:
+        def __init__(self, *, shared_limiter):
+            assert shared_limiter is enrichment._opencorporates_limiter
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _traceback):
+            return None
+
+        def lookup_company(self, name, *, jurisdiction):
+            calls.append((name, jurisdiction))
+            if name == "Broken Co":
+                raise RuntimeError("registry unavailable")
+            return record
+
+    monkeypatch.setattr(enrichment, "SyncOpenCorporatesClient", FakeOpenCorporatesClient)
+
+    result = enrichment.lookup_opencorporates(
+        [
+            {"Company": "Acme Co", "State": "VA", "_normalized_company": "acme"},
+            {"Company": "Broken Co", "State": "Virginia", "_normalized_company": "broken"},
+        ]
+    )
+
+    assert result == {"acme": record}
+    assert set(calls) == {("Acme Co", "us_va"), ("Broken Co", None)}
+    assert "Warning: OpenCorporates lookup failed for broken: registry unavailable" in (
+        capsys.readouterr().err
+    )
+
+
+def test_poll_press_wire_groups_only_known_company_hits(monkeypatch):
+    hits = [
+        PressRelease(title="First", link="https://example.test/1", matched_company="Acme Co"),
+        PressRelease(title="Second", link="https://example.test/2", matched_company="Acme Co"),
+        PressRelease(title="Other", link="https://example.test/3", matched_company="Unknown Co"),
+    ]
+
+    class FakePressWireClient:
+        watchlist = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, _exc_type, _exc, _traceback):
+            return None
+
+        def set_watchlist(self, watchlist):
+            type(self).watchlist = watchlist
+
+        def poll(self):
+            return hits
+
+    monkeypatch.setattr(enrichment, "SyncPressWireClient", FakePressWireClient)
+
+    result = enrichment.poll_press_wire(
+        [
+            {"Company": "Acme Co", "_normalized_company": "acme"},
+            {"Company": "Acme Co", "_normalized_company": "acme"},
+            {"Company": "  "},
+        ]
+    )
+
+    assert FakePressWireClient.watchlist == ["Acme Co"]
+    assert result == {"acme": hits[:2]}
+
+
+def test_fetch_solicitation_topics_uses_batch_keyword_and_awards_fallback(monkeypatch):
+    long_batch_description = "x" * 3001
+    long_fallback_description = "y" * 3001
+    extractor = SimpleNamespace(
+        extract_topics=Mock(
+            return_value=pd.DataFrame(
+                [
+                    {
+                        "topic_code": "YEAR-TOPIC",
+                        "topicTitle": "Batch title",
+                        "topicDescription": long_batch_description,
+                        "solicitationNumber": "API-SOLICITATION",
+                        "agency": "DOD",
+                        "program": "SBIR",
+                    }
+                ]
+            )
+        ),
+        deduplicate_topics=Mock(side_effect=lambda frame: frame),
+        query_by_keyword=Mock(
+            return_value=[
+                {"topicCode": "OTHER", "topicTitle": "Ignore"},
+                {"topicCode": "SEARCH-TOPIC", "topicTitle": "Keyword title"},
+            ]
+        ),
+        query_awards_for_topic=Mock(
+            return_value={
+                "title": "Awards fallback title",
+                "description": long_fallback_description,
+                "agency": "NASA",
+                "program": "STTR",
+            }
+        ),
+        close=Mock(),
+    )
+    monkeypatch.setattr(enrichment, "SolicitationExtractor", Mock(return_value=extractor))
+
+    result = enrichment.fetch_solicitation_topics(
+        [
+            {"Topic Code": "YEAR-TOPIC", "Solicitation Number": "DOD-2025-1"},
+            {"Topic Code": "SEARCH-TOPIC", "Solicitation Number": "BAA-X"},
+            {"Topic Code": "FALLBACK-TOPIC", "Solicitation Number": "NASA 2025"},
+            {"Topic Code": "YEAR-TOPIC", "Solicitation Number": "duplicate"},
+        ]
+    )
+
+    assert set(result) == {"YEAR-TOPIC", "SEARCH-TOPIC", "FALLBACK-TOPIC"}
+    assert result["YEAR-TOPIC"].solicitation_number == "API-SOLICITATION"
+    assert result["YEAR-TOPIC"].description == long_batch_description[:3000] + "..."
+    assert result["SEARCH-TOPIC"].title == "Keyword title"
+    assert result["FALLBACK-TOPIC"].description == long_fallback_description[:3000] + "..."
+    extractor.extract_topics.assert_called_once_with(year=2025, max_results=1000)
+    extractor.query_by_keyword.assert_called_once_with("BAA-X")
+    extractor.query_awards_for_topic.assert_called_once_with("FALLBACK-TOPIC")
+    extractor.close.assert_called_once_with()
+
+
+def test_fetch_solicitation_topics_returns_early_when_codes_are_missing(monkeypatch):
+    constructor = Mock(side_effect=AssertionError("extractor should not be constructed"))
+    monkeypatch.setattr(enrichment, "SolicitationExtractor", constructor)
+
+    assert enrichment.fetch_solicitation_topics([{"Topic Code": "  "}, {}]) == {}
+    constructor.assert_not_called()
+
+
+def test_fetch_solicitation_topics_closes_extractor_after_error(monkeypatch):
+    extractor = SimpleNamespace(
+        extract_topics=Mock(side_effect=RuntimeError("SBIR API unavailable")),
+        close=Mock(),
+    )
+    monkeypatch.setattr(enrichment, "SolicitationExtractor", Mock(return_value=extractor))
+
+    with pytest.raises(RuntimeError, match="SBIR API unavailable"):
+        enrichment.fetch_solicitation_topics(
+            [{"Topic Code": "TOPIC-1", "Solicitation Number": "DOD 2025"}]
+        )
+
+    extractor.close.assert_called_once_with()
+
+
+def test_fetch_usaspending_contract_descriptions_delegates_with_shared_limiter(monkeypatch):
+    awards = [{"Contract": "C-1"}]
+    delegated = {"C-1": "Contract description"}
+    fetch = Mock(return_value=delegated)
+    monkeypatch.setattr(enrichment, "_lib_fetch_usaspending_contract_descriptions", fetch)
+
+    assert enrichment.fetch_usaspending_contract_descriptions(awards) is delegated
+    fetch.assert_called_once_with(awards, rate_limiter=enrichment._usaspending_limiter)
+
+
+def test_enrich_with_inflation_normalizes_report_columns(monkeypatch):
+    captured = {}
+
+    class FakeInflationAdjuster:
+        def __init__(self, *, config):
+            captured["config"] = config
+
+        def adjust_awards_dataframe(self, frame):
+            captured["frame"] = frame.copy()
+            return pd.DataFrame(
+                {
+                    "fiscal_adjusted_amount": [1250.0, 50.0],
+                    "fiscal_base_year": [2025, 2025],
+                }
+            )
+
+    monkeypatch.setattr(enrichment, "InflationAdjuster", FakeInflationAdjuster)
+
+    result = enrichment.enrich_with_inflation(
+        [
+            {"Award Amount": "$1,000", "Proposal Award Date": "2023-01-01"},
+            {"Award Amount": "not available", "Proposal Award Date": "2024-01-01"},
+        ],
+        base_year=2025,
+    )
+
+    assert result == {"adjusted_total": 1300.0, "base_year": 2025}
+    assert captured["config"] == {"base_year": 2025}
+    assert captured["frame"]["award_amount"].tolist() == [1000.0, 0.0]
+    assert captured["frame"]["award_date"].tolist() == ["2023-01-01", "2024-01-01"]
+
+
+def test_enrich_with_inflation_returns_empty_on_adjuster_error(monkeypatch):
+    debug = Mock()
+    monkeypatch.setattr(
+        enrichment,
+        "InflationAdjuster",
+        Mock(side_effect=RuntimeError("missing CPI data")),
+    )
+    monkeypatch.setattr(enrichment, "_debug", debug)
+
+    assert enrichment.enrich_with_inflation([{"Award Amount": "100"}]) == {}
+    debug.assert_called_once_with("InflationAdjuster error: missing CPI data")
+
+
+def test_resolve_congressional_districts_skips_missing_zip_and_isolates_errors(monkeypatch):
+    calls = []
+
+    class FakeResolver:
+        def __init__(self, *, method):
+            assert method == "auto"
+
+        def resolve_single_address(self, **address):
+            calls.append(address)
+            if address["zip_code"] == "22222":
+                raise RuntimeError("Census unavailable")
+            if address["zip_code"] == "33333":
+                return SimpleNamespace(congressional_district=None, method="zip")
+            return SimpleNamespace(congressional_district="VA-08", method="census")
+
+    monkeypatch.setattr(enrichment, "CongressionalDistrictResolver", FakeResolver)
+
+    result = enrichment.resolve_congressional_districts(
+        [
+            {
+                "Company": "Acme Co",
+                "Zip": "22102-1234",
+                "State": "VA",
+                "City": "McLean",
+                "Address1": "1 Main St",
+            },
+            {"Company": "Acme Co", "Zip": "99999"},
+            {"Company": "No Zip Co", "Zip": ""},
+            {"Company": "Broken Co", "Zip": "22222"},
+            {"Company": "No Match Co", "Zip": "33333", "State": "VA"},
+            {"Company": "  ", "Zip": "11111"},
+        ]
+    )
+
+    assert result == {"ACME CO": "VA-08"}
+    assert [call["zip_code"] for call in calls] == ["22102", "22222", "33333"]
+    assert calls[0] == {
+        "address": "1 Main St",
+        "city": "McLean",
+        "state": "VA",
+        "zip_code": "22102",
+    }
+
+
+def test_map_naics_to_bea_sectors_selects_highest_weight_and_continues(monkeypatch, capsys):
+    low_weight = SimpleNamespace(allocation_weight=0.25, bea_sector_name="Low weight")
+    high_weight = SimpleNamespace(allocation_weight=0.75, bea_sector_name="High weight")
+
+    class FakeMapper:
+        def __init__(self, *, crosswalk_path, fallback_config_path):
+            assert crosswalk_path is None
+            assert fallback_config_path == "config/fiscal/naics_bea_mappings.yaml"
+
+        def map_naics_to_bea(self, code):
+            if code == "broken":
+                raise ValueError("invalid NAICS")
+            if code == "unmapped":
+                return []
+            return [low_weight, high_weight]
+
+    monkeypatch.setattr(enrichment, "NAICSToBEAMapper", FakeMapper)
+
+    result = enrichment.map_naics_to_bea_sectors(["541715", "unmapped", "broken"])
+
+    assert result == {"541715": "High weight"}
+    assert "mapping failed for 1 codes: ['broken']" in capsys.readouterr().err
+
+
+def test_map_naics_to_bea_sectors_returns_empty_when_mapper_init_fails(monkeypatch):
+    debug = Mock()
+    monkeypatch.setattr(
+        enrichment,
+        "NAICSToBEAMapper",
+        Mock(side_effect=RuntimeError("mapping config missing")),
+    )
+    monkeypatch.setattr(enrichment, "_debug", debug)
+
+    assert enrichment.map_naics_to_bea_sectors(["541715"]) == {}
+    debug.assert_called_once_with("NAICSToBEAMapper init error: mapping config missing")

--- a/tests/unit/transformers/fiscal/test_district_allocator.py
+++ b/tests/unit/transformers/fiscal/test_district_allocator.py
@@ -1,0 +1,251 @@
+"""Tests for congressional-district fiscal impact allocation."""
+
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers import fiscal_bea_mapper
+from sbir_etl.transformers.fiscal.district_allocator import (
+    allocate_state_impacts_to_districts,
+    compare_districts_within_state,
+    summarize_by_district,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _state_impacts() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "state": "CA",
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "production_impact": 1000.0,
+                "wage_impact": 400.0,
+                "proprietor_income_impact": 100.0,
+                "gross_operating_surplus": 200.0,
+                "tax_impact": 80.0,
+                "consumption_impact": 500.0,
+                "jobs_created": 10.0,
+                "confidence": 0.9,
+                "model_version": "bea-v1",
+            }
+        ]
+    )
+
+
+def test_allocate_state_impacts_proportionally_and_excludes_unresolved_awards():
+    awards = pd.DataFrame(
+        [
+            {
+                "state": "CA",
+                "congressional_district": "CA-01",
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "award_amount": 100.0,
+                "congressional_district_confidence": 0.8,
+            },
+            {
+                "state": "CA",
+                "congressional_district": "CA-01",
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "award_amount": 50.0,
+                "congressional_district_confidence": 1.0,
+            },
+            {
+                "state": "CA",
+                "congressional_district": "CA-02",
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "award_amount": 150.0,
+                "congressional_district_confidence": 0.6,
+            },
+            {
+                "state": "CA",
+                "congressional_district": None,
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "award_amount": 300.0,
+                "congressional_district_confidence": 0.2,
+            },
+        ]
+    )
+
+    result = allocate_state_impacts_to_districts(_state_impacts(), awards).set_index(
+        "congressional_district"
+    )
+
+    assert set(result.index) == {"CA-01", "CA-02"}
+    assert result.loc["CA-01", "district_award_total"] == 150.0
+    assert result.loc["CA-01", "state_award_total_from_districts"] == 300.0
+    assert result.loc["CA-01", "allocation_share"] == pytest.approx(0.5)
+    assert result.loc["CA-02", "production_impact_allocated"] == pytest.approx(500.0)
+    assert result.loc["CA-02", "wage_impact_allocated"] == pytest.approx(200.0)
+    assert result.loc["CA-02", "tax_impact_allocated"] == pytest.approx(40.0)
+    assert result.loc["CA-02", "jobs_created_allocated"] == pytest.approx(5.0)
+    assert result.loc["CA-01", "allocation_confidence"] == pytest.approx(0.6885)
+    assert result.loc["CA-02", "allocation_confidence"] == pytest.approx(0.459)
+    assert result["allocation_method"].unique().tolist() == ["proportional_by_awards"]
+    assert result["model_version"].unique().tolist() == ["bea-v1"]
+
+
+def test_allocate_state_impacts_returns_empty_without_resolved_districts():
+    awards = pd.DataFrame(
+        [
+            {
+                "state": "CA",
+                "congressional_district": None,
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "award_amount": 100.0,
+                "congressional_district_confidence": 0.0,
+            }
+        ]
+    )
+
+    assert allocate_state_impacts_to_districts(_state_impacts(), awards).empty
+
+
+def test_allocate_state_impacts_returns_empty_without_sector_source():
+    awards = pd.DataFrame(
+        [
+            {
+                "state": "CA",
+                "congressional_district": "CA-01",
+                "fiscal_year": 2024,
+                "award_amount": 100.0,
+                "congressional_district_confidence": 0.9,
+            }
+        ]
+    )
+
+    assert allocate_state_impacts_to_districts(_state_impacts(), awards).empty
+
+
+def test_allocate_state_impacts_maps_naics_when_bea_sector_is_absent(monkeypatch):
+    mapper = Mock()
+    mapper.map_naics_to_bea_summary.return_value = "54"
+    mapper_constructor = Mock(return_value=mapper)
+    monkeypatch.setattr(fiscal_bea_mapper, "NAICSToBEAMapper", mapper_constructor)
+    awards = pd.DataFrame(
+        [
+            {
+                "state": "CA",
+                "congressional_district": "CA-01",
+                "naics_code": 541715,
+                "fiscal_year": 2024,
+                "award_amount": 100.0,
+                "congressional_district_confidence": 0.9,
+            }
+        ]
+    )
+
+    result = allocate_state_impacts_to_districts(_state_impacts(), awards)
+
+    mapper_constructor.assert_called_once_with()
+    mapper.map_naics_to_bea_summary.assert_called_once_with("541715")
+    assert result.loc[0, "bea_sector"] == "54"
+    assert result.loc[0, "production_impact_allocated"] == pytest.approx(1000.0)
+
+
+def test_allocate_state_impacts_fails_fast_when_district_column_is_missing():
+    malformed_awards = pd.DataFrame(
+        [
+            {
+                "state": "CA",
+                "bea_sector": "54",
+                "fiscal_year": 2024,
+                "award_amount": 100.0,
+            }
+        ]
+    )
+
+    with pytest.raises(KeyError, match="congressional_district"):
+        allocate_state_impacts_to_districts(_state_impacts(), malformed_awards)
+
+
+def _district_impacts() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "congressional_district": "CA-01",
+                "state": "CA",
+                "bea_sector": "54",
+                "district_award_total": 100.0,
+                "production_impact_allocated": 200.0,
+                "tax_impact_allocated": 10.0,
+                "jobs_created_allocated": 1.0,
+                "wage_impact_allocated": 80.0,
+                "allocation_confidence": 0.8,
+            },
+            {
+                "congressional_district": "CA-01",
+                "state": "CA",
+                "bea_sector": "62",
+                "district_award_total": 50.0,
+                "production_impact_allocated": 100.0,
+                "tax_impact_allocated": 20.0,
+                "jobs_created_allocated": 2.0,
+                "wage_impact_allocated": 40.0,
+                "allocation_confidence": 0.6,
+            },
+            {
+                "congressional_district": "CA-02",
+                "state": "CA",
+                "bea_sector": "54",
+                "district_award_total": 120.0,
+                "production_impact_allocated": 240.0,
+                "tax_impact_allocated": 40.0,
+                "jobs_created_allocated": 2.0,
+                "wage_impact_allocated": 96.0,
+                "allocation_confidence": 0.9,
+            },
+            {
+                "congressional_district": "NV-01",
+                "state": "NV",
+                "bea_sector": "54",
+                "district_award_total": 500.0,
+                "production_impact_allocated": 1000.0,
+                "tax_impact_allocated": 100.0,
+                "jobs_created_allocated": 10.0,
+                "wage_impact_allocated": 400.0,
+                "allocation_confidence": 0.7,
+            },
+        ]
+    )
+
+
+def test_summarize_by_district_aggregates_sectors_and_sorts_by_awards():
+    summary = summarize_by_district(_district_impacts())
+
+    assert summary["congressional_district"].tolist() == ["NV-01", "CA-01", "CA-02"]
+    ca_01 = summary.set_index("congressional_district").loc["CA-01"]
+    assert ca_01["total_awards"] == 150.0
+    assert ca_01["total_production_impact"] == 300.0
+    assert ca_01["total_tax_impact"] == 30.0
+    assert ca_01["total_jobs_created"] == 3.0
+    assert ca_01["total_wage_impact"] == 120.0
+    assert ca_01["sector_count"] == 2
+    assert ca_01["avg_confidence"] == pytest.approx(0.7)
+
+
+def test_compare_districts_within_state_filters_and_adds_dense_rankings():
+    comparison = compare_districts_within_state(_district_impacts(), "CA").set_index(
+        "congressional_district"
+    )
+
+    assert set(comparison.index) == {"CA-01", "CA-02"}
+    assert comparison.loc["CA-01", "tax_impact_rank"] == 2
+    assert comparison.loc["CA-01", "jobs_rank"] == 1
+    assert comparison.loc["CA-01", "awards_rank"] == 1
+    assert comparison.loc["CA-02", "tax_impact_rank"] == 1
+    assert comparison.loc["CA-02", "jobs_rank"] == 2
+    assert comparison.loc["CA-02", "awards_rank"] == 2
+
+
+def test_compare_districts_within_state_returns_empty_for_unknown_state():
+    assert compare_districts_within_state(_district_impacts(), "TX").empty


### PR DESCRIPTION
## Summary\n- add hermetic tests for CET analytics, human sampling, inter-annotator agreement, and drift detection assets\n- cover weekly report enrichment orchestration across reuse, fallback, timeout, error, and local transformation paths\n- cover congressional-district impact allocation, NAICS mapping, summaries, and rankings\n\n## Coverage impact\n- targeted modules: 4% to 82% aggregate branch coverage\n- CET analytics: 3% to 74%\n- CET validation: 2% to 74%\n- weekly enrichment: 7% to 92%\n- district allocator: 0% to 96%\n- repository full-suite branch coverage: 71.02% to 72.73%\n\n## Validation\n- 6237 passed, 20 skipped; 72.73% branch coverage\n- 37 focused tests passed serially\n- ruff check and format verification\n- make lint-boundaries\n\n## Stack\n- builds on #604\n- #604 builds on #603\n- #603 builds on #602\n\nDraft until the stack is reviewed in order.