### PR TITLE
Fix analysis platform defects from #619

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/transition_report.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/transition_report.py
@@ -21,8 +21,10 @@ import json
 from pathlib import Path
 from typing import Any
 
+from loguru import logger
+
 from sbir_etl.analysis.contracts import AnalysisKind
-from sbir_etl.analysis.registry import load_registry
+from sbir_etl.analysis.registry import default_registry_path, load_registry
 from sbir_etl.reporting.tech_area_cohort import materialize_tech_area_cohort
 
 # ---------------------------------------------------------------------------
@@ -74,9 +76,28 @@ except Exception:  # pragma: no cover - exercised only without Dagster
             self.metadata = metadata or {}
 
 
+def _load_tech_areas() -> tuple[str, ...]:
+    """Read the cohort profiles this module generates assets for.
+
+    Runs at import because the asset factory loop below needs the ids. A broken
+    or missing registry is contained to these assets: raising here would abort
+    the whole definitions load and take every unrelated asset in the deployment
+    down with it.
+    """
+
+    try:
+        return load_registry().ids_for(AnalysisKind.TRANSITION_COHORT, dagster_asset=True)
+    except Exception as exc:  # pragma: no cover - deployment misconfiguration
+        logger.error(
+            f"Could not load analysis profile registry ({default_registry_path()}): {exc}. "
+            "No transition-report cohort assets will be generated."
+        )
+        return ()
+
+
 # Areas come from config/analysis_profiles/registry.yaml (dagster_asset: true).
 # Add a registry row to wire a new profile; do not edit this tuple by hand.
-TECH_AREAS = load_registry().ids_for(AnalysisKind.TRANSITION_COHORT, dagster_asset=True)
+TECH_AREAS = _load_tech_areas()
 EPISTEMIC_TIER = "exploratory"
 
 
@@ -195,7 +216,10 @@ def _make_cohort_check(area_id: str) -> Any:
 # One asset + one non-empty check per area, generated from TECH_AREAS (single
 # source of truth). Bound to module globals so Dagster's load_assets_from_modules
 # / load_asset_checks_from_modules discover them.
-for _area in TECH_AREAS:
-    globals()[f"tech_area_cohort_{_area}"] = _make_cohort_asset(_area)
-    globals()[f"tech_area_cohort_{_area}_nonempty"] = _make_cohort_check(_area)
-del _area
+def _generate_cohort_assets() -> None:
+    for area in TECH_AREAS:
+        globals()[f"tech_area_cohort_{area}"] = _make_cohort_asset(area)
+        globals()[f"tech_area_cohort_{area}_nonempty"] = _make_cohort_check(area)
+
+
+_generate_cohort_assets()

--- a/sbir_etl/analysis/contracts.py
+++ b/sbir_etl/analysis/contracts.py
@@ -30,18 +30,6 @@ class EvidenceChannelStage(StrEnum):
     NOT_APPLICABLE = "not_applicable"
 
 
-METRIC_CLAIM_IDS = (
-    "method_a_awards",
-    "method_b_awards",
-    "intersection",
-    "jaccard",
-    "phase2_dollars_m",
-    "unique_firms",
-    "grand_total_n",
-    "grand_total_usd",
-)
-
-
 def unavailable_channel_label(
     stage: EvidenceChannelStage = EvidenceChannelStage.UNAVAILABLE,
 ) -> str:

--- a/sbir_etl/analysis/snapshots.py
+++ b/sbir_etl/analysis/snapshots.py
@@ -16,10 +16,6 @@ from sbir_etl.utils.path_utils import ensure_parent_dir
 EPISTEMIC_TIER = "pipelines"
 
 
