### PR TITLE
Address #620/#623 review nits: O-8 L50, freeze hygiene, kernel polish

### DIFF
--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -1213,14 +1213,17 @@ spot-checked against publisher records):
 - **[L46]** Link, A.N. & Swann, C.A. (2024). "SBIR mills and the U.S. Department of Defense." *The Journal of Technology Transfer* 49(6), 2306–2335. Characterizes "SBIR mill" firms in DoD SBIR — the academic treatment of the multiple-award-firm problem behind the §638(qq)(3) performance standards [L14]. <https://doi.org/10.1007/s10961-024-10144-z>
 - **[L47]** Rovito, S.M., Kamp, J., & Etemadi, A.H. (2025). "Exploring Department of the Navy SBIR Phase III awards and corresponding public sector commercialization success factors." *The Journal of Technology Transfer* 50(4), 1363–1395. Navy Phase III awards and the firm attributes predicting public-sector commercialization; finds Phase III receipt only weakly predictive of commercialization success. Relevant to the Section B transition questions and the [`phase3-transition-groundtruth`](../specs/phase3-transition-groundtruth/) spec. <https://doi.org/10.1007/s10961-024-10141-2>
 - **[L48]** NASEM (2026). *Review of the SBIR and STTR Programs at NASA.* National Academies Press. Fills the NASA gap in the [L1]–[L8] agency-review block, which otherwise covers DoD, NIH, NSF, and DOE. <https://doi.org/10.17226/29381>
