### PR TITLE
Align make lint-boundaries with CI boundary guards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,8 +8,9 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  # Python linting and formatting (matches CI scope: production packages and tests)
-  # CI equivalent: ruff check <production-roots> tests && ruff format --check <production-roots> tests
+  # Python linting and formatting (narrower than CI by design)
+  # Local: production package roots + tests/
+  # CI equivalent: ruff check . && ruff format --check .  (whole repository)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.4
     hooks:
@@ -59,15 +60,18 @@ repos:
 #
 # SCOPE ALIGNMENT WITH CI:
 #   This pre-commit configuration overlaps with, but does not duplicate, the
-#   blocking checks in .github/workflows/ci.yml. Ruff has the same scope in
-#   both places; CI deliberately has broader MyPy and security coverage.
+#   blocking checks in .github/workflows/ci.yml. Ruff is intentionally narrower
+#   locally (production roots + tests); CI runs ruff over the whole repository
+#   via `make lint` / `ruff check .`. CI also has broader MyPy and security
+#   coverage, plus the make lint-boundaries guard suite.
 #
 #   Tool Scope Mapping:
-#   - Ruff (lint/format): all production package roots and tests
+#   - Ruff (lint/format): production package roots + tests  [CI: whole repo]
 #   - MyPy (type check):  sbir_etl/      [CI also checks sbir-graph, sbir-ml]
 #   - Bandit (security):  no local hook  [CI checks sbir_etl/ and packages/]
 #   - Standard hooks:     all files       [good practice, not in CI]
 #   - Detect-secrets:     no local hook  [CI scans the working tree against the baseline]
+#   - Boundary guards:    no local hook  [CI + `make lint-boundaries`]
 #
 # SETUP:
 #   Install pre-commit:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,13 @@ make install                           # uv sync --extra stack-dev (run this fir
 make test-unit                         # Unit tests
 uv run pytest -m integration           # Integration tests
 uv run pytest -n auto                  # Parallel execution
-make lint                              # Ruff check over the repository, MyPy over sbir_etl
-make lint-boundaries                   # Architecture, identity, and study guards
-make docs-check                        # Links, stale commands, and repository hygiene
+make lint                              # Ruff over the repo, MyPy over sbir_etl + sbir-graph + sbir-ml
+make lint-boundaries                   # Same boundary/hygiene guards as CI (incl. identity + epistemic tiers)
+make docs-check                        # Hygiene subset only (also included in lint-boundaries)
 ```
+
+`make lint-boundaries` must stay aligned with the CI quality job's guard step. If
+Make and CI diverge, CI is authoritative and the Makefile is wrong.
 
 Transition scoring changes must maintain the ≥85% Phase III retrospective
 HIGH-precision benchmark. Enforcement today is a fixture-level canary

--- a/Makefile
+++ b/Makefile
@@ -228,17 +228,27 @@ lint: ## Run linting and type checking
 	$(call run,uv run mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml)
 
 .PHONY: lint-boundaries
-lint-boundaries: ## Enforce package and archive dependency boundaries
-	@$(call info,Checking architecture boundaries)
+# Keep this list identical to the "Run architecture, documentation, and
+# repository hygiene guards" step in .github/workflows/ci.yml. Local green and
+# CI green must mean the same set of boundary checks; if they diverge, CI wins
+# and this target is a bug.
+lint-boundaries: ## Architecture, epistemic-tier, identity, config, hygiene, and study guards (matches CI)
+	@$(call info,Checking architecture, tier, identity, and repository hygiene guards)
 	$(call run,uv run python scripts/ci/check_architecture_boundaries.py)
+	$(call run,uv run python scripts/ci/check_epistemic_tiers.py)
 	$(call run,uv run python scripts/ci/check_tier_boundaries.py)
 	$(call run,uv run python scripts/ci/check_file_sizes.py)
 	$(call run,uv run python scripts/ci/check_config_boundaries.py)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
+	$(call run,uv run python scripts/ci/check_identity_boundaries.py)
 
 .PHONY: docs-check
-docs-check: ## Check docs, agent files, spec registry and question anchors, stale commands, and old code references
+# Thin alias for the hygiene script only. Full boundary coverage lives in
+# `make lint-boundaries` (which also runs this script). Prefer lint-boundaries
+# when checking a PR locally; keep docs-check for callers that only need
+# registry/link/stale-command scans.
+docs-check: ## Hygiene only: doc links, stale commands, spec registry, agent/skill mirrors
 	@$(call info,Running repository hygiene checks)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ fresh clone and are the same gates CI enforces:
 make install          # uv sync --extra stack-dev
 make test-unit        # ~5,800 unit tests, under a minute
 make lint             # Ruff lint + format across the repo, MyPy over sbir_etl and the packages
-make lint-boundaries  # architecture, epistemic-tier, config, and study guards
-make docs-check       # dead doc links, stale commands, spec-registry coverage
+make lint-boundaries  # same architecture / epistemic-tier / identity / config / hygiene / study guards as CI
+make docs-check       # hygiene subset only (links, stale commands, spec registry; also run by lint-boundaries)
 ```
 
 The remaining suites need services: `uv run pytest -m integration` expects a

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -6,7 +6,7 @@ CI is authoritative and deliberately runs checks that have no local hook.
 
 **Document Type:** Explanation
 **Owner:** @hollomancer
