### PR TITLE
Close guard bypass and D4 status collapse in the linkage kernel

### DIFF
--- a/scripts/sttr_spinout_linkage/kernel.py
+++ b/scripts/sttr_spinout_linkage/kernel.py
@@ -106,6 +106,38 @@ GENERIC_PERSON_TOKENS: frozenset[str] = frozenset(
 )
 
 
+# SUFFIX_TOKENS carries a few multi-word / punctuated spellings ("l l c",
+# "l.l.c") that can never equal a whitespace-split token, so a name spelled
+# "L.L.C." would slip past a per-token check. Normalize them the way
+# normalize_company_name normalizes a name, and match them as contiguous runs.
+ORG_GENERIC_PHRASES: tuple[tuple[str, ...], ...] = tuple(
+    sorted(
+        (
+            tuple(re.sub(r"[^a-z0-9\s]", " ", token).split())
+            for token in ORG_GENERIC_TOKENS
+            if len(re.sub(r"[^a-z0-9\s]", " ", token).split()) > 1
+        ),
+        key=len,
+        reverse=True,
+    )
+)
+
+
+def _strip_generic_org_phrases(tokens: tuple[str, ...]) -> tuple[str, ...]:
+    """Remove contiguous runs matching a multi-token generic suffix."""
+
+    remaining = list(tokens)
+    for phrase in ORG_GENERIC_PHRASES:
+        width = len(phrase)
+        index = 0
+        while index + width <= len(remaining):
+            if tuple(remaining[index : index + width]) == phrase:
+                del remaining[index : index + width]
+            else:
+                index += 1
+    return tuple(remaining)
+
+
 def generic_token_guard(tokens: Iterable[str], *, generic_tokens: frozenset[str]) -> bool:
     """Return ``True`` (guard passes) iff at least one non-generic token remains.
 
@@ -153,22 +185,42 @@ class ResolvedIdentity:
     family_name: str | None = None
 
 
+def _strip_generic_person_tokens(tokens: tuple[str, ...]) -> tuple[str, ...]:
+    """Drop titles, generational suffixes, and post-nominals from a name.
+
+    Kept separate from `generic_token_guard`, which only *detects* a name made
+    entirely of these. Stripping is what keeps "Dr. Jane Smith" and "Jane
+    Smith" comparable; a name that reduces to nothing is returned unchanged so
+    the guard can reject it rather than a caller comparing an empty string.
+    """
+
+    kept = tuple(token for token in tokens if token not in GENERIC_PERSON_TOKENS)
+    return kept or tokens
+
+
 def _normalize_person_name(value: str) -> tuple[str, tuple[str, ...]]:
     """Net-new person-name normalization: no existing primitive covers this.
 
     Case-folds, strips diacritics and punctuation other than hyphens/
-    apostrophes within a name, and reorders an explicit "Family, Given" input
-    to given-then-family order so a trailing-token family-name assumption
-    holds consistently downstream.
+    apostrophes within a name, removes titles and post-nominals, and reorders
+    an explicit "Family, Given" input to given-then-family order so a
+    trailing-token family-name assumption holds consistently downstream.
+
+    The comma is only treated as a "Family, Given" separator when what follows
+    it is not purely credentials: "Smith, Jane" reorders, while "Jane Smith,
+    PhD" does not — reordering the latter would strand the credential at the
+    front and push a real pair below any sane similarity cutoff.
     """
 
     text = unicodedata.normalize("NFKD", str(value).strip().lower())
     text = "".join(ch for ch in text if not unicodedata.combining(ch))
     if "," in text:
         family_part, _, given_part = text.partition(",")
-        text = f"{given_part.strip()} {family_part.strip()}"
+        given_tokens = re.sub(r"[^a-z\s'-]", " ", given_part).split()
+        if given_tokens and any(token not in GENERIC_PERSON_TOKENS for token in given_tokens):
+            text = f"{given_part.strip()} {family_part.strip()}"
     text = re.sub(r"[^a-z\s'-]", " ", text)
-    tokens = tuple(token for token in text.split() if token)
+    tokens = _strip_generic_person_tokens(tuple(token for token in text.split() if token))
     return " ".join(tokens), tokens
 
 
@@ -203,7 +255,9 @@ def resolve_identity(
     if kind is IdentityKind.ORGANIZATION:
         normalized = normalize_company_name(raw, profile=organization_profile)
         tokens = tuple(normalized.split())
-        guard_passed = generic_token_guard(tokens, generic_tokens=ORG_GENERIC_TOKENS)
+        guard_passed = generic_token_guard(
+            _strip_generic_org_phrases(tokens), generic_tokens=ORG_GENERIC_TOKENS
+        )
         return ResolvedIdentity(
             kind=kind,
             raw=raw,
@@ -239,6 +293,10 @@ def identity_similarity(left: ResolvedIdentity | None, right: ResolvedIdentity |
     """
 
     if left is None or right is None:
+        return 0.0
+    if left.kind is not right.kind:
+        # An organization and a person are never the same entity, however
+        # similar their strings ("Smith Robotics" the firm vs. Smith the PI).
         return 0.0
     return company_name_similarity(
         left.normalized,
@@ -354,12 +412,22 @@ class D3IpTrail:
 @dataclass(frozen=True)
 class D4MoneyTrail:
     """D4: money / paper trail. Two independent directions -- `ri_subaward_share`
-    is a subcontract marker, `form_d_officer_ri_affiliated` is a spinout marker."""
+    is a subcontract marker, `form_d_officer_ri_affiliated` is a spinout marker.
 
-    status: DimensionStatus
+    The two directions carry their own status and absence reason because
+    design.md scores them separately: a contract-instrument STTR makes the
+    subaward side `NOT_APPLICABLE` (`NON_GRANT_INSTRUMENT`) while saying
+    nothing about whether a Form D officer is RI-affiliated. A single shared
+    status would let one direction's typed absence suppress the other's
+    measured signal.
+    """
+
+    subaward_status: DimensionStatus
+    form_d_status: DimensionStatus
     ri_subaward_share: float | None = None
     form_d_officer_ri_affiliated: bool = False
-    reason: SignalAbsentReason | None = None
+    subaward_reason: SignalAbsentReason | None = None
+    form_d_reason: SignalAbsentReason | None = None
 
 
 @dataclass(frozen=True)
@@ -411,7 +479,23 @@ def classify_linkage(
     - **License absence cannot create a SUBCONTRACT.** D3's status must be
       `MEASURED` at Order 3; a `NOT_MEASURABLE` D3 (license sparsity, O-12)
       never satisfies that clause on its own.
+    - **The generic-token guard applies to every D2 person comparison**, exact
+      and fuzzy alike, and a guard failure is an unresolvable person rather
+      than a measured negative.
+
+    Raises:
+        ValueError: if ``similarity_cutoff`` is outside ``(0.0, 1.0]``. Because
+            the parameter is deliberately defaultless, a placeholder ``0.0`` is
+            the likely caller slip, and it would otherwise turn a measured 0.0
+            similarity into a qualifying fuzzy positive.
     """
+
+    if not 0.0 < similarity_cutoff <= 1.0:
+        raise ValueError(
+            f"similarity_cutoff must be in (0.0, 1.0]; got {similarity_cutoff!r}. "
+            "O-3 defers the value to a post-task-1.4 amendment; pass the "
+            "amended cutoff rather than a placeholder."
+        )
 
     # Order 0: the join spine itself is incomplete.
     if not (d1.ri_present and d1.pi_present):
@@ -421,16 +505,26 @@ def classify_linkage(
             rationale="D1 spine incomplete: RI or PI absent",
         )
 
+    # The guard is mandatory on every D2 person-name comparison, exact included:
+    # a name that reduces to generic tokens identifies nobody, however it matched.
+    person_resolvable = d2.person_guard_passed
+    exact_person = d2.exact_person_ri_affiliation and person_resolvable
     fuzzy_person = (
         d2.person_similarity is not None
         and d2.person_similarity >= similarity_cutoff
-        and d2.person_guard_passed
+        and person_resolvable
     )
-    any_person_link = d2.exact_person_ri_affiliation or fuzzy_person
+    any_person_link = exact_person or fuzzy_person
     any_ip_link = d3.patent_assigned_to_ri_with_sbc_inventor or d3.recorded_license_ri_to_sbc
 
+    # A guard failure means the person is *unresolvable*, not that a search came
+    # back empty, so D2 cannot serve as a measured negative at Order 3 either.
+    d2_measured_negative = (
+        d2.status is DimensionStatus.MEASURED and person_resolvable and not any_person_link
+    )
+
     # Order 1: one exact person or IP link with affiliation evidence.
-    if d2.status is DimensionStatus.MEASURED and d2.exact_person_ri_affiliation:
+    if d2.status is DimensionStatus.MEASURED and exact_person:
         return LinkageDecision(
             LinkageLabel.SPINOUT_T1,
             cascade_order=1,
@@ -444,15 +538,15 @@ def classify_linkage(
         )
 
     # Order 2: a fuzzy positive corroborated by a second, distinct dimension.
+    # D3 is absent from the corroborator set on purpose: a MEASURED D3 with any
+    # IP link already returned SPINOUT_T1 above, so it can never corroborate here.
     d2_fuzzy_positive = d2.status is DimensionStatus.MEASURED and fuzzy_person
     d5_positive = d5.status is DimensionStatus.MEASURED and d5.spinout_phrase
     if d2_fuzzy_positive or d5_positive:
         primary = "D2" if d2_fuzzy_positive else "D5"
         corroborated = (
-            (primary != "D3" and d3.status is DimensionStatus.MEASURED and any_ip_link)
-            or (d4.status is DimensionStatus.MEASURED and d4.form_d_officer_ri_affiliated)
-            or (primary != "D5" and d5.status is DimensionStatus.MEASURED and d5.spinout_phrase)
-        )
+            d4.form_d_status is DimensionStatus.MEASURED and d4.form_d_officer_ri_affiliated
+        ) or (primary != "D5" and d5.status is DimensionStatus.MEASURED and d5.spinout_phrase)
         if corroborated:
             return LinkageDecision(
                 LinkageLabel.SPINOUT_T2,
@@ -462,11 +556,10 @@ def classify_linkage(
 
     # Order 3: spinout-bearing dimensions measured and negative, subaward positive.
     if (
-        d4.status is DimensionStatus.MEASURED
+        d4.subaward_status is DimensionStatus.MEASURED
         and d4.ri_subaward_share is not None
         and d4.ri_subaward_share > 0
-        and d2.status is DimensionStatus.MEASURED
-        and not any_person_link
+        and d2_measured_negative
         and d3.status is DimensionStatus.MEASURED
         and not any_ip_link
         and d5.status is DimensionStatus.MEASURED

--- a/tests/unit/sttr_spinout_linkage/test_kernel.py
+++ b/tests/unit/sttr_spinout_linkage/test_kernel.py
@@ -161,7 +161,9 @@ def _d1(*, ri: bool = True, pi: bool = True) -> D1Spine:
 
 
 def _measured_empty_d2() -> D2PersonTrail:
-    return D2PersonTrail(status=DimensionStatus.MEASURED)
+    # A measured-negative D2 means the person resolved and no RI-affiliated
+    # authorship was found, so the guard must have passed.
+    return D2PersonTrail(status=DimensionStatus.MEASURED, person_guard_passed=True)
 
 
 def _measured_empty_d3() -> D3IpTrail:
@@ -169,7 +171,11 @@ def _measured_empty_d3() -> D3IpTrail:
 
 
 def _measured_empty_d4() -> D4MoneyTrail:
-    return D4MoneyTrail(status=DimensionStatus.MEASURED, ri_subaward_share=0.0)
+    return D4MoneyTrail(
+        subaward_status=DimensionStatus.MEASURED,
+        form_d_status=DimensionStatus.MEASURED,
+        ri_subaward_share=0.0,
+    )
 
 
 def _measured_empty_d5() -> D5TextTrail:
@@ -206,7 +212,11 @@ class TestClassifyLinkage:
     def test_order_1_spinout_t1_on_exact_person_affiliation(self):
         decision = classify_linkage(
             d1=_d1(),
-            d2=D2PersonTrail(status=DimensionStatus.MEASURED, exact_person_ri_affiliation=True),
+            d2=D2PersonTrail(
+                status=DimensionStatus.MEASURED,
+                exact_person_ri_affiliation=True,
+                person_guard_passed=True,
+            ),
             d3=_measured_empty_d3(),
             d4=_measured_empty_d4(),
             d5=_measured_empty_d5(),
@@ -250,7 +260,8 @@ class TestClassifyLinkage:
             ),
             d3=_measured_empty_d3(),
             d4=D4MoneyTrail(
-                status=DimensionStatus.MEASURED,
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
                 ri_subaward_share=0.0,
                 form_d_officer_ri_affiliated=True,
             ),
@@ -270,7 +281,8 @@ class TestClassifyLinkage:
             ),
             d3=_measured_empty_d3(),
             d4=D4MoneyTrail(
-                status=DimensionStatus.MEASURED,
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
                 ri_subaward_share=0.0,
                 form_d_officer_ri_affiliated=True,
             ),
@@ -289,7 +301,8 @@ class TestClassifyLinkage:
             ),
             d3=_measured_empty_d3(),
             d4=D4MoneyTrail(
-                status=DimensionStatus.MEASURED,
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
                 ri_subaward_share=0.0,
                 form_d_officer_ri_affiliated=True,
             ),
@@ -313,7 +326,7 @@ class TestClassifyLinkage:
         assert decision.label is not LinkageLabel.SPINOUT_T2
         assert decision.label is LinkageLabel.INDETERMINATE
 
-    def test_order_2_d5_phrase_corroborated_by_d3_ip_link(self):
+    def test_order_2_d5_phrase_not_corroborated_by_unmeasurable_d3(self):
         decision = classify_linkage(
             d1=_d1(),
             d2=_measured_empty_d2(),
@@ -326,7 +339,9 @@ class TestClassifyLinkage:
             similarity_cutoff=self.CUTOFF,
         )
         # D3 is NOT_MEASURABLE here (license sparsity) so it cannot corroborate;
-        # falls through to INDETERMINATE, not a false T2.
+        # falls through to INDETERMINATE, not a false T2. Note a *measured* D3
+        # with an IP link cannot reach Order 2 either -- it returns SPINOUT_T1
+        # at Order 1 -- which is why D3 is not in the corroborator set at all.
         assert decision.label is LinkageLabel.INDETERMINATE
 
     def test_order_3_subcontract_on_measured_negative_dims_and_subaward(self):
@@ -334,7 +349,11 @@ class TestClassifyLinkage:
             d1=_d1(),
             d2=_measured_empty_d2(),
             d3=_measured_empty_d3(),
-            d4=D4MoneyTrail(status=DimensionStatus.MEASURED, ri_subaward_share=0.3),
+            d4=D4MoneyTrail(
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
+                ri_subaward_share=0.3,
+            ),
             d5=_measured_empty_d5(),
             similarity_cutoff=self.CUTOFF,
         )
@@ -351,7 +370,11 @@ class TestClassifyLinkage:
                 status=DimensionStatus.NOT_MEASURABLE,
                 reason=SignalAbsentReason.LICENSE_RECORDS_SPARSE,
             ),