+- **[L50]** Bayh-Dole Act, 35 U.S.C. §§ 200–212 (Patent Rights in Inventions Made with Federal Assistance). Statutory anchor for university/nonprofit patent ownership of federally funded subject inventions and the government's retained license — the legal backdrop for D3's government-interest / confirmatory-license discussion in [`specs/sttr-spinout-linkage/`](../specs/sttr-spinout-linkage/) ([O-8](../specs/sttr-spinout-linkage/open-questions.md#o-8--bayh-dole--licensing-literature-anchor)). Citation only; it does not itself provide a public license registry ([O-12](../specs/sttr-spinout-linkage/open-questions.md#o-12--bayh-dole-government-interest-statement-data-source)). <https://www.govinfo.gov/content/pkg/USCODE-2023-title35/html/USCODE-2023-title35-partII-chap18.htm>
 
 ---
 
 ## Maintenance
 
-**Last reviewed:** 2026-08-11. The 2026-08 citation audit added [L34]–[L48] from
-the 2019–2026 literature map and pinned [L1] to its published DOI. Git history
-preserves earlier editorial and section-consolidation notes.
+**Last reviewed:** 2026-08-15. The 2026-08 citation audit added [L34]–[L48] from
+the 2019–2026 literature map and pinned [L1] to its published DOI. [L50] added
+for the Bayh-Dole statutory anchor (O-8); [L49] remains reserved for the
+unverified Jones & Fearon deposit below. Git history preserves earlier editorial
+and section-consolidation notes.
 
 Open source-verification items:
 

--- a/scripts/sttr_spinout_linkage/freeze_guard.py
+++ b/scripts/sttr_spinout_linkage/freeze_guard.py
@@ -1,11 +1,16 @@
-"""Freeze-hash guard for the STTR spinout-linkage design (Revision 1).
+"""Freeze-hash guard for the STTR spinout-linkage design.
 
-`specs/sttr-spinout-linkage/amendments.md`'s Revision 1 entry freezes
-`specs/sttr-spinout-linkage/design.md` at its raw-byte SHA-256 and requires
+`specs/sttr-spinout-linkage/amendments.md` freezes
+`specs/sttr-spinout-linkage/design.md` at a raw-byte SHA-256 and requires
 "a materializing asset [to] recompute this hash against the working copy
 before running and fail closed on any mismatch" -- including a mismatch
 caused by a well-intentioned edit to `design.md` that was never recorded as a
 further amendment. `verify_design_frozen` is that check.
+
+Revision 1 is the freeze-authorization record. Later numbered revisions may
+refresh the working-copy digest (doc hygiene, non-criteria wording) without
+thawing the cascade; the guard always checks against the **latest** digest
+recorded in `amendments.md`.
 
 Call it first, before touching any frozen criterion -- the cascade order, the
 D1-D5 evidence-dimension table, the similarity method, the partner-type
@@ -29,8 +34,8 @@ from pathlib import Path
 
 
 class DesignNotFrozenError(RuntimeError):
-    """`design.md`'s working-copy bytes no longer match the Revision 1 freeze
-    recorded in `amendments.md`."""
+    """`design.md`'s working-copy bytes no longer match the latest freeze
+    digest recorded in `amendments.md`."""
 
 
 def _find_repo_root(start: Path) -> Path:
@@ -42,18 +47,18 @@ def _find_repo_root(start: Path) -> Path:
 
 _REPO_ROOT = _find_repo_root(Path(__file__).resolve())
 DESIGN_PATH = _REPO_ROOT / "specs" / "sttr-spinout-linkage" / "design.md"
+AMENDMENTS_PATH = DESIGN_PATH.parent / "amendments.md"
 
-# specs/sttr-spinout-linkage/amendments.md, "## Revision 1 -- FREEZE", the
-# "Frozen file" bullet: raw-byte SHA-256 of design.md at freeze time
-# (2026-08-14). Do not hand-edit this constant on a design.md change --
+# Latest design.md digest recorded in amendments.md (Revision 2 as of
+# 2026-08-15). Do not hand-edit this constant on a design.md change --
 # amendments.md's append-only rule requires a new numbered revision first;
 # update both together. `test_freeze_guard.py` asserts this constant still
-# matches what is parseable out of amendments.md.
-FROZEN_DESIGN_SHA256 = "52d8b531d56f3b91e1d3b0946e1ac91dd6f5dfeab371e3d48f87dc5e6095ac49"
+# matches the latest SHA-256 parseable out of amendments.md.
+FROZEN_DESIGN_SHA256 = "8e754731f0d0841e5f48c425e269bc9db59191e761bcd8df7292032f9f78ff07"
 
 
 def verify_design_frozen(design_path: Path = DESIGN_PATH) -> str:
-    """Fail closed unless `design_path`'s raw bytes match the Revision 1 freeze.
+    """Fail closed unless `design_path`'s raw bytes match the latest freeze digest.
 
     Returns the verified SHA-256 hex digest on success.
     """
@@ -67,7 +72,7 @@ def verify_design_frozen(design_path: Path = DESIGN_PATH) -> str:
     actual = hashlib.sha256(content).hexdigest()
     if actual != FROZEN_DESIGN_SHA256:
         raise DesignNotFrozenError(
-            f"design.md has drifted from the Revision 1 freeze recorded in "
+            f"design.md has drifted from the freeze recorded in "
             f"amendments.md: expected SHA-256 {FROZEN_DESIGN_SHA256}, found {actual}. "
             "Record a new numbered amendment in amendments.md before proceeding."
         )

--- a/scripts/sttr_spinout_linkage/kernel.py
+++ b/scripts/sttr_spinout_linkage/kernel.py
@@ -159,7 +159,10 @@ def _normalize_person_name(value: str) -> tuple[str, tuple[str, ...]]:
     Case-folds, strips diacritics and punctuation other than hyphens/
     apostrophes within a name, and reorders an explicit "Family, Given" input
     to given-then-family order so a trailing-token family-name assumption
-    holds consistently downstream.
+    holds consistently downstream. Titles and generational suffixes from
+    ``GENERIC_PERSON_TOKENS`` are stripped from the token list before the
+    given/family split so ``"Dr. Jane Smith"`` yields given ``jane`` /
+    family ``smith``, not ``dr jane`` / ``smith``.
     """
 
     text = unicodedata.normalize("NFKD", str(value).strip().lower())
@@ -168,7 +171,11 @@ def _normalize_person_name(value: str) -> tuple[str, tuple[str, ...]]:
         family_part, _, given_part = text.partition(",")
         text = f"{given_part.strip()} {family_part.strip()}"
     text = re.sub(r"[^a-z\s'-]", " ", text)
-    tokens = tuple(token for token in text.split() if token)
+    tokens = tuple(
+        token
+        for token in text.split()
+        if token and token not in GENERIC_PERSON_TOKENS
+    )
     return " ".join(tokens), tokens
 
 
@@ -444,6 +451,12 @@ def classify_linkage(
         )
 
     # Order 2: a fuzzy positive corroborated by a second, distinct dimension.
+    # Live corroboration paths are D4 Form-D officer affiliation and D5 phrase
+    # (when D5 is not itself the primary). The frozen table also lists D3 as a
+    # corroborator, but any measured D3 IP hit already returns SPINOUT_T1 at
+    # Order 1 above -- so the D3 branch below is structurally unreachable for a
+    # positive IP signal. Kept for table fidelity; task 1.3 should not build
+    # separate "weak D3" scoring just to feed it.
     d2_fuzzy_positive = d2.status is DimensionStatus.MEASURED and fuzzy_person
     d5_positive = d5.status is DimensionStatus.MEASURED and d5.spinout_phrase
     if d2_fuzzy_positive or d5_positive:

--- a/specs/sttr-spinout-linkage/amendments.md
+++ b/specs/sttr-spinout-linkage/amendments.md
@@ -143,3 +143,21 @@ requires its own numbered amendment here, per the append-only rule above.
 - **Visibility at approval:** Same as Revision 0. **No classification result, incidence count,
   coverage count, negative-control result, or adjudication result had been computed or seen at the
   time of this freeze.**
+
+## Revision 2 — Doc-hygiene follow-up to Revision 1 (O-8 citation + stale freeze wording)
+
+- **Authority:** 2026-08-15 — address review nits on the Revision 1 freeze PR (#620) after merge.
+- **Reason:** Revision 1 resolved O-8 as "add `[L50]`" but left `design.md` still saying the
+  Bayh-Dole anchor was missing, and left the cascade-table header saying "pending threshold
+  decisions" after the method freeze. No classification criterion changed.
+- **Criteria impact:** None. Cascade Order 0–4 predicates, D1–D5 sourcing, similarity method,
+  partner-type precedence, and D2 scope/window are unchanged. `design.md` now cites
+  [L50](../../docs/research-questions.md) for 35 U.S.C. §§ 200–212 and the cascade-table header
+  clarifies that only the O-3 *numeric* cutoff remains deferred. Companion non-frozen docs
+  (`tasks.md` status header, `coverage-memo.md` O-12 second-pass language,
+  `docs/research-questions.md` `[L50]` entry) updated in the same change.
+- **Frozen file:** `design.md`, raw-byte **SHA-256:**
+  `8e754731f0d0841e5f48c425e269bc9db59191e761bcd8df7292032f9f78ff07`. Supersedes the Revision 1
+  digest for guard purposes; Revision 1 remains the freeze-authorization record.
+- **Freeze status:** Still **FROZEN** (this is a documented working-copy refresh, not a thaw).
+- **Visibility at authoring:** **No classification result had been computed or seen.**

--- a/specs/sttr-spinout-linkage/coverage-memo.md
+++ b/specs/sttr-spinout-linkage/coverage-memo.md
@@ -14,7 +14,7 @@ for a typical STTR award at that agency.
 |-----------|-----|-----|-----|-------------|-------|
 | **D1** Award spine | High | High | High | High | SBIR.gov carries SBC, RI, PI, agency, FY, abstract for STTR rows. |
 | **D2** Person trail (OpenAlex/PubMed/ORCID) | High | High | **Low** | Medium | Biomedical/academic authorship is densely indexed; DoD PIs are under-indexed and abstracts are terse. |
-| **D3** IP trail (USPTO assignment; Bayh-Dole) | Medium | Medium | Medium | Medium | Patent assignment coverage is real but uneven; **license records are sparse everywhere, and no public Bayh-Dole government-interest source was found to supply them at all** ([O-12](open-questions.md) — iEdison is account-gated, PatentsView/ODP's government-interest field captures funding agency/contract number rather than licensee) (encoded as typed absence, never subcontract evidence). |
+| **D3** IP trail (USPTO assignment; Bayh-Dole) | Medium | Medium | Medium | Medium | Patent assignment coverage is real but uneven; **license records are sparse everywhere, and no public or paid source directly supplies a named RI→SBC license** ([O-12](open-questions.md), two research passes — iEdison confidential; PatentsView/`convey_text` `"confirmatory license"` = federal-funding nexus only; AUTM STATT/TransACT wrong grain; SEC EDGAR EFTS is a population-partial corroborator) (encoded as typed absence, never subcontract evidence). |
 | **D4** Money trail (USASpending subaward; Form D) | High (grant) | High (grant) | **N/A→Low** (contract) | Mixed | STTR at NIH/NSF is grant-instrument (subaward share observable); much of DoD STTR is contract-instrument, so the RI subaward share is `NOT_APPLICABLE`. Form D officer/director match is instrument-independent but low base rate. |
 | **D5** Text trail (phrase lexicon) | Medium | Medium | **Low** | Medium | Tracks abstract richness. Consistent with the repository's finding that DoD descriptions are frequently near-empty. |
 
@@ -29,10 +29,12 @@ for a typical STTR award at that agency.
   no subaward record fall to `INDETERMINATE`, not `SUBCONTRACT`, by construction.
 - **License sparsity is systemic, not agency-specific.** D3 will identify spinouts primarily through
   patent assignment (RI assignee + SBC-principal inventor), not through recorded licenses. Per
-  [O-12](open-questions.md), this is closer to a **structural ceiling** than a coverage gap: no
-  public source directly supplies a Bayh-Dole government-interest statement or an RI→SBC license
-  record; the only concrete proxy is a free-text search over the local USPTO assignment
-  `convey_text` field, which is unvalidated and expected to undercount.
+  [O-12](open-questions.md) (accepted after two research passes), this is closer to a **structural
+  ceiling** than a coverage gap: no public *or paid* source directly supplies a Bayh-Dole
+  government-interest statement or an RI→SBC license record. The sharper v1 proxies — local USPTO
+  `convey_text` `"confirmatory license"` (contractor→government, not RI→SBC) plus optional SEC
+  EDGAR full-text search over later SEC filers — are unvalidated, population-partial, and expected
+  to undercount.
 
 ## Partner-type incidence readout — table shape
 

--- a/specs/sttr-spinout-linkage/design.md
+++ b/specs/sttr-spinout-linkage/design.md
@@ -78,11 +78,10 @@ The `[L#]` labels are the literature-map labels already used by
 - [Rovito, Kamp & Etemadi 2025 [L47]](../../docs/research-questions.md) find Phase III receipt
   only weakly predictive of commercialization success — a required honesty input for RQ2.
 
-**Missing anchor, do not invent:** the literature map carries **no Bayh-Dole statutory citation**
-and no dedicated licensing citation. D3 relies on Bayh-Dole government-interest statements, so a
-new statutory/legal anchor is needed. This design does **not** assign an `[L#]`; adding one is
-[open question O-8](open-questions.md). Do **not** take `[L49]` (conditionally reserved
-for an unverified Jones & Fearon deposit); the next unreserved slot is `[L50]`.
+**Bayh-Dole statutory anchor:** [35 U.S.C. §§ 200–212 [L50]](../../docs/research-questions.md)
+([O-8](open-questions.md), resolved). This is the literature citation only — it does not supply a
+public government-interest or RI→SBC license data source ([O-12](open-questions.md)). Do **not**
+take `[L49]` (conditionally reserved for an unverified Jones & Fearon deposit).
 
 ---
 
@@ -134,7 +133,7 @@ frozen by [O-3](open-questions.md) (`company_name_similarity` under `CompanyName
 gated by `generic_token_guard`); the **numeric cutoff** is explicitly deferred to a post-task-1.4
 amendment, not a Revision 1 blocker — `SPINOUT_T2` scoring cannot run until that amendment lands.
 
-| Order | Label | Exact condition (frozen predicate, pending threshold decisions) |
+| Order | Label | Exact condition (frozen predicate; O-3 numeric cutoff still deferred) |
 |-------|-------|------------------------------------------------------------------|
 | 0 | `INDETERMINATE` | `D1` incomplete: RI or PI absent on the spine → cannot classify. |
 | 1 | `SPINOUT_T1` | `D2.status == MEASURED and D2.exact_person_ri_affiliation` **OR** `D3.status == MEASURED and (D3.patent_assigned_to_RI_with_SBC_inventor or D3.recorded_license_RI_to_SBC)`. One **exact** person or IP link with affiliation evidence. |

--- a/specs/sttr-spinout-linkage/tasks.md
+++ b/specs/sttr-spinout-linkage/tasks.md
@@ -2,10 +2,10 @@
 
 **Target epistemic tier:** `exploratory`
 
-**Status:** Phase 0 design. Implementation is **not authorized** until the owner
-resolves [`open-questions.md`](open-questions.md) and Revision 1 freezes the
-criteria in [`amendments.md`](amendments.md). Exploratory-tier work: no tests or
-abstractions beyond what a single probe needs, and no citable numbers.
+**Status:** Phase 0 frozen as Revision 1; Phase 1 implementation is underway
+(exploratory-tier). Open questions are resolved in [`open-questions.md`](open-questions.md);
+criteria live in [`amendments.md`](amendments.md). No tests or abstractions beyond what a
+single probe needs, and no citable numbers until the task 1.4 gates pass.
 
 ## Phase 0 — Design (this spec)
 
@@ -43,9 +43,9 @@ abstractions beyond what a single probe needs, and no citable numbers.
     statement, and that no classification result had been seen
   - Requirements: freeze gate
 
-## Phase 1 — Implementation (blocked on 0.6)
+## Phase 1 — Implementation (unblocked; Revision 1 frozen)
 
-Do not start these tasks before Revision 1. Build at `exploratory` tier: no
+Do not silently promote past `exploratory`. Build at `exploratory` tier: no
 silent promotion, no research question marked answerable, no new causal graph
 edges.
 

--- a/tests/unit/sttr_spinout_linkage/test_freeze_guard.py
+++ b/tests/unit/sttr_spinout_linkage/test_freeze_guard.py
@@ -1,10 +1,8 @@
-"""Probes for the Revision-1 freeze-hash guard.
+"""Probes for the STTR spinout-linkage freeze-hash guard.
 
-Exploratory tier: covers the guard's pass/fail behavior only, matching task
-1.2's kernel-test scope ("no tests or abstractions beyond what a single
-probe needs"). The fail-closed case runs against a modified copy of
-`design.md`, not the real file, so this test does not itself depend on
-`design.md` never changing.
+Exploratory tier: covers the guard's pass/fail behavior only. The fail-closed
+case runs against a modified copy of `design.md`, not the real file, so this
+test does not itself depend on `design.md` never changing.
 """
 
 from __future__ import annotations
@@ -27,14 +25,13 @@ pytestmark = pytest.mark.fast
 AMENDMENTS_PATH = DESIGN_PATH.parent / "amendments.md"
 
 
-def test_frozen_hash_constant_matches_the_hash_recorded_in_amendments_md() -> None:
-    """`FROZEN_DESIGN_SHA256` must not drift from amendments.md's Revision 1 entry."""
+def test_frozen_hash_constant_matches_the_latest_hash_in_amendments_md() -> None:
+    """`FROZEN_DESIGN_SHA256` must match the latest design.md digest in amendments.md."""
 
     text = AMENDMENTS_PATH.read_text(encoding="utf-8")
-    revision_1 = text.split("## Revision 1", 1)[1]
-    match = re.search(r"SHA-256:\*\*\s*`([0-9a-f]{64})`", revision_1)
-    assert match is not None, "Could not find a SHA-256 hash in amendments.md's Revision 1 entry"
-    assert match.group(1) == FROZEN_DESIGN_SHA256
+    matches = re.findall(r"SHA-256:\*\*\s*`([0-9a-f]{64})`", text)
+    assert matches, "Could not find any SHA-256 hash in amendments.md"
+    assert matches[-1] == FROZEN_DESIGN_SHA256
 
 
 def test_verify_design_frozen_passes_on_the_current_frozen_design_md() -> None:
@@ -46,7 +43,7 @@ def test_verify_design_frozen_fails_closed_on_a_modified_copy(tmp_path: Path) ->
     original = DESIGN_PATH.read_text(encoding="utf-8")
     modified.write_text(original + "\nunreviewed drift\n", encoding="utf-8")
 
-    with pytest.raises(DesignNotFrozenError, match="drifted from the Revision 1 freeze"):
+    with pytest.raises(DesignNotFrozenError, match="drifted from the freeze"):
         verify_design_frozen(modified)
 
 

--- a/tests/unit/sttr_spinout_linkage/test_kernel.py
+++ b/tests/unit/sttr_spinout_linkage/test_kernel.py
@@ -105,6 +105,14 @@ class TestResolveIdentity:
         assert identity.given_name == "jane"
         assert identity.family_name == "smith"
 
+    def test_person_name_strips_titles_before_given_family_split(self):
+        identity = resolve_identity("Dr. Jane Smith", kind=IdentityKind.PERSON)
+        assert identity is not None
+        assert identity.given_name == "jane"
+        assert identity.family_name == "smith"
+        assert identity.normalized == "jane smith"
+        assert identity.guard_passed is True
+
     def test_person_name_guard_fails_on_title_and_suffix_only(self):
         identity = resolve_identity("Dr. Jr.", kind=IdentityKind.PERSON)
         assert identity is not None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the review comments posted on merged [#620](https://github.com/hollomancer/sbir-analytics/pull/620) and [#623](https://github.com/hollomancer/sbir-analytics/pull/623).

### From #620
- Add Bayh-Dole `[L50]` (35 U.S.C. §§ 200–212) to `docs/research-questions.md` (O-8 was resolved but not applied).
- Refresh `design.md` wording that still claimed the Bayh-Dole anchor was missing / thresholds “pending”; record as **Revision 2** with a new freeze digest and update `freeze_guard.py` to the latest digest.
- Update `tasks.md` status (Phase 1 unblocked) and `coverage-memo.md` for the O-12 second-pass findings.

### From #623
- Strip person-name titles/suffixes before the given/family split (`Dr. Jane Smith` → `jane` / `smith`).
- Document that Order-2 D3 corroboration is unreachable (Order 1 already catches measured D3 IP hits). Task 1.2 was already checked off in #626.

Companion nits on open [#621](https://github.com/hollomancer/sbir-analytics/pull/621) / [#622](https://github.com/hollomancer/sbir-analytics/pull/622) were pushed directly onto those PR branches.

## Testing
- `uv run pytest tests/unit/sttr_spinout_linkage/test_freeze_guard.py tests/unit/sttr_spinout_linkage/test_kernel.py` — 42 passed
- `check_removed_src_references` / `check_epistemic_tiers` — passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0055a-20fb-768e-82dd-bd2a4855079a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0055a-20fb-768e-82dd-bd2a4855079a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

