### PR TITLE
Research: Bayh-Dole government-interest data source for D3 (O-12)

### DIFF
--- a/specs/sttr-spinout-linkage/coverage-memo.md
+++ b/specs/sttr-spinout-linkage/coverage-memo.md
@@ -14,7 +14,7 @@ for a typical STTR award at that agency.
 |-----------|-----|-----|-----|-------------|-------|
 | **D1** Award spine | High | High | High | High | SBIR.gov carries SBC, RI, PI, agency, FY, abstract for STTR rows. |
 | **D2** Person trail (OpenAlex/PubMed/ORCID) | High | High | **Low** | Medium | Biomedical/academic authorship is densely indexed; DoD PIs are under-indexed and abstracts are terse. |
-| **D3** IP trail (USPTO assignment; Bayh-Dole) | Medium | Medium | Medium | Medium | Patent assignment coverage is real but uneven; **license records are sparse everywhere** (encoded as typed absence, never subcontract evidence). |
+| **D3** IP trail (USPTO assignment; Bayh-Dole) | Medium | Medium | Medium | Medium | Patent assignment coverage is real but uneven; **license records are sparse everywhere, and no public Bayh-Dole government-interest source was found to supply them at all** ([O-12](open-questions.md) — iEdison is account-gated, PatentsView/ODP's government-interest field captures funding agency/contract number rather than licensee) (encoded as typed absence, never subcontract evidence). |
 | **D4** Money trail (USASpending subaward; Form D) | High (grant) | High (grant) | **N/A→Low** (contract) | Mixed | STTR at NIH/NSF is grant-instrument (subaward share observable); much of DoD STTR is contract-instrument, so the RI subaward share is `NOT_APPLICABLE`. Form D officer/director match is instrument-independent but low base rate. |
 | **D5** Text trail (phrase lexicon) | Medium | Medium | **Low** | Medium | Tracks abstract richness. Consistent with the repository's finding that DoD descriptions are frequently near-empty. |
 
@@ -28,7 +28,11 @@ for a typical STTR award at that agency.
   are measured-negative — i.e., predominantly grant-instrument STTRs. Contract-instrument STTRs with
   no subaward record fall to `INDETERMINATE`, not `SUBCONTRACT`, by construction.
 - **License sparsity is systemic, not agency-specific.** D3 will identify spinouts primarily through
-  patent assignment (RI assignee + SBC-principal inventor), not through recorded licenses.
+  patent assignment (RI assignee + SBC-principal inventor), not through recorded licenses. Per
+  [O-12](open-questions.md), this is closer to a **structural ceiling** than a coverage gap: no
+  public source directly supplies a Bayh-Dole government-interest statement or an RI→SBC license
+  record; the only concrete proxy is a free-text search over the local USPTO assignment
+  `convey_text` field, which is unvalidated and expected to undercount.
 
 ## Partner-type incidence readout — table shape
 

--- a/specs/sttr-spinout-linkage/design.md
+++ b/specs/sttr-spinout-linkage/design.md
@@ -97,13 +97,20 @@ see [O-0](open-questions.md)). **Missing or null data never stands in for one of
 |-----|------|---------|-----------------|-----------------------|
 | **D1** | Award spine | SBIR.gov award data, `program = STTR` | SBC, RI, PI, agency, FY, abstract present (the join spine) | Missing RI/PI blocks scoring downstream; row is `INDETERMINATE` if D1 incomplete |
 | **D2** | Person trail | OpenAlex / PubMed authorship, ORCID | PI (and founders, if in scope — [O-1](open-questions.md)) matched to RI-affiliated authorship within ±N years of award (N default ±3, [O-2](open-questions.md)) | No RI-affiliated authorship found *after search* vs. person unresolvable (`generic_token_guard` fail) vs. source not queried |
