### PR TITLE
Enforce research-question anchors on top-level specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,7 +238,7 @@ lint-boundaries: ## Enforce package and archive dependency boundaries
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
 
 .PHONY: docs-check
-docs-check: ## Check docs, agent files, spec registry, stale commands, and old code references
+docs-check: ## Check docs, agent files, spec registry and question anchors, stale commands, and old code references
 	@$(call info,Running repository hygiene checks)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 

--- a/scripts/ci/check_removed_src_references.py
+++ b/scripts/ci/check_removed_src_references.py
@@ -63,6 +63,16 @@ MARKDOWN_REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(\S+)")
 MARKDOWN_HEADING_RE = re.compile(r"^ {0,3}#{1,6}\s+(.+?)\s*#*\s*$")
 MARKDOWN_EXPLICIT_ANCHOR_RE = re.compile(r'<a\s+(?:[^>]*?\s)?(?:id|name)=["\']([^"\']+)["\']', re.I)
 SPEC_STATUS_ENTRY_RE = re.compile(r"^- \*\*`([^`]+)`\s+—", re.MULTILINE)
+# specs/REQUIREMENTS_TEMPLATE.md mandates a research-question anchor. Accepts the
+# anchoring form ("**Research question anchor:** A2 — ...") and the operational
+# form ("- **Research question:** none directly. Operational obligation: ...").
+SPEC_QUESTION_ANCHOR_RE = re.compile(
+    r"^[ \t]*(?:>[ \t]*)*(?:[-*][ \t]+)?"
+    r"\*\*Research question(?: anchors?)?:\*\*[ \t]*(?P<body>\S.*)$",
+    re.MULTILINE,
+)
+# The unfilled template placeholder, e.g. "[e.g., A3 — DoD leverage ratio]".
+TEMPLATE_PLACEHOLDER_RE = re.compile(r"^\[.*\]$")
 CODEX_AGENT_NAME_RE = re.compile(r'^name\s*=\s*"([^"]+)"\s*$', re.MULTILINE)
 CODEX_AGENT_INSTRUCTIONS_RE = re.compile(
     r'^developer_instructions\s*=\s*"""(.*?)"""\s*$', re.MULTILINE | re.DOTALL
@@ -368,6 +378,68 @@ def scan_spec_registry(*, root: Path = REPOSITORY_ROOT) -> list[Violation]:
     return violations
 
 
+def _spec_requirement_documents(specs_root: Path) -> list[tuple[str, Path]]:
+    """Return (spec name, requirements document) for every top-level feature spec."""
+    documents: list[tuple[str, Path]] = []
+    for path in sorted(specs_root.iterdir()):
+        if path.is_dir():
+            if path.name == "archive":
+                continue
+            documents.append((path.name, path / "requirements.md"))
+        elif path.suffix == ".md" and path.name not in {"REQUIREMENTS_TEMPLATE.md", "status.md"}:
+            documents.append((path.name, path))
+    return documents
+
+
+def scan_spec_question_anchors(*, root: Path = REPOSITORY_ROOT) -> list[Violation]:
+    """Require every top-level feature spec to declare its research-question anchor.
+
+    A spec with no research question must say so explicitly rather than stay
+    silent, so that an unanchored spec is a deliberate statement instead of an
+    omission. Without this, an area can only be inferred, and inference misreads
+    design labels as question ids.
+    """
+    specs_root = root / "specs"
+    if not specs_root.is_dir():
+        return []
+
+    violations: list[Violation] = []
+    for name, document in _spec_requirement_documents(specs_root):
+        relative = _relative_to_repository(document, root)
+        if not document.is_file():
+            violations.append(
+                Violation(relative, 1, f"spec is missing requirements.md: {name}", "")
+            )
+            continue
+
+        text = document.read_text(encoding="utf-8")
+        match = SPEC_QUESTION_ANCHOR_RE.search(text)
+        if match is None:
+            violations.append(
+                Violation(
+                    relative,
+                    1,
+                    "missing '**Research question anchor:**' declaration "
+                    "(use '**Research question:** none directly. Operational obligation: ...' "
+                    "when the spec answers no inventory question)",
+                    "",
+                )
+            )
+            continue
+
+        body = match.group("body").strip()
+        if TEMPLATE_PLACEHOLDER_RE.match(body):
+            violations.append(
+                Violation(
+                    relative,
+                    text[: match.start()].count("\n") + 1,
+                    "research-question anchor still holds the template placeholder",
+                    body,
+                )
+            )
+    return violations
+
+
 def scan_agent_definition_routes(*, root: Path = REPOSITORY_ROOT) -> list[Violation]:
     """Keep Codex wrappers and shared agent/skill instructions synchronized."""
     claude_agents = root / ".claude" / "agents"
@@ -481,6 +553,10 @@ def main() -> int:
         (
             "The specification status registry is incomplete:",
             scan_spec_registry(),
+        ),
+        (
+            "Specifications are missing a research-question anchor:",
+            scan_spec_question_anchors(),
         ),
         (
             "Agent definitions or skill copies are out of sync:",

--- a/specs/actions-migration-followups/requirements.md
+++ b/specs/actions-migration-followups/requirements.md
@@ -2,6 +2,12 @@
 
 **Target epistemic tier:** `pipelines`
 
+- **Research question:** none directly. Operational obligation: the scheduled GitHub Actions
+  workflows were retired along with the deterministic repository and setup checks they ran.
+  This spec restores those checks so repository hygiene stays a measured fact rather than an
+  asserted policy. It answers no inventory question in
+  [docs/research-questions.md](../../docs/research-questions.md).
+
 This operational spec restores deterministic repository and setup checks after
 the scheduled GitHub Actions workflows were retired. The detailed decisions and
 acceptance evidence remain in:

--- a/specs/dark-majority-resolution/requirements.md
+++ b/specs/dark-majority-resolution/requirements.md
@@ -2,6 +2,10 @@
 
 **Target epistemic tier:** `evidence`
 
+**Research question anchor:** B2 / B3 — award-to-contract transition and transition rate by
+technology area, for the Phase II cohort whose commercialization status is currently
+indeterminate rather than negative
+
 **Problem:** 82.6% of the nanotech Phase II cohort (2,352 of 2,849 awards) has indeterminate
 commercialization status. The findings report (`docs/research/nanotech_sbir_transition_findings.md`,
 Finding 3) shows this "dark majority" is measurement failure more than proven failure — but

--- a/specs/follow-on-multiplier-validation/requirements.md
+++ b/specs/follow-on-multiplier-validation/requirements.md
@@ -2,6 +2,10 @@
 
 **Target epistemic tier:** `evidence`
 
+**Research question anchor:** A3 — DoD follow-on funding multiplier (NASEM's *leverage ratio*):
+the aggregate multiplier and its stratification by vintage, firm size, technology area, and
+firm experience
+
 The target contract is the validation, sensitivity, and review-sampling design
 in [design.md](design.md). The multiplier is externally reportable only after
 the evidence-tier gates described there are implemented and passed.

--- a/specs/ma-discovery-integration/requirements.md
+++ b/specs/ma-discovery-integration/requirements.md
@@ -2,6 +2,9 @@
 
 **Target epistemic tier:** `pipelines`
 
+**Research question anchor:** A4 / F2 — M&A detection and transition pathways, and
+acquirer-type concentration among SBIR-firm acquirers
+
 The target contract is the confidence-bounded discovery and collision policy
 in [design.md](design.md). Candidate discovery remains non-citable until the
 specified validation and provenance requirements are implemented.

--- a/specs/phase-iii-census/requirements.md
+++ b/specs/phase-iii-census/requirements.md
@@ -2,6 +2,9 @@
 
 **Target epistemic tier:** `evidence`
 
+**Research question anchor:** B2 / B3 / E1 — follow-on contracts never labelled Phase III,
+how much Phase III work goes unrecorded, and Phase III identification
+
 The frozen criteria, declared estimand, amendments, materialization gates, and
 limitations are defined in [design.md](design.md), [amendments.md](amendments.md),
 and the versioned [`study.yaml`](../../studies/phase-iii-census/study.yaml).

--- a/specs/phase-iii-hand-label-validation/requirements.md
+++ b/specs/phase-iii-hand-label-validation/requirements.md
@@ -2,6 +2,9 @@
 
 **Target epistemic tier:** `pipelines`
 
+**Research question anchor:** B2 / B3 — follow-on contracts never labelled Phase III, and
+how much Phase III work goes unrecorded (supplies the hand-labelled validation both require)
+
 This specification defines the Phase III census hand-label survivor substantiation audit.
 The estimand, design, and decision boundaries are defined in [design.md](design.md).
 

--- a/specs/phase-iii-source-materialization/requirements.md
+++ b/specs/phase-iii-source-materialization/requirements.md
@@ -2,6 +2,12 @@
 
 **Target epistemic tier:** `pipelines`
 
+- **Research question:** none directly. Operational obligation: this layer supplies the
+  schema-verified USAspending and SBIR.gov inputs that the Phase III census and the other
+  transition consumers read. It materializes inputs; it does not apply census criteria or
+  produce findings, so the questions it serves are anchored by those consumers rather than
+  here. See [docs/research-questions.md](../../docs/research-questions.md).
+
 The deterministic source, schema, grain, fingerprint, and atomic-publication
 contracts are defined in [design.md](design.md). This layer materializes inputs;
 it does not apply Phase III census criteria or produce findings.

--- a/specs/phase3-match-benchmark/requirements.md
+++ b/specs/phase3-match-benchmark/requirements.md
@@ -2,6 +2,9 @@
 
 **Target epistemic tier:** `evidence`
 
+**Research question anchor:** B3 / E1 — how much Phase III work goes unrecorded (protocol and
+current evidence limits), and Phase III identification
+
 Status: **research protocol / draft implementation**. Parent issue: #448.
 Foundation: PR #449 and issue #447. Production source lifecycle: issue #442.
 

--- a/specs/procurement-transition-p1-remediation/requirements.md
+++ b/specs/procurement-transition-p1-remediation/requirements.md
@@ -2,6 +2,9 @@
 
 **Target epistemic tier:** `evidence`
 
+**Research question anchor:** B2 / E1 — research-to-procurement transitions (which SBIR-funded
+companies transitioned research into federal procurements) and Phase III identification
+
 The award-lineage, cold-start, source-matching, enrichment, and ranking safety
 requirements and their acceptance gates are maintained in [plan.md](plan.md).
 The packet remains a human review queue until those evidence gates are met.

--- a/tests/unit/scripts/test_repository_hygiene.py
+++ b/tests/unit/scripts/test_repository_hygiene.py
@@ -162,6 +162,60 @@ def test_spec_registry_requires_each_top_level_spec(tmp_path: Path):
     ]
 
 
+def test_spec_question_anchors_require_an_explicit_declaration(tmp_path: Path):
+    _write(
+        tmp_path,
+        "specs/anchored/requirements.md",
+        "# Anchored\n\n**Research question anchor:** A2 — OT consortium attribution\n",
+    )
+    _write(
+        tmp_path,
+        "specs/quoted-anchor/requirements.md",
+        "# Quoted\n\n> **Research question anchor:** F2 — M&A evidence by vintage\n",
+    )
+    _write(
+        tmp_path,
+        "specs/operational/requirements.md",
+        "# Operational\n\n- **Research question:** none directly. Operational obligation: CI.\n",
+    )
+    _write(tmp_path, "specs/unanchored/requirements.md", "# Unanchored\n\nNo anchor here.\n")
+    _write(tmp_path, "specs/no-requirements/design.md", "# Design only\n")
+    _write(
+        tmp_path,
+        "specs/placeholder/requirements.md",
+        "# Placeholder\n\n**Research question anchor:** [e.g., A3 — DoD leverage ratio]\n",
+    )
+    _write(tmp_path, "specs/standalone.md", "# Standalone\n\nNo anchor.\n")
+    _write(tmp_path, "specs/REQUIREMENTS_TEMPLATE.md", "# Template\n")
+    _write(tmp_path, "specs/status.md", "# Registry\n")
+    _write(tmp_path, "specs/archive/old/requirements.md", "# Archived\n")
+
+    violations = hygiene.scan_spec_question_anchors(root=tmp_path)
+
+    assert [(violation.path, violation.message) for violation in violations] == [
+        (
+            "specs/no-requirements/requirements.md",
+            "spec is missing requirements.md: no-requirements",
+        ),
+        (
+            "specs/placeholder/requirements.md",
+            "research-question anchor still holds the template placeholder",
+        ),
+        (
+            "specs/standalone.md",
+            "missing '**Research question anchor:**' declaration "
+            "(use '**Research question:** none directly. Operational obligation: ...' "
+            "when the spec answers no inventory question)",
+        ),
+        (
+            "specs/unanchored/requirements.md",
+            "missing '**Research question anchor:**' declaration "
+            "(use '**Research question:** none directly. Operational obligation: ...' "
+            "when the spec answers no inventory question)",
+        ),
+    ]
+
+
 def test_archive_guard_ignores_archive_scripts_and_flags_live_references(tmp_path: Path):
     live_code = _write(
         tmp_path,


### PR DESCRIPTION
## Description

`specs/REQUIREMENTS_TEMPLATE.md` mandates a research-question anchor in two header slots, but nothing enforced it. Comparing the three template-mandated header facts makes the cause plain:

| Header fact | Guard | Conformance |
|---|---|---|
| Target epistemic tier | `check_epistemic_tiers.py` | 32/32 spec directories |
| Registry membership | `check_removed_src_references.py::scan_spec_registry` | 33/33 |
| **Research question anchor** | **none** | **24/33** |

The two guarded fields have full conformance. The unguarded one had drifted on nine specs. This PR adds the missing guard and brings those nine into conformance.

### The guard

`scan_spec_question_anchors` in the existing repository-hygiene check (already wired into CI at `.github/workflows/ci.yml:78` and `make docs-check`). It accepts both forms already in use in the repo:

- anchoring — `**Research question anchor:** A2 — OT consortium sub-award attribution`
- operational — `- **Research question:** none directly. Operational obligation: ...`

It tolerates the blockquoted and bulleted variants already present (`sbir-ma-match-rate-by-fy` carries a valid F2 anchor inside a `>` banner and is intentionally left untouched), and rejects the unfilled template placeholder.

### The nine specs

**Anchors already recorded elsewhere — lifted into the canonical field, no new judgment:**

- `phase-iii-census` → B2 / B3 / E1 (from `design.md:294`)
- `phase-iii-hand-label-validation` → B2 / B3 (from `design.md:8`, which used the variant spelling `**Research-question anchors:**`)
- `phase3-match-benchmark` → B3 / E1 (from the `docs/research-questions.md:582` backlink)

**Evidence-tier specs with no anchor in either direction — anchors proposed, please confirm:**

- `follow-on-multiplier-validation` → A3 (DoD follow-on funding multiplier)
- `procurement-transition-p1-remediation` → B2 / E1
- `dark-majority-resolution` → B2 / B3

These three are the reason this is worth fixing rather than cosmetic: the `evidence` tier's contract requires a declared estimand tied to a question, which a spec with no declared question cannot satisfy. `follow-on-multiplier-validation` is the sharpest case — it validates the most-quoted SBIR leverage statistic and the registry calls it "an immediate research-plan gap," with no written link to A3.

**Answer no inventory question — now say so explicitly:**

- `actions-migration-followups`
- `phase-iii-source-materialization` (its requirements already stated it "materializes inputs; it does not apply Phase III census criteria or produce findings")

**Anchored to stop an active mis-inference:**

- `ma-discovery-integration` → A4 / F2. A regex sweep for question ids reads `C3` out of its `design.md:19` line *"Adopted: option C with collision rule C3"* — a design option label, not research question C3. This mis-assigned the spec to area C in a status survey. Same failure mode the repo already special-cases for `B82`.

The six proposed anchors are the reviewable part of this PR; the guard and the three lifted anchors are mechanical.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)

CI guard plus spec-header documentation; no runtime or public API surface is touched.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

Added `test_spec_question_anchors_require_an_explicit_declaration`, covering the anchoring form, a blockquoted anchor, the operational form, a missing anchor, a missing `requirements.md`, an unfilled placeholder, and a loose top-level `.md` spec.

```
uv run pytest tests/unit/scripts/test_repository_hygiene.py   # 14 passed
uv run pytest tests/unit -n auto                              # 6001 passed, 7 skipped
make docs-check                                               # passed
make lint                                                     # ruff + 305 files mypy clean
```

Verified the guard fails before the fixes and passes after: it reported exactly the nine drifted specs on the pre-fix tree.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtsvnVmN88P8DL5gSWM3Ub)_