### PR TITLE
STTR spinout-linkage: D5 text-trail scorer + frozen v1 phrase lexicon (task 1.3 slice)

### DIFF
--- a/data/reference/sttr_spinout_linkage/d5_phrase_lexicon_v1.json
+++ b/data/reference/sttr_spinout_linkage/d5_phrase_lexicon_v1.json
@@ -1,0 +1,90 @@
+{
+  "lexicon_name": "d5_spinout_phrase_lexicon",
+  "version": "v1",
+  "frozen": "2026-08-15",
+  "purpose": "STTR spinout-linkage D5 text-trail dimension (specs/sttr-spinout-linkage/design.md#evidence-dimensions): a small, deterministic, hand-curated set of phrase patterns that plausibly describe a founding-or-licensing spinout relationship between an STTR small business (SBC) and its research-institution (RI) partner, as opposed to a generic partnership/collaboration mention.",
+  "resolution": "O-4 (specs/sttr-spinout-linkage/open-questions.md#o-4) resolved that a small hand-curated v1 lexicon ships, with the exact phrase list drafted and frozen at task 1.3 implementation time -- this file is that freeze. No ML text classifier; per O-4, that remains explicitly future work.",
+  "scope_note": "v1 searches only the D1 spine's award abstract field. design.md's D5 row also names 'firm text' as a source, but no firm-text field exists on the D1 spine this scorer consumes -- searching a source that is not actually present would misrepresent NOT_MEASURABLE rows as MEASURED. Extending to firm text (e.g. a company-website or SBIR.gov firm-profile corpus) is future work, not invented here.",
+  "matching_rules": "Case-insensitive, deterministic substring/regex matching only (re.IGNORECASE). No fuzzy matching, no stemming beyond the literal alternations spelled out per pattern, no ML/embedding similarity -- per O-4's explicit prohibition on ML matching in v1. A match on any single pattern sets spinout_phrase = True; the lexicon does not weight or count matches.",
+  "cascade_risk_note": "design.md's Order-2 cascade rule lets D5.spinout_phrase serve as one of the two dimensions whose positive signal can trigger SPINOUT_T2 (with independent corroboration required from a second, distinct dimension). A D5 false positive therefore has real downstream cost even though it alone can never assign a label. Every pattern below was chosen to require an explicit founding-, spin-out-, or licensing-specific verb/construction, not a bare relationship word (no 'partner', 'collaborate', 'work with', 'team with', 'support from') -- see 'deliberately_excluded' below.",
+  "patterns": [
+    {
+      "id": "spun_out",
+      "category": "spinout_verb",
+      "pattern": "\\bspun[\\s-]+(out|off)\\s+(of|from)\\b",
+      "examples_matched": ["spun out of MIT", "spun off from the university's lab"],
+      "rationale": "Direct illustrative phrase from design.md's D5 row ('spun out of'); unambiguous founding-event language, not a generic partnership verb."
+    },
+    {
+      "id": "spin_out_noun",
+      "category": "spinout_verb",
+      "pattern": "\\bspin[\\s-]?(out|off)\\s+(of|from)\\b",
+      "examples_matched": ["a spin-out of Stanford University", "spinoff from the RI's research program"],
+      "rationale": "Noun-form variant of spun_out ('spin-off of', 'spinout from') -- same founding-event specificity, common alternate spelling/hyphenation."
+    },
+    {
+      "id": "exclusive_license_from",
+      "category": "license",
+      "pattern": "\\bexclusive(?:ly)?\\s+licens(?:e|ed|ing)\\s+from\\b",
+      "examples_matched": ["holds an exclusive license from the university", "exclusively licensed from the research institution"],
+      "rationale": "Exclusivity is the specific marker: an exclusive license from a named institution is a real IP transfer, not a routine vendor/tool license. Deliberately narrower than design.md's bare illustrative 'licensed from' -- see deliberately_excluded."
+    },
+    {
+      "id": "licensed_technology_from",
+      "category": "license",
+      "pattern": "\\b(?:in-)?licens(?:e|ed)\\s+(?:the\\s+)?technology\\s+from\\b",
+      "examples_matched": ["licensed technology from the university", "in-licensed the technology from the lab"],
+      "rationale": "'technology' as the direct object anchors this to a core-IP license (design.md's 'licensed technology from' variant), not licensing an unrelated tool, dataset, or facility."
+    },
+    {
+      "id": "founded_by_title",
+      "category": "founded_by",
+      "pattern": "\\b(?:co-?)?founded\\s+by\\s+(?:a\\s+|an\\s+|the\\s+)?(?:professor|prof\\.?|dr\\.?|doctor)\\b",
+      "examples_matched": ["founded by Professor Jane Smith", "co-founded by Dr. Lee"],
+      "rationale": "Direct illustrative phrase from design.md's D5 row ('founded by Professor ...'); an academic title after 'founded by' is a strong, specific founding-relationship marker."
+    },
+    {
+      "id": "founded_by_role",
+      "category": "founded_by",
+      "pattern": "\\b(?:co-?)?founded\\s+by\\s+(?:a\\s+|an\\s+|the\\s+)?(?:\\w+\\s+){0,4}?(?:researcher|faculty member|scientist)\\b",
+      "examples_matched": ["founded by a researcher at the institute", "co-founded by a faculty member of the university"],
+      "rationale": "Covers the design.md 'co-founded by a [RI] researcher/faculty member' variant when no academic title word ('Professor'/'Dr.') is used but an academic role noun is; bounded word-gap (<=4 words) keeps the match tied to a single founding clause rather than matching across unrelated sentences."
+    },
+    {
+      "id": "based_on_research_at",
+      "category": "based_on",
+      "pattern": "\\bbased\\s+on\\s+(?:the\\s+)?research\\s+conducted\\s+at\\b",
+      "examples_matched": ["based on research conducted at the university"],
+      "rationale": "Direct illustrative phrase from design.md's D5 row; ties the SBC's core offering to research performed at a named institution, which is the founding-technology-origin signal, not a collaboration mention."
+    },
+    {
+      "id": "based_on_technology_at",
+      "category": "based_on",
+      "pattern": "\\bbased\\s+on\\s+(?:the\\s+)?technology\\s+developed\\s+at\\b",
+      "examples_matched": ["based on technology developed at the research institute"],
+      "rationale": "Direct illustrative phrase from design.md's D5 row; same rationale as based_on_research_at, technology-origin variant."
+    }
+  ],
+  "deliberately_excluded": [
+    {
+      "phrase_or_class": "bare \"licensed from\" (no 'exclusive' / 'technology' qualifier)",
+      "reason": "Too generic -- an abstract can say a firm 'licensed [a component/tool/dataset] from [a vendor]' with no spinout relationship at all. design.md lists 'licensed from' only as an illustrative example, not a frozen requirement; narrowing to exclusive_license_from and licensed_technology_from keeps precision high given D5's Order-2 cascade role."
+    },
+    {
+      "phrase_or_class": "bare \"founded by [Name]\" with no academic title or role noun",
+      "reason": "A founder name alone (no 'Professor'/'Dr.'/'researcher'/'faculty member') cannot be distinguished from a founder with no RI affiliation at all -- would require cross-referencing D2's person trail to mean anything, which is out of scope for a text-only D5 pattern and would double-count evidence D2 already scores independently."
+    },
+    {
+      "phrase_or_class": "\"partnership with\", \"collaboration with\", \"working with\", \"teaming with\", \"in collaboration with\", \"support from\"",
+      "reason": "Exactly the generic partnership/collaboration language the task brief calls out as the false-positive risk to avoid; every STTR abstract describes an SBC-RI collaboration by definition of the program, so these words carry no discriminating signal between SPINOUT and SUBCONTRACT."
+    },
+    {
+      "phrase_or_class": "\"subcontract\", \"subcontractor\", \"teaming agreement\"",
+      "reason": "These are SUBCONTRACT-direction words, not spinout words; including them in a spinout lexicon would be a category error, not merely a precision problem."
+    },
+    {
+      "phrase_or_class": "generic \"technology transfer\" / \"tech transfer office\"",
+      "reason": "Refers to the RI's institutional TTO function, present in many STTR abstracts regardless of whether this particular SBC is a spinout -- not evidence of a founding-or-licensing relationship for the specific award."
+    }
+  ]
+}

