### PR TITLE
STTR spinout-linkage: D1 spine loader + freeze-hash guard (task 1.3 substrate)

### DIFF
--- a/scripts/sttr_spinout_linkage/d1_spine.py
+++ b/scripts/sttr_spinout_linkage/d1_spine.py
@@ -1,0 +1,219 @@
+"""D1 award-spine loader for the STTR spinout-linkage RQ1 cascade.
+
+Loads the STTR Phase II award population design.md's D1 row anchors on
+(`program = STTR`, SBIR.gov award data) and computes each award's `D1Spine`
+(`kernel.D1Spine`) from RI/PI presence. Every D2-D5 dimension scorer and the
+cascade-assembly step (task 1.3+) starts from this population; this module
+does not itself score D1-D5's later dimensions.
+
+Filtering reuses the exact `first_col` / STTR / Phase II filter pattern
+already used twice in this repo for the same population --
+`notebooks/explorations/b1_sttr_partner_type_commercialization.ipynb` and
+`notebooks/explorations/sttr_rq1_data_availability.ipynb` -- extracted here so
+a third, differently-written copy of the same filter never exists. The two
+notebooks are not rewritten to import this module in this PR (out of scope
+per the task brief); a follow-on housekeeping change can do that.
+
+No Neo4j, no CANDIDATE-assertion emission, no Parquet write. Per design.md,
+"Parquet is authoritative; Neo4j is a disposable investigative projection" --
+this loader only needs to hand a population to the D2-D5 scorers that follow,
+so it returns a `pandas.DataFrame`, matching what both precedent notebooks
+already produce.
+
+Epistemic tier: exploratory (`specs/sttr-spinout-linkage/tasks.md` header):
+no tests or abstractions beyond what a single probe needs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pandas as pd
+
+from sbir_etl.utils.coercion import _blank
+
+from .freeze_guard import verify_design_frozen
+from .kernel import D1Spine
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").exists() and (candidate / "sbir_etl").exists():
+            return candidate
+    raise RuntimeError("Not inside the sbir-analytics checkout")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+
+# Same candidate order as both precedent notebooks: prefer the enriched
+# parquet, fall back to the raw SBIR.gov CSV.
+DEFAULT_AWARD_CANDIDATES: tuple[Path, ...] = (
+    _REPO_ROOT / "data" / "processed" / "enriched_sbir_awards.parquet",
+    _REPO_ROOT / "data" / "raw" / "sbir" / "award_data.csv",
+)
+
+
+def first_col(frame: pd.DataFrame, names: tuple[str, ...]) -> str | None:
+    """Return the first column in `frame` matching any of `names`, case-insensitively.
+
+    The exact helper both precedent notebooks define locally
+    (`b1_sttr_partner_type_commercialization.ipynb`,
+    `sttr_rq1_data_availability.ipynb`); extracted here so a third
+    implementation is never written.
+    """
+
+    lookup = {column.lower(): column for column in frame.columns}
+    for name in names:
+        if name.lower() in lookup:
+            return lookup[name.lower()]
+    return None
+
+
+def is_sttr(value: object) -> bool:
+    """`program` column predicate, identical to both precedent notebooks."""
+
+    text = str(value or "").strip().upper()
+    return text == "STTR"
+
+
+def is_phase_ii(value: object) -> bool:
+    """`phase` column predicate, identical to both precedent notebooks."""
+
+    text = str(value or "").strip().upper().replace("PHASE ", "")
+    return text in {"II", "2"}
+
+
+def resolve_award_data_path(candidates: tuple[Path, ...] = DEFAULT_AWARD_CANDIDATES) -> Path:
+    """First existing candidate path, or the last (canonical) one if none exist."""
+
+    return next((path for path in candidates if path.exists()), candidates[-1])
+
+
+def load_award_data(path: Path) -> pd.DataFrame:
+    """Read the SBIR award population from parquet or CSV, matching both notebooks."""
+
+    if not path.exists():
+        raise FileNotFoundError(f"No award data at {path}")
+    if path.suffix == ".parquet":
+        return pd.read_parquet(path)
+    return pd.read_csv(path, dtype=str, low_memory=False)
+
+
+def filter_sttr_phase_ii(frame: pd.DataFrame) -> pd.DataFrame:
+    """Filter to `program = STTR`, `phase = Phase II` rows.
+
+    Same predicate both precedent notebooks apply. Raises `KeyError` if the
+    award frame lacks recognizable program/phase columns rather than
+    silently returning an empty population -- this is a shared substrate for
+    downstream scorers, not an interactive probe, so a missing column must
+    fail loud here.
+    """
+
+    program_col = first_col(frame, ("program", "Program"))
+    phase_col = first_col(frame, ("phase", "Phase"))
+    if program_col is None or phase_col is None:
+        raise KeyError(f"Award frame lacks program/phase columns: {list(frame.columns)}")
+    return frame.loc[frame[program_col].map(is_sttr) & frame[phase_col].map(is_phase_ii)].copy()
+
+
+@dataclass(frozen=True)
+class D1SpineRecord:
+    """One STTR Phase II award: the D1-row fields plus its computed `D1Spine`."""
+
+    award_id: object
+    agency: object
+    award_year: object
+    award_date: object
+    uei: object
+    company_name: object
+    ri_name: object
+    pi_name: object
+    abstract: object
+    spine: D1Spine
+
+
+def build_d1_spine_frame(sttr_p2: pd.DataFrame) -> pd.DataFrame:
+    """Select/rename the D1 fields and attach `ri_present`/`pi_present`/`d1_spine`.
+
+    `sttr_p2` must already be filtered to STTR Phase II rows
+    (`filter_sttr_phase_ii`). Presence uses `sbir_etl.utils.coercion._blank`
+    -- the same blank/NaN/whitespace check `kernel.py` already imports for
+    its own presence logic, not a new definition of "present."
+    """
+
+    award_id_col = first_col(
+        sttr_p2, ("award_id", "Agency Tracking Number", "agency_tracking_number")
+    )
+    agency_col = first_col(sttr_p2, ("agency", "Agency"))
+    year_col = first_col(sttr_p2, ("award_year", "Award Year"))
+    date_col = first_col(sttr_p2, ("award_date", "Proposal Award Date"))
+    uei_col = first_col(sttr_p2, ("uei", "UEI", "company_uei"))
+    company_col = first_col(sttr_p2, ("company_name", "Company", "company"))
+    ri_col = first_col(sttr_p2, ("ri_name", "RI Name", "research_institution"))
+    pi_col = first_col(sttr_p2, ("pi_name", "PI Name", "principal_investigator"))
+    abstract_col = first_col(sttr_p2, ("abstract", "Abstract"))
+
+    def _column(col: str | None) -> pd.Series:
+        return sttr_p2[col] if col else pd.Series(pd.NA, index=sttr_p2.index)
+
+    spine = pd.DataFrame(
+        {
+            "award_id": _column(award_id_col),
+            "agency": _column(agency_col),
+            "award_year": _column(year_col),
+            "award_date": _column(date_col),
+            "uei": _column(uei_col),
+            "company_name": _column(company_col),
+            "ri_name": _column(ri_col),
+            "pi_name": _column(pi_col),
+            "abstract": _column(abstract_col),
+        }
+    )
+    spine["ri_present"] = ~spine["ri_name"].map(_blank)
+    spine["pi_present"] = ~spine["pi_name"].map(_blank)
+    spine["d1_spine"] = [
+        D1Spine(ri_present=bool(ri), pi_present=bool(pi))
+        for ri, pi in zip(spine["ri_present"], spine["pi_present"], strict=True)
+    ]
+    return spine
+
+
+def load_d1_spine(
+    award_data_path: Path | None = None,
+    *,
+    verify_freeze: bool = True,
+) -> pd.DataFrame:
+    """Load the D1 award spine for the STTR Phase II population.
+
+    Calls `verify_design_frozen` first (skip with `verify_freeze=False` only
+    if the caller already verified once in the same process) -- design.md's
+    D1 row and the Order-0 cascade rule this spine feeds are both part of the
+    Revision 1 freeze.
+    """
+
+    if verify_freeze:
+        verify_design_frozen()
+    path = award_data_path or resolve_award_data_path()
+    awards_raw = load_award_data(path)
+    sttr_p2 = filter_sttr_phase_ii(awards_raw)
+    return build_d1_spine_frame(sttr_p2)
+
+
+def iter_d1_spine_records(frame: pd.DataFrame) -> Iterator[D1SpineRecord]:
+    """Yield one `D1SpineRecord` per row of a `load_d1_spine` frame."""
+
+    for row in frame.itertuples(index=False):
+        yield D1SpineRecord(
+            award_id=row.award_id,
+            agency=row.agency,
+            award_year=row.award_year,
+            award_date=row.award_date,
+            uei=row.uei,
+            company_name=row.company_name,
+            ri_name=row.ri_name,
+            pi_name=row.pi_name,
+            abstract=row.abstract,
+            spine=row.d1_spine,
+        )

--- a/scripts/sttr_spinout_linkage/freeze_guard.py
+++ b/scripts/sttr_spinout_linkage/freeze_guard.py
@@ -1,0 +1,74 @@
+"""Freeze-hash guard for the STTR spinout-linkage design (Revision 1).
+
+`specs/sttr-spinout-linkage/amendments.md`'s Revision 1 entry freezes
+`specs/sttr-spinout-linkage/design.md` at its raw-byte SHA-256 and requires
+"a materializing asset [to] recompute this hash against the working copy
+before running and fail closed on any mismatch" -- including a mismatch
+caused by a well-intentioned edit to `design.md` that was never recorded as a
+further amendment. `verify_design_frozen` is that check.
+
+Call it first, before touching any frozen criterion -- the cascade order, the
+D1-D5 evidence-dimension table, the similarity method, the partner-type
+precedence, or the D2 window. This module's own `d1_spine` loader calls it;
+every D2-D5 dimension-scorer and cascade-assembly PR that follows (task 1.3+)
+should do the same as its first line.
+
+Mirrors the hash-verification pattern already used by
+`packages/sbir-analytics/sbir_analytics/assets/phase_iii_census/assets.py`
+(`verify_frozen_spec` / `_verified_raw_digest`), scaled down to this spec's
+single frozen file -- this spec's `amendments.md` records no self-hash for
+itself the way the census spec's does, so only `design.md` is verified here.
+
+Epistemic tier: exploratory (`specs/sttr-spinout-linkage/tasks.md` header).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+class DesignNotFrozenError(RuntimeError):
+    """`design.md`'s working-copy bytes no longer match the Revision 1 freeze
+    recorded in `amendments.md`."""
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").exists() and (candidate / "sbir_etl").exists():
+            return candidate
+    raise RuntimeError("Not inside the sbir-analytics checkout")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+DESIGN_PATH = _REPO_ROOT / "specs" / "sttr-spinout-linkage" / "design.md"
+
+# specs/sttr-spinout-linkage/amendments.md, "## Revision 1 -- FREEZE", the
+# "Frozen file" bullet: raw-byte SHA-256 of design.md at freeze time
+# (2026-08-14). Do not hand-edit this constant on a design.md change --
+# amendments.md's append-only rule requires a new numbered revision first;
+# update both together. `test_freeze_guard.py` asserts this constant still
+# matches what is parseable out of amendments.md.
+FROZEN_DESIGN_SHA256 = "52d8b531d56f3b91e1d3b0946e1ac91dd6f5dfeab371e3d48f87dc5e6095ac49"
+
+
+def verify_design_frozen(design_path: Path = DESIGN_PATH) -> str:
+    """Fail closed unless `design_path`'s raw bytes match the Revision 1 freeze.
+
+    Returns the verified SHA-256 hex digest on success.
+    """
+
+    try:
+        content = design_path.read_bytes()
+    except OSError as exc:
+        raise DesignNotFrozenError(
+            f"Frozen design spec is missing or unreadable at {design_path}: {exc}"
+        ) from exc
+    actual = hashlib.sha256(content).hexdigest()
+    if actual != FROZEN_DESIGN_SHA256:
+        raise DesignNotFrozenError(
+            f"design.md has drifted from the Revision 1 freeze recorded in "
+            f"amendments.md: expected SHA-256 {FROZEN_DESIGN_SHA256}, found {actual}. "
+            "Record a new numbered amendment in amendments.md before proceeding."
+        )
+    return actual

