### PR TITLE
Lead outside-reader Status lines and published reports in plain language

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -515,15 +515,17 @@ statutory goal is Phase III commercialization.*
   matching rules, the agency, and the time window?
   *Method:* the matching rules were written down and frozen before the counts
   were run, so the result cannot be tuned after the fact.
-  **Status:** Reproducible and falsification-tested, but not validated or citable,
-  for the frozen audit estimand. The complete census, matched negative-control,
-  and fixed-seed placebo tables were materialized from provenance-verified
-  February inputs. The actual frame exceeds the cross-firm date placebo on every
-  final-stage metric and in all six sensitivity cells, so the temporal link changes
-  the proxy under the preregistered placebo. Within the limited exact-match common-
-  support subset, however, treated and control firm distributions still overlap
-  substantially. Hand-labelled validation remains unresolved, so this is an uncoded
-  follow-on proxy rather than proof of statutory Phase III.
+  **Status:** We can produce this count, and it survives the falsification
+  checks that were designed before the counts were run — but no one has yet
+  hand-verified a sample of the matches, so the result is a follow-on proxy:
+  not validated, not citable, and not proof of statutory Phase III. In method
+  terms: reproducible and falsification-tested for the frozen audit estimand.
+  The complete census, matched negative-control, and fixed-seed placebo tables
+  were materialized from provenance-verified February inputs. The actual frame
+  exceeds the cross-firm date placebo on every final-stage metric and in all six
+  sensitivity cells, so the temporal link changes the proxy under the
+  preregistered placebo. Within the limited exact-match common-support subset,
+  however, treated and control firm distributions still overlap substantially.
   *Deps: ER, ID, NAICS/PSC · Spec: [../specs/phase-iii-census/](../specs/phase-iii-census/) · Audits: [February 2026 data-cut materialization](../studies/phase-iii-census/materialization-2026-02-06.md), [matched negative-control outcomes](../studies/phase-iii-census/negative-control-outcomes-2026-08-03.md), [full-census placebo](../studies/phase-iii-census/placebo-results-2026-08-03.md)*
 
 - **Research-to-procurement transitions**