--- a/scripts/sttr_spinout_linkage/d5_scorer.py
+++ b/scripts/sttr_spinout_linkage/d5_scorer.py
@@ -1,0 +1,115 @@
+"""D5 text-trail scorer for the STTR spinout-linkage RQ1 cascade.
+
+Scores `kernel.D5TextTrail` for one award from a frozen, hand-curated v1
+phrase lexicon (`data/reference/sttr_spinout_linkage/d5_phrase_lexicon_v1.json`)
+searched over the award abstract -- the only text source the D1 spine
+(`d1_spine.load_d1_spine`) actually supplies. design.md's D5 row also names
+"firm text" as a source; no firm-text field exists on the D1 spine this
+scorer consumes, so searching one is not invented here (see the lexicon
+file's `scope_note`).
+
+Per O-4 (`specs/sttr-spinout-linkage/open-questions.md#o-4`): a small,
+frozen, hand-curated lexicon ships in v1; this module performs deterministic
+case-insensitive regex/substring matching only -- no fuzzy matching, no ML
+text classifier.
+
+What this module does NOT do: it does not assemble the cascade
+(`kernel.classify_linkage` takes the `D5TextTrail` this module returns as one
+of five caller-supplied inputs), and it does not write Parquet, Neo4j, or any
+`CANDIDATE` assertion -- scoring only.
+
+Epistemic tier: exploratory (`specs/sttr-spinout-linkage/tasks.md` header):
+no tests or abstractions beyond what a single probe needs, and no citable
+numbers from any hit-rate this module produces.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from sbir_etl.utils.coercion import _blank
+
+from .kernel import DimensionStatus, D5TextTrail, SignalAbsentReason
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").exists() and (candidate / "sbir_etl").exists():
+            return candidate
+    raise RuntimeError("Not inside the sbir-analytics checkout")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+
+DEFAULT_LEXICON_PATH = (
+    _REPO_ROOT / "data" / "reference" / "sttr_spinout_linkage" / "d5_phrase_lexicon_v1.json"
+)
+
+
+@dataclass(frozen=True)
+class D5Lexicon:
+    """A loaded, compiled D5 phrase lexicon."""
+
+    version: str
+    frozen: str
+    pattern_ids: tuple[str, ...]
+    compiled: tuple[re.Pattern[str], ...]
+
+
+def load_lexicon(path: Path = DEFAULT_LEXICON_PATH) -> D5Lexicon:
+    """Load and compile the D5 phrase lexicon from its frozen JSON file.
+
+    Raises `FileNotFoundError` if the lexicon file is missing rather than
+    silently scoring against an empty pattern set -- an empty lexicon would
+    make every award look like a measured negative instead of surfacing the
+    real problem (the frozen artifact is gone or misconfigured).
+    """
+
+    if not path.exists():
+        raise FileNotFoundError(f"D5 phrase lexicon not found at {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    patterns = data["patterns"]
+    return D5Lexicon(
+        version=data["version"],
+        frozen=data["frozen"],
+        pattern_ids=tuple(p["id"] for p in patterns),
+        compiled=tuple(re.compile(p["pattern"], re.IGNORECASE) for p in patterns),
+    )
+
+
+@lru_cache(maxsize=1)
+def _default_lexicon() -> D5Lexicon:
+    return load_lexicon()
+
+
+def score_d5_text_trail(
+    abstract: object,
+    *,
+    lexicon: D5Lexicon | None = None,
+) -> D5TextTrail:
+    """Score one award's D5 text trail from its abstract.
+
+    - Blank/missing abstract -> `NOT_MEASURABLE` /
+      `SOURCE_FIELD_UNAVAILABLE` (design.md's D5 "Typed absence encodes"
+      column: "no firm text available" -- the abstract is the only text
+      field actually present on the D1 spine, so its absence is this case).
+    - Non-blank abstract -> `MEASURED`, with `spinout_phrase` set to whether
+      any lexicon pattern matched (case-insensitive). A `MEASURED` row with
+      `spinout_phrase=False` is a real, searched negative -- the lexicon ran
+      and found nothing -- never conflated with the `NOT_MEASURABLE` case.
+    """
+
+    if _blank(abstract):
+        return D5TextTrail(
+            status=DimensionStatus.NOT_MEASURABLE,
+            reason=SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE,
+        )
+
+    active_lexicon = lexicon or _default_lexicon()
+    text = str(abstract)
+    matched = any(pattern.search(text) for pattern in active_lexicon.compiled)
+    return D5TextTrail(status=DimensionStatus.MEASURED, spinout_phrase=matched)

--- a/tests/unit/sttr_spinout_linkage/test_d5_scorer.py
+++ b/tests/unit/sttr_spinout_linkage/test_d5_scorer.py
@@ -1,0 +1,106 @@
+"""Probes for the D5 text-trail scorer and its frozen v1 phrase lexicon.
+
+Exploratory tier: covers phrase-matching correctness on realistic and edge
+cases (blank abstract, no match, exact match, case variation) and the
+`D5TextTrail` status/reason mapping -- not a comprehensive matrix over every
+lexicon pattern or every conceivable abstract phrasing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.sttr_spinout_linkage.d5_scorer import (
+    DEFAULT_LEXICON_PATH,
+    load_lexicon,
+    score_d5_text_trail,
+)
+from scripts.sttr_spinout_linkage.kernel import DimensionStatus, SignalAbsentReason
+
+
+pytestmark = pytest.mark.fast
+
+
+class TestLoadLexicon:
+    def test_loads_the_frozen_v1_lexicon_file(self) -> None:
+        lexicon = load_lexicon()
+        assert lexicon.version == "v1"
+        assert len(lexicon.pattern_ids) >= 5
+        assert len(lexicon.compiled) == len(lexicon.pattern_ids)
+
+    def test_raises_on_a_missing_lexicon_file(self, tmp_path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_lexicon(tmp_path / "does-not-exist.json")
+
+    def test_default_lexicon_path_exists(self) -> None:
+        assert DEFAULT_LEXICON_PATH.exists()
+
+
+class TestScoreD5TextTrail:
+    def test_blank_abstract_is_not_measurable_with_source_field_unavailable(self) -> None:
+        for blank in (None, "", "   ", float("nan")):
+            trail = score_d5_text_trail(blank)
+            assert trail.status is DimensionStatus.NOT_MEASURABLE
+            assert trail.reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE
+            assert trail.spinout_phrase is False
+
+    def test_abstract_with_no_lexicon_match_is_measured_negative(self) -> None:
+        abstract = (
+            "This Phase II project develops a novel widget for detecting "
+            "corrosion in aerospace structures using ultrasonic sensors."
+        )
+        trail = score_d5_text_trail(abstract)
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.spinout_phrase is False
+        assert trail.reason is None
+
+    def test_exact_phrase_match_is_measured_positive(self) -> None:
+        abstract = "The company was spun out of MIT's Media Lab in 2019."
+        trail = score_d5_text_trail(abstract)
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.spinout_phrase is True
+
+    def test_match_is_case_insensitive(self) -> None:
+        abstract = "The firm was SPUN OUT OF Stanford University."
+        trail = score_d5_text_trail(abstract)
+        assert trail.spinout_phrase is True
+
+    def test_founded_by_professor_title_matches(self) -> None:
+        abstract = "The startup was founded by Professor Jane Smith of UC Berkeley."
+        trail = score_d5_text_trail(abstract)
+        assert trail.spinout_phrase is True
+
+    def test_founded_by_bare_name_does_not_match(self) -> None:
+        """Deliberately excluded per the lexicon's `deliberately_excluded` list:
+        a founder name with no academic title or role noun is not distinguishable
+        from a non-RI-affiliated founder from text alone."""
+        abstract = "The company was founded by John Doe in 2015."
+        trail = score_d5_text_trail(abstract)
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.spinout_phrase is False
+
+    def test_exclusive_license_from_matches(self) -> None:
+        abstract = "The firm holds an exclusive license from the University of Texas."
+        trail = score_d5_text_trail(abstract)
+        assert trail.spinout_phrase is True
+
+    def test_bare_licensed_from_does_not_match(self) -> None:
+        """Deliberately excluded: too generic a phrase to be spinout-specific
+        (see the lexicon's `deliberately_excluded` list)."""
+        abstract = "The team licensed from a commercial vendor a standard software toolkit."
+        trail = score_d5_text_trail(abstract)
+        assert trail.spinout_phrase is False
+
+    def test_generic_partnership_language_does_not_match(self) -> None:
+        abstract = (
+            "This STTR project is conducted in partnership with and in collaboration "
+            "with the research institution, which provides technical support."
+        )
+        trail = score_d5_text_trail(abstract)
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.spinout_phrase is False
+
+    def test_based_on_technology_developed_at_matches(self) -> None:
+        abstract = "This product is based on technology developed at Carnegie Mellon University."
+        trail = score_d5_text_trail(abstract)
+        assert trail.spinout_phrase is True


### PR DESCRIPTION
## Summary

This is task 1.3's D5 slice for `specs/sttr-spinout-linkage/` (frozen Revision 1, see `amendments.md`). It resolves the *content* half of [O-4](specs/sttr-spinout-linkage/open-questions.md#o-4) (O-4 itself only resolved that a small hand-curated v1 lexicon ships; the exact phrase list was explicitly deferred to task 1.3) and implements the D5 scorer described in `design.md`'s [evidence-dimensions table](specs/sttr-spinout-linkage/design.md#evidence-dimensions).

**Branch note:** the task brief said to branch off `origin/claude/sttr-d1-spine-loader` and open this PR stacked on PR #627. By the time this ran, #627 had already merged into `main` (commit `085d124c`) and its branch was deleted, so this branches off `main` directly instead — same D1 substrate (`d1_spine.py`, `freeze_guard.py`, `kernel.py`), just not stacked.

### 1. The v1 phrase lexicon — `data/reference/sttr_spinout_linkage/d5_phrase_lexicon_v1.json`

8 deterministic, case-insensitive regex patterns across 5 categories, each with an inline `rationale` field:

| Category | Patterns | Example |
|---|---|---|
| `spinout_verb` | `spun out/off of/from`, `spin-out/spinoff of/from` | "spun out of MIT's Media Lab" |
| `license` | `exclusive(ly) license(d) from`, `licensed technology from` | "exclusive license from the University of Texas" |
| `founded_by` | `(co-)founded by Professor/Dr.`, `(co-)founded by ... researcher/faculty member` | "founded by Professor Jane Smith" |
| `based_on` | `based on research conducted at`, `based on technology developed at` | "based on technology developed at Carnegie Mellon" |

**Deliberately excluded** (documented in the JSON's `deliberately_excluded` array, with reasons):
- Bare `"licensed from"` (design.md's illustrative example, dropped) — too generic; an abstract can license a tool/dataset from a vendor with zero spinout relationship.
- Bare `"founded by [Name]"` with no academic title/role noun — can't be distinguished from a non-RI-affiliated founder from text alone.
- `"partnership with"`, `"collaboration with"`, `"working with"`, `"teaming with"` — every STTR abstract describes an SBC-RI collaboration by program definition, so these carry no discriminating signal.
- `"subcontract"`, `"teaming agreement"` — SUBCONTRACT-direction words, a category error in a spinout lexicon.
- Generic `"technology transfer"` / `"tech transfer office"` — describes the RI's institutional function, not this award's relationship.

This precision-over-recall choice is deliberate: `design.md`'s Order-2 cascade rule lets `D5.spinout_phrase` be one of two dimensions whose positive signal can trigger `SPINOUT_T2` (given independent corroboration from a second, distinct dimension), so a D5 false positive has real downstream cost even though D5 alone never assigns a label.

Frozen with `version: "v1"`, `frozen: "2026-08-15"` in the JSON itself, mirroring `seed-list-provenance.md`'s versioning discipline.

### 2. The scorer — `scripts/sttr_spinout_linkage/d5_scorer.py`

`score_d5_text_trail(abstract) -> D5TextTrail`:
- Blank/missing abstract → `DimensionStatus.NOT_MEASURABLE` / `SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE` — design.md's D5 "Typed absence encodes" column says "no firm text available"; the abstract is the *only* text field the D1 spine actually supplies, so its absence is exactly this case. No firm-text source is invented.
- Non-blank abstract → `DimensionStatus.MEASURED`, `spinout_phrase` set from whether any lexicon pattern matched (`re.IGNORECASE`, no fuzzy/ML matching, per O-4's explicit prohibition).

A `MEASURED` + `spinout_phrase=False` row means the lexicon was searched and found nothing — a real negative, never conflated with the `NOT_MEASURABLE` case.

### 3. Real hit-rate distribution over the D1 spine population

Ran `score_d5_text_trail` over every abstract from `d1_spine.load_d1_spine()` (real STTR Phase II award data, not synthetic):

```
Total STTR Phase II awards on D1 spine: 5,841
MEASURED + spinout_phrase=True:    8    (0.14%)
MEASURED + spinout_phrase=False: 5,642 (96.59%)
NOT_MEASURABLE (no abstract):      191  (3.27%)
```

Pattern breakdown of the 8 positives: `spin_out_noun` (5), `exclusive_license_from` (2), `founded_by_title` (1).

**Not citable.** This is an exploratory-tier, deterministic-lexicon hit-rate over abstract text — not a measured spinout rate, not run through the cascade, and not corroborated by any other dimension. It says nothing on its own about `SPINOUT_T1`/`SPINOUT_T2` incidence, which also needs D2-D4 plus the Order-2 corroboration rule.

## Scope boundaries (kept)

- No cascade assembly, no D2/D3/D4 scoring, no partner-type classification.
- No Neo4j, no `CANDIDATE`-assertion emission — plain `D5TextTrail` dataclass output only.
- `tasks.md`'s 1.3 checkbox is intentionally left unchecked — this is one slice of that task; D2-D4 scoring, the partner-type classifier, and cascade assembly are still open.

## Test plan

- [x] `uv run pytest tests/unit/sttr_spinout_linkage/test_d5_scorer.py -v` — 13 passed (blank abstract → `NOT_MEASURABLE`/`SOURCE_FIELD_UNAVAILABLE`, no-match → `MEASURED`/`False`, exact match → `MEASURED`/`True`, case-insensitivity, each deliberate-exclusion case)
- [x] `uv run pytest tests/unit/sttr_spinout_linkage/ -v` — 61 passed (full module regression, including kernel/d1_spine/freeze_guard)
- [x] `make lint` — ruff check, ruff format --check, mypy all pass
- [x] `make docs-check` — passes
- [x] `uv run python scripts/ci/check_epistemic_tiers.py` — passes
- [x] Ran the scorer over the real D1 spine population and reported the distribution above

🤖 Generated with [Claude Code](https://claude.com/claude-code)