### PR TITLE
Add D2 person-trail scorer for STTR spinout-linkage (task 1.3 D2 slice)

### DIFF
--- a/scripts/sttr_spinout_linkage/d2_person_scorer.py
+++ b/scripts/sttr_spinout_linkage/d2_person_scorer.py
@@ -1,0 +1,359 @@
+"""D2 person-trail scorer for the STTR spinout-linkage RQ1 cascade (task 1.3).
+
+Scores `kernel.D2PersonTrail` for one award: PI plus Form-D-derived founder
+names, matched against OpenAlex / PubMed / ORCID authorship affiliations for
+the award's RI. Composes `kernel.resolve_identity` / `identity_similarity` /
+`generic_token_guard` and the existing `Sync{OpenAlex,PubMed,ORCID}Client`
+``.lookup(name)`` facades (`sbir_etl/enrichers/sync_wrappers.py`) -- no
+forked identity or API-calling logic, and no second rate-limit/retry layer
+(the clients' own `RateLimiter`/`BaseAsyncAPIClient` retry already covers
+that).
+
+**Scope (O-1, resolved).** D2 covers the PI plus founders, where "founders"
+means officer/director names already surfaced by a *high-confidence* Form-D
+company match in `data/form_d_details.jsonl` -- no new founder-discovery
+pipeline. `founder_names_for_company` implements this join, reusing the exact
+`CompanyNameProfile.FORM_D_JOIN_V1` name-key pattern already used in
+`notebooks/explorations/b1_sttr_partner_type_commercialization.ipynb`'s
+`join-channels` cell (Form D carries no UEI, so the join is name-key only,
+same as that cell). An award whose firm has no Form-D match falls back to
+PI-only D2 matching, per O-1.
+
+**±5-year window (O-2, resolved) -- known limitation.** Design.md's D2 row
+requires RI-affiliated authorship within ±5 years of the award date to
+count. `OpenAlexRecord` / `PubMedRecord` / `ORCIDRecord` -- the dataclasses
+`SyncOpenAlexClient.lookup` / `SyncPubMedClient.lookup` /
+`SyncORCIDClient.lookup` return -- carry an `affiliations: list[str]`
+snapshot with no per-affiliation dates (OpenAlex's raw API *does* carry a
+``years`` list per affiliation, and ORCID's raw employment summaries carry
+start/end dates, but extracting them means reading the raw profile dict
+below the `.lookup()` facade the task brief specifies, which starts to
+duplicate the clients' own parsing). This scorer therefore accepts
+`award_year` / `window_years` so the window is declared and threaded through
+the call, but does **not** mechanically filter affiliation matches by year
+in v1 -- `exact_person_ri_affiliation` and `person_similarity` are affiliation
+-list-membership checks, not date-windowed ones. This is a real, flagged gap
+(specs/sttr-spinout-linkage/design.md's D2 row), not silently assumed away;
+follow-on work can extend the client parsing or add a dedicated
+years-aware lookup to close it.
+
+Epistemic tier: exploratory (`specs/sttr-spinout-linkage/tasks.md`, task
+1.3's D2 slice). No dimension score from this module is citable.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from loguru import logger
+
+from sbir_etl.exceptions import APIError
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+from sbir_etl.utils.coercion import _blank
+
+from .kernel import (
+    D2PersonTrail,
+    DimensionStatus,
+    IdentityKind,
+    ResolvedIdentity,
+    SignalAbsentReason,
+    identity_similarity,
+    resolve_identity,
+)
+
+
+EPISTEMIC_TIER = "exploratory"
+
+DEFAULT_WINDOW_YEARS = 5
+
+_OFFICER_DIRECTOR_TITLE_RE = re.compile(r"director|officer", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Form-D founder-name join (O-1: officer/director names only, no new
+# discovery pipeline)
+# ---------------------------------------------------------------------------
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start, *start.parents):
+        if (candidate / "pyproject.toml").exists() and (candidate / "sbir_etl").exists():
+            return candidate
+    raise RuntimeError("Not inside the sbir-analytics checkout")
+
+
+_REPO_ROOT = _find_repo_root(Path(__file__).resolve())
+DEFAULT_FORM_D_PATH = _REPO_ROOT / "data" / "form_d_details.jsonl"
+
+
+def load_form_d_founder_index(
+    path: Path | None = None,
+    *,
+    min_confidence_tier: str | None = "high",
+) -> dict[str, list[str]]:
+    """Load `data/form_d_details.jsonl` into `{FORM_D_JOIN_V1 firm key: officer/director names}`.
+
+    Same file, same `keep=lambda rec: match_confidence.tier == "high"` filter, and same
+    `CompanyNameProfile.FORM_D_JOIN_V1` name key as
+    `notebooks/explorations/b1_sttr_partner_type_commercialization.ipynb`'s `join-channels`
+    cell's `load_jsonl_names` -- Form D carries no UEI, so name-key is the only join key,
+    matching that precedent exactly. `min_confidence_tier=None` disables the tier filter.
+
+    A missing file returns an empty index (channel not searched), matching that same
+    notebook's missingness discipline -- never raises, never fabricates founder names.
+    Officer/director names come from each `offerings[].related_persons[]` entry whose
+    `title` contains "director" or "officer" (case-insensitive); other roles (e.g. plain
+    "Promoter") are excluded.
+    """
+
+    if path is None:
+        path = DEFAULT_FORM_D_PATH
+    index: dict[str, set[str]] = defaultdict(set)
+    if not path.exists():
+        logger.warning("Form D details file not found at {} -- founder names not searched", path)
+        return {}
+
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            tier = (record.get("match_confidence") or {}).get("tier")
+            if min_confidence_tier is not None and tier != min_confidence_tier:
+                continue
+            key = normalize_company_name(
+                record.get("company_name"), profile=CompanyNameProfile.FORM_D_JOIN_V1
+            )
+            if not key:
+                continue
+            for offering in record.get("offerings") or []:
+                for person in offering.get("related_persons") or []:
+                    name = person.get("name")
+                    title = str(person.get("title") or "")
+                    if name and _OFFICER_DIRECTOR_TITLE_RE.search(title):
+                        index[key].add(name)
+
+    return {key: sorted(names) for key, names in index.items()}
+
+
+def founder_names_for_company(
+    company_name: object, form_d_index: dict[str, list[str]]
+) -> list[str]:
+    """Look up Form-D-derived officer/director names for one award's company name.
+
+    Returns `[]` (not an error) when the company has no Form-D match, no name at all, or
+    `form_d_index` is empty (file absent) -- D2 falls back to PI-only matching per O-1.
+    """
+
+    if _blank(company_name):
+        return []
+    key = normalize_company_name(company_name, profile=CompanyNameProfile.FORM_D_JOIN_V1)
+    return form_d_index.get(key, [])
+
+
+# ---------------------------------------------------------------------------
+# D2 person-trail scoring
+# ---------------------------------------------------------------------------
+
+
+class PersonLookupClient(Protocol):
+    """Structural type for the three `Sync*Client.lookup(name)` facades this scorer calls.
+
+    Satisfied by `SyncOpenAlexClient`, `SyncPubMedClient`, `SyncORCIDClient`
+    (`sbir_etl/enrichers/sync_wrappers.py`) without importing them here, so unit tests can
+    inject a bare fake implementing only `.lookup`.
+    """
+
+    def lookup(self, name: str) -> object | None: ...
+
+
+def _record_author_name(record: object) -> str | None:
+    """Extract the API record's own author-name string, whichever dataclass it is.
+
+    `OpenAlexRecord.display_name`, `PubMedRecord.author_name`, or
+    `ORCIDRecord.given_name`/`family_name` -- the three `lookup()` return types named in
+    the task brief. Duck-typed via `getattr` so this module does not import the enricher
+    dataclasses (no new coupling beyond the `.lookup()` call itself).
+    """
+
+    display_name = getattr(record, "display_name", None)
+    if display_name:
+        return str(display_name)
+    author_name = getattr(record, "author_name", None)
+    if author_name:
+        return str(author_name)
+    family_name = getattr(record, "family_name", None)
+    if family_name:
+        given_name = getattr(record, "given_name", None) or ""
+        return f"{given_name} {family_name}".strip()
+    return None
+
+
+@dataclass(frozen=True)
+class _SourceHit:
+    """One candidate-name x source-client query outcome, already RI-scoped.
+
+    `ri_affiliation_hit=False` means the record's affiliations did not contain the award's
+    RI at all -- this hit contributes nothing to either the exact or fuzzy path. Both
+    `exact_identity` and `similarity` are only meaningful when `ri_affiliation_hit=True`,
+    matching `D2PersonTrail.person_similarity`'s kernel-level contract ("the raw
+    `identity_similarity` score between the best-candidate person name and an
+    RI-affiliated authorship name" -- the fuzziness is about the *name* match, not
+    the affiliation, which is exact per O-3).
+    """
+
+    ri_affiliation_hit: bool
+    exact_identity: bool
+    similarity: float | None
+    author_guard_passed: bool
+
+
+def _score_one_source(
+    candidate: ResolvedIdentity,
+    ri_identity: ResolvedIdentity,
+    client: PersonLookupClient,
+) -> _SourceHit | None:
+    """Query one source for one candidate name; `None` means no usable record came back."""
+
+    try:
+        record = client.lookup(candidate.raw)
+    except APIError as exc:
+        logger.warning("D2 lookup failed for {!r}: {}", candidate.raw, exc)
+        return None
+    if record is None:
+        return None
+
+    author_name = _record_author_name(record)
+    author_identity = resolve_identity(author_name, kind=IdentityKind.PERSON)
+    if author_identity is None:
+        return None
+
+    affiliations: Iterable[str] = getattr(record, "affiliations", None) or []
+    ri_affiliation_hit = any(
+        resolved is not None
+        and resolved.guard_passed
+        and resolved.normalized == ri_identity.normalized
+        for resolved in (
+            resolve_identity(affiliation, kind=IdentityKind.ORGANIZATION)
+            for affiliation in affiliations
+        )
+    )
+    if not ri_affiliation_hit:
+        return _SourceHit(
+            ri_affiliation_hit=False,
+            exact_identity=False,
+            similarity=None,
+            author_guard_passed=author_identity.guard_passed,
+        )
+
+    exact_identity = (
+        author_identity.guard_passed and author_identity.normalized == candidate.normalized
+    )
+    similarity = identity_similarity(candidate, author_identity)
+    return _SourceHit(
+        ri_affiliation_hit=True,
+        exact_identity=exact_identity,
+        similarity=similarity,
+        author_guard_passed=author_identity.guard_passed,
+    )
+
+
+def score_d2_person_trail(
+    *,
+    pi_name: object,
+    founder_names: Sequence[str] = (),
+    ri_name: object,
+    award_year: int | None = None,
+    window_years: int = DEFAULT_WINDOW_YEARS,
+    openalex: PersonLookupClient | None = None,
+    pubmed: PersonLookupClient | None = None,
+    orcid: PersonLookupClient | None = None,
+) -> D2PersonTrail:
+    """Score D2 for one award: PI + Form-D founders against OpenAlex/PubMed/ORCID.
+
+    `award_year` / `window_years` are accepted and threaded through (module docstring's
+    "±5-year window -- known limitation": not mechanically enforced in v1, since
+    `.lookup()`'s `affiliations: list[str]` carries no per-affiliation dates).
+
+    A `None` source client means that source was not queried this call (the caller's
+    batch-rate-limit/skip decision) -- if **all three** are `None`, the whole trail is
+    `NOT_EVALUATED`/`SOURCE_NOT_QUERIED`, never presented as a negative. At least one
+    configured source with no hits is a real `MEASURED` negative.
+    """
+
+    del award_year, window_years  # declared, not enforced -- see module docstring
+
+    candidate_names = [name for name in (pi_name, *founder_names) if not _blank(name)]
+    if not candidate_names:
+        return D2PersonTrail(
+            status=DimensionStatus.NOT_MEASURABLE,
+            reason=SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE,
+        )
+
+    ri_identity = resolve_identity(ri_name, kind=IdentityKind.ORGANIZATION)
+    if ri_identity is None or not ri_identity.guard_passed:
+        return D2PersonTrail(
+            status=DimensionStatus.NOT_MEASURABLE,
+            reason=SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE,
+        )
+
+    candidates: list[ResolvedIdentity] = []
+    seen_normalized: set[str] = set()
+    for raw_name in candidate_names:
+        identity = resolve_identity(raw_name, kind=IdentityKind.PERSON)
+        if identity is None or not identity.guard_passed:
+            continue
+        if identity.normalized in seen_normalized:
+            continue
+        seen_normalized.add(identity.normalized)
+        candidates.append(identity)
+    if not candidates:
+        return D2PersonTrail(
+            status=DimensionStatus.NOT_MEASURABLE,
+            reason=SignalAbsentReason.NAME_GENERIC_TOKEN_GUARD_FAILED,
+        )
+
+    sources: dict[str, PersonLookupClient | None] = {
+        "openalex": openalex,
+        "pubmed": pubmed,
+        "orcid": orcid,
+    }
+    configured = {name: client for name, client in sources.items() if client is not None}
+    if not configured:
+        return D2PersonTrail(
+            status=DimensionStatus.NOT_EVALUATED,
+            reason=SignalAbsentReason.SOURCE_NOT_QUERIED,
+        )
+
+    any_exact = False
+    best_similarity: float | None = None
+    best_guard_passed = False
+    for candidate in candidates:
+        for client in configured.values():
+            hit = _score_one_source(candidate, ri_identity, client)
+            if hit is None or not hit.ri_affiliation_hit:
+                continue
+            if hit.exact_identity:
+                any_exact = True
+            elif hit.similarity is not None and (
+                best_similarity is None or hit.similarity > best_similarity
+            ):
+                best_similarity = hit.similarity
+                best_guard_passed = hit.author_guard_passed
+
+    return D2PersonTrail(
+        status=DimensionStatus.MEASURED,
+        exact_person_ri_affiliation=any_exact,
+        person_similarity=best_similarity,
+        person_guard_passed=best_guard_passed,
+    )

--- a/tests/unit/sttr_spinout_linkage/test_d2_person_scorer.py
+++ b/tests/unit/sttr_spinout_linkage/test_d2_person_scorer.py
@@ -1,0 +1,390 @@
+"""Probes for the D2 person-trail scorer (task 1.3's D2 slice).
+
+Exploratory tier: covers the typed-absence branching the task brief calls out --
+no PI/founder name, `generic_token_guard` failure, source-not-queried vs. a real
+measured negative -- plus the exact/fuzzy scoring logic and the Form-D
+officer/director join. No network calls: source clients are bare fakes
+implementing only `.lookup(name)`, matching the mocked-client pattern in
+`tests/unit/enrichers/test_openalex_client.py`. Not a comprehensive matrix.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from scripts.sttr_spinout_linkage.d2_person_scorer import (
+    founder_names_for_company,
+    load_form_d_founder_index,
+    score_d2_person_trail,
+)
+from scripts.sttr_spinout_linkage.kernel import DimensionStatus, SignalAbsentReason
+from sbir_etl.exceptions import APIError
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# Fake lookup clients / records -- duck-typed to match OpenAlexRecord /
+# PubMedRecord / ORCIDRecord's relevant fields without importing them.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeOpenAlexRecord:
+    display_name: str
+    affiliations: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _FakePubMedRecord:
+    author_name: str
+    affiliations: list[str] = field(default_factory=list)
+
+
+@dataclass
+class _FakeORCIDRecord:
+    given_name: str | None
+    family_name: str
+    affiliations: list[str] = field(default_factory=list)
+
+
+class _FakeClient:
+    """A bare `.lookup(name)` stand-in; `responses` maps query name -> record|None."""
+
+    def __init__(self, responses: dict[str, object | None]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    def lookup(self, name: str) -> object | None:
+        self.calls.append(name)
+        return self._responses.get(name)
+
+
+class _RaisingClient:
+    def lookup(self, name: str) -> object | None:
+        raise APIError("boom", api_name="fake", http_status=500)
+
+
+RI_NAME = "Massachusetts Institute of Technology"
+
+
+# ---------------------------------------------------------------------------
+# Typed-absence branching
+# ---------------------------------------------------------------------------
+
+
+class TestTypedAbsence:
+    def test_no_pi_or_founder_name_is_not_measurable_source_field_unavailable(self) -> None:
+        trail = score_d2_person_trail(pi_name=None, founder_names=(), ri_name=RI_NAME)
+
+        assert trail.status is DimensionStatus.NOT_MEASURABLE
+        assert trail.reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE
+        assert trail.exact_person_ri_affiliation is False
+
+    def test_blank_founder_names_and_blank_pi_is_not_measurable(self) -> None:
+        trail = score_d2_person_trail(pi_name="  ", founder_names=("", None), ri_name=RI_NAME)
+
+        assert trail.status is DimensionStatus.NOT_MEASURABLE
+        assert trail.reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE
+
+    def test_blank_ri_name_is_not_measurable_source_field_unavailable(self) -> None:
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=None)
+
+        assert trail.status is DimensionStatus.NOT_MEASURABLE
+        assert trail.reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE
+
+    def test_generic_token_only_name_fails_the_guard(self) -> None:
+        trail = score_d2_person_trail(
+            pi_name="Dr. Jr.",
+            ri_name=RI_NAME,
+            openalex=_FakeClient({}),
+        )
+
+        assert trail.status is DimensionStatus.NOT_MEASURABLE
+        assert trail.reason is SignalAbsentReason.NAME_GENERIC_TOKEN_GUARD_FAILED
+
+    def test_guard_failure_never_silently_falls_through_to_no_signal(self) -> None:
+        # A generic-token-only name must not be reported the same as a real
+        # "queried and found nothing" measured negative.
+        trail = score_d2_person_trail(pi_name="Prof.", ri_name=RI_NAME, openalex=_FakeClient({}))
+
+        assert trail.status is not DimensionStatus.MEASURED
+        assert trail.reason is SignalAbsentReason.NAME_GENERIC_TOKEN_GUARD_FAILED
+
+    def test_no_source_clients_configured_is_not_evaluated_source_not_queried(self) -> None:
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME)
+
+        assert trail.status is DimensionStatus.NOT_EVALUATED
+        assert trail.reason is SignalAbsentReason.SOURCE_NOT_QUERIED
+        assert trail.exact_person_ri_affiliation is False
+
+    def test_queried_but_no_ri_affiliated_hit_is_a_real_measured_negative(self) -> None:
+        openalex = _FakeClient({"Jane Smith": _FakeOpenAlexRecord(display_name="Jane Smith")})
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, openalex=openalex)
+
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.exact_person_ri_affiliation is False
+        assert trail.person_similarity is None
+        assert trail.reason is None
+        assert openalex.calls == ["Jane Smith"]
+
+    def test_lookup_returning_none_is_still_a_measured_negative(self) -> None:
+        openalex = _FakeClient({})  # no match for anything
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, openalex=openalex)
+
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.exact_person_ri_affiliation is False
+
+
+# ---------------------------------------------------------------------------
+# Exact match (Order 1 SPINOUT_T1 input)
+# ---------------------------------------------------------------------------
+
+
+class TestExactMatch:
+    def test_exact_identity_and_ri_affiliation_sets_exact_person_ri_affiliation(self) -> None:
+        openalex = _FakeClient(
+            {
+                "Jane Smith": _FakeOpenAlexRecord(
+                    display_name="Jane Smith",
+                    affiliations=["Massachusetts Institute of Technology"],
+                )
+            }
+        )
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, openalex=openalex)
+
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.exact_person_ri_affiliation is True
+
+    def test_pubmed_author_name_field_used_for_exact_match(self) -> None:
+        pubmed = _FakeClient(
+            {"Jane Smith": _FakePubMedRecord(author_name="Jane Smith", affiliations=[RI_NAME])}
+        )
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, pubmed=pubmed)
+
+        assert trail.exact_person_ri_affiliation is True
+
+    def test_orcid_given_family_name_used_for_exact_match(self) -> None:
+        orcid = _FakeClient(
+            {
+                "Jane Smith": _FakeORCIDRecord(
+                    given_name="Jane", family_name="Smith", affiliations=[RI_NAME]
+                )
+            }
+        )
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, orcid=orcid)
+
+        assert trail.exact_person_ri_affiliation is True
+
+    def test_affiliation_not_matching_ri_does_not_count_even_with_exact_name(self) -> None:
+        openalex = _FakeClient(
+            {
+                "Jane Smith": _FakeOpenAlexRecord(
+                    display_name="Jane Smith", affiliations=["Some Other University"]
+                )
+            }
+        )
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, openalex=openalex)
+
+        assert trail.exact_person_ri_affiliation is False
+        assert trail.person_similarity is None
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy match (feeds person_similarity / person_guard_passed, not thresholded here)
+# ---------------------------------------------------------------------------
+
+
+class TestFuzzyMatch:
+    def test_ri_affiliated_but_name_mismatch_reports_similarity_not_exact(self) -> None:
+        # Returned author name is a near-miss of the query name.
+        openalex = _FakeClient(
+            {"Jane Smith": _FakeOpenAlexRecord(display_name="Jane Smyth", affiliations=[RI_NAME])}
+        )
+
+        trail = score_d2_person_trail(pi_name="Jane Smith", ri_name=RI_NAME, openalex=openalex)
+
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.exact_person_ri_affiliation is False
+        assert trail.person_similarity is not None
+        assert 0.0 < trail.person_similarity < 1.0
+        assert trail.person_guard_passed is True
+
+    def test_scorer_does_not_apply_a_cutoff_itself(self) -> None:
+        # Even a very low-similarity RI-affiliated hit is reported, not dropped --
+        # thresholding is classify_linkage's job (O-3), not this scorer's.
+        openalex = _FakeClient(
+            {
+                "Zephyr Quorlax": _FakeOpenAlexRecord(
+                    display_name="Bob Jones", affiliations=[RI_NAME]
+                )
+            }
+        )
+
+        trail = score_d2_person_trail(pi_name="Zephyr Quorlax", ri_name=RI_NAME, openalex=openalex)
+
+        assert trail.person_similarity is not None
+
+
+# ---------------------------------------------------------------------------
+# Founders (O-1) and multi-source / multi-candidate behavior
+# ---------------------------------------------------------------------------
+
+
+class TestFoundersAndMultiSource:
+    def test_founder_name_can_supply_the_exact_match_when_pi_does_not(self) -> None:
+        openalex = _FakeClient(
+            {
+                "Alex Founder": _FakeOpenAlexRecord(
+                    display_name="Alex Founder", affiliations=[RI_NAME]
+                )
+            }
+        )
+
+        trail = score_d2_person_trail(
+            pi_name="Jane Smith",
+            founder_names=["Alex Founder"],
+            ri_name=RI_NAME,
+            openalex=openalex,
+        )
+
+        assert trail.exact_person_ri_affiliation is True
+
+    def test_duplicate_normalized_names_are_queried_once(self) -> None:
+        openalex = _FakeClient({"Jane Smith": _FakeOpenAlexRecord(display_name="Jane Smith")})
+
+        score_d2_person_trail(
+            pi_name="Jane Smith",
+            founder_names=["Jane Smith", "jane smith"],
+            ri_name=RI_NAME,
+            openalex=openalex,
+        )
+
+        assert openalex.calls == ["Jane Smith"]
+
+    def test_exact_hit_from_one_source_wins_even_if_another_source_has_no_hit(self) -> None:
+        openalex = _FakeClient({"Jane Smith": None})
+        pubmed = _FakeClient(
+            {"Jane Smith": _FakePubMedRecord(author_name="Jane Smith", affiliations=[RI_NAME])}
+        )
+
+        trail = score_d2_person_trail(
+            pi_name="Jane Smith", ri_name=RI_NAME, openalex=openalex, pubmed=pubmed
+        )
+
+        assert trail.exact_person_ri_affiliation is True
+
+    def test_source_raising_api_error_is_treated_as_no_hit_not_a_crash(self) -> None:
+        trail = score_d2_person_trail(
+            pi_name="Jane Smith", ri_name=RI_NAME, openalex=_RaisingClient()
+        )
+
+        assert trail.status is DimensionStatus.MEASURED
+        assert trail.exact_person_ri_affiliation is False
+
+
+# ---------------------------------------------------------------------------
+# Form-D officer/director founder-name join
+# ---------------------------------------------------------------------------
+
+
+FORM_D_LINES = [
+    {
+        "company_name": "Acme Robotics Inc",
+        "match_confidence": {"tier": "high"},
+        "offerings": [
+            {
+                "related_persons": [
+                    {"name": "Alex Founder", "title": "Executive Officer, Director"},
+                    {"name": "Casey Investor", "title": "Promoter"},
+                ]
+            },
+            {
+                "related_persons": [
+                    {"name": "Alex Founder", "title": "Director"},
+                    {"name": "Dana Board", "title": "Director"},
+                ]
+            },
+        ],
+    },
+    {
+        "company_name": "Low Confidence Co",
+        "match_confidence": {"tier": "medium"},
+        "offerings": [{"related_persons": [{"name": "Weak Match", "title": "Officer"}]}],
+    },
+    {
+        "company_name": "No Persons Co",
+        "match_confidence": {"tier": "high"},
+        "offerings": [{"related_persons": []}],
+    },
+]
+
+
+def _write_form_d_jsonl(path: Path, records: list[dict]) -> Path:
+    with path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record) + "\n")
+    return path
+
+
+class TestFormDFounderIndex:
+    def test_loads_deduped_officer_director_names_at_default_high_tier(
+        self, tmp_path: Path
+    ) -> None:
+        path = _write_form_d_jsonl(tmp_path / "form_d.jsonl", FORM_D_LINES)
+
+        index = load_form_d_founder_index(path)
+
+        key = normalize_company_name("Acme Robotics Inc", profile=CompanyNameProfile.FORM_D_JOIN_V1)
+        assert index[key] == ["Alex Founder", "Dana Board"]
+
+    def test_excludes_non_officer_director_titles(self, tmp_path: Path) -> None:
+        path = _write_form_d_jsonl(tmp_path / "form_d.jsonl", FORM_D_LINES)
+
+        index = load_form_d_founder_index(path)
+
+        key = normalize_company_name("Acme Robotics Inc", profile=CompanyNameProfile.FORM_D_JOIN_V1)
+        assert "Casey Investor" not in index[key]
+
+    def test_medium_tier_excluded_by_default(self, tmp_path: Path) -> None:
+        path = _write_form_d_jsonl(tmp_path / "form_d.jsonl", FORM_D_LINES)
+
+        index = load_form_d_founder_index(path)
+
+        key = normalize_company_name("Low Confidence Co", profile=CompanyNameProfile.FORM_D_JOIN_V1)
+        assert key not in index
+
+    def test_missing_file_returns_empty_index_not_an_error(self, tmp_path: Path) -> None:
+        index = load_form_d_founder_index(tmp_path / "does_not_exist.jsonl")
+
+        assert index == {}
+
+    def test_founder_names_for_company_falls_back_to_empty_list(self, tmp_path: Path) -> None:
+        path = _write_form_d_jsonl(tmp_path / "form_d.jsonl", FORM_D_LINES)
+        index = load_form_d_founder_index(path)
+
+        assert founder_names_for_company("Unknown Firm Inc", index) == []
+        assert founder_names_for_company(None, index) == []
+
+    def test_founder_names_for_company_joins_by_name_key(self, tmp_path: Path) -> None:
+        path = _write_form_d_jsonl(tmp_path / "form_d.jsonl", FORM_D_LINES)
+        index = load_form_d_founder_index(path)
+
+        # FORM_D_JOIN_V1 normalizes case but not punctuation; match on a
+        # case-only variant of the stored company name.
+        assert founder_names_for_company("acme robotics inc", index) == [
+            "Alex Founder",
+            "Dana Board",
+        ]


