### PR TITLE
Add OpenAlex and PubMed enricher clients

### DIFF
--- a/sbir_etl/enrichers/openalex_client.py
+++ b/sbir_etl/enrichers/openalex_client.py
@@ -1,0 +1,197 @@
+"""OpenAlex API client for researcher author-record lookups.
+
+Queries the `OpenAlex API <https://api.openalex.org/>`_ (a free, open
+catalog of scholarly works, authors, and institutions) to find author
+profiles and extract institutional affiliations, publication counts,
+and any ORCID the author has on record.
+
+No API key is required. OpenAlex offers a "polite pool" with faster,
+more reliable rate limits to callers who identify themselves via a
+``mailto`` query parameter. Set ``OPENALEX_MAILTO`` (or pass ``mailto``
+to the constructor) to opt in; requests are unauthenticated either way.
+
+This client inherits shared rate limiting, retry, and error
+translation from :class:`BaseAsyncAPIClient`. Synchronous callers
+should use :class:`sbir_etl.enrichers.sync_wrappers.SyncOpenAlexClient`.
+
+Usage (sync)::
+
+    from sbir_etl.enrichers.sync_wrappers import SyncOpenAlexClient
+
+    with SyncOpenAlexClient(mailto="you@example.com") as client:
+        record = client.lookup("Jane Smith")
+        if record:
+            print(record.openalex_id, record.affiliations)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
+from sbir_etl.enrichers.rate_limiting import RateLimiter
+from sbir_etl.exceptions import APIError
+
+OPENALEX_API_URL = "https://api.openalex.org"
+DEFAULT_RATE_LIMIT_PER_MINUTE = 100
+
+
+@dataclass
+class OpenAlexRecord:
+    """Key data from an OpenAlex author record."""
+
+    openalex_id: str
+    display_name: str | None = None
+    affiliations: list[str] = field(default_factory=list)
+    orcid: str | None = None
+    works_count: int = 0
+    cited_by_count: int = 0
+
+
+def _last_path_segment(value: str | None) -> str | None:
+    """Extract the trailing path segment from an OpenAlex/ORCID URL or ID.
+
+    OpenAlex returns IDs and ORCID cross-links as full URLs (e.g.
+    ``https://openalex.org/A5110956653``, ``https://orcid.org/0000-...``).
+    Bare IDs are passed through unchanged.
+    """
+    if not value:
+        return None
+    return value.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _parse_author(profile: dict[str, Any]) -> OpenAlexRecord:
+    """Parse an OpenAlex author API response into an :class:`OpenAlexRecord`."""
+    openalex_id = _last_path_segment(profile.get("id")) or str(profile.get("id", ""))
+
+    affiliations: list[str] = []
+    for aff in profile.get("affiliations", [])[:10]:
+        inst_name = aff.get("institution", {}).get("display_name")
+        if inst_name and inst_name not in affiliations:
+            affiliations.append(inst_name)
+
+    return OpenAlexRecord(
+        openalex_id=openalex_id,
+        display_name=profile.get("display_name"),
+        affiliations=affiliations,
+        orcid=_last_path_segment(profile.get("orcid")),
+        works_count=profile.get("works_count", 0) or 0,
+        cited_by_count=profile.get("cited_by_count", 0) or 0,
+    )
+
+
+class OpenAlexClient(BaseAsyncAPIClient):
+    """Async client for the OpenAlex API.
+
+    Inherits retry, rate limiting, and typed error translation from
+    :class:`BaseAsyncAPIClient`. For sync callers, use
+    :class:`sbir_etl.enrichers.sync_wrappers.SyncOpenAlexClient`.
+
+    Args:
+        mailto: Optional contact email to opt into OpenAlex's "polite
+            pool" (faster, more reliable rate limits). Defaults to the
+            ``OPENALEX_MAILTO`` environment variable. When unset, no
+            ``mailto`` parameter is sent and requests use the common pool.
+        timeout: HTTP request timeout in seconds.
+        rate_limit_per_minute: Requests per minute when no
+            ``shared_limiter`` is provided. Defaults to 100.
+        shared_limiter: Optional shared synchronous :class:`RateLimiter` for
+            sharing a global budget across worker threads. Dispatched via
+            :func:`asyncio.to_thread`.
+        http_client: Optional pre-constructed :class:`httpx.AsyncClient`
+            (useful for testing).
+    """
+
+    api_name = "openalex"
+
+    def __init__(
+        self,
+        *,
+        mailto: str | None = None,
+        timeout: int = 30,
+        rate_limit_per_minute: int = DEFAULT_RATE_LIMIT_PER_MINUTE,
+        shared_limiter: RateLimiter | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(shared_limiter=shared_limiter)
+        self.base_url = OPENALEX_API_URL
+        self.rate_limit_per_minute = rate_limit_per_minute
+        self._mailto = mailto or os.environ.get("OPENALEX_MAILTO", "")
+        self._client = http_client or httpx.AsyncClient(timeout=timeout)
+
+    def _with_mailto(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Merge the polite-pool ``mailto`` parameter into a query dict."""
+        merged = dict(params)
+        if self._mailto:
+            merged["mailto"] = self._mailto
+        return merged
+
+    async def search_authors(self, name: str, limit: int = 5) -> list[dict[str, Any]]:
+        """Search for authors by name.
+
+        Returns the ``results`` list from the API response (possibly
+        empty). Returns an empty list on 4xx client errors; propagates
+        :class:`APIError` on 5xx.
+        """
+        try:
+            data = await self._make_request(
+                "GET",
+                "authors",
+                params=self._with_mailto({"search": name, "per_page": limit}),
+            )
+        except APIError as e:
+            status = e.details.get("http_status")
+            if status and 400 <= status < 500:
+                return []
+            raise
+        return data.get("results", []) or []
+
+    async def get_author_details(self, openalex_id: str) -> dict[str, Any] | None:
+        """Fetch full author details by OpenAlex ID.
+
+        Accepts either a bare ID (``A5110956653``) or a full OpenAlex
+        URL. Returns ``None`` if not found (404); propagates
+        :class:`APIError` on other failures.
+        """
+        short_id = _last_path_segment(openalex_id) or openalex_id
+        try:
+            return await self._make_request(
+                "GET",
+                f"authors/{short_id}",
+                params=self._with_mailto({}),
+            )
+        except APIError as e:
+            if e.details.get("http_status") == 404:
+                return None
+            raise
+
+    async def lookup(self, name: str) -> OpenAlexRecord | None:
+        """Look up a researcher's OpenAlex author record by full name.
+
+        Searches, then fetches the full record for the best match.
+        Returns ``None`` when no match is found. Propagates
+        :class:`APIError` on real API failures so callers can
+        distinguish.
+        """
+        name = name.strip()
+        if not name:
+            return None
+
+        results = await self.search_authors(name)
+        if not results:
+            return None
+
+        best = results[0]
+        short_id = _last_path_segment(best.get("id"))
+        if not short_id:
+            return None
+
+        profile = await self.get_author_details(short_id)
+        if profile is None:
+            return None
+
+        return _parse_author(profile)

--- a/sbir_etl/enrichers/pubmed_client.py
+++ b/sbir_etl/enrichers/pubmed_client.py
@@ -1,0 +1,238 @@
+"""PubMed (NCBI E-utilities) client for researcher authorship lookups.
+
+Queries `NCBI E-utilities <https://eutils.ncbi.nlm.nih.gov/entrez/eutils/>`_
+to find PubMed articles by author and extract the author's affiliation
+strings as recorded on that article (PubMed carries free-text
+affiliations per author, not a normalized institution ID).
+
+No API key is required (rate limited to 3 requests/second). Set
+``NCBI_API_KEY`` for a higher limit (10 requests/second).
+
+This client inherits shared rate limiting, retry, and error
+translation from :class:`BaseAsyncAPIClient`. ``esearch`` responses are
+JSON; ``efetch`` responses are PubMed XML, so
+:meth:`get_author_affiliations` uses the body-agnostic
+:meth:`BaseAsyncAPIClient._request_raw` (see the FPDS Atom client for
+the same pattern). Synchronous callers should use
+:class:`sbir_etl.enrichers.sync_wrappers.SyncPubMedClient`.
+
+Usage (sync)::
+
+    from sbir_etl.enrichers.sync_wrappers import SyncPubMedClient
+
+    with SyncPubMedClient() as client:
+        record = client.lookup("Jane Smith")
+        if record:
+            print(record.pmid, record.affiliations)
+"""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
+from sbir_etl.enrichers.rate_limiting import RateLimiter
+from sbir_etl.exceptions import APIError
+
+PUBMED_API_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+DEFAULT_RATE_LIMIT_PER_MINUTE_NO_KEY = 180  # 3 req/sec, NCBI's unauthenticated limit
+DEFAULT_RATE_LIMIT_PER_MINUTE_WITH_KEY = 600  # 10 req/sec, with NCBI_API_KEY
+
+
+@dataclass
+class PubMedRecord:
+    """Author affiliation data extracted from a PubMed article."""
+
+    pmid: str
+    author_name: str
+    affiliations: list[str] = field(default_factory=list)
+    title: str | None = None
+
+
+def _parse_efetch_xml(xml_text: str) -> dict[str, Any] | None:
+    """Parse an ``efetch`` PubMed XML body into title + per-author affiliations.
+
+    Returns ``None`` if the body doesn't parse or contains no article.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as e:
+        logger.debug("PubMed XML parse error: {}", e)
+        return None
+
+    article = root.find(".//PubmedArticle")
+    if article is None:
+        return None
+
+    title_el = article.find(".//ArticleTitle")
+    title = title_el.text.strip() if title_el is not None and title_el.text else None
+
+    authors: list[dict[str, Any]] = []
+    for author_el in article.findall(".//AuthorList/Author"):
+        last = author_el.findtext("LastName") or ""
+        fore = author_el.findtext("ForeName") or ""
+        name = f"{fore} {last}".strip() or (author_el.findtext("CollectiveName") or "")
+        affiliations = [
+            aff.text.strip() for aff in author_el.findall("AffiliationInfo/Affiliation") if aff.text
+        ]
+        authors.append({"name": name, "affiliations": affiliations})
+
+    return {"title": title, "authors": authors}
+
+
+def _best_matching_author(authors: list[dict[str, Any]], query_name: str) -> dict[str, Any] | None:
+    """Pick the author entry whose name best matches *query_name*.
+
+    Best-effort match on last name (case-insensitive substring); falls
+    back to the first author if no name matches.
+    """
+    if not authors:
+        return None
+    parts = query_name.strip().split()
+    if not parts:
+        return authors[0]
+    last_name = parts[-1].lower()
+    for author in authors:
+        if last_name in author["name"].lower():
+            return author
+    return authors[0]
+
+
+class PubMedClient(BaseAsyncAPIClient):
+    """Async client for NCBI E-utilities (PubMed search + fetch).
+
+    Inherits retry, rate limiting, and typed error translation from
+    :class:`BaseAsyncAPIClient`. For sync callers, use
+    :class:`sbir_etl.enrichers.sync_wrappers.SyncPubMedClient`.
+
+    Args:
+        api_key: Optional NCBI API key. Defaults to the ``NCBI_API_KEY``
+            environment variable. Sent as the ``api_key`` query parameter
+            (E-utilities does not use header-based auth). When set, and
+            *rate_limit_per_minute* is not explicitly overridden, the
+            default rate limit rises from 3 req/sec to 10 req/sec.
+        timeout: HTTP request timeout in seconds.
+        rate_limit_per_minute: Requests per minute when no
+            ``shared_limiter`` is provided. Defaults based on whether an
+            API key is configured.
+        shared_limiter: Optional shared synchronous :class:`RateLimiter` for
+            sharing a global budget across worker threads. Dispatched via
+            :func:`asyncio.to_thread`.
+        http_client: Optional pre-constructed :class:`httpx.AsyncClient`
+            (useful for testing).
+    """
+
+    api_name = "pubmed"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: int = 30,
+        rate_limit_per_minute: int | None = None,
+        shared_limiter: RateLimiter | None = None,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(shared_limiter=shared_limiter)
+        self.base_url = PUBMED_API_URL
+        self._api_key = api_key or os.environ.get("NCBI_API_KEY", "")
+        if rate_limit_per_minute is None:
+            rate_limit_per_minute = (
+                DEFAULT_RATE_LIMIT_PER_MINUTE_WITH_KEY
+                if self._api_key
+                else DEFAULT_RATE_LIMIT_PER_MINUTE_NO_KEY
+            )
+        self.rate_limit_per_minute = rate_limit_per_minute
+        self._client = http_client or httpx.AsyncClient(timeout=timeout)
+
+    def _with_api_key(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Merge the ``api_key`` query parameter into a query dict."""
+        merged = dict(params)
+        if self._api_key:
+            merged["api_key"] = self._api_key
+        return merged
+
+    async def search_pmids(self, author: str, limit: int = 5) -> list[str]:
+        """Search PubMed for articles by author name.
+
+        Returns the list of matching PMIDs (possibly empty). Returns an
+        empty list on 4xx client errors; propagates :class:`APIError`
+        on 5xx.
+        """
+        try:
+            data = await self._make_request(
+                "GET",
+                "esearch.fcgi",
+                params=self._with_api_key(
+                    {
+                        "db": "pubmed",
+                        "term": f"{author}[Author]",
+                        "retmode": "json",
+                        "retmax": limit,
+                    }
+                ),
+            )
+        except APIError as e:
+            status = e.details.get("http_status")
+            if status and 400 <= status < 500:
+                return []
+            raise
+        return data.get("esearchresult", {}).get("idlist", []) or []
+
+    async def get_author_affiliations(self, pmid: str) -> dict[str, Any] | None:
+        """Fetch an article's title and per-author affiliation strings.
+
+        Uses ``efetch`` (PubMed XML), not ``esummary``, because
+        ``esummary`` does not carry affiliation data. Returns ``None``
+        if the article isn't found or the body doesn't parse;
+        propagates :class:`APIError` on 5xx failures.
+        """
+        try:
+            response = await self._request_raw(
+                "GET",
+                "efetch.fcgi",
+                params=self._with_api_key(
+                    {"db": "pubmed", "id": pmid, "rettype": "abstract", "retmode": "xml"}
+                ),
+            )
+        except APIError as e:
+            status = e.details.get("http_status")
+            if status and 400 <= status < 500:
+                return None
+            raise
+        return _parse_efetch_xml(response.text)
+
+    async def lookup(self, name: str) -> PubMedRecord | None:
+        """Look up a researcher's most recent PubMed affiliation by name.
+
+        Two-step: author search → fetch affiliations for the top hit.
+        Returns ``None`` when no match is found. Propagates
+        :class:`APIError` on real API failures so callers can
+        distinguish.
+        """
+        name = name.strip()
+        if not name:
+            return None
+
+        pmids = await self.search_pmids(name)
+        if not pmids:
+            return None
+
+        pmid = pmids[0]
+        parsed = await self.get_author_affiliations(pmid)
+        if parsed is None:
+            return None
+
+        author = _best_matching_author(parsed["authors"], name)
+        return PubMedRecord(
+            pmid=pmid,
+            author_name=author["name"] if author else name,
+            affiliations=author["affiliations"] if author else [],
+            title=parsed.get("title"),
+        )

--- a/sbir_etl/enrichers/sync_wrappers.py
+++ b/sbir_etl/enrichers/sync_wrappers.py
@@ -24,6 +24,12 @@ Usage::
 
     with SyncSemanticScholarClient() as s2:
         record = s2.lookup_author("Jane Smith")
+
+    with SyncOpenAlexClient(mailto="you@example.com") as oa:
+        record = oa.lookup("Jane Smith")
+
+    with SyncPubMedClient() as pm:
+        record = pm.lookup("Jane Smith")
 """
 
 from __future__ import annotations
@@ -34,8 +40,10 @@ from ..utils.async_tools import run_sync
 from .fpds_atom import FPDSAtomClient, FPDSRecord
 from .lens_patents import LensPatentClient, LensPatentRecord
 from .opencorporates import CorporateRecord, Officer, OpenCorporatesClient
+from .openalex_client import OpenAlexClient, OpenAlexRecord
 from .orcid_client import ORCIDClient, ORCIDRecord
 from .press_wire import PressRelease, PressWireClient
+from .pubmed_client import PubMedClient, PubMedRecord
 from .rate_limiting import RateLimiter
 from .sam_gov.client import SAMGovAPIClient
 from .semantic_scholar import PublicationRecord, SemanticScholarClient
@@ -260,6 +268,70 @@ class SyncORCIDClient(_SyncFacade):
         return run_sync(self._client.get_profile(orcid_id))
 
     def lookup(self, name: str) -> ORCIDRecord | None:
+        return run_sync(self._client.lookup(name))
+
+
+class SyncOpenAlexClient(_SyncFacade):
+    """Synchronous facade for :class:`OpenAlexClient`.
+
+    Supports ``shared_limiter`` for sharing a global rate budget across
+    worker threads.
+    """
+
+    def __init__(
+        self,
+        *,
+        mailto: str | None = None,
+        timeout: int = 30,
+        rate_limit_per_minute: int = 100,
+        shared_limiter: RateLimiter | None = None,
+    ) -> None:
+        self._client = OpenAlexClient(
+            mailto=mailto,
+            timeout=timeout,
+            rate_limit_per_minute=rate_limit_per_minute,
+            shared_limiter=shared_limiter,
+        )
+
+    def search_authors(self, name: str, limit: int = 5) -> list[dict[str, Any]]:
+        return run_sync(self._client.search_authors(name, limit))
+
+    def get_author_details(self, openalex_id: str) -> dict[str, Any] | None:
+        return run_sync(self._client.get_author_details(openalex_id))
+
+    def lookup(self, name: str) -> OpenAlexRecord | None:
+        return run_sync(self._client.lookup(name))
+
+
+class SyncPubMedClient(_SyncFacade):
+    """Synchronous facade for :class:`PubMedClient`.
+
+    Supports ``shared_limiter`` for sharing a global rate budget across
+    worker threads.
+    """
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        timeout: int = 30,
+        rate_limit_per_minute: int | None = None,
+        shared_limiter: RateLimiter | None = None,
+    ) -> None:
+        self._client = PubMedClient(
+            api_key=api_key,
+            timeout=timeout,
+            rate_limit_per_minute=rate_limit_per_minute,
+            shared_limiter=shared_limiter,
+        )
+
+    def search_pmids(self, author: str, limit: int = 5) -> list[str]:
+        return run_sync(self._client.search_pmids(author, limit))
+
+    def get_author_affiliations(self, pmid: str) -> dict[str, Any] | None:
+        return run_sync(self._client.get_author_affiliations(pmid))
+
+    def lookup(self, name: str) -> PubMedRecord | None:
         return run_sync(self._client.lookup(name))
 
 

--- a/tests/unit/enrichers/test_openalex_client.py
+++ b/tests/unit/enrichers/test_openalex_client.py
@@ -1,0 +1,344 @@
+"""Tests for OpenAlexClient (async) and SyncOpenAlexClient.
+
+Follows the ``AsyncMock``-based pattern established in
+test_orcid_client.py / test_semantic_scholar.py — no real network calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from sbir_etl.enrichers.openalex_client import (
+    OpenAlexClient,
+    OpenAlexRecord,
+    _last_path_segment,
+    _parse_author,
+)
+from sbir_etl.enrichers.rate_limiting import RateLimiter
+from sbir_etl.enrichers.sync_wrappers import SyncOpenAlexClient
+from sbir_etl.exceptions import APIError
+
+pytestmark = pytest.mark.fast
+
+
+# ==================== Sample data ====================
+
+
+SAMPLE_SEARCH_RESULT = {
+    "id": "https://openalex.org/A5110956653",
+    "display_name": "Jane McKee Smith",
+    "orcid": None,
+}
+
+SAMPLE_PROFILE = {
+    "id": "https://openalex.org/A5110956653",
+    "display_name": "Jane McKee Smith",
+    "orcid": "https://orcid.org/0000-0001-6678-1514",
+    "works_count": 188,
+    "cited_by_count": 6897,
+    "affiliations": [
+        {"institution": {"display_name": "University of Notre Dame"}},
+        {"institution": {"display_name": "United States Army Corps of Engineers"}},
+        {"institution": {"display_name": "University of Notre Dame"}},  # duplicate
+    ],
+}
+
+
+# ==================== Pure parsing helpers ====================
+
+
+class TestLastPathSegment:
+    def test_extracts_from_url(self):
+        assert _last_path_segment("https://openalex.org/A5110956653") == "A5110956653"
+
+    def test_extracts_orcid_from_url(self):
+        assert _last_path_segment("https://orcid.org/0000-0001-6678-1514") == "0000-0001-6678-1514"
+
+    def test_passes_through_bare_id(self):
+        assert _last_path_segment("A5110956653") == "A5110956653"
+
+    def test_none_input(self):
+        assert _last_path_segment(None) is None
+
+    def test_empty_input(self):
+        assert _last_path_segment("") is None
+
+
+class TestParseAuthor:
+    def test_extracts_id(self):
+        rec = _parse_author(SAMPLE_PROFILE)
+        assert rec.openalex_id == "A5110956653"
+
+    def test_extracts_affiliations_deduped(self):
+        rec = _parse_author(SAMPLE_PROFILE)
+        assert rec.affiliations == [
+            "University of Notre Dame",
+            "United States Army Corps of Engineers",
+        ]
+
+    def test_extracts_orcid_bare(self):
+        rec = _parse_author(SAMPLE_PROFILE)
+        assert rec.orcid == "0000-0001-6678-1514"
+
+    def test_missing_orcid(self):
+        profile = {**SAMPLE_PROFILE, "orcid": None}
+        rec = _parse_author(profile)
+        assert rec.orcid is None
+
+    def test_counts(self):
+        rec = _parse_author(SAMPLE_PROFILE)
+        assert rec.works_count == 188
+        assert rec.cited_by_count == 6897
+
+
+# ==================== Fixtures ====================
+
+
+def _mock_response(status: int = 200, payload: dict | None = None) -> Mock:
+    resp = Mock()
+    resp.status_code = status
+    resp.json.return_value = payload or {}
+    resp.text = str(payload or "")
+    resp.raise_for_status = Mock()
+    return resp
+
+
+@pytest.fixture
+def mock_http_client() -> AsyncMock:
+    mock = AsyncMock(spec=httpx.AsyncClient)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def client(mock_http_client: AsyncMock) -> OpenAlexClient:
+    return OpenAlexClient(http_client=mock_http_client)
+
+
+# ==================== Initialization / mailto ====================
+
+
+class TestInitialization:
+    def test_defaults(self, client: OpenAlexClient) -> None:
+        assert client.api_name == "openalex"
+        assert client.base_url == "https://api.openalex.org"
+        assert client.rate_limit_per_minute == 100
+
+    def test_inherits_from_base(self, client: OpenAlexClient) -> None:
+        from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
+
+        assert isinstance(client, BaseAsyncAPIClient)
+
+    def test_no_mailto_by_default(self, mock_http_client: AsyncMock) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            c = OpenAlexClient(http_client=mock_http_client)
+        assert c._with_mailto({"a": 1}) == {"a": 1}
+
+    def test_explicit_mailto(self, mock_http_client: AsyncMock) -> None:
+        c = OpenAlexClient(mailto="you@example.com", http_client=mock_http_client)
+        assert c._with_mailto({})["mailto"] == "you@example.com"
+
+    def test_env_mailto(self, mock_http_client: AsyncMock) -> None:
+        with patch.dict("os.environ", {"OPENALEX_MAILTO": "env@example.com"}):
+            c = OpenAlexClient(http_client=mock_http_client)
+        assert c._with_mailto({})["mailto"] == "env@example.com"
+
+
+# ==================== Shared limiter ====================
+
+
+class TestSharedLimiterOverride:
+    async def test_shared_limiter_invoked(self, mock_http_client: AsyncMock) -> None:
+        shared = RateLimiter(rate_limit_per_minute=30)
+        shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
+        c = OpenAlexClient(shared_limiter=shared, http_client=mock_http_client)
+        mock_http_client.get.return_value = _mock_response(200, {"results": []})
+
+        await c.search_authors("Smith")
+
+        shared.wait_if_needed.assert_called_once()
+
+
+# ==================== search_authors ====================
+
+
+class TestSearchAuthors:
+    async def test_returns_results_list(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_response(200, {"results": [SAMPLE_SEARCH_RESULT]})
+
+        result = await client.search_authors("Jane Smith")
+
+        assert result == [SAMPLE_SEARCH_RESULT]
+
+    async def test_empty_results_returns_empty_list(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_response(200, {"results": []})
+
+        assert await client.search_authors("Nobody") == []
+
+    async def test_4xx_returns_empty(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp = Mock()
+        resp.status_code = 400
+        resp.text = "bad"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "400", request=Mock(), response=resp
+        )
+
+        assert await client.search_authors("x") == []
+
+    async def test_5xx_propagates(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp = Mock()
+        resp.status_code = 500
+        resp.text = "boom"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "500", request=Mock(), response=resp
+        )
+
+        with pytest.raises(APIError):
+            await client.search_authors("x")
+
+
+# ==================== get_author_details ====================
+
+
+class TestGetAuthorDetails:
+    async def test_returns_profile(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_response(200, SAMPLE_PROFILE)
+
+        result = await client.get_author_details("A5110956653")
+
+        assert result == SAMPLE_PROFILE
+
+    async def test_accepts_full_url_id(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_response(200, SAMPLE_PROFILE)
+
+        await client.get_author_details("https://openalex.org/A5110956653")
+
+        url = mock_http_client.get.call_args[0][0]
+        assert url.endswith("/authors/A5110956653")
+
+    async def test_404_returns_none(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp = Mock()
+        resp.status_code = 404
+        resp.text = "not found"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "404", request=Mock(), response=resp
+        )
+
+        assert await client.get_author_details("GONE") is None
+
+    async def test_500_propagates(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp = Mock()
+        resp.status_code = 500
+        resp.text = "boom"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "500", request=Mock(), response=resp
+        )
+
+        with pytest.raises(APIError):
+            await client.get_author_details("A5110956653")
+
+
+# ==================== lookup ====================
+
+
+class TestLookup:
+    async def test_success_two_step(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.side_effect = [
+            _mock_response(200, {"results": [SAMPLE_SEARCH_RESULT]}),
+            _mock_response(200, SAMPLE_PROFILE),
+        ]
+
+        rec = await client.lookup("Jane Smith")
+
+        assert rec is not None
+        assert rec.openalex_id == "A5110956653"
+        assert "University of Notre Dame" in rec.affiliations
+
+    async def test_no_search_match_returns_none(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_response(200, {"results": []})
+
+        assert await client.lookup("Nobody") is None
+
+    async def test_empty_name_returns_none(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        assert await client.lookup("") is None
+        mock_http_client.get.assert_not_called()
+
+    async def test_missing_id_in_result_returns_none(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_response(
+            200, {"results": [{"display_name": "No ID Here"}]}
+        )
+
+        assert await client.lookup("Jane Smith") is None
+
+    async def test_profile_404_returns_none(
+        self, client: OpenAlexClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp_404 = Mock()
+        resp_404.status_code = 404
+        resp_404.text = "gone"
+        mock_http_client.get.side_effect = [
+            _mock_response(200, {"results": [SAMPLE_SEARCH_RESULT]}),
+            httpx.HTTPStatusError("404", request=Mock(), response=resp_404),
+        ]
+
+        assert await client.lookup("Jane Smith") is None
+
+
+# ==================== Sync facade ====================
+
+
+class TestSyncFacade:
+    def test_context_manager(self) -> None:
+        with SyncOpenAlexClient() as client:
+            assert hasattr(client, "lookup")
+            assert hasattr(client, "search_authors")
+            assert hasattr(client, "get_author_details")
+
+    def test_lookup_delegates_to_async(self) -> None:
+        with SyncOpenAlexClient() as client:
+            client._client.lookup = AsyncMock(  # type: ignore[method-assign]
+                return_value=OpenAlexRecord(openalex_id="A5110956653", works_count=188)
+            )
+
+            rec = client.lookup("Jane Smith")
+
+            assert rec is not None
+            assert rec.openalex_id == "A5110956653"
+            assert rec.works_count == 188
+            client._client.lookup.assert_awaited_once_with("Jane Smith")
+
+    def test_shared_limiter_plumbs_through(self) -> None:
+        shared = RateLimiter(rate_limit_per_minute=30)
+        with SyncOpenAlexClient(shared_limiter=shared) as client:
+            assert client._client._shared_limiter is shared
+
+    def test_mailto_plumbs_through(self) -> None:
+        with SyncOpenAlexClient(mailto="you@example.com") as client:
+            assert client._client._mailto == "you@example.com"

--- a/tests/unit/enrichers/test_pubmed_client.py
+++ b/tests/unit/enrichers/test_pubmed_client.py
@@ -1,0 +1,347 @@
+"""Tests for PubMedClient (async) and SyncPubMedClient.
+
+Follows the ``AsyncMock``-based pattern established in
+test_orcid_client.py / test_fpds_atom.py — no real network calls.
+``efetch`` returns XML (like FPDS), ``esearch`` returns JSON.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import httpx
+import pytest
+
+from sbir_etl.enrichers.pubmed_client import (
+    PubMedClient,
+    PubMedRecord,
+    _best_matching_author,
+    _parse_efetch_xml,
+)
+from sbir_etl.enrichers.rate_limiting import RateLimiter
+from sbir_etl.enrichers.sync_wrappers import SyncPubMedClient
+from sbir_etl.exceptions import APIError
+
+pytestmark = pytest.mark.fast
+
+
+# ==================== Sample data ====================
+
+
+SAMPLE_ESEARCH_RESULT = {
+    "esearchresult": {"idlist": ["42599173", "42598748"]},
+}
+
+SAMPLE_EFETCH_XML = """<?xml version="1.0" ?>
+<PubmedArticleSet>
+<PubmedArticle><MedlineCitation><PMID Version="1">42599173</PMID>
+<Article><ArticleTitle>Validation of the Catatonia Quick Screen.</ArticleTitle>
+<AuthorList CompleteYN="Y">
+<Author ValidYN="Y"><LastName>Luccarelli</LastName><ForeName>James</ForeName><Initials>J</Initials>
+<AffiliationInfo><Affiliation>Harvard Medical School, Boston, MA, USA.</Affiliation></AffiliationInfo>
+</Author>
+<Author ValidYN="Y"><LastName>Smith</LastName><ForeName>Joshua Ryan</ForeName><Initials>JR</Initials>
+<AffiliationInfo><Affiliation>Vanderbilt University Medical Center, Nashville, TN, USA.</Affiliation></AffiliationInfo>
+<AffiliationInfo><Affiliation>Vanderbilt Kennedy Center, Nashville, TN, USA.</Affiliation></AffiliationInfo>
+</Author>
+</AuthorList>
+</Article>
+</MedlineCitation>
+</PubmedArticle>
+</PubmedArticleSet>
+"""
+
+SAMPLE_EFETCH_XML_NO_ARTICLE = """<?xml version="1.0" ?>
+<PubmedArticleSet>
+</PubmedArticleSet>
+"""
+
+
+# ==================== Pure parsing helpers ====================
+
+
+class TestParseEfetchXml:
+    def test_extracts_title(self):
+        parsed = _parse_efetch_xml(SAMPLE_EFETCH_XML)
+        assert parsed is not None
+        assert parsed["title"] == "Validation of the Catatonia Quick Screen."
+
+    def test_extracts_authors_and_affiliations(self):
+        parsed = _parse_efetch_xml(SAMPLE_EFETCH_XML)
+        assert parsed is not None
+        names = [a["name"] for a in parsed["authors"]]
+        assert "James Luccarelli" in names
+        assert "Joshua Ryan Smith" in names
+        smith = next(a for a in parsed["authors"] if a["name"] == "Joshua Ryan Smith")
+        assert "Vanderbilt University Medical Center, Nashville, TN, USA." in smith["affiliations"]
+        assert len(smith["affiliations"]) == 2
+
+    def test_no_article_returns_none(self):
+        assert _parse_efetch_xml(SAMPLE_EFETCH_XML_NO_ARTICLE) is None
+
+    def test_malformed_xml_returns_none(self):
+        assert _parse_efetch_xml("<not><valid") is None
+
+
+class TestBestMatchingAuthor:
+    def test_matches_by_last_name(self):
+        authors = [
+            {"name": "James Luccarelli", "affiliations": []},
+            {"name": "Joshua Ryan Smith", "affiliations": ["Vanderbilt"]},
+        ]
+        best = _best_matching_author(authors, "Jane Smith")
+        assert best is not None
+        assert best["name"] == "Joshua Ryan Smith"
+
+    def test_no_match_falls_back_to_first(self):
+        authors = [{"name": "James Luccarelli", "affiliations": []}]
+        best = _best_matching_author(authors, "Nobody Here")
+        assert best is not None
+        assert best["name"] == "James Luccarelli"
+
+    def test_empty_authors_returns_none(self):
+        assert _best_matching_author([], "Jane Smith") is None
+
+
+# ==================== Fixtures ====================
+
+
+def _mock_json_response(status: int = 200, payload: dict | None = None) -> Mock:
+    resp = Mock()
+    resp.status_code = status
+    resp.json.return_value = payload or {}
+    resp.text = str(payload or "")
+    resp.raise_for_status = Mock()
+    return resp
+
+
+def _mock_xml_response(status: int = 200, xml_text: str = "") -> Mock:
+    resp = Mock()
+    resp.status_code = status
+    resp.text = xml_text
+    resp.raise_for_status = Mock()
+    return resp
+
+
+@pytest.fixture
+def mock_http_client() -> AsyncMock:
+    mock = AsyncMock(spec=httpx.AsyncClient)
+    mock.aclose = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def client(mock_http_client: AsyncMock) -> PubMedClient:
+    return PubMedClient(http_client=mock_http_client)
+
+
+# ==================== Initialization / api key ====================
+
+
+class TestInitialization:
+    def test_defaults_no_key(self, client: PubMedClient) -> None:
+        assert client.api_name == "pubmed"
+        assert client.base_url == "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+        assert client.rate_limit_per_minute == 180
+
+    def test_inherits_from_base(self, client: PubMedClient) -> None:
+        from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
+
+        assert isinstance(client, BaseAsyncAPIClient)
+
+    def test_no_key_no_param(self, mock_http_client: AsyncMock) -> None:
+        with patch.dict("os.environ", {}, clear=True):
+            c = PubMedClient(http_client=mock_http_client)
+        assert "api_key" not in c._with_api_key({})
+
+    def test_explicit_key_raises_default_rate_limit(self, mock_http_client: AsyncMock) -> None:
+        c = PubMedClient(api_key="abc-key", http_client=mock_http_client)
+        assert c._with_api_key({})["api_key"] == "abc-key"
+        assert c.rate_limit_per_minute == 600
+
+    def test_env_key(self, mock_http_client: AsyncMock) -> None:
+        with patch.dict("os.environ", {"NCBI_API_KEY": "env-key"}):
+            c = PubMedClient(http_client=mock_http_client)
+        assert c._with_api_key({})["api_key"] == "env-key"
+        assert c.rate_limit_per_minute == 600
+
+    def test_explicit_rate_limit_overrides_key_default(self, mock_http_client: AsyncMock) -> None:
+        c = PubMedClient(api_key="abc-key", rate_limit_per_minute=42, http_client=mock_http_client)
+        assert c.rate_limit_per_minute == 42
+
+
+# ==================== Shared limiter ====================
+
+
+class TestSharedLimiterOverride:
+    async def test_shared_limiter_invoked(self, mock_http_client: AsyncMock) -> None:
+        shared = RateLimiter(rate_limit_per_minute=30)
+        shared.wait_if_needed = MagicMock()  # type: ignore[method-assign]
+        c = PubMedClient(shared_limiter=shared, http_client=mock_http_client)
+        mock_http_client.get.return_value = _mock_json_response(200, SAMPLE_ESEARCH_RESULT)
+
+        await c.search_pmids("Smith")
+
+        shared.wait_if_needed.assert_called_once()
+
+
+# ==================== search_pmids ====================
+
+
+class TestSearchPmids:
+    async def test_returns_pmid_list(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_json_response(200, SAMPLE_ESEARCH_RESULT)
+
+        result = await client.search_pmids("Jane Smith")
+
+        assert result == ["42599173", "42598748"]
+
+    async def test_empty_results_returns_empty_list(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_json_response(
+            200, {"esearchresult": {"idlist": []}}
+        )
+
+        assert await client.search_pmids("Nobody") == []
+
+    async def test_4xx_returns_empty(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp = Mock()
+        resp.status_code = 400
+        resp.text = "bad"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "400", request=Mock(), response=resp
+        )
+
+        assert await client.search_pmids("x") == []
+
+    async def test_5xx_propagates(self, client: PubMedClient, mock_http_client: AsyncMock) -> None:
+        resp = Mock()
+        resp.status_code = 500
+        resp.text = "boom"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "500", request=Mock(), response=resp
+        )
+
+        with pytest.raises(APIError):
+            await client.search_pmids("x")
+
+
+# ==================== get_author_affiliations ====================
+
+
+class TestGetAuthorAffiliations:
+    async def test_returns_parsed_xml(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_xml_response(200, SAMPLE_EFETCH_XML)
+
+        result = await client.get_author_affiliations("42599173")
+
+        assert result is not None
+        assert result["title"] == "Validation of the Catatonia Quick Screen."
+        assert len(result["authors"]) == 2
+
+    async def test_4xx_returns_none(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp = Mock()
+        resp.status_code = 404
+        resp.text = "not found"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "404", request=Mock(), response=resp
+        )
+
+        assert await client.get_author_affiliations("GONE") is None
+
+    async def test_5xx_propagates(self, client: PubMedClient, mock_http_client: AsyncMock) -> None:
+        resp = Mock()
+        resp.status_code = 500
+        resp.text = "boom"
+        mock_http_client.get.side_effect = httpx.HTTPStatusError(
+            "500", request=Mock(), response=resp
+        )
+
+        with pytest.raises(APIError):
+            await client.get_author_affiliations("42599173")
+
+
+# ==================== lookup ====================
+
+
+class TestLookup:
+    async def test_success_two_step(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.side_effect = [
+            _mock_json_response(200, SAMPLE_ESEARCH_RESULT),
+            _mock_xml_response(200, SAMPLE_EFETCH_XML),
+        ]
+
+        rec = await client.lookup("Joshua Smith")
+
+        assert rec is not None
+        assert rec.pmid == "42599173"
+        assert rec.author_name == "Joshua Ryan Smith"
+        assert "Vanderbilt University Medical Center, Nashville, TN, USA." in rec.affiliations
+        assert rec.title == "Validation of the Catatonia Quick Screen."
+
+    async def test_no_search_match_returns_none(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        mock_http_client.get.return_value = _mock_json_response(
+            200, {"esearchresult": {"idlist": []}}
+        )
+
+        assert await client.lookup("Nobody") is None
+
+    async def test_empty_name_returns_none(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        assert await client.lookup("") is None
+        mock_http_client.get.assert_not_called()
+
+    async def test_affiliations_fetch_failure_returns_none(
+        self, client: PubMedClient, mock_http_client: AsyncMock
+    ) -> None:
+        resp_404 = Mock()
+        resp_404.status_code = 404
+        resp_404.text = "gone"
+        mock_http_client.get.side_effect = [
+            _mock_json_response(200, SAMPLE_ESEARCH_RESULT),
+            httpx.HTTPStatusError("404", request=Mock(), response=resp_404),
+        ]
+
+        assert await client.lookup("Joshua Smith") is None
+
+
+# ==================== Sync facade ====================
+
+
+class TestSyncFacade:
+    def test_context_manager(self) -> None:
+        with SyncPubMedClient() as client:
+            assert hasattr(client, "lookup")
+            assert hasattr(client, "search_pmids")
+            assert hasattr(client, "get_author_affiliations")
+
+    def test_lookup_delegates_to_async(self) -> None:
+        with SyncPubMedClient() as client:
+            client._client.lookup = AsyncMock(  # type: ignore[method-assign]
+                return_value=PubMedRecord(pmid="42599173", author_name="Joshua Ryan Smith")
+            )
+
+            rec = client.lookup("Joshua Smith")
+
+            assert rec is not None
+            assert rec.pmid == "42599173"
+            client._client.lookup.assert_awaited_once_with("Joshua Smith")
+
+    def test_shared_limiter_plumbs_through(self) -> None:
+        shared = RateLimiter(rate_limit_per_minute=30)
+        with SyncPubMedClient(shared_limiter=shared) as client:
+            assert client._client._shared_limiter is shared


### PR DESCRIPTION
## What gap this fills

While scoping the STTR spinout-linkage spec's D2 "person trail" evidence dimension (`specs/sttr-spinout-linkage/design.md`, D2 row of the Evidence dimensions table — detecting whether a small-business PI has RI-affiliated authorship via OpenAlex/PubMed + ORCID), an exploratory data-availability notebook confirmed `sbir_etl/enrichers/orcid_client.py` already exists but **no OpenAlex or PubMed client existed anywhere in the repo**. This PR fills that gap with general-purpose client infrastructure.

## What this is (and isn't)

This is `pipelines`-tier enrichment infrastructure per `docs/steering/epistemic-tiers.md` (deterministic retrieval, no inference) — the same category as `orcid_client.py` and `semantic_scholar.py`, both of which live outside any spec's gating (`sbir_etl/enrichers/__init__.py` declares `EPISTEMIC_TIER = "pipelines"`).

It does **not**:
- touch anything under `specs/sttr-spinout-linkage/` (still ungated pending Revision 1 freeze per that spec's `tasks.md`)
- implement any RI-affiliation matching/classification logic (the D2 cascade itself)
- fetch data for the STTR award population — the client is unused by any pipeline; only mocked unit tests exercise it

## What was built

Mirrors the existing `ORCIDClient`/`SemanticScholarClient` pattern exactly:

- **`sbir_etl/enrichers/openalex_client.py`** — `OpenAlexClient(BaseAsyncAPIClient)` over the OpenAlex API. No API key required; supports the optional "polite pool" `mailto` param (`OPENALEX_MAILTO` env var) for faster/more-reliable rate limits. Exposes `search_authors()`, `get_author_details(openalex_id)`, and a `lookup(name) -> OpenAlexRecord | None` convenience method. `OpenAlexRecord` carries `openalex_id`, `display_name`, `affiliations` (institution names), `orcid` (cross-link when OpenAlex has one on file), `works_count`, `cited_by_count`.

- **`sbir_etl/enrichers/pubmed_client.py`** — `PubMedClient(BaseAsyncAPIClient)` over NCBI E-utilities. No key required (3 req/sec); `NCBI_API_KEY` env var raises the limit to 10 req/sec, mirroring ORCID's access-token pattern. Exposes `search_pmids()` (`esearch.fcgi`), `get_author_affiliations(pmid)` (`efetch.fcgi` XML — `esummary` doesn't carry affiliation strings, verified against the live API during development), and `lookup(name) -> PubMedRecord | None`. `PubMedRecord` carries `pmid`, `author_name`, `affiliations`, `title`.

- **`sbir_etl/enrichers/sync_wrappers.py`** — registers `SyncOpenAlexClient` and `SyncPubMedClient` following the exact `_SyncFacade` pattern already used for `SyncORCIDClient`/`SyncSemanticScholarClient`.

- **Tests** (`tests/unit/enrichers/test_openalex_client.py`, `test_pubmed_client.py`) — mirror `test_orcid_client.py`'s structure: mocked `httpx.AsyncClient` via the existing `http_client=` constructor injection point, no live network calls. Cover successful lookup, no-match/empty-result, and 4xx-returns-empty/None vs 5xx-propagates error handling (matching `ORCIDClient.search`'s contract).

Response shapes for both APIs were verified against live endpoints during development (OpenAlex `/authors` search + `/authors/{id}`; NCBI `esearch.fcgi` + `efetch.fcgi` XML) to make sure the parsing logic matches reality, but the committed test suite requires no network access.

## Test plan

- [x] `uv run pytest tests/unit/enrichers/test_openalex_client.py tests/unit/enrichers/test_pubmed_client.py -v` — 61 passed
- [x] `make lint` (ruff + mypy over `sbir_etl`) — passed
- [x] `make docs-check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)