--- a/tests/unit/sttr_spinout_linkage/test_d1_spine.py
+++ b/tests/unit/sttr_spinout_linkage/test_d1_spine.py
@@ -1,0 +1,99 @@
+"""Probes for the D1 award-spine loader.
+
+Exploratory tier: covers filter correctness (STTR + Phase II) and D1Spine
+presence computation on a small synthetic frame -- not a comprehensive
+column-name or real-data-file matrix. `load_d1_spine`'s freeze-guard call is
+covered separately in `test_freeze_guard.py`; these tests pass
+`verify_freeze=False` to stay independent of that mechanism.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from scripts.sttr_spinout_linkage.d1_spine import (
+    D1SpineRecord,
+    build_d1_spine_frame,
+    filter_sttr_phase_ii,
+    first_col,
+    is_phase_ii,
+    is_sttr,
+    iter_d1_spine_records,
+)
+from scripts.sttr_spinout_linkage.kernel import D1Spine
+
+
+pytestmark = pytest.mark.fast
+
+
+RAW_AWARDS = pd.DataFrame(
+    {
+        "Program": ["STTR", "STTR", "SBIR", "STTR"],
+        "Phase": ["Phase II", "Phase I", "Phase II", "II"],
+        "award_id": ["A1", "A2", "A3", "A4"],
+        "Agency": ["DOD", "DOD", "NSF", "NIH"],
+        "Award Year": ["2020", "2019", "2021", "2022"],
+        "UEI": ["U1", "U2", "U3", ""],
+        "Company": ["Acme", "Beta", "Gamma", "Delta"],
+        "RI Name": ["MIT", "", "Stanford", None],
+        "PI Name": ["Jane Doe", "John Roe", "", "Sam Lee"],
+        "Abstract": ["a widget", "b widget", "c widget", "d widget"],
+    }
+)
+
+
+class TestFilterPredicates:
+    def test_is_sttr(self) -> None:
+        assert is_sttr("STTR") is True
+        assert is_sttr("sttr ") is True
+        assert is_sttr("SBIR") is False
+        assert is_sttr(None) is False
+
+    def test_is_phase_ii(self) -> None:
+        assert is_phase_ii("Phase II") is True
+        assert is_phase_ii("II") is True
+        assert is_phase_ii("2") is True
+        assert is_phase_ii("Phase I") is False
+
+    def test_first_col_is_case_insensitive_and_falls_back_to_none(self) -> None:
+        assert first_col(RAW_AWARDS, ("program", "Program")) == "Program"
+        assert first_col(RAW_AWARDS, ("missing",)) is None
+
+
+class TestFilterSttrPhaseIi:
+    def test_keeps_only_sttr_phase_ii_rows(self) -> None:
+        filtered = filter_sttr_phase_ii(RAW_AWARDS)
+        # A2 is STTR Phase I (excluded); A3 is SBIR (excluded); A1/A4 kept.
+        assert sorted(filtered["award_id"]) == ["A1", "A4"]
+
+    def test_raises_when_program_or_phase_columns_are_absent(self) -> None:
+        with pytest.raises(KeyError):
+            filter_sttr_phase_ii(RAW_AWARDS.drop(columns=["Program"]))
+
+
+class TestBuildD1SpineFrame:
+    def test_computes_ri_pi_presence_and_d1_spine(self) -> None:
+        sttr_p2 = filter_sttr_phase_ii(RAW_AWARDS)
+        spine = build_d1_spine_frame(sttr_p2)
+        by_id = spine.set_index("award_id")
+
+        # A1: RI="MIT" (present), PI="Jane Doe" (present) -> complete spine.
+        assert bool(by_id.loc["A1", "ri_present"]) is True
+        assert bool(by_id.loc["A1", "pi_present"]) is True
+        assert by_id.loc["A1", "d1_spine"] == D1Spine(ri_present=True, pi_present=True)
+
+        # A4: RI=None (absent), PI="Sam Lee" (present) -> spine incomplete on RI.
+        assert bool(by_id.loc["A4", "ri_present"]) is False
+        assert bool(by_id.loc["A4", "pi_present"]) is True
+        assert by_id.loc["A4", "d1_spine"] == D1Spine(ri_present=False, pi_present=True)
+
+    def test_iter_d1_spine_records_yields_one_record_per_row(self) -> None:
+        sttr_p2 = filter_sttr_phase_ii(RAW_AWARDS)
+        spine = build_d1_spine_frame(sttr_p2)
+
+        records = list(iter_d1_spine_records(spine))
+
+        assert len(records) == len(spine)
+        assert all(isinstance(record, D1SpineRecord) for record in records)
+        assert {record.award_id for record in records} == {"A1", "A4"}

--- a/tests/unit/sttr_spinout_linkage/test_freeze_guard.py
+++ b/tests/unit/sttr_spinout_linkage/test_freeze_guard.py
@@ -1,0 +1,55 @@
+"""Probes for the Revision-1 freeze-hash guard.
+
+Exploratory tier: covers the guard's pass/fail behavior only, matching task
+1.2's kernel-test scope ("no tests or abstractions beyond what a single
+probe needs"). The fail-closed case runs against a modified copy of
+`design.md`, not the real file, so this test does not itself depend on
+`design.md` never changing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from scripts.sttr_spinout_linkage.freeze_guard import (
+    DESIGN_PATH,
+    FROZEN_DESIGN_SHA256,
+    DesignNotFrozenError,
+    verify_design_frozen,
+)
+
+
+pytestmark = pytest.mark.fast
+
+AMENDMENTS_PATH = DESIGN_PATH.parent / "amendments.md"
+
+
+def test_frozen_hash_constant_matches_the_hash_recorded_in_amendments_md() -> None:
+    """`FROZEN_DESIGN_SHA256` must not drift from amendments.md's Revision 1 entry."""
+
+    text = AMENDMENTS_PATH.read_text(encoding="utf-8")
+    revision_1 = text.split("## Revision 1", 1)[1]
+    match = re.search(r"SHA-256:\*\*\s*`([0-9a-f]{64})`", revision_1)
+    assert match is not None, "Could not find a SHA-256 hash in amendments.md's Revision 1 entry"
+    assert match.group(1) == FROZEN_DESIGN_SHA256
+
+
+def test_verify_design_frozen_passes_on_the_current_frozen_design_md() -> None:
+    assert verify_design_frozen() == FROZEN_DESIGN_SHA256
+
+
+def test_verify_design_frozen_fails_closed_on_a_modified_copy(tmp_path: Path) -> None:
+    modified = tmp_path / "design.md"
+    original = DESIGN_PATH.read_text(encoding="utf-8")
+    modified.write_text(original + "\nunreviewed drift\n", encoding="utf-8")
+
+    with pytest.raises(DesignNotFrozenError, match="drifted from the Revision 1 freeze"):
+        verify_design_frozen(modified)
+
+
+def test_verify_design_frozen_fails_closed_on_a_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(DesignNotFrozenError, match="missing or unreadable"):
+        verify_design_frozen(tmp_path / "does-not-exist.md")


