### PR TITLE
Release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ version.
 
 ## [Unreleased]
 
+## [0.5.1] — 2026-08-12
+
+### Added
+
+- A weekly comprehensive test and branch-coverage lane with a 70% floor, plus
+  hermetic end-to-end tests on every pull request (#602, #603).
+- Operated-path coverage for CET analytics and validation, weekly enrichment,
+  and congressional-district fiscal allocation (#605).
+
 ### Changed
 
 - Lint now runs over the whole repository, including exploratory `scripts/` and
@@ -20,6 +29,11 @@ version.
 - Normalized spec and document naming to kebab-case, and added an index for
   `examples/`.
 - Relocated the generated `pytest-split` timing file to `tests/.test_durations`.
+- Reclassified component-level tests into unit and integration suites, leaving
+  the E2E suite to execute two production Dagster workflows with hermetic inputs
+  and explicit network rejection (#604).
+- Removed environment-variable skips that silently prevented slow ML tests from
+  running in the comprehensive suite (#603).
 
 ## [0.5.0] — 2026-08-12
 
@@ -105,7 +119,8 @@ across the root project and the three packages under `packages/`.
 `vMAJOR.MINOR.PATCH` form it requires. Per that policy published tags are never
 moved or reused, so they remain as historical markers.
 
-[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.2.0...v0.3.0

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.5.0"
+  version: "0.5.1"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.5.0"
+version = "0.5.1"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.5.0"
+version = "0.5.1"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.5.0"
+version = "0.5.1"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.5.0"
+version = "0.5.1"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2834,7 +2834,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2985,7 +2985,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3004,7 +3004,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Summary

- release repository and test-infrastructure maintenance as v0.5.1
- synchronize all package, runtime, configuration, and lockfile versions
- roll the current Unreleased changelog into the v0.5.1 section

## Verification

- `uv run python scripts/ci/check_versioning.py --tag v0.5.1`
- `uv lock --check`
- 146 focused version, configuration, and User-Agent tests passed
- post-merge comprehensive CI for #603-#605 passed before release preparation