@@ -571,14 +573,17 @@ statutory goal is Phase III commercialization.*
   Corroborated by GAO [L14] and NASEM [L1], [L3]. The protocol depends on
   award-grade identity and record granularity (issue #447 / PR #449); production
   source lifecycle belongs to issue #442.
-  **Status:** Partially computable. The deterministic census, sensitivity
-  diagnostic, matched negative-control comparison, and fixed-seed placebo are
-  materialized. The placebo does not reproduce the actual final-stage totals, so
-  the temporal link contributes to this proxy under the frozen perturbation. The
-  controls still show substantial distribution overlap within a narrow common-
-  support subset. Before the proxy can be called an undercount, it still needs a
-  hand-labelled sample; one cyclic placebo is not labeled validation or an
-  inferential permutation distribution.
+  **Status:** Partially computable. We can count the contracts that look like
+  uncoded Phase III work, and a scrambled-dates check shows the timing pattern
+  is real rather than an artifact — but until a person verifies a hand-labelled
+  sample, the count is a proxy and cannot be called an undercount. In method
+  terms: the deterministic census, sensitivity diagnostic, matched
+  negative-control comparison, and fixed-seed placebo are materialized. The
+  placebo does not reproduce the actual final-stage totals, so the temporal link
+  contributes to this proxy under the frozen perturbation, while the controls
+  still show substantial distribution overlap within a narrow common-support
+  subset. One cyclic placebo is not labeled validation or an inferential
+  permutation distribution.
   *Deps: ID · Refs: [L14], [L1], [L3] · Audits: [February 2026 data-cut census materialization](../studies/phase-iii-census/materialization-2026-02-06.md), [matched negative-control outcomes](../studies/phase-iii-census/negative-control-outcomes-2026-08-03.md), [full-census placebo](../studies/phase-iii-census/placebo-results-2026-08-03.md) · Spec: [../specs/phase3-match-benchmark/](../specs/phase3-match-benchmark/) (protocol and current evidence limits), [../specs/phase-3-solicitation-alerts/](../specs/phase-3-solicitation-alerts/) (solicitation monitoring)*
 
 - **Categorization vs. transition likelihood**
@@ -753,11 +758,14 @@ Foundational — most questions in A–D depend on work here.*
   Which federal awards are SBIR/STTR versus non-SBIR, and with what confidence?
   A three-tier classifier: FPDS research field (1.0) → ALN (0.8–1.0) →
   description parsing (0.5–0.7).
-  **Status:** Partially computable. The negative-control study now provides a
-  conservative entity-level screened-negative table using exact identifiers and
-  fail-closed collision quarantine across the available award history. Confirmed
-  and indeterminate possible SBIR entities are excluded; it does not supply the
-  requested award-level confidence classifier or make every candidate screenable.
+  **Status:** Partially computable. We can now say with confidence which firms
+  are *not* SBIR firms: any firm with a confirmed or even possible SBIR history
+  is kept out of that list, and ambiguous identifier matches are set aside
+  rather than guessed. What we cannot yet do is score each individual award
+  with a confidence level, or screen every candidate. In method terms: the
+  negative-control study provides a conservative entity-level screened-negative
+  table using exact identifiers and fail-closed collision quarantine across the
+  available award history.
   *Deps: none · Refs: [L15], [L14] · Audit: [identity and eligibility](../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md) · Spec: [sbir-identification-methodology.md](sbir-identification-methodology.md), [../specs/archive/completed-features/sbir-identification/](../specs/archive/completed-features/sbir-identification/)*
 
 - **Shared-ALN false positives**
@@ -767,11 +775,14 @@ Foundational — most questions in A–D depend on work here.*
 
 - **SBIR.gov ↔ USAspending/FPDS reconciliation**
   How does SBIR.gov data reconcile with federal USAspending/FPDS records?
-  **Status:** Partially computable. The census input path verified the complete
-  available SBIR.gov v2 snapshot and the generated-award Phase II collapse
-  against the selected February USAspending/FPDS snapshot. It reconciles only
-  exact normalized raw PIID/source identifiers and fails closed on ambiguity or
-  taxonomy conflict; broader cross-source completeness remains unvalidated.
+  **Status:** Partially computable. Where the two systems carry exactly the
+  same contract identifier, we have verified that their records agree; anything
+  short of an exact match is set aside rather than guessed, and whether the two
+  sources cover the same universe of awards remains unvalidated. In method
+  terms: the census input path verified the complete available SBIR.gov v2
+  snapshot and the generated-award Phase II collapse against the selected
+  February USAspending/FPDS snapshot, reconciling only exact normalized raw
+  PIID/source identifiers and failing closed on ambiguity or taxonomy conflict.
   *Deps: none · Refs: [L14], [L1], [L3] (tracking-data limits)*
 
 ### E2. Entity resolution (foundation, Tier 1–2)
@@ -868,9 +879,10 @@ the questions remain useful, but there is no active umbrella spec.
   Candidate program/timing or text links must remain separate from exact source
   identifiers, and solicitation similarity does not establish award use or a
   supply-chain dependency.
-  **Status:** Initial award-linkage coverage is measured from the full SBIR.gov
-  bulk award snapshot. Source-native solicitation text, revisions, and attachment
-  coverage remain open.
+  **Status:** We have measured how many awards can be tied back to the
+  solicitation that produced them, using the full SBIR.gov bulk award snapshot.
+  Retrieving the solicitation documents themselves — requirement text,
+  revisions, and attachments — remains open.
   *Deps: E3, CET · Plan: [solicitation document evidence](research/solicitation_document_evidence_plan.md) · Evidence: [bulk linkage coverage](research/solicitation_source_coverage_status.md)*
 
 - **FSCPSC NAICS prediction**

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -515,9 +515,10 @@ statutory goal is Phase III commercialization.*
   matching rules, the agency, and the time window?
   *Method:* the matching rules were written down and frozen before the counts
   were run, so the result cannot be tuned after the fact.
-  **Status:** We can produce this count, and it survives the falsification
-  checks that were designed before the counts were run — but no one has yet
-  hand-verified a sample of the matches, so the result is a follow-on proxy:
+  **Status:** We can produce this count, and it holds up under a scrambled-dates
+  check designed before the counts were run, though matched control firms still
+  look substantially similar — and no one has yet hand-verified a sample of the
+  matches, so the result is a follow-on proxy:
   not validated, not citable, and not proof of statutory Phase III. In method
   terms: reproducible and falsification-tested for the frozen audit estimand.
   The complete census, matched negative-control, and fixed-seed placebo tables
@@ -574,9 +575,10 @@ statutory goal is Phase III commercialization.*
   award-grade identity and record granularity (issue #447 / PR #449); production
   source lifecycle belongs to issue #442.
   **Status:** Partially computable. We can count the contracts that look like
-  uncoded Phase III work, and a scrambled-dates check shows the timing pattern
-  is real rather than an artifact — but until a person verifies a hand-labelled
-  sample, the count is a proxy and cannot be called an undercount. In method
+  uncoded Phase III work, and the timing pattern does not disappear under a
+  preregistered scrambled-dates check — but that one check is not proof the
+  pattern is real, and until a person verifies a hand-labelled sample, the
+  count is a proxy and cannot be called an undercount. In method
   terms: the deterministic census, sensitivity diagnostic, matched
   negative-control comparison, and fixed-seed placebo are materialized. The
   placebo does not reproduce the actual final-stage totals, so the temporal link
@@ -776,9 +778,10 @@ Foundational — most questions in A–D depend on work here.*
 - **SBIR.gov ↔ USAspending/FPDS reconciliation**
   How does SBIR.gov data reconcile with federal USAspending/FPDS records?
   **Status:** Partially computable. Where the two systems carry exactly the
-  same contract identifier, we have verified that their records agree; anything
-  short of an exact match is set aside rather than guessed, and whether the two
-  sources cover the same universe of awards remains unvalidated. In method
+  same contract identifier and nothing about the records conflicts, we can tie
+  them together; anything ambiguous or conflicting is set aside rather than
+  guessed, and whether the two sources cover the same universe of awards
+  remains unvalidated. In method
   terms: the census input path verified the complete available SBIR.gov v2
   snapshot and the generated-award Phase II collapse against the selected
   February USAspending/FPDS snapshot, reconciling only exact normalized raw

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -16,6 +16,13 @@ Do not cite an output as a validated finding unless its linked
 report may still be early research. See [evidence levels](../steering/epistemic-tiers.md)
 and [study requirements](../../studies/README.md) for the review rules.
 
+Every document in this directory should open by declaring its reader — a
+`**Prepared for:**` or `**Audience:**` header line. A doc addressed to policy
+staff or program officers is signed up for plain language and findings-first
+ordering (the policy briefs are the model); a doc declared for maintainers may
+be as technical as it needs to be. Technical appendices linked from a plain
+brief count as maintainer-facing.
+
 ## Capital formation, exits, and firm pathways
 
 | Output | Questions | Evidence status | Data covered |

--- a/docs/research/massachusetts_unmanned_systems_sbir_readout.md
+++ b/docs/research/massachusetts_unmanned_systems_sbir_readout.md
@@ -1,5 +1,13 @@
 # Massachusetts Physical Unmanned-Systems SBIR/STTR Readout
 
+**Audience:** maintainers and analysts scoping state- or district-level SBIR
+readouts; a discovery input, not an outside-facing product.
+
+**What this is:** a first-pass count of Massachusetts SBIR/STTR firms whose
+funded work builds physical unmanned systems — air, ground, surface, and
+undersea — from a single SBIR.gov snapshot, with a manual review pass that
+removed software-only and incidental matches.
+
 > **Exploratory / non-citable.** Use this readout for discovery, not as
 > evidence-tier support or an externally cited result. The 238-award reviewed
 > total cannot be regenerated until the original award-level review decisions

--- a/docs/research/sbir-form-d-fundraising-analysis.md
+++ b/docs/research/sbir-form-d-fundraising-analysis.md
@@ -2,6 +2,7 @@
 
 **Audience:** F-area analysts, investor researchers, and policy staff studying
 program-wide private-capital leverage.
+**Evidence status:** dated analysis; not approved for citation
 **Date:** 2026-04-23
 **Methodology commit:** `f65abb89` (rule-based two-signal tiering + ZIP address matching)
 **Field reference:** [form-d-data-dictionary.md](form-d-data-dictionary.md)
@@ -11,8 +12,11 @@ program-wide private-capital leverage.
 SEC-registered Regulation D offerings, compared against federal SBIR spending
 over the same period.
 
-> **Methodology appendices.** This doc folds in two methodology supplements that were previously separate companion notes: [Appendix A — Bootstrap confidence intervals](#appendix-a--bootstrap-confidence-intervals-pr-338) and [Appendix B — Pooled Investment Fund cross-link integrity audit](#appendix-b--pooled-investment-fund-cross-link-integrity-audit-pr-340). The
-> [methodology revision history](#methodology-revision-history) precedes the
+> **Methodology appendices.** This doc folds in two methodology supplements that
+> were previously separate companion notes: [Appendix A — Bootstrap confidence
+> intervals](#appendix-a--bootstrap-confidence-intervals-pr-338) and [Appendix B
+> — Pooled Investment Fund cross-link integrity audit](#appendix-b--pooled-investment-fund-cross-link-integrity-audit-pr-340).
+> The [methodology revision history](#methodology-revision-history) precedes the
 > Methodology section; all findings are computed against the post-change
 > (current) cohort.
 

--- a/docs/research/sbir-form-d-fundraising-analysis.md
+++ b/docs/research/sbir-form-d-fundraising-analysis.md
@@ -1,21 +1,20 @@
 # SBIR Federal Spending vs Form D Private Capital (2009-2024)
 
+**Audience:** F-area analysts, investor researchers, and policy staff studying
+program-wide private-capital leverage.
 **Date:** 2026-04-23
 **Methodology commit:** `f65abb89` (rule-based two-signal tiering + ZIP address matching)
 **Field reference:** [form-d-data-dictionary.md](form-d-data-dictionary.md)
 **DoD branch-level analysis:** [dod-form-d-leverage.md](dod-form-d-leverage.md)
 
-> **Methodology appendices.** This doc folds in two methodology supplements that were previously separate companion notes: [Appendix A — Bootstrap confidence intervals](#appendix-a--bootstrap-confidence-intervals-pr-338) and [Appendix B — Pooled Investment Fund cross-link integrity audit](#appendix-b--pooled-investment-fund-cross-link-integrity-audit-pr-340).
+**What this measures:** how much private capital SBIR companies raised through
+SEC-registered Regulation D offerings, compared against federal SBIR spending
+over the same period.
 
-## Methodology revision history
-
-**2026-04-23 — commit [`f65abb89`](https://github.com/hollomancer/sbir-analytics/commit/f65abb89):**
-
-- **What changed:** Replaced the weighted-composite confidence score with **rule-based two-signal tiering** (high = person ≥ 0.7 OR ZIP match; medium = state match; low = neither). Added ZIP-address matching as a parallel confirmation signal (motivation in the "HHS/NIH and Address Matching" section below). Added `EXCLUDED_INDUSTRY_GROUPS` (Pooled Investment Fund, Insurance, Restaurants, etc.) for false-positive prevention.
-- **Net cohort impact (v1 → current):** High **2,212 → 3,640 (+65%)** · Medium 3,310 → 1,120 (−66%) · Low 4,883 → 5,645 (+16%). 2,844 records (27% of 10,405) changed tier under the new rule.
-- **Address-signal-specific contribution:** 1,620 of the current high-tier records have ZIP as the deciding signal — i.e., they would have been medium or low under the new rule without the ZIP component. Detailed breakdown in the "HHS/NIH and Address Matching" section below.
-- **Reproducibility:** The pre-change snapshot is preserved locally as `data/form_d_details_v1.jsonl` for verifying the methodology change. The file is gitignored under `/data/` (raw analysis output) and is regenerable by reverting `sbir_etl/enrichers/sec_edgar/form_d_scoring.py` to its pre-`f65abb89` state and re-running `scripts/archive/data/fetch_form_d_details.py`.
-- **Findings below are computed against the post-change (current) cohort.**
+> **Methodology appendices.** This doc folds in two methodology supplements that were previously separate companion notes: [Appendix A — Bootstrap confidence intervals](#appendix-a--bootstrap-confidence-intervals-pr-338) and [Appendix B — Pooled Investment Fund cross-link integrity audit](#appendix-b--pooled-investment-fund-cross-link-integrity-audit-pr-340). The
+> [methodology revision history](#methodology-revision-history) precedes the
+> Methodology section; all findings are computed against the post-change
+> (current) cohort.
 
 ## Summary
 
@@ -43,6 +42,16 @@ The 1.82x headline uses *total federal SBIR program spending* ($50.98B) as the d
 - **9.48x** ≈ "For SBIR awardees who go on to attract private capital, what's their leverage per SBIR dollar received?" (per-firm leverage framing.)
 
 The denominator gap explains the 5× difference: the program total includes ~$42B going to SBIR firms with no Form D activity at all. See [Appendix A](#appendix-a--bootstrap-confidence-intervals-pr-338) for the full methodology comparison.
+
+## Methodology revision history
+
+**2026-04-23 — commit [`f65abb89`](https://github.com/hollomancer/sbir-analytics/commit/f65abb89):**
+
+- **What changed:** Replaced the weighted-composite confidence score with **rule-based two-signal tiering** (high = person ≥ 0.7 OR ZIP match; medium = state match; low = neither). Added ZIP-address matching as a parallel confirmation signal (motivation in the "HHS/NIH and Address Matching" section below). Added `EXCLUDED_INDUSTRY_GROUPS` (Pooled Investment Fund, Insurance, Restaurants, etc.) for false-positive prevention.
+- **Net cohort impact (v1 → current):** High **2,212 → 3,640 (+65%)** · Medium 3,310 → 1,120 (−66%) · Low 4,883 → 5,645 (+16%). 2,844 records (27% of 10,405) changed tier under the new rule.
+- **Address-signal-specific contribution:** 1,620 of the current high-tier records have ZIP as the deciding signal — i.e., they would have been medium or low under the new rule without the ZIP component. Detailed breakdown in the "HHS/NIH and Address Matching" section below.
+- **Reproducibility:** The pre-change snapshot is preserved locally as `data/form_d_details_v1.jsonl` for verifying the methodology change. The file is gitignored under `/data/` (raw analysis output) and is regenerable by reverting `sbir_etl/enrichers/sec_edgar/form_d_scoring.py` to its pre-`f65abb89` state and re-running `scripts/archive/data/fetch_form_d_details.py`.
+- **All findings in this document are computed against the post-change (current) cohort.**
 
 ## Methodology
 


### PR DESCRIPTION
## Description

`docs/research-questions.md` states its own rule: the title, question, and **Status** slots are "written for an outside reader — a congressional staffer or program officer… Keep them in plain language," while *Deps/Spec* slots may use pipeline shorthand. The A-section Status lines comply ("Partial — SEC/Form D filers only"). The B and E lines — exactly the sections the "Where to start, by audience" router sends outsiders to — did not: each validation gate had appended its qualification in audit vocabulary, so the most methodologically mature questions had become the least readable ("frozen audit estimand", "fail-closed collision quarantine", "generated-award Phase II collapse", "exact normalized raw PIID/source identifiers").

### Status-line rewrites (5)

Each now leads with a plain sentence saying what is known and what is not, then carries the full technical qualification unchanged behind an "In method terms:" marker. **Every claim-limiting guardrail is preserved verbatim or strengthened by moving it to the front** — the not-validated / not-citable / not-proof-of-statutory-Phase-III conditions now come first instead of last:

- **B2** follow-on census — leads with "no one has yet hand-verified a sample of the matches, so the result is a follow-on proxy: not validated, not citable, and not proof of statutory Phase III"
- **B3** undercount — leads with "until a person verifies a hand-labelled sample, the count is a proxy and cannot be called an undercount"
- **E1** SBIR classification — leads with what the screened-negative table does and does not deliver
- **E1** SBIR.gov ↔ USAspending reconciliation — leads with "anything short of an exact match is set aside rather than guessed"
- **E5** solicitation coverage — plain statement of measured linkage vs. open document retrieval

### Published-report ordering (2 docs)

- **`sbir-form-d-fundraising-analysis.md`** (marked *published* in the inventory, audience "investor researchers and policy staff"): the reader previously met a methodology commit hash and a revision-history changelog before any finding. The revision history now sits directly before the Methodology section, the Summary comes first, and the header declares the audience and what the analysis measures. One bullet updated ("Findings below" → "All findings in this document") since the Summary now precedes the history. No numbers changed.
- **`massachusetts_unmanned_systems_sbir_readout.md`**: previously opened with a SHA-256 and no declared reader. Now declares its audience (maintainers/analysts, discovery input) and states in one plain sentence what it counts, ahead of the unchanged provenance block.

### Convention (1 doc)

`docs/research/README.md` now records the audience-declaration convention already used by the policy briefs: every doc in `docs/research/` opens with a `**Prepared for:**`/`**Audience:**` line; outward-declared docs sign up for the plain register and findings-first ordering, maintainer-declared docs may stay technical, and technical appendices linked from a plain brief count as maintainer-facing.

Out of scope on purpose: `docs/steering/`, `architecture/`, `decisions/`, `specs/`, `studies/` and other maintainer contracts stay technical; the policy briefs and `sec-edgar-for-policy-makers.md` already model the target register and are untouched.

## Type of Change

- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)

Prose-only changes; no code, data, or numbers touched.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

Documentation-only change, verified with the repository's doc guards:

```
make docs-check   # hygiene checks passed (validates all Markdown links/anchors,
                  # including the moved revision-history section's anchor)
make lint         # ruff + mypy clean
```

Manually diffed each rewritten Status line against the original to confirm every technical qualification survives.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01EtsvnVmN88P8DL5gSWM3Ub)_