### PR DESCRIPTION
## Summary

Shared substrate for `specs/sttr-spinout-linkage` task 1.3, split out as its
own PR because every D2-D5 dimension-scorer PR that follows needs both
pieces first, and this merges before any of them.

- **`scripts/sttr_spinout_linkage/freeze_guard.py`** — `verify_design_frozen()`
  reads `design.md`'s raw bytes, computes their SHA-256, and compares against
  `FROZEN_DESIGN_SHA256` — a constant hardcoded from `amendments.md`'s
  Revision 1 "Frozen file" bullet (comment points at the exact line). A test
  (`test_frozen_hash_constant_matches_the_hash_recorded_in_amendments_md`)
  parses that hash back out of `amendments.md` and asserts it matches the
  constant, so the two can't silently drift apart. On mismatch or a missing
  file, raises `DesignNotFrozenError` (typed, not a silent `False`). Meant to
  be the first line of every downstream dimension-scorer / cascade-assembly
  PR, and `d1_spine.load_d1_spine()` already calls it.

- **`scripts/sttr_spinout_linkage/d1_spine.py`** — `load_d1_spine()` loads the
  STTR Phase II award population from `data/processed/enriched_sbir_awards.parquet`
  (falling back to `data/raw/sbir/award_data.csv`) and returns a `DataFrame`
  with one row per award: `award_id`, `agency`, `award_year`/`award_date`,
  `uei`, `company_name`, `ri_name`, `pi_name`, `abstract`, `ri_present`,
  `pi_present`, and a `d1_spine` column of `kernel.D1Spine` instances.
  `iter_d1_spine_records()` yields the same data as one `D1SpineRecord` per
  award for callers that prefer records over a frame. The `program = STTR`,
  `phase = Phase II` filter (`first_col`/`is_sttr`/`is_phase_ii`) is the exact
  pattern already used in
  `notebooks/explorations/b1_sttr_partner_type_commercialization.ipynb` and
  `notebooks/explorations/sttr_rq1_data_availability.ipynb`, extracted here
  instead of writing a third, differently-shaped copy. The two notebooks are
  not rewritten to import this module — out of scope for this PR.

## Scope

Per `specs/sttr-spinout-linkage/tasks.md`'s exploratory-tier header: no D2-D5
dimension scoring, no Neo4j, no CANDIDATE-assertion emission, no Parquet
write (returns a `DataFrame`, matching the notebook precedent).

## Test plan

- [x] `uv run pytest tests/unit/sttr_spinout_linkage/ -v` — 48 passed (8 new:
      4 freeze-guard, 4 D1-spine), including a fail-closed freeze-guard test
      against a modified copy of `design.md` (not the real file)
- [x] `make lint` — ruff + mypy pass
- [x] `make lint-boundaries` — architecture/tier/config/study-manifest checks pass
- [x] `make docs-check` — passes
- [x] `uv run python scripts/ci/check_epistemic_tiers.py` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)