-            d4=D4MoneyTrail(status=DimensionStatus.MEASURED, ri_subaward_share=0.3),
+            d4=D4MoneyTrail(
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
+                ri_subaward_share=0.3,
+            ),
             d5=_measured_empty_d5(),
             similarity_cutoff=self.CUTOFF,
         )
@@ -370,7 +393,11 @@ class TestClassifyLinkage:
                 status=DimensionStatus.NOT_MEASURABLE,
                 reason=SignalAbsentReason.LICENSE_RECORDS_SPARSE,
             ),
-            d4=D4MoneyTrail(status=DimensionStatus.MEASURED, ri_subaward_share=1.0),
+            d4=D4MoneyTrail(
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
+                ri_subaward_share=1.0,
+            ),
             d5=D5TextTrail(status=DimensionStatus.NOT_EVALUATED),
             similarity_cutoff=self.CUTOFF,
         )
@@ -382,8 +409,9 @@ class TestClassifyLinkage:
             d2=_measured_empty_d2(),
             d3=_measured_empty_d3(),
             d4=D4MoneyTrail(
-                status=DimensionStatus.NOT_APPLICABLE,
-                reason=SignalAbsentReason.NON_GRANT_INSTRUMENT,
+                subaward_status=DimensionStatus.NOT_APPLICABLE,
+                form_d_status=DimensionStatus.MEASURED,
+                subaward_reason=SignalAbsentReason.NON_GRANT_INSTRUMENT,
             ),
             d5=_measured_empty_d5(),
             similarity_cutoff=self.CUTOFF,