-def snapshot_path(root: Path, profile_id: str, period: str) -> Path:
-    return root / "analysis_snapshots" / profile_id / f"{period}.json"
-
-
 def write_snapshot(run: AnalysisRun, path: Path) -> Path:
     ensure_parent_dir(path)
     path.write_text(

--- a/sbir_etl/utils/tech_census.py
+++ b/sbir_etl/utils/tech_census.py
@@ -12,10 +12,14 @@ non-citable.
 
 from __future__ import annotations
 
+import csv
+import hashlib
+import json
 import math
 import re
 from collections import defaultdict
 from collections.abc import Iterable
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -611,3 +615,105 @@ def load_award_data_csv(path: Path) -> list[CensusAward]:
             }
         )
     return awards
+
+
+CENSUS_AWARD_COLUMNS = [
+    "company",
+    "city",
+    "state",
+    "uei",
+    "duns",
+    "title",
+    "agency",
+    "program",
+    "phase",
+    "year",
+    "amount",
+    "subset",
+    "scope_class",
+    "agency_tracking_number",
+    "contract",
+    "source_row",
+    "gate_evidence",
+    "physical_evidence",
+    "subset_evidence",
+    "scope_evidence",
+    "classification_source",
+    "override_reason",
+]
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _source_timestamp(path: Path) -> str:
+    return datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat()
+
+
+def write_census_artifacts(
+    result: dict[str, Any],
+    out_dir: Path,
+    *,
+    awards_csv: Path,
+    source_row_count: int,
+    reporting_row_count: int,
+    data_vintage: str | None = None,
+    selected_fys: list[int] | None = None,
+    selected_states: tuple[str, ...] | None = None,
+) -> dict[str, Path]:
+    """Write ``classified_awards.csv`` and ``summary.json`` for one census run.
+
+    Shared by ``build_tech_census.py`` and the ``run_analysis.py`` census
+    strategy so both emit the same artifacts from the same ``run_census``
+    result. Returns the written paths keyed by artifact name.
+    """
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    rows = result["classified_awards"]
+
+    awards_path = out_dir / "classified_awards.csv"
+    extra_columns = [key for row in rows for key in row if key not in CENSUS_AWARD_COLUMNS]
+    cols = list(dict.fromkeys(CENSUS_AWARD_COLUMNS + extra_columns))
+    with awards_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=cols, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+    summary_path = out_dir / "summary.json"
+    json_safe = {
+        "_epistemic": result["_epistemic"],
+        "area_id": result["area_id"],
+        "display_name": result["display_name"],
+        "grand_total": result["grand_total"],
+        "fy_totals": {str(k): v for k, v in result["fy_totals"].items()},
+        "subset_totals": result["subset_totals"],
+        "by_fy_subset": {f"{fy}|{subset}": v for (fy, subset), v in result["by_fy_subset"].items()},
+        "exclusion_counts": result["exclusion_counts"],
+        "adjacent_counts": result["adjacent_counts"],
+        "program_exclusion_counts": result["program_exclusion_counts"],
+        "rejection_counts": result["rejection_counts"],
+        "config_version": result["config_version"],
+        "override_version": result["override_version"],
+        "programs": result["programs"],
+        "scope_totals": result["scope_totals"],
+        "reporting_window": {
+            "fiscal_years": selected_fys or None,
+            "states": list(selected_states or ()) or None,
+            "programs": result["programs"],
+        },
+        "provenance": {
+            "source_path": str(awards_csv.resolve()),
+            "sha256": _sha256(awards_csv),
+            "source_timestamp": _source_timestamp(awards_csv),
+            "data_vintage": data_vintage,
+            "source_row_count": source_row_count,
+            "reporting_row_count": reporting_row_count,
+        },
+    }
+    summary_path.write_text(json.dumps(json_safe, indent=2) + "\n", encoding="utf-8")
+    return {"classified_awards": awards_path, "summary": summary_path}

--- a/scripts/data/build_tech_census.py
+++ b/scripts/data/build_tech_census.py
@@ -18,11 +18,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import csv
-import hashlib
-import json
 import sys
