### PR TITLE
Fix USAspending refresh pipeline defects from #619

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/usaspending_iterative_enrichment.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/usaspending_iterative_enrichment.py
@@ -22,7 +22,7 @@ from pydantic import Field
 from sbir_etl.config.loader import get_config
 from sbir_etl.enrichers.source_adapter import SourceAdapter, SourceRefreshRunner
 from sbir_etl.enrichers.usaspending import USAspendingSourceAdapter
-from sbir_etl.exceptions import ValidationError
+from sbir_etl.enrichers.usaspending.requests import has_identifier, stale_awards_to_requests
 from sbir_etl.utils.enrichment.checkpoints import CheckpointStore
 from sbir_etl.utils.enrichment.freshness import FreshnessStore
 from sbir_etl.utils.enrichment.metrics import EnrichmentMetricsCollector
@@ -71,9 +71,9 @@ def usaspending_freshness_ledger(context: AssetExecutionContext) -> Output[pd.Da
 
 def _load_enriched_awards(context: AssetExecutionContext) -> pd.DataFrame | None:
     """Load enriched SBIR awards written by sbir_usaspending_enrichment."""
-    from sbir_etl.utils.cloud_storage import get_data_root
+    from sbir_etl.enrichers.usaspending.requests import enriched_awards_path
 
-    src = get_data_root() / "processed" / "enriched" / "sbir_awards.parquet"
+    src = enriched_awards_path()
     if not src.is_file():
         context.log.info(f"No enriched awards at {src}")
         return None
@@ -149,53 +149,6 @@ def stale_usaspending_awards(
     )
 
 
-def _first_present_column(frame: pd.DataFrame, candidates: list[str]) -> str | None:
-    for col in candidates:
-        if col in frame.columns:
-            return col
-    return None
-
-
-def stale_awards_to_requests(stale_awards: pd.DataFrame) -> list[dict[str, Any]]:
-    """Map a stale-award frame to runner request dicts."""
-
-    if stale_awards.empty:
-        return []
-    award_id_col = _first_present_column(stale_awards, ["award_id", "Award_ID", "id", "ID"])
-    if not award_id_col:
-        raise ValidationError(
-            "Could not find award ID column",
-            component="assets.usaspending_iterative_enrichment",
-            operation="enrich_stale_usaspending_records",
-            details={
-                "expected_columns": ["award_id", "Award_ID", "id", "ID"],
-                "available_columns": list(stale_awards.columns),
-            },
-        )
-    uei_col = _first_present_column(stale_awards, ["UEI", "uei", "company_uei", "recipient_uei"])
-    duns_col = _first_present_column(
-        stale_awards, ["Duns", "duns", "company_duns", "recipient_duns"]
-    )
-    cage_col = _first_present_column(
-        stale_awards, ["CAGE", "cage", "company_cage", "recipient_cage"]
-    )
-    contract_col = _first_present_column(
-        stale_awards, ["Contract", "contract", "contract_number", "piid"]
-    )
-    requests: list[dict[str, Any]] = []
-    for _, row in stale_awards.iterrows():
-        requests.append(
-            {
-                "award_id": str(row[award_id_col]),
-                "uei": row[uei_col] if uei_col else None,
-                "duns": row[duns_col] if duns_col else None,
-                "cage": row[cage_col] if cage_col else None,
-                "piid": row[contract_col] if contract_col else None,
-            }
-        )
-    return requests
-
-
 def build_usaspending_adapter(*, freshness: FreshnessStore) -> SourceAdapter:
     """Factory so tests can inject a hermetic adapter without constructing the client."""
 
@@ -231,9 +184,15 @@ def usaspending_refresh_batch(
         )
 
     requests = stale_awards_to_requests(stale_usaspending_awards)
+    usable = [request for request in requests if has_identifier(request)]
+    unusable = len(requests) - len(usable)
+    if unusable:
+        context.log.warning(
+            f"Skipping {unusable} stale award(s) with no UEI/DUNS/CAGE/PIID to look up"
+        )
     refresh_config = get_config().enrichment_refresh.usaspending
     batch_size = config.batch_size or refresh_config.batch_size
-    requests = requests[:batch_size]
+    requests = usable[:batch_size]
 
     adapter = build_usaspending_adapter(freshness=store)
     metrics_collector = EnrichmentMetricsCollector()
@@ -242,6 +201,7 @@ def usaspending_refresh_batch(
         checkpoints=CheckpointStore(),
         metrics=metrics_collector,
         partition_id="usaspending-default",
+        checkpoint_interval=refresh_config.checkpoint_interval,
     )
     stats = runner.refresh_records(adapter, requests).as_dict()
 

--- a/sbir_etl/enrichers/refresh_cli.py
+++ b/sbir_etl/enrichers/refresh_cli.py
@@ -13,6 +13,15 @@ from typing import Any
 from sbir_etl.config.loader import get_config
 from sbir_etl.enrichers.source_adapter import SourceRefreshRunner
 from sbir_etl.enrichers.usaspending.adapter import USAspendingSourceAdapter
+from sbir_etl.enrichers.usaspending.requests import (
+    AWARD_ID_COLUMNS,
+    enriched_awards_path,
+    filter_by_window,
+    first_present_column,
+    has_identifier,
+    load_enriched_awards,
+    stale_awards_to_requests,
+)
 from sbir_etl.utils.enrichment.checkpoints import CheckpointStore
 from sbir_etl.utils.enrichment.freshness import FreshnessStore
 
@@ -26,7 +35,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--window",
         default=None,
-        help="Optional start:end window (ISO dates). Applied when award_date is present.",
+        help="Optional START:END window (ISO dates) applied to the award date column.",
     )
     parser.add_argument(
         "--award-id",
@@ -38,17 +47,47 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _requests_for_source(source: str, award_ids: Sequence[str] | None) -> list[dict[str, Any]]:
+def _requests_for_source(
+    source: str,
+    award_ids: Sequence[str] | None,
+    window: str | None = None,
+) -> list[dict[str, Any]]:
     config = get_config()
     source_config = getattr(config.enrichment_refresh, source, None)
     if source_config is None:
         raise SystemExit(f"unknown enrichment source: {source}")
-    if not source_config.enabled and source != "usaspending":
+    if not source_config.enabled:
         raise SystemExit(f"enrichment source {source} is disabled")
     store = FreshnessStore()
     sla = source_config.sla_staleness_days
     stale = store.get_awards_needing_refresh(source, sla, list(award_ids) if award_ids else None)
-    return [{"award_id": award_id} for award_id in stale]
+    if not stale:
+        return []
+
+    # The ledger stores award ids only. Identifiers (UEI / DUNS / CAGE / PIID) live
+    # on the enriched award frame, and enrich_award cannot match an award without
+    # at least one of them, so join rather than sending bare ids.
+    enriched = load_enriched_awards()
+    if enriched is None or enriched.empty:
+        raise SystemExit(
+            f"{enriched_awards_path()} is unavailable; refresh needs enriched awards "
+            "for recipient identifiers. Materialize sbir_usaspending_enrichment first."
+        )
+    award_id_col = first_present_column(enriched, AWARD_ID_COLUMNS)
+    if not award_id_col:
+        raise SystemExit(
+            f"no award id column on {enriched_awards_path()}; expected one of {AWARD_ID_COLUMNS}"
+        )
+    stale_frame = enriched.loc[enriched[award_id_col].astype(str).isin(set(stale))].copy()
+    if window:
+        stale_frame = filter_by_window(stale_frame, window)
+
+    requests = stale_awards_to_requests(stale_frame)
+    usable = [request for request in requests if has_identifier(request)]
+    dropped = len(requests) - len(usable)
+    if dropped:
+        print(f"skipping {dropped} stale award(s) with no usable identifier", file=sys.stderr)
+    return usable
 
 
 def run_refresh(
@@ -59,18 +98,18 @@ def run_refresh(
     runner: SourceRefreshRunner | None = None,
     adapter: Any = None,
 ) -> dict[str, Any]:
-    del window  # reserved; date columns are not on the freshness ledger
     if source != "usaspending":
         raise SystemExit(
             f"source {source!r} has no adapter yet; implement SourceAdapter to join the runner"
         )
-    requests = _requests_for_source(source, award_ids)
+    requests = _requests_for_source(source, award_ids, window)
     freshness = FreshnessStore()
     active_adapter = adapter or USAspendingSourceAdapter(freshness=freshness)
     active_runner = runner or SourceRefreshRunner(
         freshness=freshness,
         checkpoints=CheckpointStore(),
         partition_id=f"{source}-cli",
+        checkpoint_interval=get_config().enrichment_refresh.usaspending.checkpoint_interval,
     )
     return active_runner.refresh_records(active_adapter, requests).as_dict()
 

--- a/sbir_etl/enrichers/refresh_cli.py
+++ b/sbir_etl/enrichers/refresh_cli.py
@@ -67,7 +67,10 @@ def _requests_for_source(
     # The ledger stores award ids only. Identifiers (UEI / DUNS / CAGE / PIID) live
     # on the enriched award frame, and enrich_award cannot match an award without
     # at least one of them, so join rather than sending bare ids.
-    enriched = load_enriched_awards()
+    try:
+        enriched = load_enriched_awards()
+    except Exception as exc:
+        raise SystemExit(f"failed to load enriched awards: {exc}") from exc
     if enriched is None or enriched.empty:
         raise SystemExit(
             f"{enriched_awards_path()} is unavailable; refresh needs enriched awards "
@@ -78,7 +81,15 @@ def _requests_for_source(
         raise SystemExit(
             f"no award id column on {enriched_awards_path()}; expected one of {AWARD_ID_COLUMNS}"
         )
-    stale_frame = enriched.loc[enriched[award_id_col].astype(str).isin(set(stale))].copy()
+    stale_ids = {str(award_id) for award_id in stale}
+    stale_frame = enriched.loc[enriched[award_id_col].astype(str).isin(stale_ids)].copy()
+    matched_ids = set(stale_frame[award_id_col].astype(str))
+    missing_from_enriched = len(stale_ids - matched_ids)
+    if missing_from_enriched:
+        print(
+            f"skipping {missing_from_enriched} stale award(s) absent from enriched awards",
+            file=sys.stderr,
+        )
     if window:
         stale_frame = filter_by_window(stale_frame, window)
 

--- a/sbir_etl/enrichers/source_adapter.py
+++ b/sbir_etl/enrichers/source_adapter.py
@@ -100,18 +100,26 @@ class SourceRefreshRunner:
         checkpoints: CheckpointStore,
         metrics: EnrichmentMetricsCollector | None = None,
         partition_id: str = "default",
+        checkpoint_interval: int = 50,
     ) -> None:
         self.freshness = freshness
         self.checkpoints = checkpoints
         self.metrics = metrics or EnrichmentMetricsCollector()
         self.partition_id = partition_id
+        self.checkpoint_interval = max(1, checkpoint_interval)
 
     def refresh_records(
         self,
         adapter: SourceAdapter,
         records: Sequence[Mapping[str, Any]],
     ) -> RefreshStats:
-        """Refresh each record through the adapter. Resume from checkpoint."""
+        """Refresh each record through the adapter.
+
+        Resumes from an in-progress checkpoint left by a crashed pass, then clears
+        it once the pass completes so the next SLA-driven run re-refreshes the same
+        awards. Only successes are recorded as processed; a failed award is retried
+        on resume rather than being skipped forever.
+        """
 
         stats = RefreshStats(total=len(records))
         existing = self.checkpoints.load_checkpoint(self.partition_id, adapter.source_id)
@@ -119,6 +127,7 @@ class SourceRefreshRunner:
         if existing and isinstance(existing.metadata, dict):
             raw_ids = existing.metadata.get("processed_ids") or []
             processed_ids = {str(item) for item in raw_ids}
+        since_checkpoint = 0
 
         for request in records:
             award_id = str(request.get("award_id") or "")
@@ -163,6 +172,7 @@ class SourceRefreshRunner:
                 else:
                     stats.failed += 1
                     stats.errors.append(f"{award_id}: {error}")
+                record_succeeded = success
             except Exception as exc:
                 stats.failed += 1
                 stats.errors.append(f"{award_id}: {exc}")
@@ -174,20 +184,38 @@ class SourceRefreshRunner:
                     success=False,
                     error_message=str(exc),
                 )
+                record_succeeded = False
 
-            processed_ids.add(award_id)
-            self.checkpoints.save_checkpoint(
-                EnrichmentCheckpoint(
-                    partition_id=self.partition_id,
-                    source=adapter.source_id,
-                    last_processed_award_id=award_id,
-                    last_success_timestamp=datetime.now(UTC),
-                    records_processed=stats.success + stats.unchanged,
-                    records_failed=stats.failed,
-                    records_total=stats.total,
-                    checkpoint_timestamp=datetime.now(UTC),
-                    metadata={"processed_ids": sorted(processed_ids)},
-                )
-            )
+            if record_succeeded:
+                processed_ids.add(award_id)
+            since_checkpoint += 1
+            if since_checkpoint >= self.checkpoint_interval:
+                self._save_checkpoint(adapter, award_id, stats, processed_ids)
+                since_checkpoint = 0
 
+        self.checkpoints.delete_checkpoint(self.partition_id, adapter.source_id)
         return stats
+
+    def _save_checkpoint(
+        self,
+        adapter: SourceAdapter,
+        award_id: str,
+        stats: RefreshStats,
+        processed_ids: set[str],
+    ) -> None:
+        """Persist resume state for an in-progress pass."""
+
+        now = datetime.now(UTC)
+        self.checkpoints.save_checkpoint(
+            EnrichmentCheckpoint(
+                partition_id=self.partition_id,
+                source=adapter.source_id,
+                last_processed_award_id=award_id,
+                last_success_timestamp=now,
+                records_processed=stats.success + stats.unchanged,
+                records_failed=stats.failed,
+                records_total=stats.total,
+                checkpoint_timestamp=now,
+                metadata={"processed_ids": sorted(processed_ids)},
+            )
+        )

--- a/sbir_etl/enrichers/usaspending/requests.py
+++ b/sbir_etl/enrichers/usaspending/requests.py
@@ -1,0 +1,144 @@
+"""Build USAspending refresh requests from a stale-award frame.
+
+Epistemic tier: pipelines. One canonical mapping from enriched-award columns to
+runner request dicts, shared by the Dagster asset and the operator CLI so both
+paths supply the identifiers ``enrich_award`` looks up (UEI / DUNS / CAGE / PIID).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from sbir_etl.exceptions import ValidationError
+
+
+EPISTEMIC_TIER = "pipelines"
+
+AWARD_ID_COLUMNS = ["award_id", "Award_ID", "id", "ID"]
+UEI_COLUMNS = ["UEI", "uei", "company_uei", "recipient_uei"]
+DUNS_COLUMNS = ["Duns", "duns", "company_duns", "recipient_duns"]
+CAGE_COLUMNS = ["CAGE", "cage", "company_cage", "recipient_cage"]
+PIID_COLUMNS = ["Contract", "contract", "contract_number", "piid"]
+AWARD_DATE_COLUMNS = ["award_date", "Award_Date", "Award Date", "proposal_award_date", "Award Year"]
+
+IDENTIFIER_FIELDS = ("uei", "duns", "cage", "piid")
+
+
+def first_present_column(frame: pd.DataFrame, candidates: list[str]) -> str | None:
+    """Return the first candidate column present on ``frame``."""
+
+    for col in candidates:
+        if col in frame.columns:
+            return col
+    return None
+
+
+def enriched_awards_path() -> Path:
+    """Canonical location of the enriched award parquet."""
+
+    from sbir_etl.utils.cloud_storage import get_data_root
+
+    return get_data_root() / "processed" / "enriched" / "sbir_awards.parquet"
+
+
+def load_enriched_awards(path: Path | None = None) -> pd.DataFrame | None:
+    """Load the enriched award parquet, or ``None`` when it is unavailable."""
+
+    src = path or enriched_awards_path()
+    if not src.is_file():
+        return None
+    try:
+        return pd.read_parquet(src)
+    except Exception:
+        return None
+
+
+def _identifier(row: pd.Series, column: str | None) -> str | None:
+    """Read one identifier cell, mapping missing values to ``None``.
+
+    ``pd.notna`` matters here: a NaN cell stringifies to ``"nan"``, which is
+    truthy and would be sent to the API as a real identifier.
+    """
+
+    if not column:
+        return None
+    value = row.get(column)
+    if not pd.notna(value):
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def stale_awards_to_requests(stale_awards: pd.DataFrame) -> list[dict[str, Any]]:
+    """Map a stale-award frame to runner request dicts."""
+
+    if stale_awards.empty:
+        return []
+    award_id_col = first_present_column(stale_awards, AWARD_ID_COLUMNS)
+    if not award_id_col:
+        raise ValidationError(
+            "Could not find award ID column",
+            component="enrichers.usaspending.requests",
+            operation="stale_awards_to_requests",
+            details={
+                "expected_columns": AWARD_ID_COLUMNS,
+                "available_columns": list(stale_awards.columns),
+            },
+        )
+    uei_col = first_present_column(stale_awards, UEI_COLUMNS)
+    duns_col = first_present_column(stale_awards, DUNS_COLUMNS)
+    cage_col = first_present_column(stale_awards, CAGE_COLUMNS)
+    contract_col = first_present_column(stale_awards, PIID_COLUMNS)
+    requests: list[dict[str, Any]] = []
+    for _, row in stale_awards.iterrows():
+        requests.append(
+            {
+                "award_id": str(row[award_id_col]),
+                "uei": _identifier(row, uei_col),
+                "duns": _identifier(row, duns_col),
+                "cage": _identifier(row, cage_col),
+                "piid": _identifier(row, contract_col),
+            }
+        )
+    return requests
+
+
+def has_identifier(request: dict[str, Any]) -> bool:
+    """True when a request carries at least one identifier ``enrich_award`` can use."""
+
+    return any(request.get(field) for field in IDENTIFIER_FIELDS)
+
+
+def filter_by_window(frame: pd.DataFrame, window: str) -> pd.DataFrame:
+    """Restrict ``frame`` to rows whose award date falls inside ``start:end``.
+
+    Raises ``ValidationError`` when the frame carries no recognizable award-date
+    column, rather than silently widening the refresh to the full stale set.
+    """
+
+    start_text, _, end_text = window.partition(":")
+    if not start_text or not end_text:
+        raise ValidationError(
+            "window must be formatted as START:END (ISO dates)",
+            component="enrichers.usaspending.requests",
+            operation="filter_by_window",
+            details={"window": window},
+        )
+    date_col = first_present_column(frame, AWARD_DATE_COLUMNS)
+    if not date_col:
+        raise ValidationError(
+            "no award-date column available to apply --window",
+            component="enrichers.usaspending.requests",
+            operation="filter_by_window",
+            details={
+                "expected_columns": AWARD_DATE_COLUMNS,
+                "available_columns": list(frame.columns),
+            },
+        )
+    dates = pd.to_datetime(frame[date_col], errors="coerce", format="mixed")
+    start = pd.to_datetime(start_text)
+    end = pd.to_datetime(end_text)
+    return frame.loc[dates.between(start, end)].copy()

--- a/sbir_etl/enrichers/usaspending/requests.py
+++ b/sbir_etl/enrichers/usaspending/requests.py
@@ -45,15 +45,25 @@ def enriched_awards_path() -> Path:
 
 
 def load_enriched_awards(path: Path | None = None) -> pd.DataFrame | None:
-    """Load the enriched award parquet, or ``None`` when it is unavailable."""
+    """Load the enriched award parquet, or ``None`` when the file is missing.
+
+    Distinguishes a missing file (``None``) from a corrupt/unreadable one
+    (raises ``ValidationError``) so operators are not told to rematerialize
+    when the path exists but cannot be parsed.
+    """
 
     src = path or enriched_awards_path()
     if not src.is_file():
         return None
     try:
         return pd.read_parquet(src)
-    except Exception:
-        return None
+    except Exception as exc:
+        raise ValidationError(
+            f"enriched awards at {src} exist but could not be read",
+            component="enrichers.usaspending.requests",
+            operation="load_enriched_awards",
+            details={"path": str(src), "error": str(exc)},
+        ) from exc
 
 
 def _identifier(row: pd.Series, column: str | None) -> str | None:

--- a/tests/unit/enrichers/test_refresh_cli.py
+++ b/tests/unit/enrichers/test_refresh_cli.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import pandas as pd
+
+from sbir_etl.config.loader import get_config
 from sbir_etl.enrichers.refresh_cli import build_parser, run_refresh
 from sbir_etl.enrichers.source_adapter import (
     QualityResult,
@@ -23,8 +26,12 @@ pytestmark = pytest.mark.fast
 class _Adapter:
     source_id = "usaspending"
 
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
     def fetch_page(self, request, cursor):
         del cursor
+        self.requests.append(dict(request))
         return RawPage(
             payload={"success": True, "payload_hash": "x"}, record_id=request["award_id"]
         )
@@ -54,23 +61,129 @@ def test_parser_help_lists_source() -> None:
     assert "--window" in help_text
 
 
-def test_run_refresh_mocked(tmp_path, monkeypatch) -> None:
+def _stale_store(tmp_path, award_id: str = "AW-CLI") -> FreshnessStore:
     store = FreshnessStore(tmp_path / "freshness.parquet")
     store.save_record(
         EnrichmentFreshnessRecord(
-            award_id="AW-CLI",
+            award_id=award_id,
             source="usaspending",
             last_attempt_at=datetime(2020, 1, 1),
             last_success_at=datetime(2020, 1, 1),
             status=EnrichmentStatus.SUCCESS,
         )
     )
+    return store
+
+
+def _patch_cli(monkeypatch, store: FreshnessStore, enriched: pd.DataFrame | None) -> None:
     monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.FreshnessStore", lambda: store)
-    runner = SourceRefreshRunner(
+    monkeypatch.setattr(
+        "sbir_etl.enrichers.refresh_cli.load_enriched_awards", lambda *a, **k: enriched
+    )
+
+
+def _runner(tmp_path, store: FreshnessStore) -> SourceRefreshRunner:
+    return SourceRefreshRunner(
         freshness=store,
         checkpoints=CheckpointStore(tmp_path / "ck.parquet"),
         partition_id="cli",
     )
-    stats = run_refresh(source="usaspending", adapter=_Adapter(), runner=runner)
+
+
+def test_run_refresh_mocked(tmp_path, monkeypatch) -> None:
+    store = _stale_store(tmp_path)
+    enriched = pd.DataFrame([{"award_id": "AW-CLI", "UEI": "ABC123456789"}])
+    _patch_cli(monkeypatch, store, enriched)
+
+    stats = run_refresh(
+        source="usaspending", adapter=_Adapter(), runner=_runner(tmp_path, store)
+    )
+
     assert stats["success"] == 1
     assert stats["failed"] == 0
+
+
+def test_requests_carry_identifiers_not_just_award_ids(tmp_path, monkeypatch) -> None:
+    """enrich_award cannot match on award_id alone, so the CLI must join them (regression)."""
+
+    store = _stale_store(tmp_path)
+    enriched = pd.DataFrame(
+        [{"award_id": "AW-CLI", "UEI": "ABC123456789", "Contract": "W911-24-C-1"}]
+    )
+    _patch_cli(monkeypatch, store, enriched)
+    adapter = _Adapter()
+
+    run_refresh(source="usaspending", adapter=adapter, runner=_runner(tmp_path, store))
+
+    assert adapter.requests == [
+        {
+            "award_id": "AW-CLI",
+            "uei": "ABC123456789",
+            "duns": None,
+            "cage": None,
+            "piid": "W911-24-C-1",
+        }
+    ]
+
+
+def test_awards_without_identifiers_are_skipped(tmp_path, monkeypatch) -> None:
+    store = _stale_store(tmp_path)
+    _patch_cli(monkeypatch, store, pd.DataFrame([{"award_id": "AW-CLI", "UEI": None}]))
+    adapter = _Adapter()
+
+    stats = run_refresh(source="usaspending", adapter=adapter, runner=_runner(tmp_path, store))
+
+    assert adapter.requests == []
+    assert stats["total"] == 0
+    assert stats["failed"] == 0
+
+
+def test_missing_enriched_awards_fails_fast(tmp_path, monkeypatch) -> None:
+    store = _stale_store(tmp_path)
+    _patch_cli(monkeypatch, store, None)
+
+    with pytest.raises(SystemExit, match="enriched awards"):
+        run_refresh(source="usaspending", adapter=_Adapter(), runner=_runner(tmp_path, store))
+
+
+def test_window_is_applied_rather_than_discarded(tmp_path, monkeypatch) -> None:
+    store = _stale_store(tmp_path)
+    store.save_record(
+        EnrichmentFreshnessRecord(
+            award_id="AW-OLD",
+            source="usaspending",
+            last_attempt_at=datetime(2020, 1, 1),
+            last_success_at=datetime(2020, 1, 1),
+            status=EnrichmentStatus.SUCCESS,
+        )
+    )
+    enriched = pd.DataFrame(
+        [
+            {"award_id": "AW-CLI", "UEI": "ABC123456789", "award_date": "2024-06-01"},
+            {"award_id": "AW-OLD", "UEI": "DEF123456789", "award_date": "2019-06-01"},
+        ]
+    )
+    _patch_cli(monkeypatch, store, enriched)
+    adapter = _Adapter()
+
+    run_refresh(
+        source="usaspending",
+        window="2024-01-01:2024-12-31",
+        adapter=adapter,
+        runner=_runner(tmp_path, store),
+    )
+
+    assert [request["award_id"] for request in adapter.requests] == ["AW-CLI"]
+
+
+def test_disabled_source_is_refused(tmp_path, monkeypatch) -> None:
+    """The enabled=false kill switch must apply to usaspending too (regression)."""
+
+    store = _stale_store(tmp_path)
+    _patch_cli(monkeypatch, store, pd.DataFrame([{"award_id": "AW-CLI", "UEI": "ABC123456789"}]))
+    config = get_config()
+    monkeypatch.setattr(config.enrichment_refresh.usaspending, "enabled", False)
+    monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.get_config", lambda: config)
+
+    with pytest.raises(SystemExit, match="disabled"):
+        run_refresh(source="usaspending", adapter=_Adapter(), runner=_runner(tmp_path, store))

--- a/tests/unit/enrichers/test_refresh_cli.py
+++ b/tests/unit/enrichers/test_refresh_cli.py
@@ -95,9 +95,7 @@ def test_run_refresh_mocked(tmp_path, monkeypatch) -> None:
     enriched = pd.DataFrame([{"award_id": "AW-CLI", "UEI": "ABC123456789"}])
     _patch_cli(monkeypatch, store, enriched)
 
-    stats = run_refresh(
-        source="usaspending", adapter=_Adapter(), runner=_runner(tmp_path, store)
-    )
+    stats = run_refresh(source="usaspending", adapter=_Adapter(), runner=_runner(tmp_path, store))
 
     assert stats["success"] == 1
     assert stats["failed"] == 0

--- a/tests/unit/enrichers/test_refresh_cli.py
+++ b/tests/unit/enrichers/test_refresh_cli.py
@@ -185,3 +185,15 @@ def test_disabled_source_is_refused(tmp_path, monkeypatch) -> None:
 
     with pytest.raises(SystemExit, match="disabled"):
         run_refresh(source="usaspending", adapter=_Adapter(), runner=_runner(tmp_path, store))
+
+
+def test_stale_ids_absent_from_enriched_are_reported(tmp_path, monkeypatch, capsys) -> None:
+    store = _stale_store(tmp_path, award_id="AW-MISSING")
+    _patch_cli(monkeypatch, store, pd.DataFrame([{"award_id": "AW-OTHER", "UEI": "ABC123456789"}]))
+    adapter = _Adapter()
+
+    stats = run_refresh(source="usaspending", adapter=adapter, runner=_runner(tmp_path, store))
+
+    assert adapter.requests == []
+    assert stats["total"] == 0
+    assert "absent from enriched awards" in capsys.readouterr().err

--- a/tests/unit/enrichers/test_source_adapter.py
+++ b/tests/unit/enrichers/test_source_adapter.py
@@ -75,6 +75,7 @@ def test_runner_fetch_normalize_validate_freshness_checkpoint(tmp_path) -> None:
         freshness=freshness,
         checkpoints=checkpoints,
         partition_id="part-1",
+        checkpoint_interval=1,
     )
 
     stats = runner.refresh_records(adapter, [{"award_id": "A1"}, {"award_id": "A2"}])
@@ -82,13 +83,92 @@ def test_runner_fetch_normalize_validate_freshness_checkpoint(tmp_path) -> None:
     assert stats.as_dict()["success"] == 2
     assert adapter.fetched == ["A1", "A2"]
     assert freshness.get_record("A1", "usaspending") is not None
+    # A completed pass clears its checkpoint so the next SLA-driven run refreshes again.
+    assert checkpoints.load_checkpoint("part-1", "usaspending") is None
+
+
+def test_completed_pass_does_not_skip_awards_on_the_next_run(tmp_path) -> None:
+    """A finished pass must not permanently suppress re-refresh (regression)."""
+
+    freshness = FreshnessStore(tmp_path / "freshness.parquet")
+    checkpoints = CheckpointStore(tmp_path / "checkpoints.parquet")
+    adapter = FakeAdapter()
+    runner = SourceRefreshRunner(
+        freshness=freshness,
+        checkpoints=checkpoints,
+        partition_id="part-1",
+        checkpoint_interval=1,
+    )
+    records = [{"award_id": "A1"}, {"award_id": "A2"}]
+
+    runner.refresh_records(adapter, records)
+    second = runner.refresh_records(adapter, records)
+
+    assert second.skipped == 0
+    assert second.success == 2
+    assert adapter.fetched == ["A1", "A2", "A1", "A2"]
+
+
+def test_resume_skips_succeeded_and_retries_failed(tmp_path) -> None:
+    """A crashed pass leaves a checkpoint; only successes are skipped on resume."""
+
+    freshness = FreshnessStore(tmp_path / "freshness.parquet")
+    checkpoints = CheckpointStore(tmp_path / "checkpoints.parquet")
+    runner = SourceRefreshRunner(
+        freshness=freshness,
+        checkpoints=checkpoints,
+        partition_id="part-1",
+        checkpoint_interval=1,
+    )
+
+    class _CrashingAdapter(FakeAdapter):
+        def fetch_page(self, request: Mapping[str, Any], cursor: str | None) -> RawPage:
+            award_id = str(request["award_id"])
+            if award_id == "A2":
+                self.fetched.append(award_id)
+                raise RuntimeError("transient network error")
+            if award_id == "A3":
+                raise KeyboardInterrupt("operator stopped the run")
+            return super().fetch_page(request, cursor)
+
+    crashing = _CrashingAdapter()
+    records = [{"award_id": "A1"}, {"award_id": "A2"}, {"award_id": "A3"}]
+    with pytest.raises(KeyboardInterrupt):
+        runner.refresh_records(crashing, records)
+
     checkpoint = checkpoints.load_checkpoint("part-1", "usaspending")
     assert checkpoint is not None
-    assert set(checkpoint.metadata["processed_ids"]) == {"A1", "A2"}
+    # A1 succeeded; A2 failed and must not be recorded as processed.
+    assert set(checkpoint.metadata["processed_ids"]) == {"A1"}
 
-    second = runner.refresh_records(adapter, [{"award_id": "A1"}, {"award_id": "A2"}])
-    assert second.skipped == 2
-    assert adapter.fetched == ["A1", "A2"]
+    resumed = FakeAdapter()
+    stats = runner.refresh_records(resumed, records)
+    assert stats.skipped == 1
+    assert resumed.fetched == ["A2", "A3"]
+
+
+def test_checkpoint_interval_limits_writes(tmp_path) -> None:
+    freshness = FreshnessStore(tmp_path / "freshness.parquet")
+    checkpoints = CheckpointStore(tmp_path / "checkpoints.parquet")
+    saves: list[str] = []
+    original = checkpoints.save_checkpoint
+
+    def _counting_save(checkpoint):
+        saves.append(checkpoint.last_processed_award_id)
+        return original(checkpoint)
+
+    checkpoints.save_checkpoint = _counting_save  # type: ignore[method-assign]
+    runner = SourceRefreshRunner(
+        freshness=freshness,
+        checkpoints=checkpoints,
+        partition_id="part-1",
+        checkpoint_interval=5,
+    )
+
+    runner.refresh_records(FakeAdapter(), [{"award_id": f"A{i}"} for i in range(12)])
+
+    # 12 records at interval 5 → writes after the 5th and 10th, not once per record.
+    assert saves == ["A4", "A9"]
 
 
 class _FakeClient:

--- a/tests/unit/enrichers/test_usaspending_requests.py
+++ b/tests/unit/enrichers/test_usaspending_requests.py
@@ -1,0 +1,79 @@
+"""Request building for USAspending refresh."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.usaspending.requests import (
+    filter_by_window,
+    has_identifier,
+    stale_awards_to_requests,
+)
+from sbir_etl.exceptions import ValidationError
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_nan_identifiers_become_none_not_the_string_nan() -> None:
+    """A NaN cell must not reach the API as the literal string 'nan' (regression)."""
+
+    frame = pd.DataFrame(
+        [{"award_id": "A1", "UEI": np.nan, "Duns": None, "CAGE": "", "Contract": "W911-24-C-1"}]
+    )
+
+    requests = stale_awards_to_requests(frame)
+
+    assert requests == [
+        {"award_id": "A1", "uei": None, "duns": None, "cage": None, "piid": "W911-24-C-1"}
+    ]
+
+
+def test_identifiers_are_read_from_alternate_column_names() -> None:
+    frame = pd.DataFrame([{"Award_ID": "A2", "recipient_uei": "ABC123456789"}])
+
+    requests = stale_awards_to_requests(frame)
+
+    assert requests[0]["award_id"] == "A2"
+    assert requests[0]["uei"] == "ABC123456789"
+
+
+def test_has_identifier_rejects_award_id_only_requests() -> None:
+    assert not has_identifier({"award_id": "A1"})
+    assert not has_identifier({"award_id": "A1", "uei": None, "piid": None})
+    assert has_identifier({"award_id": "A1", "piid": "W911-24-C-1"})
+
+
+def test_missing_award_id_column_raises() -> None:
+    with pytest.raises(ValidationError):
+        stale_awards_to_requests(pd.DataFrame([{"UEI": "ABC123456789"}]))
+
+
+def test_empty_frame_returns_no_requests() -> None:
+    assert stale_awards_to_requests(pd.DataFrame()) == []
+
+
+def test_filter_by_window_restricts_to_the_requested_range() -> None:
+    frame = pd.DataFrame(
+        [
+            {"award_id": "A1", "award_date": "2024-03-01"},
+            {"award_id": "A2", "award_date": "2025-03-01"},
+        ]
+    )
+
+    filtered = filter_by_window(frame, "2024-01-01:2024-12-31")
+
+    assert filtered["award_id"].tolist() == ["A1"]
+
+
+def test_filter_by_window_rejects_a_frame_with_no_date_column() -> None:
+    with pytest.raises(ValidationError):
+        filter_by_window(pd.DataFrame([{"award_id": "A1"}]), "2024-01-01:2024-12-31")
+
+
+def test_filter_by_window_rejects_a_malformed_window() -> None:
+    frame = pd.DataFrame([{"award_id": "A1", "award_date": "2024-03-01"}])
+    with pytest.raises(ValidationError):
+        filter_by_window(frame, "2024-01-01")

--- a/tests/unit/enrichers/test_usaspending_requests.py
+++ b/tests/unit/enrichers/test_usaspending_requests.py
@@ -9,6 +9,7 @@ import pytest
 from sbir_etl.enrichers.usaspending.requests import (
     filter_by_window,
     has_identifier,
+    load_enriched_awards,
     stale_awards_to_requests,
 )
 from sbir_etl.exceptions import ValidationError
@@ -53,6 +54,18 @@ def test_missing_award_id_column_raises() -> None:
 
 def test_empty_frame_returns_no_requests() -> None:
     assert stale_awards_to_requests(pd.DataFrame()) == []
+
+
+def test_load_enriched_awards_returns_none_when_missing(tmp_path) -> None:
+    assert load_enriched_awards(tmp_path / "missing.parquet") is None
+
+
+def test_load_enriched_awards_raises_when_corrupt(tmp_path) -> None:
+    path = tmp_path / "broken.parquet"
+    path.write_text("not a parquet file", encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="could not be read"):
+        load_enriched_awards(path)
 
 
 def test_filter_by_window_restricts_to_the_requested_range() -> None:


### PR DESCRIPTION
## Description

Follow-up to #619, which was merged ~5 minutes after opening without review. Three defects left the #442 refresh path unable to do its job. Each fix has a regression test that fails against `6720c89`.

**`refresh-enrichment` could not succeed for any award.** `_requests_for_source` built requests holding only `award_id`, but `enrich_award` matches on UEI / DUNS / CAGE / PIID and returns `"No recipient/award data found"` when all four are absent (`client.py:566-579`). Every award was marked FAILED in the freshness ledger and the CLI exited 1 — the headline "restores `refresh-enrichment`" feature could not work. The CLI now joins stale ids against the enriched award frame for identifiers, and fails fast with an actionable message when that frame is unavailable rather than issuing requests that cannot match.

**The runner checkpoint was never cleared.** Awards were added to `processed_ids` on every pass, *including failures*, and the checkpoint persisted after the pass completed. An award refreshed once was skipped forever, so the SLA-driven re-refresh could never fire, and an award that failed on a transient network error was never retried. `CheckpointStore.delete_checkpoint` existed but was never called, unlike the established `chunked_enrichment.clear_checkpoints` pattern. The runner now clears the checkpoint when a pass completes, records only successes as processed, and honors the configured `checkpoint_interval` (50) instead of rewriting the full sorted id list after every record — the old form was O(n²) and grew without bound.

**NaN identifiers reached the API as the string `"nan"`.** The rewrite dropped the `pd.notna` guards the old op had, and `_optional_str(float("nan"))` returns `"nan"`, which is truthy. That produced junk lookups like `get_recipient_by_uei("nan")` against a rate-limited API. The column mapping now lives in `sbir_etl.enrichers.usaspending.requests`, shared by the Dagster asset and the CLI with the guards restored; awards carrying no usable identifier are skipped with a count rather than spent as failed API calls.

Also honors `--window` (previously parsed, documented, and silently discarded via `del window`) and the `enabled: false` kill switch, which was explicitly bypassed for usaspending (`if not source_config.enabled and source != "usaspending"`).

Not addressed here: refresh is now strictly sequential (one `run_sync` round-trip per award) where the deleted op used `asyncio.gather`, so batch wall-clock grows to roughly N × per-request latency. Restoring concurrency needs an async batch hook on the `SourceAdapter` protocol; that is a design change, not a bug fix, and does not belong in the same PR as these.

Relates to #442.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [x] PATCH: backward-compatible fix or documentation correction

New public import `sbir_etl.enrichers.usaspending.requests`; `stale_awards_to_requests` moves there from the Dagster asset module. No asset-key changes.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

New regression tests, each verified to fail against the merged code:

- `test_completed_pass_does_not_skip_awards_on_the_next_run` — the cross-run checkpoint bug the previous test masked by only exercising same-run resume
- `test_resume_skips_succeeded_and_retries_failed` — a crashed pass leaves a checkpoint; failures retry
- `test_checkpoint_interval_limits_writes` — 12 records at interval 5 writes twice, not 12 times
- `test_requests_carry_identifiers_not_just_award_ids` — the CLI identifier join
- `test_nan_identifiers_become_none_not_the_string_nan` — the restored guard
- `test_window_is_applied_rather_than_discarded`, `test_disabled_source_is_refused`, `test_missing_enriched_awards_fails_fast`

```
uv run pytest tests/unit/enrichers/     # 914 passed
uv run pytest tests/e2e/test_enrichment_job.py  # 1 passed
uv run ruff check . && uv run mypy sbir_etl     # clean
check_architecture_boundaries / check_tier_boundaries / check_epistemic_tiers  # pass
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZeXLL2oC39ZT9KsqoZPqg)_