-| **D3** | IP trail | USPTO assignment data; Bayh-Dole government-interest statements | Patent assigned to the RI naming an SBC principal as inventor; **recorded license** RI→SBC | License **absence** → `NOT_MEASURABLE` (`LICENSE_RECORDS_SPARSE`), **never** `SUBCONTRACT` evidence |
+| **D3** | IP trail | USPTO assignment data (local, confirmed — patent-assignment sub-signal only); **no confirmed public source for Bayh-Dole government-interest statements or a structured RI→SBC license record** ([O-12](open-questions.md)) | Patent assigned to the RI naming an SBC principal as inventor; **recorded license** RI→SBC | License **absence** → `NOT_MEASURABLE` (`LICENSE_RECORDS_SPARSE`), **never** `SUBCONTRACT` evidence |
 | **D4** | Money / paper trail | USASpending subawards; Form D officers/directors (existing pipeline) | RI subaward share on grant-based STTRs (a positive **subcontract** marker); Form D officer/director matched to RI-affiliated name (a positive **spinout** marker) | No subaward record vs. non-grant instrument (`NOT_APPLICABLE`) vs. Form D absent |
 | **D5** | Text trail | Deterministic phrase lexicon over award abstracts and firm text | "spun out of", "licensed from", "founded by Professor …" ([O-4](open-questions.md) fixes the v1 lexicon) | No phrase matched vs. no firm text available |
 
 Discipline notes carried from the brief:
 - **D3 licenses are asymmetric evidence.** A recorded license is positive spinout evidence; its
   absence proves nothing and is encoded as typed absence, never as subcontract evidence.
+- **The `recorded_license_RI_to_SBC` sub-signal has no confirmed public data source.** iEdison
+  (the actual Bayh-Dole reporting system) is account-gated, not public; PatentsView/USPTO's
+  `government_interest` extraction captures the *funding agency and contract number* named in a
+  patent's front-matter clause, not license recipients. The only known proxy today is a free-text
+  search for "license" wording inside the `convey_text` field of the local USPTO assignment bulk
+  data — a weak, unvalidated signal, not a government-interest statement. See
+  [O-12](open-questions.md) for the full research record.
 - **`generic_token_guard` is mandatory on D2 person names** and on all organization-name matching
   (partner type). A name dominated by generic tokens cannot produce an accepted match.
 - **D4 has two directions.** The RI subaward share is a *subcontract* marker; a Form

--- a/specs/sttr-spinout-linkage/open-questions.md
+++ b/specs/sttr-spinout-linkage/open-questions.md
@@ -136,3 +136,86 @@ consistency with prior transition work; decide at RQ2 implementation, not now.
 Partner-type classification shares the D1 spine with RQ1 but is conceptually independent.
 **Proposed default (from the addendum):** ship it in this spec — it shares the spine. Promote to
 its own primitive only if a second consumer appears.