-from datetime import UTC, datetime
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
@@ -36,19 +32,8 @@ from sbir_etl.utils.tech_census import (  # noqa: E402
     normalize_state_code,
     normalize_state_codes,
     run_census,
+    write_census_artifacts,
 )
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        while chunk := handle.read(1024 * 1024):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _source_timestamp(path: Path) -> str:
-    return datetime.fromtimestamp(path.stat().st_mtime, UTC).isoformat()
 
 
 def main() -> int:
@@ -192,78 +177,19 @@ def main() -> int:
         + f"{grand['n']:>7,} (${grand['usd'] / 1e6:>7.1f}M)"
     )
 
-    out_dir = DATA / "tech_census" / compiled.area_id
-    out_dir.mkdir(parents=True, exist_ok=True)
+    written = write_census_artifacts(
+        result,
+        DATA / "tech_census" / compiled.area_id,
+        awards_csv=awards_csv,
+        source_row_count=len(awards),
+        reporting_row_count=len(reporting_awards),
+        data_vintage=args.data_vintage,
+        selected_fys=selected_fys,
+        selected_states=selected_states,
+    )
 
-    awards_csv_path = out_dir / "classified_awards.csv"
-    rows = result["classified_awards"]
-    preferred_columns = [
-        "company",
-        "city",
-        "state",
-        "uei",
-        "duns",
-        "title",
-        "agency",
-        "program",
-        "phase",
-        "year",
-        "amount",
-        "subset",
-        "scope_class",
-        "agency_tracking_number",
-        "contract",
-        "source_row",
-        "gate_evidence",
-        "physical_evidence",
-        "subset_evidence",
-        "scope_evidence",
-        "classification_source",
-        "override_reason",
-    ]
-    extra_columns = [key for row in rows for key in row if key not in preferred_columns]
-    cols = list(dict.fromkeys(preferred_columns + extra_columns))
-    with open(awards_csv_path, "w", newline="", encoding="utf-8") as f:
-        w = csv.DictWriter(f, fieldnames=cols, extrasaction="ignore")
-        w.writeheader()
-        w.writerows(rows)
-
-    summary_path = out_dir / "summary.json"
-    source_timestamp = _source_timestamp(awards_csv)
-    json_safe = {
-        "_epistemic": result["_epistemic"],
-        "area_id": result["area_id"],
-        "display_name": result["display_name"],
-        "grand_total": result["grand_total"],
-        "fy_totals": {str(k): v for k, v in result["fy_totals"].items()},
-        "subset_totals": result["subset_totals"],
-        "by_fy_subset": {f"{fy}|{subset}": v for (fy, subset), v in result["by_fy_subset"].items()},
-        "exclusion_counts": result["exclusion_counts"],
-        "adjacent_counts": result["adjacent_counts"],
-        "program_exclusion_counts": result["program_exclusion_counts"],
-        "rejection_counts": result["rejection_counts"],
-        "config_version": result["config_version"],
-        "override_version": result["override_version"],
-        "programs": result["programs"],
-        "scope_totals": result["scope_totals"],
-        "reporting_window": {
-            "fiscal_years": selected_fys or None,
-            "states": list(selected_states) or None,
-            "programs": result["programs"],
-        },
-        "provenance": {
-            "source_path": str(awards_csv.resolve()),
-            "sha256": _sha256(awards_csv),
-            "source_timestamp": source_timestamp,
-            "data_vintage": args.data_vintage,
-            "source_row_count": len(awards),
-            "reporting_row_count": len(reporting_awards),
-        },
-    }
-    summary_path.write_text(json.dumps(json_safe, indent=2) + "\n", encoding="utf-8")
-
-    print(f"\nWrote {awards_csv_path} ({grand['n']:,} rows)")
-    print(f"Wrote {summary_path}")
+    print(f"\nWrote {written['classified_awards']} ({grand['n']:,} rows)")
+    print(f"Wrote {written['summary']}")
     return 0
 
 

--- a/scripts/data/run_analysis.py
+++ b/scripts/data/run_analysis.py
@@ -44,6 +44,8 @@ def _census_strategy(spec: AnalysisSpec) -> dict:
     awards = load_award_data_csv(spec.corpus.source_path)
     result = run_census(awards, compiled)
     out_dir = REPO / "data" / "tech_census" / spec.profile_id
