### PR TITLE
Fix v0.5.1 deployment regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,7 +398,7 @@ jobs:
             sh -c 'touch /app/reports/legacy && printf "999:999\n" > /app/reports/.sbir-runtime-owner-v1'
           docker run --rm -v "$runtime_volume:/app/reports" \
             sbir-analytics:ci-${{ github.sha }} \
-            sh /app/scripts/docker/entrypoint.sh -- true
+            sh /app/scripts/docker/entrypoint.sh true
           docker run --rm -v "$runtime_volume:/app/reports" \
             sbir-analytics:ci-${{ github.sha }} \
             sh -c 'test "$(cat /app/reports/.sbir-runtime-owner-v1)" = "1001:1001" && test "$(stat -c %u:%g /app/reports/legacy)" = "1001:1001"'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,19 @@ jobs:
             sbir-analytics:ci-${{ github.sha }} \
             dagster definitions validate -m sbir_analytics.definitions
 
+          runtime_volume="sbir-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          docker volume create "$runtime_volume"
+          trap 'docker volume rm "$runtime_volume"' EXIT
+          docker run --rm -v "$runtime_volume:/app/reports" \
+            sbir-analytics:ci-${{ github.sha }} \
+            sh -c 'touch /app/reports/legacy && printf "999:999\n" > /app/reports/.sbir-runtime-owner-v1'
+          docker run --rm -v "$runtime_volume:/app/reports" \
+            sbir-analytics:ci-${{ github.sha }} \
+            sh /app/scripts/docker/entrypoint.sh -- true
+          docker run --rm -v "$runtime_volume:/app/reports" \
+            sbir-analytics:ci-${{ github.sha }} \
+            sh -c 'test "$(cat /app/reports/.sbir-runtime-owner-v1)" = "1001:1001" && test "$(stat -c %u:%g /app/reports/legacy)" = "1001:1001"'
+
   verify-setup-script:
     name: Verify Developer Setup Script
     needs: [detect-changes]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ version.
 
 ## [Unreleased]
 
+### Fixed
+
+- Corrected the live-server health check to use production Neo4j variables and
+  dependencies instead of E2E-only assumptions.
+- Made the Tailscale route helper runnable with the macOS system Python used by
+  host preflight checks.
+- Made server rebuilds remove services retired from the Compose definition.
+- Restored the non-root `sbir` runtime contract for all three Dagster services,
+  including one-time ownership migration for existing persistent directories.
+
 ## [0.5.1] — 2026-08-12
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,12 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        gosu \
         netcat-openbsd \
     && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install "uv==${UV_VERSION}"
+    && python -m pip install "uv==${UV_VERSION}" \
+    && groupadd --system sbir \
+    && useradd --system --gid sbir --home-dir /app --no-create-home --shell /bin/sh sbir
 
 # Install locked dependencies before copying source. Workspace metadata is
 # enough for uv to select the `server` extra, while `--no-install-workspace`
@@ -72,7 +75,8 @@ COPY studies/phase-iii-census/ ./studies/phase-iii-census/
 COPY workspace.server.yaml ./workspace.server.yaml
 COPY data/reference/ ./data/reference/
 