-**Last-Reviewed:** 2026-08-09
+**Last-Reviewed:** 2026-08-15
 **Status:** Active
 
 ## Overview
@@ -21,7 +21,9 @@ Developers should not encounter an *undocumented* difference where:
 
 This document explains the differences. The executable configurations remain
 the source of truth: `.pre-commit-config.yaml` for local hooks and
-`.github/workflows/ci.yml` for CI.
+`.github/workflows/ci.yml` for CI. For architecture / epistemic-tier / identity /
+config / hygiene / study guards, `make lint-boundaries` must match the CI quality
+job's guard step; if they diverge, CI is authoritative.
 
 ### Architecture
 
@@ -29,16 +31,18 @@ the source of truth: `.pre-commit-config.yaml` for local hooks and
 Local pre-commit hook            Runs in CI as
 ─────────────────────            ──────────────
 Standard file checks       →     (local only)
-Ruff (lint/format)         →     ci.yml · quality job
+Ruff (prod roots + tests)  →     ci.yml · quality job (whole repo via `ruff check .`)
 MyPy (sbir_etl only)       →     ci.yml · quality job (also sbir-graph + sbir-ml)
+(no local hook)            →     make lint-boundaries / ci.yml quality guards
 (no local hook)            →     ci.yml · security job (Bandit)
 (no local hook)            →     ci.yml · security job (detect-secrets)
 (no local hook)            →     ci.yml · quality job (actionlint)
 ```
 
-**Key Principle:** Pre-commit provides fast local feedback. CI repeats Ruff,
-supersets the local MyPy scope, and adds blocking security, architecture, and
-workflow checks.
+**Key Principle:** Pre-commit provides fast local feedback. CI supersets local
+Ruff and MyPy scope, and adds blocking security, boundary, and workflow checks.
+Use `make lint` and `make lint-boundaries` before pushing when you need the
+CI-equivalent local run.
 
 **Intentional local gaps:** Bandit and detect-secrets are not pre-commit hooks.
 Both run in CI's blocking `security` / "Security Scan" job. The local
@@ -52,9 +56,10 @@ The scopes below are the current contract, including intentional differences:
 
 | Tool | Local Scope | CI Scope | Configuration | Notes |
 |------|------------|----------|---------------|-------|
-| **Ruff** (lint) | Four production roots + `tests/` | Same | `.pre-commit-config.yaml` + `pyproject.toml` | Local hook fixes; CI only checks |
-| **Ruff** (format) | Four production roots + `tests/` | Same | `.pre-commit-config.yaml` + `pyproject.toml` | Local hook formats; CI only checks |
+| **Ruff** (lint) | Four production roots + `tests/` | Whole repository (`ruff check .`) | `.pre-commit-config.yaml` + `pyproject.toml` | Local hook is narrower; use `make lint` for CI parity |
+| **Ruff** (format) | Four production roots + `tests/` | Whole repository (`ruff format --check .`) | `.pre-commit-config.yaml` + `pyproject.toml` | Same intentional gap as lint |
 | **MyPy** (types) | `sbir_etl/` | `sbir_etl/`, `sbir-graph`, `sbir-ml` | `.pre-commit-config.yaml` + `pyproject.toml` | CI is deliberately broader |
+| **Boundary guards** | No hook; `make lint-boundaries` | Same scripts as Make | `Makefile` + `ci.yml` | Must stay identical |
 | **Bandit** (security) | No hook | `sbir_etl/` and `packages/` | `ci.yml` + `pyproject.toml` | Blocking `security` job |
 | **Standard hooks** | All files | N/A | `.pre-commit-config.yaml` | YAML validation, EOL, trailing whitespace (local only) |
 | **Detect-secrets** | No hook | Working tree against `.secrets.baseline` | `ci.yml` + `.secrets.baseline` | Blocking `security` job |
@@ -74,11 +79,12 @@ The scopes below are the current contract, including intentional differences:
 - Bandit's `pyproject.toml` configuration excludes tests
 - Avoiding a local hook keeps pre-commit focused on fast checks
 
-**Why production packages + `tests/` for Ruff?**
+**Why is local Ruff narrower than CI?**
 
-- Tests should follow the same code style as production code
-- Ruff is fast and catches important issues (unused imports, naming)
-- Consistent formatting improves readability
+- Pre-commit stays fast on the production packages and tests most PRs touch
+- CI / `make lint` run `ruff check .` so exploratory `scripts/` and notebooks
+  cannot silently drift outside the formatter/linter contract
+- Use `make lint` before pushing when you edited scripts or notebooks
 
 **Why all files for standard hooks?**
 
@@ -162,10 +168,12 @@ Some rule failed
 
 **Common issues:**
 
-- **Ruff errors:** Run `ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests --fix` to auto-fix many issues
+- **Ruff errors:** Run `make format` or `uv run ruff check . --fix` for CI-parity
+  fixes; the pre-commit hook only auto-fixes production roots + tests
 - **MyPy errors:** Read the error message and add type hints or `# type: ignore` comments
 - **CI Bandit alerts:** Review and fix security issues, or add a justified `# nosec` for a false positive
 - **CI detect-secrets alerts:** Review the secret, or update `.secrets.baseline` if approved