@@ -396,3 +424,128 @@ class TestClassifyLinkage:
 
         signature = inspect.signature(classify_linkage)
         assert signature.parameters["similarity_cutoff"].default is inspect.Parameter.empty
+
+
+class TestGuardAndCutoffRegressions:
+    """Regressions for defects found reviewing the initial kernel."""
+
+    CUTOFF = 0.9
+
+    def test_exact_person_failing_guard_does_not_advance_to_t1(self):
+        # The guard is mandatory on every D2 person comparison, not just fuzzy;
+        # a name that reduces to generic tokens identifies nobody.
+        decision = classify_linkage(
+            d1=_d1(),
+            d2=D2PersonTrail(
+                status=DimensionStatus.MEASURED,
+                exact_person_ri_affiliation=True,
+                person_guard_passed=False,
+            ),
+            d3=_measured_empty_d3(),
+            d4=_measured_empty_d4(),
+            d5=_measured_empty_d5(),
+            similarity_cutoff=self.CUTOFF,
+        )
+        assert decision.label is not LinkageLabel.SPINOUT_T1
+
+    def test_guard_failure_is_not_a_measured_negative(self):
+        # A strong similarity that fails only the guard means "unresolvable",
+        # not "searched and found nothing", so it cannot support SUBCONTRACT.
+        decision = classify_linkage(
+            d1=_d1(),
+            d2=D2PersonTrail(
+                status=DimensionStatus.MEASURED,
+                person_similarity=0.99,
+                person_guard_passed=False,
+            ),
+            d3=_measured_empty_d3(),
+            d4=D4MoneyTrail(
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.MEASURED,
+                ri_subaward_share=0.3,
+            ),
+            d5=_measured_empty_d5(),
+            similarity_cutoff=self.CUTOFF,
+        )
+        assert decision.label is LinkageLabel.INDETERMINATE
+        assert decision.cascade_order == 4
+
+    def test_non_grant_instrument_does_not_suppress_form_d_signal(self):
+        # D4's two directions are scored separately: a contract instrument makes
+        # the subaward side NOT_APPLICABLE but says nothing about Form D.
+        decision = classify_linkage(
+            d1=_d1(),
+            d2=D2PersonTrail(
+                status=DimensionStatus.MEASURED,
+                person_similarity=0.97,
+                person_guard_passed=True,
+            ),
+            d3=_measured_empty_d3(),
+            d4=D4MoneyTrail(
+                subaward_status=DimensionStatus.NOT_APPLICABLE,
+                form_d_status=DimensionStatus.MEASURED,
+                subaward_reason=SignalAbsentReason.NON_GRANT_INSTRUMENT,
+                form_d_officer_ri_affiliated=True,
+            ),
+            d5=_measured_empty_d5(),
+            similarity_cutoff=self.CUTOFF,
+        )
+        assert decision.label is LinkageLabel.SPINOUT_T2
+        assert decision.cascade_order == 2
+
+    def test_absent_form_d_does_not_corroborate(self):
+        decision = classify_linkage(
+            d1=_d1(),
+            d2=D2PersonTrail(
+                status=DimensionStatus.MEASURED,
+                person_similarity=0.97,
+                person_guard_passed=True,
+            ),
+            d3=_measured_empty_d3(),
+            d4=D4MoneyTrail(
+                subaward_status=DimensionStatus.MEASURED,
+                form_d_status=DimensionStatus.NOT_MEASURABLE,
+                ri_subaward_share=0.0,
+                form_d_reason=SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE,
+                form_d_officer_ri_affiliated=True,
+            ),
+            d5=_measured_empty_d5(),
+            similarity_cutoff=self.CUTOFF,
+        )
+        assert decision.label is not LinkageLabel.SPINOUT_T2
+
+    @pytest.mark.parametrize("cutoff", [0.0, -0.1, 1.5])
+    def test_cutoff_outside_the_unit_interval_is_rejected(self, cutoff):
+        # O-3 leaves the cutoff defaultless; a placeholder 0.0 would otherwise
+        # promote a measured 0.0 similarity into a fuzzy positive.
+        with pytest.raises(ValueError, match="similarity_cutoff"):
+            classify_linkage(
+                d1=_d1(),
+                d2=_measured_empty_d2(),
+                d3=_measured_empty_d3(),
+                d4=_measured_empty_d4(),
+                d5=_measured_empty_d5(),
+                similarity_cutoff=cutoff,
+            )
+
+    def test_credentialed_person_name_still_matches_the_bare_name(self):
+        left = resolve_identity("Jane Smith, PhD", kind=IdentityKind.PERSON)
+        right = resolve_identity("Jane Smith", kind=IdentityKind.PERSON)
+        assert identity_similarity(left, right) == 1.0
+
+    def test_titles_and_generational_suffixes_are_stripped(self):
+        assert resolve_identity("Dr. Jane Smith", kind=IdentityKind.PERSON).given_name == "jane"
+        assert resolve_identity("John Smith Jr.", kind=IdentityKind.PERSON).family_name == "smith"
+
+    def test_family_given_order_still_reorders(self):
+        resolved = resolve_identity("Smith, Jane", kind=IdentityKind.PERSON)
+        assert resolved.normalized == "jane smith"
+        assert resolved.family_name == "smith"
+
+    def test_punctuated_legal_suffix_alone_fails_the_guard(self):
+        assert resolve_identity("L.L.C.", kind=IdentityKind.ORGANIZATION).guard_passed is False
+
+    def test_organization_and_person_never_compare_equal(self):
+        org = resolve_identity("Smith Robotics", kind=IdentityKind.ORGANIZATION)
+        person = resolve_identity("Smith Robotics", kind=IdentityKind.PERSON)
+        assert identity_similarity(org, person) == 0.0