-RUN mkdir -p data logs reports artifacts dagster_home
+RUN mkdir -p data logs reports artifacts dagster_home \
+    && chown -R sbir:sbir /app
 
 # Compose's CI profile adds test dependencies at image-build time. It never
 # mutates the environment when the test container starts.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         netcat-openbsd \
     && rm -rf /var/lib/apt/lists/* \
     && python -m pip install "uv==${UV_VERSION}" \
-    && groupadd --system sbir \
-    && useradd --system --gid sbir --home-dir /app --no-create-home --shell /bin/sh sbir
+    && groupadd --system --gid 1001 sbir \
+    && useradd --system --uid 1001 --gid sbir --home-dir /app --no-create-home --shell /bin/sh sbir
 
 # Install locked dependencies before copying source. Workspace metadata is
 # enough for uv to select the `server` extra, while `--no-install-workspace`
@@ -61,22 +61,21 @@ RUN playwright install --with-deps chromium \
 # wheels. PYTHONPATH intentionally keeps the historical repo-root `sbir_etl`
 # import behavior; the three packages below resolve from the installed wheels
 # unless the development Compose profile explicitly mounts live source paths.
-COPY sbir_etl/ ./sbir_etl/
-COPY packages/ ./packages/
+COPY --chown=sbir:sbir sbir_etl/ ./sbir_etl/
+COPY --chown=sbir:sbir packages/ ./packages/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-dev --extra server --no-editable
 
-COPY scripts/ ./scripts/
-COPY config/ ./config/
-COPY specs/phase-iii-census/ ./specs/phase-iii-census/
-COPY specs/phase3-notice-corpus-fusion/ ./specs/phase3-notice-corpus-fusion/
-COPY studies/phase-iii-census/ ./studies/phase-iii-census/
-COPY workspace.server.yaml ./workspace.server.yaml
-COPY data/reference/ ./data/reference/
+COPY --chown=sbir:sbir scripts/ ./scripts/
+COPY --chown=sbir:sbir config/ ./config/
+COPY --chown=sbir:sbir specs/phase-iii-census/ ./specs/phase-iii-census/
+COPY --chown=sbir:sbir specs/phase3-notice-corpus-fusion/ ./specs/phase3-notice-corpus-fusion/
+COPY --chown=sbir:sbir studies/phase-iii-census/ ./studies/phase-iii-census/
+COPY --chown=sbir:sbir workspace.server.yaml ./workspace.server.yaml
+COPY --chown=sbir:sbir data/reference/ ./data/reference/
 
-RUN mkdir -p data logs reports artifacts dagster_home \
-    && chown -R sbir:sbir /app
+RUN install -d -o sbir -g sbir data logs reports artifacts dagster_home
 
 # Compose's CI profile adds test dependencies at image-build time. It never
 # mutates the environment when the test container starts.

--- a/Makefile
+++ b/Makefile
@@ -609,7 +609,7 @@ server-rebuild: server-check ## Rebuild the locked app image and restart the sta
 	@$(call info,Rebuilding the application image from its pinned base and uv.lock)
 	$(call run,$(SERVER_COMPOSE) --profile server build --pull)
 	@$(call info,Restarting the stack on the new images)
-	$(call run,$(SERVER_COMPOSE) --profile server up -d --wait --wait-timeout 300)
+	$(call run,$(SERVER_COMPOSE) --profile server up -d --remove-orphans --wait --wait-timeout 300)
 	$(call run,$(SERVER_COMPOSE) --profile server ps)
 	@$(call success,Server stack rebuilt. Run 'docker image prune' to reclaim superseded layers)
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -147,19 +147,10 @@ services:
     container_name: ${DAGSTER_CODE_SERVER_CONTAINER_NAME:-sbir-server-dagster-code}
     profiles:
       - server
-    environment: *server-environment
-    command:
-      - dagster
-      - api
-      - grpc
-      - --host
-      - 0.0.0.0
-      - --port
-      - "4000"
-      - --module-name
-      - sbir_analytics.definitions
-      - --location-name
-      - sbir-analytics-production
+    environment:
+      <<: *server-environment
+      ENV_DAGSTER_CMD: dagster api grpc --host 0.0.0.0 --port 4000 --module-name sbir_analytics.definitions --location-name sbir-analytics-production
+    command: ["sh", "/app/scripts/docker/entrypoint.sh", "dagster-code-server"]
     volumes:
       - ./config:/app/config:rw
       - ${SERVER_REPORTS_DIR:-./reports}:/app/reports:rw

--- a/docs/deployment/self-hosted-server.md
+++ b/docs/deployment/self-hosted-server.md
@@ -181,9 +181,34 @@ prefer a quiet window.
 
 The first rebuild after adopting the non-root runtime recursively transfers the
 five application mount roots (`data`, `reports`, `logs`, `artifacts`, and
-`dagster_home`) to the container's `sbir` account. Each root receives a
-`.sbir-runtime-owner-v1` marker so later restarts do not rescan it. Plan the
-first restart for a quiet window when those trees are large.
+`dagster_home`) to the container's `sbir` account, whose UID and GID are both
+pinned to `1001`. The first four are host bind mounts, so this operation changes
+their ownership on the server filesystem too; direct access from the operator
+account may require `sudo` afterward. The `dagster_home` tree is a Docker named
+volume. Each root receives a `.sbir-runtime-owner-v1` marker containing the
+applied `UID:GID`; a missing or mismatched identity reruns the migration.
+
+Plan the first restart for a quiet window when those trees are large. The
+recursive ownership change can exceed `server-rebuild`'s 300-second wait and
+make the command report a timeout while the containers legitimately continue
+starting. Follow its progress, then rerun `make server-status`:
+
+```bash
+docker compose --env-file .env.server -f docker-compose.server.yml logs -f
+```
+
+If the migration was a mistake, stop the stack before restoring ownership. Use
+the real absolute bind-mount paths from `.env.server` (not the placeholders
+below), and set them back to the intended host account:
+
+```bash
+make server-down
+sudo chown -R "$(id -u):$(id -g)" /absolute/data /absolute/reports \
+  /absolute/logs /absolute/artifacts
+```
+
+The next container start will intentionally apply `1001:1001` again unless the
+non-root deployment change is reverted first.
 
 ## Tailscale grant (least privilege)
 

--- a/docs/deployment/self-hosted-server.md
+++ b/docs/deployment/self-hosted-server.md
@@ -179,6 +179,12 @@ Python image digest in `Dockerfile`, rather than an unreviewed mutable-tag pull.
 killed**. Check `make server-status` for active runs before using it, and
 prefer a quiet window.
 
+The first rebuild after adopting the non-root runtime recursively transfers the
+five application mount roots (`data`, `reports`, `logs`, `artifacts`, and
+`dagster_home`) to the container's `sbir` account. Each root receives a
+`.sbir-runtime-owner-v1` marker so later restarts do not rescan it. Plan the
+first restart for a quiet window when those trees are large.
+
 ## Tailscale grant (least privilege)
 
 Restrict who can reach the server. Tag the server node `tag:sbir-server`, grant

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -78,8 +78,8 @@ _make_exec_prefix() {
   exec_prefix=""
   if [ "$(id -u)" = "0" ]; then
     if ! id sbir >/dev/null 2>&1; then
-      # The lightweight runtime image does not currently create this account.
-      # Do not select runuser solely because the binary happens to exist.
+      # Some development or downstream images may omit this account. Do not
+      # select runuser solely because the binary happens to exist.
       log "Warning: sbir user is unavailable; continuing as root" >&2
       printf '%s' "$exec_prefix"
       return 0
@@ -109,14 +109,19 @@ _make_exec_prefix() {
 prepare_runtime_directories() {
   [ "$(id -u)" = "0" ] || return 0
   id sbir >/dev/null 2>&1 || return 0
+  owner_identity="$(id -u sbir):$(id -g sbir)"
 
   for dir in /app/data /app/logs /app/reports /app/artifacts /app/dagster_home; do
     [ -d "$dir" ] || continue
     marker="$dir/.sbir-runtime-owner-v1"
-    if [ ! -f "$marker" ]; then
-      log "Preparing runtime ownership: $dir"
+    recorded_identity=""
+    if [ -f "$marker" ]; then
+      recorded_identity="$(sed -n '1p' "$marker")"
+    fi
+    if [ "$recorded_identity" != "$owner_identity" ]; then
+      log "Preparing runtime ownership for ${owner_identity}: $dir"
       chown -R sbir:sbir "$dir"
-      touch "$marker"
+      printf '%s\n' "$owner_identity" > "$marker"
       chown sbir:sbir "$marker"
     fi
   done

--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -103,6 +103,25 @@ _make_exec_prefix() {
   printf '%s' "$exec_prefix"
 }
 
+# Existing deployments may have runtime files created by the historical root
+# process. Repair each mounted tree once before dropping privileges; the marker
+# avoids rescanning persistent datasets on every container restart.
+prepare_runtime_directories() {
+  [ "$(id -u)" = "0" ] || return 0
+  id sbir >/dev/null 2>&1 || return 0
+
+  for dir in /app/data /app/logs /app/reports /app/artifacts /app/dagster_home; do
+    [ -d "$dir" ] || continue
+    marker="$dir/.sbir-runtime-owner-v1"
+    if [ ! -f "$marker" ]; then
+      log "Preparing runtime ownership: $dir"
+      chown -R sbir:sbir "$dir"
+      touch "$marker"
+      chown sbir:sbir "$marker"
+    fi
+  done
+}
+
 probe_tcp() {
   host="$1"
   port="$2"
@@ -220,6 +239,8 @@ main() {
   # Load environment defaults and secrets
   load_env
 
+  prepare_runtime_directories
+
   # allow overriding arguments via SERVICE env var if no args provided
   if [ "$#" -eq 0 ]; then
     if [ -n "${SERVICE-}" ]; then
@@ -237,6 +258,21 @@ main() {
   EXEC_PREFIX="$(_make_exec_prefix)"
 
   case "$service" in
+    dagster-code-server)
+      log "Starting service: dagster-code-server"
+      if ! wait_for_neo4j; then
+        log "Failed dependency check: Neo4j not available"
+        exit 1
+      fi
+      CMD="${ENV_DAGSTER_CMD:-dagster api grpc --host 0.0.0.0 --port 4000 --module-name sbir_analytics.definitions --location-name sbir-analytics-production}"
+      log "Exec: ${EXEC_PREFIX} ${CMD}"
+      if [ -n "$EXEC_PREFIX" ]; then
+        eval "exec ${EXEC_PREFIX} sh -c '${CMD}'"
+      else
+        exec sh -c "${CMD}"
+      fi
+      ;;
+
     dagster-webserver)
       log "Starting service: dagster-webserver"
       # Ensure Neo4j is up before starting webserver (helps CI/flaky startup)

--- a/scripts/e2e_health_check.py
+++ b/scripts/e2e_health_check.py
@@ -15,13 +15,17 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
-def check_neo4j_connection() -> tuple[bool, str]:
+def check_neo4j_connection(profile: str = "e2e") -> tuple[bool, str]:
     """Check Neo4j database connectivity."""
     try:
         from neo4j import GraphDatabase
 
-        uri = os.getenv("SBIR_ETL__NEO4J__BOLT_URL", "bolt://neo4j-e2e:7687")
-        username = os.getenv("NEO4J_USERNAME", "neo4j")
+        if profile == "server":
+            uri = os.getenv("NEO4J_URI", "bolt://neo4j:7687")
+            username = os.getenv("NEO4J_USER", "neo4j")
+        else:
+            uri = os.getenv("SBIR_ETL__NEO4J__BOLT_URL", "bolt://neo4j-e2e:7687")
+            username = os.getenv("NEO4J_USERNAME", "neo4j")
         password = os.getenv("NEO4J_PASSWORD", "e2e-password")
 
         driver = GraphDatabase.driver(uri, auth=(username, password))
@@ -42,14 +46,17 @@ def check_neo4j_connection() -> tuple[bool, str]:
         return False, f"Neo4j connection failed: {str(e)}"
 
 
-def check_environment_variables() -> tuple[bool, str]:
+def check_environment_variables(profile: str = "e2e") -> tuple[bool, str]:
     """Check required environment variables."""
-    required_vars = [
-        "NEO4J_USERNAME",
-        "NEO4J_PASSWORD",
-        "SBIR_ETL__NEO4J__BOLT_URL",
-        "ENVIRONMENT",
-    ]
+    if profile == "server":
+        required_vars = ["NEO4J_USER", "NEO4J_PASSWORD", "NEO4J_URI", "ENVIRONMENT"]
+    else:
+        required_vars = [
+            "NEO4J_USERNAME",
+            "NEO4J_PASSWORD",
+            "SBIR_ETL__NEO4J__BOLT_URL",
+            "ENVIRONMENT",
+        ]
 
     missing_vars = []
     for var in required_vars:
@@ -81,15 +88,11 @@ def check_test_data_availability() -> tuple[bool, str]:
     return True, f"Test data available at: {', '.join(available_paths)}"
 
 
-def check_python_dependencies() -> tuple[bool, str]:
+def check_python_dependencies(profile: str = "e2e") -> tuple[bool, str]:
     """Check if required Python packages are available."""
-    required_packages = [
-        "dagster",
-        "pandas",
-        "neo4j",
-        "pytest",
-        "pydantic",
-    ]
+    required_packages = ["dagster", "pandas", "neo4j", "pydantic"]
+    if profile == "e2e":
+        required_packages.append("pytest")
 
     missing_packages = []
     for package in required_packages:
@@ -148,11 +151,11 @@ CHECK_PROFILES = {
 def run_health_checks(profile: str = "e2e") -> dict[str, tuple[bool, str]]:
     """Run the profile's health checks and return results."""
     all_checks = {
-        "Environment Variables": check_environment_variables,
-        "Python Dependencies": check_python_dependencies,
+        "Environment Variables": lambda: check_environment_variables(profile),
+        "Python Dependencies": lambda: check_python_dependencies(profile),
         "Test Data": check_test_data_availability,
         "Resource Constraints": check_resource_constraints,
-        "Neo4j Connection": check_neo4j_connection,
+        "Neo4j Connection": lambda: check_neo4j_connection(profile),
     }
     checks = {name: all_checks[name] for name in CHECK_PROFILES[profile]}
 

--- a/scripts/server/tailscale-route-state.py
+++ b/scripts/server/tailscale-route-state.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Classify ownership of one Tailscale Serve route."""
 
+from __future__ import annotations
+
 import json
 import sys
 from typing import Any

--- a/tests/unit/phase_iii_census/test_import_isolation.py
+++ b/tests/unit/phase_iii_census/test_import_isolation.py
@@ -83,8 +83,8 @@ assert assets.verify_materialization_gate()["materialization_allowed"] is True
     )
 
     assert result.returncode == 0, result.stderr or result.stdout
-    docker_copy = "COPY specs/phase-iii-census/ ./specs/phase-iii-census/"
-    study_copy = "COPY studies/phase-iii-census/ ./studies/phase-iii-census/"
+    docker_copy = "COPY --chown=sbir:sbir specs/phase-iii-census/ ./specs/phase-iii-census/"
+    study_copy = "COPY --chown=sbir:sbir studies/phase-iii-census/ ./studies/phase-iii-census/"
     docker_text = (REPOSITORY_ROOT / "Dockerfile").read_text(encoding="utf-8")
     assert docker_copy in docker_text
     assert study_copy in docker_text

--- a/tests/unit/test_server_health_check.py
+++ b/tests/unit/test_server_health_check.py
@@ -1,0 +1,99 @@
+"""Regression tests for the live-server health-check profile."""
+
+import builtins
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import e2e_health_check as health
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def test_server_environment_uses_compose_variable_contract(monkeypatch):
+    for name in (
+        "NEO4J_USER",
+        "NEO4J_PASSWORD",
+        "NEO4J_URI",
+        "ENVIRONMENT",
+        "NEO4J_USERNAME",
+        "SBIR_ETL__NEO4J__BOLT_URL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("NEO4J_USER", "neo4j")
+    monkeypatch.setenv("NEO4J_PASSWORD", "secret")
+    monkeypatch.setenv("NEO4J_URI", "bolt://neo4j:7687")
+    monkeypatch.setenv("ENVIRONMENT", "prod")
+
+    success, message = health.check_environment_variables("server")
+
+    assert success, message
+
+
+def test_server_dependencies_do_not_require_pytest(monkeypatch):
+    real_import = builtins.__import__
+
+    def import_without_pytest(name, *args, **kwargs):
+        if name == "pytest":
+            raise ImportError
+        if name in {"dagster", "pandas", "neo4j", "pydantic"}:
+            return object()
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_pytest)
+
+    server_success, server_message = health.check_python_dependencies("server")
+    e2e_success, _ = health.check_python_dependencies("e2e")
+
+    assert server_success, server_message
+    assert not e2e_success
+
+
+def test_server_neo4j_connection_uses_production_uri_and_user(monkeypatch):
+    captured = {}
+
+    class FakeResult:
+        @staticmethod
+        def single():
+            return {"test": 1}
+
+    class FakeSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        @staticmethod
+        def run(_query):
+            return FakeResult()
+
+    class FakeDriver:
+        @staticmethod
+        def session():
+            return FakeSession()
+
+        @staticmethod
+        def close():
+            return None
+
+    class FakeGraphDatabase:
+        @staticmethod
+        def driver(uri, auth):
+            captured.update(uri=uri, auth=auth)
+            return FakeDriver()
+
+    monkeypatch.setitem(sys.modules, "neo4j", SimpleNamespace(GraphDatabase=FakeGraphDatabase))
+    monkeypatch.setenv("NEO4J_URI", "bolt://neo4j:7687")
+    monkeypatch.setenv("NEO4J_USER", "server-user")
+    monkeypatch.setenv("NEO4J_PASSWORD", "server-password")
+
+    success, message = health.check_neo4j_connection("server")
+
+    assert success, message
+    assert captured == {
+        "uri": "bolt://neo4j:7687",
+        "auth": ("server-user", "server-password"),
+    }

--- a/tests/unit/test_server_ops.py
+++ b/tests/unit/test_server_ops.py
@@ -15,6 +15,8 @@ pytestmark = [pytest.mark.fast, pytest.mark.unit]
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BACKUP = REPO_ROOT / "scripts" / "server" / "backup.sh"
 TAILSCALE = REPO_ROOT / "scripts" / "server" / "tailscale-serve.sh"
+TAILSCALE_ROUTE_STATE = REPO_ROOT / "scripts" / "server" / "tailscale-route-state.py"
+MAKEFILE = REPO_ROOT / "Makefile"
 
 
 def _executable(path: Path, body: str) -> None:
@@ -90,6 +92,19 @@ def _install_fake_docker(bin_dir: Path) -> None:
 
 def _call_index(calls: list[list[str]], *tokens: str) -> int:
     return next(index for index, call in enumerate(calls) if all(token in call for token in tokens))
+
+
+def test_tailscale_route_helper_defers_annotations_for_host_python_compatibility():
+    source = TAILSCALE_ROUTE_STATE.read_text()
+
+    assert "from __future__ import annotations" in source
+
+
+def test_server_rebuild_removes_services_retired_from_compose():
+    makefile = MAKEFILE.read_text()
+    rebuild = makefile.split("server-rebuild:", 1)[1].split(".PHONY: server-up", 1)[0]
+
+    assert "up -d --remove-orphans --wait" in rebuild
 
 
 def test_backup_honors_env_directory_and_runs_offline(tmp_path):

--- a/tests/unit/test_server_runtime_contract.py
+++ b/tests/unit/test_server_runtime_contract.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SERVER_COMPOSE = REPO_ROOT / "docker-compose.server.yml"
 SERVER_ENV_EXAMPLE = REPO_ROOT / ".env.server.example"
 DOCKERFILE = REPO_ROOT / "Dockerfile"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 SERVER_WORKSPACE = REPO_ROOT / "workspace.server.yaml"
 ROOT_PROJECT = REPO_ROOT / "pyproject.toml"
 DAGSTER_HEALTHCHECK = REPO_ROOT / "scripts" / "docker" / "healthcheck" / "dagster.sh"
@@ -61,7 +62,11 @@ def test_dagster_uses_shared_internal_code_server():
 
     assert "host: dagster-code-server" in workspace
     assert "port: 4000" in workspace
-    assert "COPY workspace.server.yaml ./workspace.server.yaml" in DOCKERFILE.read_text()
+    assert re.search(
+        r"^COPY --chown=sbir:sbir workspace\.server\.yaml ./workspace\.server\.yaml$",
+        DOCKERFILE.read_text(),
+        re.MULTILINE,
+    )
     assert "\n    ports:" not in code_server
     assert 'expose:\n      - "4000"' in code_server
     assert "grpc-health-check" in code_server
@@ -86,9 +91,10 @@ def test_docker_build_rejects_lock_drift_and_caches_dependency_layers():
     assert "uv sync --frozen" not in dockerfile
     assert "--no-install-project --no-install-workspace" in dockerfile
     assert dockerfile.count("--mount=type=cache,target=/root/.cache/uv") >= 2
-    assert dockerfile.index("--no-install-workspace") < dockerfile.index("COPY sbir_etl/")
+    source_copy = "COPY --chown=sbir:sbir sbir_etl/"
+    assert dockerfile.index("--no-install-workspace") < dockerfile.index(source_copy)
     assert dockerfile.index("playwright install --with-deps chromium") < dockerfile.index(
-        "COPY sbir_etl/"
+        source_copy
     )
 
 
@@ -96,9 +102,19 @@ def test_runtime_image_provides_non_root_account_and_privilege_drop_tool():
     dockerfile = DOCKERFILE.read_text()
 
     assert "gosu" in dockerfile
-    assert "groupadd --system sbir" in dockerfile
-    assert "useradd --system --gid sbir" in dockerfile
-    assert "chown -R sbir:sbir /app" in dockerfile
+    assert re.search(r"groupadd --system --gid 1001 sbir", dockerfile)
+    assert re.search(r"useradd --system --uid 1001 --gid sbir\b", dockerfile)
+    assert "COPY --chown=sbir:sbir sbir_etl/" in dockerfile
+    assert "chown -R sbir:sbir /app" not in dockerfile
+
+
+def test_ci_smoke_tests_identity_aware_runtime_ownership_migration():
+    workflow = CI_WORKFLOW.read_text()
+
+    assert 'printf "999:999\\n" > /app/reports/.sbir-runtime-owner-v1' in workflow
+    assert "sh /app/scripts/docker/entrypoint.sh -- true" in workflow
+    assert "cat /app/reports/.sbir-runtime-owner-v1" in workflow
+    assert "stat -c %u:%g /app/reports/legacy" in workflow
 
 
 def test_server_extra_locks_default_spacy_pipeline():
@@ -234,6 +250,9 @@ def test_entrypoint_prepares_persistent_directories_before_privilege_drop():
     )
     assert "/app/dagster_home" in entrypoint
     assert "chown -R sbir:sbir" in entrypoint
+    assert 'owner_identity="$(id -u sbir):$(id -g sbir)"' in entrypoint
+    assert 'recorded_identity" != "$owner_identity' in entrypoint
+    assert 'printf \'%s\\n\' "$owner_identity" > "$marker"' in entrypoint
 
 
 def test_daemon_healthcheck_uses_heartbeat_liveness_without_procps(tmp_path):

--- a/tests/unit/test_server_runtime_contract.py
+++ b/tests/unit/test_server_runtime_contract.py
@@ -67,6 +67,18 @@ def test_dagster_uses_shared_internal_code_server():
     assert "grpc-health-check" in code_server
 
 
+def test_server_code_server_uses_privilege_dropping_entrypoint():
+    compose = SERVER_COMPOSE.read_text()
+    code_server = compose.split("  dagster-code-server:", 1)[1].split("\n  dagster-webserver:", 1)[
+        0
+    ]
+
+    assert 'command: ["sh", "/app/scripts/docker/entrypoint.sh", "dagster-code-server"]' in (
+        code_server
+    )
+    assert "ENV_DAGSTER_CMD: dagster api grpc" in code_server
+
+
 def test_docker_build_rejects_lock_drift_and_caches_dependency_layers():
     dockerfile = DOCKERFILE.read_text()
 
@@ -78,6 +90,15 @@ def test_docker_build_rejects_lock_drift_and_caches_dependency_layers():
     assert dockerfile.index("playwright install --with-deps chromium") < dockerfile.index(
         "COPY sbir_etl/"
     )
+
+
+def test_runtime_image_provides_non_root_account_and_privilege_drop_tool():
+    dockerfile = DOCKERFILE.read_text()
+
+    assert "gosu" in dockerfile
+    assert "groupadd --system sbir" in dockerfile
+    assert "useradd --system --gid sbir" in dockerfile
+    assert "chown -R sbir:sbir /app" in dockerfile
 
 
 def test_server_extra_locks_default_spacy_pipeline():
@@ -202,6 +223,17 @@ def test_entrypoint_only_drops_privileges_when_sbir_user_exists():
     prefix_function = entrypoint.split("_make_exec_prefix()", 1)[1].split("probe_tcp()", 1)[0]
     assert "id sbir" in prefix_function
     assert "continuing as root" in prefix_function
+
+
+def test_entrypoint_prepares_persistent_directories_before_privilege_drop():
+    entrypoint = ENTRYPOINT.read_text()
+    main = entrypoint.split("main() {", 1)[1]
+
+    assert main.index("prepare_runtime_directories") < main.index(
+        'EXEC_PREFIX="$(_make_exec_prefix)"'
+    )
+    assert "/app/dagster_home" in entrypoint
+    assert "chown -R sbir:sbir" in entrypoint
 
 
 def test_daemon_healthcheck_uses_heartbeat_liveness_without_procps(tmp_path):

--- a/tests/unit/test_server_runtime_contract.py
+++ b/tests/unit/test_server_runtime_contract.py
@@ -112,7 +112,7 @@ def test_ci_smoke_tests_identity_aware_runtime_ownership_migration():
     workflow = CI_WORKFLOW.read_text()
 
     assert 'printf "999:999\\n" > /app/reports/.sbir-runtime-owner-v1' in workflow
-    assert "sh /app/scripts/docker/entrypoint.sh -- true" in workflow
+    assert "sh /app/scripts/docker/entrypoint.sh true" in workflow
     assert "cat /app/reports/.sbir-runtime-owner-v1" in workflow
     assert "stat -c %u:%g /app/reports/legacy" in workflow
 


### PR DESCRIPTION
## Summary

Fixes the four defects found while deploying v0.5.1 to the operated local server:

- make the server health profile validate the production Neo4j variables and dependency set;
- defer Tailscale-helper annotations so host preflight works with macOS Python 3.9;
- remove retired Compose services during `server-rebuild`;
- restore the intended non-root `sbir` runtime for all three Dagster services, including an identity-aware ownership migration for existing persistent mount trees.

The runtime account is pinned to UID/GID `1001`, migration markers record the applied identity, and CI exercises stale-marker repair against a real Docker volume. The runbook documents the host bind-mount ownership change, timeout behavior, and rollback procedure.

Closes #607.
Closes #608.
Closes #609.
Closes #610.

## Root causes

- The server health profile reused E2E-only variable names, hostname, and the test-only `pytest` dependency.
- The host route helper evaluated Python 3.10 union annotations under Apple's Python 3.9.
- The rebuild target omitted Compose's `--remove-orphans`.
- The consolidated production image stopped creating the `sbir` account and privilege-drop tool, while the entrypoint still expected them; the code server also bypassed that entrypoint.

## Validation

- `make lint`
- `make docs-check`
- 48 focused server/deployment regression tests passed after the review changes
- Tailscale route helper executed successfully under `/usr/bin/python3` 3.9
- production Compose configuration validated with the operated server environment
- complete unit suite before the review update: 5,998 passed, 7 skipped, one unrelated parallel failure; the failing Neo4j loader test passed immediately in isolation
- GitHub Docker build and entrypoint smoke tests passed before the review update; the updated workflow additionally verifies identity-aware runtime migration in a real Docker volume