+- **Boundary / hygiene failures:** Run `make lint-boundaries` locally (same scripts as CI)
 
 ---
 
@@ -181,9 +189,10 @@ This workflow runs on:
 **Jobs (in parallel/sequence):**
 
 1. **quality** ("Lint, Types, and Guards")
-   - Runs: `ruff check`, `ruff format --check`, `mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml`, Dagster definition validation, the architecture/documentation/hygiene guards, compose-file validation, and actionlint.
-   - Purpose: Pull-request and push quality gate. Ruff mirrors the local scope;
-     MyPy adds `sbir-graph` and `sbir-ml` to the local `sbir_etl` scope.
+   - Runs: `ruff check .`, `ruff format --check .`, `mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml`, Dagster definition validation, the architecture/documentation/hygiene guards (same scripts as `make lint-boundaries`), compose-file validation, and actionlint.
+   - Purpose: Pull-request and push quality gate. Ruff covers the whole repository
+     (broader than the local pre-commit hook); MyPy adds `sbir-graph` and `sbir-ml`
+     to the local `sbir_etl` scope.
    - Time: ~5-10 minutes.
 
    There is no separate package-type-check job: all three type-checked roots are
@@ -264,10 +273,11 @@ Local hook environments and CI select tool versions independently:
 
 | Item | Local | CI | Notes |
 |------|-------|----|----|
-| Ruff scope | `.pre-commit-config.yaml` | `ci.yml` | Both: all production roots plus `tests` |
+| Ruff scope | `.pre-commit-config.yaml` | `ci.yml` | Local: production roots + tests. CI / `make lint`: whole repo |
 | Ruff config | `pyproject.toml` | `pyproject.toml` | Identical |
 | MyPy scope | `pyproject.toml` + `.pre-commit-config.yaml` | `ci.yml` | Local: `sbir_etl`. CI: `sbir_etl` **plus** `sbir-graph` and `sbir-ml`, all in the `quality` job |
 | MyPy config | `pyproject.toml` | `pyproject.toml` | Identical |
+| Boundary guards | `Makefile` `lint-boundaries` | `ci.yml` quality job | Must stay identical |
 | Bandit scope | No hook; manual command available | `ci.yml` | CI scans `sbir_etl/` and `packages/` in the `security` job |
 | Bandit config | `pyproject.toml` | `pyproject.toml` | Same when reproduced locally |
 | Detect-secrets scope | No hook; manual command available | `ci.yml` | CI scans the working tree against `.secrets.baseline` |