+    # This CLI path does not apply FY/state filters the way build_tech_census.py
+    # can, so source and reporting row counts are the same corpus length here.
     write_census_artifacts(
         result,
         out_dir,
@@ -70,7 +72,9 @@ def _cohort_strategy(spec: AnalysisSpec) -> dict:
     composition_path = report_dir / "composition.json"
     summary = json.loads(summary_path.read_text(encoding="utf-8")) if summary_path.exists() else {}
     composition = (
-        json.loads(composition_path.read_text(encoding="utf-8")) if composition_path.exists() else {}
+        json.loads(composition_path.read_text(encoding="utf-8"))
+        if composition_path.exists()
+        else {}
     )
     overlap = summary.get("overlap") or {}
     totals = composition.get("totals") or {}
@@ -120,14 +124,20 @@ def _frozen_snapshot(args: argparse.Namespace, profile_id: str) -> Path | None:
 
     Opt-in rather than always-on: ``compare_snapshots`` also gates on
     ``source_sha256``, so an implicit baseline would refuse every ordinary run
-    against refreshed award data, not just a methodology change.
+    against refreshed award data, not just a methodology change. When the
+    operator does ask for a baseline, missing files fail fast rather than
+    silently disabling the gate.
     """
 
     if not args.frozen_snapshot:
         return None
     if args.frozen_snapshot == "previous":
-        return SNAPSHOT_ROOT / profile_id / f"{args.period}.json"
-    return Path(args.frozen_snapshot)
+        path = SNAPSHOT_ROOT / profile_id / f"{args.period}.json"
+    else:
+        path = Path(args.frozen_snapshot)
+    if not path.is_file():
+        raise SystemExit(f"frozen snapshot not found: {path}")
+    return path
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/data/run_analysis.py
+++ b/scripts/data/run_analysis.py
@@ -36,6 +36,7 @@ def _census_strategy(spec: AnalysisSpec) -> dict:
         load_award_data_csv,
         load_census_config,
         run_census,
+        write_census_artifacts,
     )
 
     cfg = load_census_config(spec.profile_id)
@@ -43,7 +44,13 @@ def _census_strategy(spec: AnalysisSpec) -> dict:
     awards = load_award_data_csv(spec.corpus.source_path)
     result = run_census(awards, compiled)
     out_dir = REPO / "data" / "tech_census" / spec.profile_id
-    out_dir.mkdir(parents=True, exist_ok=True)
+    write_census_artifacts(
+        result,
+        out_dir,
+        awards_csv=spec.corpus.source_path,
+        source_row_count=len(awards),
+        reporting_row_count=len(awards),
+    )
     grand = result["grand_total"]
     return {
         "output_dir": str(out_dir),
@@ -96,7 +103,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="Permit a run when methodology_version differs from a frozen snapshot",
     )
     parser.add_argument("--period", default="latest", help="Snapshot period label")
+    parser.add_argument(
+        "--frozen-snapshot",
+        default=None,
+        help=(
+            "Baseline snapshot to gate this run against; pass 'previous' to use the "
+            "existing snapshot for this profile and period. Without it there is no "
+            "baseline and no drift check."
+        ),
+    )
     return parser
+
+
+def _frozen_snapshot(args: argparse.Namespace, profile_id: str) -> Path | None:
+    """Resolve the drift baseline.
+
+    Opt-in rather than always-on: ``compare_snapshots`` also gates on
+    ``source_sha256``, so an implicit baseline would refuse every ordinary run
+    against refreshed award data, not just a methodology change.
+    """
+
+    if not args.frozen_snapshot:
+        return None
+    if args.frozen_snapshot == "previous":
+        return SNAPSHOT_ROOT / profile_id / f"{args.period}.json"
+    return Path(args.frozen_snapshot)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -117,6 +148,7 @@ def main(argv: list[str] | None = None) -> int:
         strategy=strategy_for(entry.analysis_kind),
         snapshot_root=SNAPSHOT_ROOT,
         period=args.period,
+        frozen_snapshot=_frozen_snapshot(args, entry.profile_id),
     )
     print(json.dumps(run.to_snapshot_dict(), indent=2, sort_keys=True))
     return 0

--- a/tests/unit/assets/test_transition_report_assets.py
+++ b/tests/unit/assets/test_transition_report_assets.py
@@ -101,3 +101,19 @@ def test_factory_wired_all_three_areas(mod):
     for area in mod.TECH_AREAS:
         assert hasattr(mod, f"tech_area_cohort_{area}")
         assert hasattr(mod, f"tech_area_cohort_{area}_nonempty")
+
+
+def test_broken_registry_does_not_break_the_module_import(monkeypatch):
+    """A bad registry must not abort the whole Dagster definitions load (regression)."""
+
+    import sbir_etl.analysis.registry as registry
+
+    def _boom(*args, **kwargs):
+        raise ValueError("unknown analysis_kind")
+
+    monkeypatch.setattr(registry, "load_registry", _boom)
+
+    degraded = _load_module()
+
+    assert degraded.TECH_AREAS == ()
+    assert not hasattr(degraded, "tech_area_cohort_hypersonics")

--- a/tests/unit/scripts/test_run_analysis_cli.py
+++ b/tests/unit/scripts/test_run_analysis_cli.py
@@ -86,15 +86,20 @@ def test_census_strategy_writes_artifacts(tmp_path, monkeypatch) -> None:
     assert summary["provenance"]["sha256"]
 
 
-def test_frozen_snapshot_flag_resolves_previous(tmp_path) -> None:
+def test_frozen_snapshot_flag_resolves_previous(tmp_path, monkeypatch) -> None:
     cli = _load_cli()
+    snapshot_root = tmp_path / "snapshots"
+    previous = snapshot_root / "dummy" / "fy2024.json"
+    previous.parent.mkdir(parents=True)
+    previous.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(cli, "SNAPSHOT_ROOT", snapshot_root)
     args = cli.build_parser().parse_args(
         ["--profile", "dummy", "--frozen-snapshot", "previous", "--period", "fy2024"]
     )
 
     resolved = cli._frozen_snapshot(args, "dummy")
 
-    assert resolved == cli.SNAPSHOT_ROOT / "dummy" / "fy2024.json"
+    assert resolved == previous
 
 
 def test_frozen_snapshot_defaults_to_no_baseline() -> None:
@@ -107,6 +112,16 @@ def test_frozen_snapshot_defaults_to_no_baseline() -> None:
 def test_frozen_snapshot_accepts_an_explicit_path(tmp_path) -> None:
     cli = _load_cli()
     baseline = tmp_path / "frozen.json"
+    baseline.write_text("{}", encoding="utf-8")
     args = cli.build_parser().parse_args(["--profile", "dummy", "--frozen-snapshot", str(baseline)])
 
     assert cli._frozen_snapshot(args, "dummy") == baseline
+
+
+def test_frozen_snapshot_fails_fast_when_missing(tmp_path) -> None:
+    cli = _load_cli()
+    missing = tmp_path / "missing.json"
+    args = cli.build_parser().parse_args(["--profile", "dummy", "--frozen-snapshot", str(missing)])
+
+    with pytest.raises(SystemExit, match="frozen snapshot not found"):
+        cli._frozen_snapshot(args, "dummy")

--- a/tests/unit/scripts/test_run_analysis_cli.py
+++ b/tests/unit/scripts/test_run_analysis_cli.py
@@ -107,8 +107,6 @@ def test_frozen_snapshot_defaults_to_no_baseline() -> None:
 def test_frozen_snapshot_accepts_an_explicit_path(tmp_path) -> None:
     cli = _load_cli()
     baseline = tmp_path / "frozen.json"
-    args = cli.build_parser().parse_args(
-        ["--profile", "dummy", "--frozen-snapshot", str(baseline)]
-    )
+    args = cli.build_parser().parse_args(["--profile", "dummy", "--frozen-snapshot", str(baseline)])
 
     assert cli._frozen_snapshot(args, "dummy") == baseline

--- a/tests/unit/scripts/test_run_analysis_cli.py
+++ b/tests/unit/scripts/test_run_analysis_cli.py
@@ -1,0 +1,114 @@
+"""CLI wiring for scripts/data/run_analysis.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+REPO = Path(__file__).resolve().parents[3]
+
+
+def _load_cli():
+    spec = importlib.util.spec_from_file_location(
+        "run_analysis_cli", REPO / "scripts" / "data" / "run_analysis.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["run_analysis_cli"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_census_strategy_writes_artifacts(tmp_path, monkeypatch) -> None:
+    """The strategy must emit the artifacts build_tech_census.py emits (regression)."""
+
+    cli = _load_cli()
+    from sbir_etl.analysis.contracts import AnalysisKind, AnalysisSpec, AwardCorpus
+
+    awards = tmp_path / "awards.csv"
+    awards.write_text("award_id\n1\n", encoding="utf-8")
+    out_root = tmp_path / "repo"
+    monkeypatch.setattr(cli, "REPO", out_root)
+
+    captured: dict = {}
+
+    def _fake_run_census(awards_arg, compiled, **kwargs):
+        captured["called"] = True
+        return {
+            "_epistemic": {"tier": "exploratory", "notice": "non-citable"},
+            "area_id": "dummy",
+            "display_name": "Dummy",
+            "config_version": "v1",
+            "override_version": "v0",
+            "programs": ["SBIR"],
+            "classified_awards": [{"company": "ACME", "year": 2024, "amount": 100.0}],
+            "excluded_awards": [],
+            "by_fy_subset": {(2024, "core"): {"n": 1, "usd": 100.0}},
+            "subset_totals": {"core": {"n": 1, "usd": 100.0}},
+            "scope_totals": {"in_scope": {"n": 1, "usd": 100.0}},
+            "fy_totals": {2024: {"n": 1, "usd": 100.0}},
+            "grand_total": {"n": 1, "usd": 100.0},
+            "exclusion_counts": {},
+            "adjacent_counts": {},
+            "program_exclusion_counts": {},
+            "rejection_counts": {},
+        }
+
+    import sbir_etl.utils.tech_census as tech_census
+
+    monkeypatch.setattr(tech_census, "run_census", _fake_run_census)
+    monkeypatch.setattr(tech_census, "load_census_config", lambda profile_id: {"area_id": "dummy"})
+    monkeypatch.setattr(tech_census, "CompiledCensus", lambda cfg: object())
+    monkeypatch.setattr(tech_census, "load_award_data_csv", lambda path: [{"award_key": "1"}])
+
+    spec = AnalysisSpec(
+        profile_id="dummy",
+        analysis_kind=AnalysisKind.TECH_CENSUS,
+        config_path=tmp_path / "profile.yaml",
+        taxonomy_version="t1",
+        methodology_version="m1",
+        corpus=AwardCorpus.from_sbir_csv(awards),
+    )
+
+    payload = cli._census_strategy(spec)
+
+    out_dir = Path(payload["output_dir"])
+    assert (out_dir / "classified_awards.csv").is_file()
+    summary = json.loads((out_dir / "summary.json").read_text(encoding="utf-8"))
+    assert summary["grand_total"] == {"n": 1, "usd": 100.0}
+    assert summary["provenance"]["sha256"]
+
+
+def test_frozen_snapshot_flag_resolves_previous(tmp_path) -> None:
+    cli = _load_cli()
+    args = cli.build_parser().parse_args(
+        ["--profile", "dummy", "--frozen-snapshot", "previous", "--period", "fy2024"]
+    )
+
+    resolved = cli._frozen_snapshot(args, "dummy")
+
+    assert resolved == cli.SNAPSHOT_ROOT / "dummy" / "fy2024.json"
+
+
+def test_frozen_snapshot_defaults_to_no_baseline() -> None:
+    cli = _load_cli()
+    args = cli.build_parser().parse_args(["--profile", "dummy"])
+
+    assert cli._frozen_snapshot(args, "dummy") is None
+
+
+def test_frozen_snapshot_accepts_an_explicit_path(tmp_path) -> None:
+    cli = _load_cli()
+    baseline = tmp_path / "frozen.json"
+    args = cli.build_parser().parse_args(
+        ["--profile", "dummy", "--frozen-snapshot", str(baseline)]
+    )
+
+    assert cli._frozen_snapshot(args, "dummy") == baseline


### PR DESCRIPTION
## Description

Follow-up to #619, which was merged ~5 minutes after opening without review. The #441 platform landed with its new CLI path missing the outputs it deprecates the old path in favor of. Companion to #621, which covers the #442 refresh defects.

**`run_analysis.py --profile` wrote no census artifacts.** `_census_strategy` `mkdir`'d the output directory and returned grand totals, while `build_tech_census.py` — which the same PR made warn *"prefer `scripts/data/run_analysis.py --profile <area_id>`"* — writes `classified_awards.csv` and `summary.json`. Following the deprecation left an empty directory, or worse, stale artifacts from an earlier `build_tech_census` run that no longer matched the snapshot's metrics and hashes. The writer moves to `tech_census.write_census_artifacts` and both entry points call it, so there is one artifact-emitting path rather than two that disagree.

**The calibration-drift gate was unreachable.** `materialize_analysis` was never passed `frozen_snapshot`, so the `"refusing silent calibration drift"` check in `runner.py` could not fire from the CLI and `--allow-methodology-change` changed nothing. Adds `--frozen-snapshot`, taking a path or `previous`. It is opt-in rather than defaulted on purpose: `compare_snapshots` also gates on `source_sha256`, so an implicit baseline would refuse every ordinary run against refreshed award data, not just a methodology change — which would push operators to pass a bypass flag habitually and defeat the gate.

**`TECH_AREAS` read the registry YAML at module import**, so a missing or malformed `registry.yaml` (one bad row is enough — an unknown `analysis_kind` raises in `AnalysisKind()`) raised during the Dagster definitions load and took *every* asset in the deployment down, not just the three cohort assets. The load is now contained to these assets and logs the registry path on failure.

Fixing that surfaced a latent crash in the asset factory: `del _area` after the loop raised `NameError` whenever `TECH_AREAS` was empty, which would have defeated the containment (verified — the first version of this fix still crashed at import). The loop moves into a function so no loop variable leaks and there is nothing to `del`.

Also drops `snapshot_path()` and `METRIC_CLAIM_IDS`, both added unused by #619. `snapshot_path` additionally disagreed with the runner's own path scheme, inserting a second `analysis_snapshots` segment against the root the CLI passes.

Relates to #441.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [x] PATCH: backward-compatible fix or documentation correction

Adds `tech_census.write_census_artifacts` and a `--frozen-snapshot` flag. Removes two unused symbols added by #619 and never imported anywhere.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

New tests:

- `test_census_strategy_writes_artifacts` — the strategy emits the same artifacts as the script it deprecates
- `test_frozen_snapshot_flag_resolves_previous` / `_defaults_to_no_baseline` / `_accepts_an_explicit_path`
- `test_broken_registry_does_not_break_the_module_import` — a bad registry degrades to zero cohort assets instead of aborting the definitions load

`test_build_tech_census` (pre-existing) exercises the refactored writer end to end and still passes, as do the calibration tests named in #619.

```
uv run pytest tests/unit/     # 6080 passed, 7 skipped
uv run ruff check . && uv run mypy sbir_etl   # clean
check_architecture_boundaries / check_tier_boundaries / check_epistemic_tiers / check_removed_src_references  # pass
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZeXLL2oC39ZT9KsqoZPqg)_