+
+## O-12 — Bayh-Dole government-interest statement data source
+
+**The gap.** The [D3 evidence-dimension row](design.md#evidence-dimensions) names "Bayh-Dole
+government-interest statements" as a source, and the [Order-1 cascade
+rule](design.md#classification-cascade-rq1) treats a **recorded license from the RI to the SBC**
+(`D3.recorded_license_RI_to_SBC`) as `SPINOUT_T1` evidence — but **no source for that data was ever
+named**, in `design.md`, `coverage-memo.md`, or anywhere else in the spec. This is distinct from
+[O-8](#o-8--bayh-dole--licensing-literature-anchor), which is only about adding a **statutory
+citation** to the literature map; O-8 does not address where the government-interest-statement
+*data* would come from. This question is research/sourcing only — no ingestion, fetch, or parsing
+is authorized here or before the Revision 1 freeze.
+
+**Candidate sources researched (2026-08-14):**
+
+- **NIH/interagency iEdison (now NIST-operated, transferred from NIH August 2022).** The system of
+  record for Bayh-Dole subject-invention and utilization-report filings, used across NIH, NSF, DoD,
+  DOE, and ~30 other agencies. **Restricted, not public.** Access requires an organization-level
+  iEdison account and login.gov authentication ([NIST iEdison FAQ](https://www.nist.gov/iedison/iedison-frequently-asked-questions-faqs));
+  the [iEdison API](https://github.com/usnistgov/iEdison-API-Documentation) requires "Setting Up
+  Your API Account" — no anonymous or public endpoint is documented. **Verdict: Not public.** A
+  recent GAO report on iEdison data,
+  [GAO-26-107971](https://files.gao.gov/reports/GAO-26-107971/index.html) ("Funding Recipients Keep
+  Most Federally Funded Inventions, but Some Cited Reporting Challenges"), analyzes FY2020–2024
+  iEdison filings across 30 agencies but publishes only **aggregate narrative statistics** (e.g.,
+  ~56% title-retention rate) — no individual-invention or license-level microdata release. It does
+  not name a licensee, so it would not help even if released.
+- **PatentsView / USPTO Open Data Portal `government_interest` extraction.** PatentsView runs an
+  NER pipeline over the "GOVERNMENT INTERESTS" clause in granted-patent front matter, resolving
+  matches against a list of 300+ U.S. government organizations
+  ([extraction-process methodology](https://patentsview.org/government-interest/extraction-process);
+  [pv-government-interest](https://github.com/PatentsView/pv-government-interest)). This is
+  **public, bulk-downloadable, patent-level** structured data — the cleanest-sounding candidate.
+  **But it captures the wrong thing for D3's stated use**: the extracted fields are the **funding
+  agency and contract/grant award number** named in the clause (e.g., "awarded by NIH, grant
+  R01..."), not a license grantee. It confirms federal funding nexus, not an RI→SBC license.
+  PatentsView migrated into the USPTO Open Data Portal (`data.uspto.gov`) on March 20, 2026, and its
+  standalone search API was shut down
+  ([USPTO transition notice](https://www.uspto.gov/subscription-center/2026/patentsview-migrating-uspto-open-data-portal-march-20)).
+  As of this writing, ODP bulk/API access remains free but now requires a registered USPTO.gov
+  account with MFA (required starting June 18, 2026, with additional profile fields required
+  starting August 18, 2026 per ODP onboarding notices) — free registration, not open-anonymous, and
+  a tightening requirement worth re-checking before any future capture. **Verdict: Feasible with
+  work, but answers the wrong question** — usable for confirming federal-funding nexus, not license
+  evidence.
+- **USPTO assignment bulk data already in `data/raw/uspto/assignments/`.** Directly inspected the
+  local files (not fetched new data). `assignment_conveyance.csv.zip` classifies every recorded
+  conveyance into one of 10 categories (`assignment`, `namechg`, `correct`, `govern`, `security`,
+  `merger`, `release`, `other`, `missing`, `employee` — counted directly from the local file,
+  10.5M rows total); **`license` is not one of them.** USPTO's own conveyance-type list separately
+  documents `Government Interest Agreement` and `Confirmatory License` as distinct filing types, but
+  neither surfaces as a queryable category in this bulk product — `govern` (111,537 rows locally) is
+  the closest analog and is a title/rights recordation, not a license grant. However, the free-text
+  `convey_text` field in `assignment.csv.zip` **does** contain literal "LICENSE" wording on a
+  meaningful minority of records (≈0.5% of a 2M-row sample, i.e. tens of thousands of records
+  repo-wide), joinable to `assignor.csv.zip` / `assignee.csv.zip` by `rf_id` to recover the naming
+  parties. **Verdict: Feasible now, as a weak proxy only** — a `convey_text` free-text search for
+  license wording, cross-checked against RI/SBC names on the award spine, is the only concrete,
+  already-in-repo path to any license-adjacent signal. It is not a Bayh-Dole government-interest
+  statement, is unvalidated (recorded licenses are optional and most private license agreements are
+  never filed with USPTO at all — recordation is voluntary, not required), and will systematically
+  undercount.
+- **DOE VIPS (national-lab IP licensing database) and NASA e-NTR / NTRS.** DOE's [Visual
+  Intellectual Property Search](https://www.energy.gov/technologycommercialization/articles/doe-unveils-public-database-featuring-intellectual-property)
+  lists national-lab patents/software available for licensing (public), and NASA's e-NTR
+  (`invention.nasa.gov`) tracks New Technology Reports internally. Neither is a general-purpose
+  Bayh-Dole license registry: DOE VIPS shows licensing *availability* from federal labs, not
+  confirmed *executed* licenses to named third parties, and it is scoped to DOE national labs — not
+  the university/RI population that dominates STTR partners. NASA's system is internal, not public.
+  **Verdict: Not applicable** to the general D3 case; noted for completeness only.
+
+**Recommended default.** No public source directly supplies "a recorded license from the RI to the
+SBC" as declared. Treat this as a **structural limitation of D3, not a temporary sourcing gap**:
+(a) drop "Bayh-Dole government-interest statements" from D3's declared sources (done — see the
+`design.md` amendment accompanying this entry) since no accessible source of that name exists; (b)
+keep `D3.patent_assigned_to_RI_with_SBC_inventor` as the real, confirmed-available D3 signal
+(USPTO assignment data, already local); (c) if `D3.recorded_license_RI_to_SBC` ships at all in v1,
+source it only from the `convey_text` free-text proxy above, labeled explicitly as low-recall and
+unvalidated, never presented as a Bayh-Dole compliance record. This **corroborates and sharpens**
+`coverage-memo.md`'s existing D3 row ("license records are sparse everywhere"): the records are not
+merely sparse, they are close to **structurally unobservable** from any public Bayh-Dole compliance
+channel — the sparsity is a source-availability ceiling, not a coverage artifact that more querying
+would fix.

--- a/specs/sttr-spinout-linkage/open-questions.md
+++ b/specs/sttr-spinout-linkage/open-questions.md
@@ -153,16 +153,34 @@ is authorized here or before the Revision 1 freeze.
 
 - **NIH/interagency iEdison (now NIST-operated, transferred from NIH August 2022).** The system of
   record for Bayh-Dole subject-invention and utilization-report filings, used across NIH, NSF, DoD,
-  DOE, and ~30 other agencies. **Restricted, not public.** Access requires an organization-level
-  iEdison account and login.gov authentication ([NIST iEdison FAQ](https://www.nist.gov/iedison/iedison-frequently-asked-questions-faqs));
-  the [iEdison API](https://github.com/usnistgov/iEdison-API-Documentation) requires "Setting Up
-  Your API Account" — no anonymous or public endpoint is documented. **Verdict: Not public.** A
-  recent GAO report on iEdison data,
+  DOE, and ~30 other agencies. **Not obtainable even in principle, not merely account-gated.** Three
+  independent barriers stack:
+  1. **Statutory confidentiality.** The Bayh-Dole Act authorizes agencies to withhold
+     invention-disclosure data from the public, and utilization/licensing-effort information is
+     treated as commercial and financial information that is privileged, confidential, and not
+     subject to disclosure — this is a FOIA-exemption-grade bar, not just a login wall. A FOIA
+     request for licensee-level data would predictably be denied on this basis; see the SBIR/STTR
+     data-rights briefing on this point
+     ([Patent and Data Rights under SBIR/STTR Awards](https://www.orau.gov/2018SBIRPhase2/presentations/Mike_Dobbs_SBIR-STTR_Phase_I_PI_Meeting_Dec_2018.pdf)).
+  2. **Account access is organization-scoped, not query access.** Web access requires an
+     organization-level iEdison account with login.gov authentication
+     ([NIST iEdison FAQ](https://www.nist.gov/iedison/iedison-frequently-asked-questions-faqs)); an
+     authenticated user sees their own organization's filings, not a cross-agency corpus.
+  3. **The API is a system-to-system filer interface, not a research read endpoint.** The
+     [iEdison API](https://www.nist.gov/iedison/iedison-api) requires a system account and a
+     NIST-issued PKI client certificate
+     ([Setting up your API Account](https://www.nist.gov/iedison/setting-your-api-account)) — built
+     for an institution's own grants-management system to submit/query *its own* reports, not for
+     third-party bulk read access.
+
+  **Verdict: Not obtainable — a statutory and architectural dead end, not a temporary access
+  friction.** Even with credentials, there is no path from one organization's account to the
+  government-wide STTR population this cascade needs. A recent GAO report on iEdison data,
   [GAO-26-107971](https://files.gao.gov/reports/GAO-26-107971/index.html) ("Funding Recipients Keep
   Most Federally Funded Inventions, but Some Cited Reporting Challenges"), analyzes FY2020–2024
   iEdison filings across 30 agencies but publishes only **aggregate narrative statistics** (e.g.,
-  ~56% title-retention rate) — no individual-invention or license-level microdata release. It does
-  not name a licensee, so it would not help even if released.
+  ~56% title-retention rate) — no individual-invention or license-level microdata release, and it
+  does not name a licensee, so it would not help even if released.
 - **PatentsView / USPTO Open Data Portal `government_interest` extraction.** PatentsView runs an
   NER pipeline over the "GOVERNMENT INTERESTS" clause in granted-patent front matter, resolving
   matches against a list of 300+ U.S. government organizations

--- a/specs/sttr-spinout-linkage/tasks.md
+++ b/specs/sttr-spinout-linkage/tasks.md
@@ -27,7 +27,7 @@ abstractions beyond what a single probe needs, and no citable numbers.
   - Requirements: header
 
 - [ ] 0.5 Owner resolves remaining open questions (O-0 through O-5, O-8 through
-      O-11)
+      O-12)
   - Verify: each resolution is a numbered revision in `amendments.md`
   - Requirements: freeze gate
 


### PR DESCRIPTION
## Summary

- Adds **O-12** to `specs/sttr-spinout-linkage/open-questions.md`, documenting a gap: D3's declared source "Bayh-Dole government-interest statements" was never actually sourced anywhere in the spec. This is distinct from O-8, which is only about adding a statutory citation to the literature map.
- Researched candidate public data sources for a Bayh-Dole government-interest statement / RI→SBC license record:
  - **iEdison** (NIST-operated Bayh-Dole reporting system) — account-gated, not public. A recent GAO report (GAO-26-107971) analyzing iEdison filings publishes only aggregate statistics, no microdata.
  - **PatentsView / USPTO Open Data Portal `government_interest` extraction** — public, bulk-downloadable, patent-level, but captures the **funding agency and contract number**, not a license recipient. Answers a different question than D3 needs. (Also: PatentsView migrated into ODP on 2026-03-20; ODP now requires a free but registered USPTO.gov account with MFA.)
  - **Local USPTO assignment bulk data** (`data/raw/uspto/assignments/`) — directly inspected. No structured "license" conveyance category exists (10 categories total: assignment, namechg, correct, govern, security, merger, release, other, missing, employee), but the free-text `convey_text` field does contain "LICENSE" wording on a meaningful minority of records, joinable to assignor/assignee names by `rf_id`. This is the only concrete, already-in-repo proxy — weak, unvalidated, and expected to undercount.
  - **DOE VIPS / NASA e-NTR** — not applicable to the general RI/university population STTR spinouts draw from.
- **Verdict: no public source directly supplies "a recorded license from the RI to the SBC" as D3 declares.** This is treated as a structural limitation of D3, not a temporary sourcing gap.
- Lightly amends `design.md`'s D3 Sources cell (was overstating availability) and a discipline-note bullet, and sharpens `coverage-memo.md`'s existing "license records are sparse everywhere" note with this finding.
- Adds O-12 to the `tasks.md` 0.5 list of open questions the owner must resolve before Revision 1 freeze.

**This PR is research/documentation only** — no code, no ingestion pipeline, no data fetched or downloaded, no parsing implemented, consistent with the spec's Phase 0 (design-only) discipline and the explicit gate in `tasks.md` ("Do not start these tasks before Revision 1").

## Branching note

The task instructions asked to branch off `origin/main`, but `main` does not yet contain `specs/sttr-spinout-linkage/` at all — that spec only exists on `cursor/sttr-spinout-linkage-83e3`, which has its own open PR (#615) into main. Branching off `main` was infeasible (the target files don't exist there), so this PR is based on `cursor/sttr-spinout-linkage-83e3` instead, to keep the diff scoped to this change alone.

## Test plan

- [x] `make docs-check` passes
- [x] `uv run python scripts/ci/check_epistemic_tiers.py` passes
- [x] No code changes; documentation-only diff reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)