@@ -305,14 +315,14 @@ files locally. If the same tool and file fail differently:
 **Check scope:**
 
 ```bash
-# Local pre-commit and CI use the same four production roots plus tests/
-# Make sure you're checking the same files
+# Local pre-commit: production roots + tests only
+pre-commit run ruff --all-files
 
-pre-commit run ruff --all-files  # Same file scope; see version table above
-
-# Or manually
-uv run python -m ruff check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests
-uv run python -m ruff format --check sbir_etl packages/sbir-analytics/sbir_analytics packages/sbir-ml/sbir_ml packages/sbir-graph/sbir_graph tests
+# CI / make lint: whole repository
+make lint
+# or
+uv run python -m ruff check .
+uv run python -m ruff format --check .
 ```
 
 ### "MyPy passes locally but fails in CI"

--- a/docs/steering/README.md
+++ b/docs/steering/README.md
@@ -4,12 +4,15 @@ Durable engineering contracts. These describe rules that hold across features â€
 change them deliberately, not as a side effect of a feature branch. Several are
 enforced by guards in `scripts/ci/`.
 
+`make lint-boundaries` and the CI quality job must run the same boundary/hygiene
+scripts. If they diverge, CI is authoritative and the Makefile is wrong.
+
 | Contract | Enforced by |
 |---|---|
-| [Epistemic tiers](epistemic-tiers.md) | `check_epistemic_tiers.py` |
-| [Company identity](company-identity.md) | `check_identity_boundaries.py` |
-| [Repository structure](structure.md) | `check_architecture_boundaries.py` |
-| [Versioning and releases](versioning.md) | `check_versioning.py` |
+| [Epistemic tiers](epistemic-tiers.md) | `check_epistemic_tiers.py` + `check_tier_boundaries.py` (Make + CI) |
+| [Company identity](company-identity.md) | `check_identity_boundaries.py` (Make + CI) |
+| [Repository structure](structure.md) | `check_architecture_boundaries.py` (Make + CI) |
+| [Versioning and releases](versioning.md) | `check_versioning.py` (versioning workflow) |
 | [Data quality](data-quality.md) | Asset checks |
 | [Enrichment patterns](enrichment-patterns.md) | Convention |
 | [Pipeline orchestration](pipeline-orchestration.md) | Convention |

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -213,10 +213,11 @@ What already holds:
 - `sbir_etl/` is a clean foundation layer — 141 imports inbound from
   `packages/`, zero outbound.
 - `sbir_etl/identity/` meets the `primitives` contract, with a boundary checker
-  at `scripts/ci/check_identity_boundaries.py` enforced by the CI quality job.
+  at `scripts/ci/check_identity_boundaries.py` enforced by `make lint-boundaries`
+  and the CI quality job.
 - Active specs declare a target tier in `requirements.md`;
   `scripts/ci/check_epistemic_tiers.py` rejects missing, duplicate, and
-  invalid declarations in CI.
+  invalid declarations in `make lint-boundaries` and CI.
 - The tier dependency lattice is executable: `scripts/ci/check_tier_boundaries.py`
   (in `make lint-boundaries` and CI) resolves each module's effective tier and
   blocks imports below it. Its `TIER_IMPORT_ALLOWLIST` is empty — every seeded


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 of the governance cleanup: make local Make targets tell the same story as CI.

### Changes
- **`make lint-boundaries`** now runs the same eight scripts as the CI quality job’s guard step, including `check_epistemic_tiers.py` and `check_identity_boundaries.py` (previously CI-only).
- **`make docs-check`** documented as hygiene-only (still useful; also included inside `lint-boundaries`).
- **CLAUDE / README / steering** one-liners updated so they no longer oversell or undersell the targets.
- **Pre-commit docs + comments** corrected: local Ruff is production roots + tests; CI / `make lint` is whole-repo (`ruff check .`).

### Verification
```text
Make scripts == CI scripts (exact order match)
make lint-boundaries  # all eight guards passed
```

### Non-goals (later phases)
StrEnum policy, evidence-tier contract enforcement, CLAUDE dedup, glossary confidence bands.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0055a-20fb-768e-82dd-bd2a4855079a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0055a-20fb-768e-82dd-bd2a4855079a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