### PR DESCRIPTION
## Description

Follow-up to #623, which merged while these findings were being written up. Four defects in `classify_linkage` changed emitted labels — which matters because the task 1.3/1.4 negative-control and adjudication gates get calibrated against whatever this emits.

**`generic_token_guard` was bypassed on the exact D2 path.** Only the fuzzy branch checked `person_guard_passed`, so `exact_person_ri_affiliation=True` with a failed guard returned `SPINOUT_T1` — the leakage negative control #2 exists to catch. `design.md` calls the guard mandatory on D2 person names without qualifying it to the fuzzy path. The guard now applies to every D2 person comparison.

**A guard failure was folded into Order 3's measured negative.** `any_person_link` was `exact or fuzzy`, so a 0.99 similarity failing only the guard collapsed to "no link" and produced `SUBCONTRACT` on a positive subaward. That inverts the spec's own distinction: a guard failure means the person is *unresolvable* (`NAME_GENERIC_TOKEN_GUARD_FAILED`), not "searched and found nothing." Typed absence must block a label, never advance one.

**`D4MoneyTrail` gave one `status` to both directions**, which `design.md` scores separately. A contract-instrument STTR (subaward side `NOT_APPLICABLE` / `NON_GRANT_INSTRUMENT`) suppressed an unrelated, genuinely measured Form D officer signal, returning `INDETERMINATE` instead of `SPINOUT_T2`. Split into `subaward_status` / `form_d_status` with their own absence reasons.