### PR DESCRIPTION
## Summary

Implements the D2 slice of task 1.3 (`specs/sttr-spinout-linkage/tasks.md`): a scorer that
produces `kernel.D2PersonTrail` for one award by matching PI + Form-D-derived founder
names against OpenAlex / PubMed / ORCID authorship affiliations for the award's RI.

(Originally planned to stack on #627, the D1 spine loader PR — that merged to `main` while
this was in progress, along with #629, the D5 scorer. Rebased onto current `main`, so this
targets `main` directly instead of the now-deleted `claude/sttr-d1-spine-loader` branch.)

- `scripts/sttr_spinout_linkage/d2_person_scorer.py`:
  - `score_d2_person_trail(...)` — the D2 scorer itself. Composes the frozen
    `kernel.resolve_identity` / `identity_similarity` / `generic_token_guard` primitives
    and the existing `Sync{OpenAlex,PubMed,ORCID}Client.lookup(name)` facades
    (`sbir_etl/enrichers/sync_wrappers.py`) — no forked identity or API-calling logic, no
    second rate-limit/retry layer (the clients' own `RateLimiter`/`BaseAsyncAPIClient`
    retry already covers that).
  - `load_form_d_founder_index` / `founder_names_for_company` — the O-1 founder join:
    officer/director names from `data/form_d_details.jsonl`'s `offerings[].related_persons[]`
    (title matching `director|officer`), keyed by `CompanyNameProfile.FORM_D_JOIN_V1`
    company-name normalization, restricted to `match_confidence.tier == "high"` records.
    Reuses the exact join pattern from
    `notebooks/explorations/b1_sttr_partner_type_commercialization.ipynb`'s
    `join-channels` cell (Form D carries no UEI, so it's a name-key-only join there too).
    A company with no Form-D match falls back to PI-only D2 matching, per O-1.

### Typed-absence handling (per the task brief)

- No PI/founder name at all → `NOT_MEASURABLE` / `SOURCE_FIELD_UNAVAILABLE` (also applied
  when the RI name itself is blank — D2 can't measure without an RI anchor).
- Name present but `generic_token_guard` fails for every candidate → `NOT_MEASURABLE` /
  `NAME_GENERIC_TOKEN_GUARD_FAILED` — never silently falls through to "no signal."
- Name present, guard passes, at least one source configured and queried, no RI-affiliated
  authorship found → `MEASURED`, `exact_person_ri_affiliation=False` — a real measured
  negative.
- No source clients passed at all (e.g. a caller skipping/rate-limiting in a batch run) →
  `NOT_EVALUATED` / `SOURCE_NOT_QUERIED` — never presented as a negative.

### Exact vs. fuzzy (O-3 method, cutoff still deferred)

Per-source hits are RI-scoped first: an API record only contributes if its affiliation
list contains the award's RI (normalized-equality, per O-3's exact-match definition for
organization names). Only among RI-affiliated hits does the *person*-name match branch:
identity-normalized equality → `exact_person_ri_affiliation=True` (Order 1 input);
otherwise the raw `identity_similarity` score is recorded on `person_similarity` /
`person_guard_passed` (Order 2 input) — this scorer reports the score, it does not apply
the O-3 cutoff itself (that's `classify_linkage`'s job once the cutoff amendment lands).

### Known limitation: ±5-year window (O-2) not mechanically enforced

Design.md's D2 row requires RI-affiliated authorship within ±5 years of the award date.
`OpenAlexRecord` / `PubMedRecord` / `ORCIDRecord` — what `.lookup()` returns — carry an
`affiliations: list[str]` snapshot with no per-affiliation dates. Pulling dates would mean
reading each client's raw profile dict below the `.lookup()` facade the task brief
specifies, which starts to duplicate the clients' own parsing (out of scope per "don't
fork the enrichment clients"). `score_d2_person_trail` accepts and threads through
`award_year` / `window_years` so the window is declared in the call signature, but the
affiliation check itself is list-membership only in v1. Flagged in the module docstring
as a real, open gap — not silently assumed away. Follow-on work: extend client parsing,
or add a dedicated years-aware lookup.

## Real sample run (15 awards, live APIs)

Ran `score_d2_person_trail` against a random sample of 15 STTR Phase II awards with a
complete D1 spine (5,678 of 5,841 total), using live `SyncOpenAlexClient` /
`SyncPubMedClient` / `SyncORCIDClient` (no API keys configured — unauthenticated tier for
all three). All 15 completed; zero exceptions, zero rate-limit failures (one award with 19
Form-D founder names took ~52s due to ORCID's ~60/min unauthenticated limit, but completed).

- **1 exact match**: award `N074-028-0065` — PI "Thomas Schnell" / RI "University of
  Iowa" → `exact_person_ri_affiliation=True`.
- **1 fuzzy match**: award `R42AI104034` — PI "Pamela A Maher" / RI "Salk Institute For
  Biological Studies" → `person_similarity=0.9548`, `person_guard_passed=True`,
  `exact_person_ri_affiliation=False` (a middle-initial mismatch against the returned
  author name, RI-affiliation still confirmed).
- **13 measured negatives**: no RI-affiliated authorship found across the configured
  sources — real `MEASURED` results, not absence.
- **2 of 15** awards had a high-confidence Form-D founder match (6 and 19 officer/director
  names respectively); the rest fell back to PI-only matching, as expected — most STTR
  firms in this sample have no Form-D record.
- No guard failures or not-evaluated results in this sample (all 15 rows came from the
  spine-complete population with real PI names); those paths are covered by the mocked
  unit tests instead.

## Scope boundaries respected

- No cascade assembly, no D3/D4 scoring, no partner-type classification.
- No Neo4j, no CANDIDATE-assertion emission.
- **Full-population run (~5,841 awards) explicitly NOT done here** — left as follow-on
  work. At the unauthenticated rate limits observed in the sample (ORCID ~60/min being the
  binding constraint), a full run needs either an ORCID access token, batching across
  hours, or both; that's out of scope for this PR per the task brief.

## Test plan

- [x] `uv run pytest tests/unit/sttr_spinout_linkage/test_d2_person_scorer.py -v` — 24
  tests, all passing, no network calls (bare fakes implementing `.lookup(name)`).
- [x] `uv run pytest tests/unit/sttr_spinout_linkage/ -v` — 85 tests passing (D1/D2/D5/
  kernel/freeze-guard together).
- [x] `make lint` (ruff check + format + mypy) — clean.
- [x] `make lint-boundaries` — clean.
- [x] `make docs-check` — clean.
- [x] `uv run python scripts/ci/check_epistemic_tiers.py` — clean.
- [x] Live 15-award sample run against real OpenAlex/PubMed/ORCID APIs — see above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)