**The Order 2 D3 corroboration branch was unreachable.** `primary` is never `"D3"`, and the remaining condition is the Order 1 predicate that already returned `SPINOUT_T1`. Removed, with a comment recording why D3 cannot corroborate. The test that appeared to cover it built a `NOT_MEASURABLE` D3 and asserted `INDETERMINATE`; renamed to say what it actually tests.

Also: `similarity_cutoff` is validated to `(0.0, 1.0]` so a placeholder `0.0` can't promote a measured 0.0 similarity into a fuzzy positive (the parameter is defaultless precisely because O-3 defers the number, which makes a placeholder the likely slip); person-name normalization strips titles/post-nominals and no longer reorders on a credential-only comma (`"Jane Smith, PhD"` scored **0.838** against `"Jane Smith"`, below any sane cutoff); the org guard now matches multi-token legal suffixes like `"L.L.C."` that could never equal a whitespace-split token; and `identity_similarity` returns 0.0 across identity kinds.

**Deliberately not changed:** Order 2 still accepts `D4.form_d_officer_ri_affiliated` as a corroborator for a D2 fuzzy positive, even though O-1 scopes D2's founders to Form-D-derived names — so one name can satisfy both halves of the two-independent-signals rule. That originates in the now-frozen `design.md` (raised on #620); fixing it in code alone would make the implementation diverge from the frozen spec. It needs an amendment.

Relates to #623.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)

`D4MoneyTrail`'s field rename is a signature change, but the kernel is exploratory-tier, spec-local, and has no importers outside its own tests (verified by grep across the repo, including #627's task-1.3 substrate).

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

Eleven regression tests added, one per finding, including the two fixture updates that were silently relying on the guard bypass (`_measured_empty_d2` now sets `person_guard_passed=True`, since a measured-negative D2 means the person resolved).

```
uv run pytest tests/unit/sttr_spinout_linkage/   # 60 passed
uv run pytest tests/unit/                        # 6135 passed, 7 skipped
uv run ruff check . && uv run ruff format --check .   # clean
check_architecture_boundaries / check_tier_boundaries / check_epistemic_tiers / check_removed_src_references   # pass
```

`design.md` is untouched, so the Revision 1 freeze hash and #627's freeze-hash guard are unaffected.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_015ZeXLL2oC39ZT9KsqoZPqg)_