### PR TITLE
Migrate to StrEnum; unify Python 3.11–3.12 wording

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Run Ruff lint
         run: uv run python -m ruff check .
 
+      # UP042 (StrEnum) is still preview; keep it targeted so the main lint does
+      # not opt into every unstable preview rule.
+      - name: Run Ruff StrEnum check (UP042 preview)
+        run: uv run python -m ruff check sbir_etl packages tests --preview --select UP042
+
       # Formatting is scoped to the primitives/pipelines trees; `[tool.ruff.format]`
       # in pyproject.toml excludes the exploratory-tier directories.
       - name: Run Ruff format check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,9 @@ PR; the full benchmark against the S3 corpus is run manually via
 ## Code Standards
 
 - Line length: 100
-- Target: Python 3.11
+- Target: Python 3.11–3.12 (`requires-python >=3.11,<3.13`)
 - Ruff rules: E, W, F, I, B, C4, UP
-- Use `StrEnum` not `str, Enum`
+- Use `StrEnum` not `str, Enum` (UP042 via `ruff --preview --select UP042` in `make lint` / CI)
 - Use `datetime.UTC` not `timezone.utc`
 - Do not postpone annotations on a Dagster-decorated function whose context type
   Dagster must inspect at runtime. Follow the local pattern in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ document under `docs/steering/` or `specs/`.
 
 ## Set Up a Development Environment
 
-The supported Python versions are 3.11 and 3.12. From the repository root:
+The supported Python versions are 3.11 and 3.12 (`requires-python >=3.11,<3.13`). From the repository root:
 
 ```bash
 make install

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,9 @@ lint: ## Run linting and type checking
 	@$(call info,Running linting and type checking)
 	$(call run,uv run ruff check .)
 	$(call run,uv run ruff format --check .)
+	# UP042 is still a preview rule; run it targeted so we do not opt into every
+	# unstable preview lint. Prefer StrEnum over (str, Enum) in production code.
+	$(call run,uv run ruff check sbir_etl packages tests --preview --select UP042)
 	$(call run,uv run mypy sbir_etl packages/sbir-graph/sbir_graph packages/sbir-ml/sbir_ml)
 
 .PHONY: lint-boundaries

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SBIR/STTR Commercialization Analytics
 
 [![CI](https://github.com/hollomancer/sbir-analytics/actions/workflows/ci.yml/badge.svg)](https://github.com/hollomancer/sbir-analytics/actions/workflows/ci.yml)
-[![Python 3.11](https://img.shields.io/badge/python-3.11-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
 A research project linking federal SBIR/STTR award data to
@@ -163,7 +163,7 @@ repository, start with these documents in order:
 
 ## Running it
 
-The project targets **Python 3.11** and uses
+The project targets **Python 3.11–3.12** (`requires-python >=3.11,<3.13`) and uses
 [`uv`](https://github.com/astral-sh/uv) for
 dependency management. There is intentionally no `requirements.txt` — the
 dependency set is defined by `pyproject.toml` and pinned in `uv.lock`. (If you

--- a/docs/architecture/detailed-overview.md
+++ b/docs/architecture/detailed-overview.md
@@ -37,7 +37,7 @@ later, its tool and Make target belong in the repository first.
 
 | Concern | Technology | Canonical location |
 | --- | --- | --- |
-| Language and packaging | Python 3.11 or 3.12, uv workspace | `pyproject.toml`, `uv.lock` |
+| Language and packaging | Python 3.11–3.12 (`requires-python >=3.11,<3.13`), uv workspace | `pyproject.toml`, `uv.lock` |
 | Tabular processing | pandas, DuckDB, PyArrow | `sbir_etl/`, assets, studies |
 | Configuration | Pydantic and YAML | `sbir_etl/config/`, `config/` |
 | Orchestration | Dagster | `packages/sbir-analytics/` |

--- a/docs/development/pre-commit-ci-consistency.md
+++ b/docs/development/pre-commit-ci-consistency.md
@@ -58,6 +58,7 @@ The scopes below are the current contract, including intentional differences:
 |------|------------|----------|---------------|-------|
 | **Ruff** (lint) | Four production roots + `tests/` | Whole repository (`ruff check .`) | `.pre-commit-config.yaml` + `pyproject.toml` | Local hook is narrower; use `make lint` for CI parity |
 | **Ruff** (format) | Four production roots + `tests/` | Whole repository (`ruff format --check .`) | `.pre-commit-config.yaml` + `pyproject.toml` | Same intentional gap as lint |
+| **Ruff** (UP042 / StrEnum) | No hook | `sbir_etl` + `packages` + `tests` via `--preview --select UP042` | `Makefile` `lint` + `ci.yml` | Preview rule; targeted so other preview lints stay off |
 | **MyPy** (types) | `sbir_etl/` | `sbir_etl/`, `sbir-graph`, `sbir-ml` | `.pre-commit-config.yaml` + `pyproject.toml` | CI is deliberately broader |
 | **Boundary guards** | No hook; `make lint-boundaries` | Same scripts as Make | `Makefile` + `ci.yml` | Must stay identical |
 | **Bandit** (security) | No hook | `sbir_etl/` and `packages/` | `ci.yml` + `pyproject.toml` | Blocking `security` job |

--- a/docs/steering/tech.md
+++ b/docs/steering/tech.md
@@ -12,7 +12,7 @@ testing, configuration, or deployment commands; use the linked operational refer
 
 ## Supported stack
 
-- Python 3.11 or 3.12, managed as a uv workspace.
+- Python 3.11–3.12 (`requires-python >=3.11,<3.13`), managed as a uv workspace.
 - pandas, DuckDB, and PyArrow for tabular processing and interchange.
 - Pydantic plus YAML for typed configuration.
 - Dagster for assets, jobs, schedules, sensors, and run metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,7 +140,6 @@ ignore = [
     "C901", # too complex
     "E402", # module level import not at top - OK for conditional imports after version checks
     "I001", # import sorting - OK for optional imports in try blocks
-    "UP042", # preserve str/Enum behavior until a dedicated StrEnum migration
 ]
 
 [tool.ruff.lint.isort]

--- a/sbir_etl/models/benchmark_models.py
+++ b/sbir_etl/models/benchmark_models.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any
 
 
-class BenchmarkTier(str, Enum):
+class BenchmarkTier(StrEnum):
     """Tier of benchmark applicability."""
 
     NOT_SUBJECT = "not_subject"
@@ -33,7 +33,7 @@ class BenchmarkTier(str, Enum):
     INCREASED_TIER2 = "increased_tier2"
 
 
-class BenchmarkStatus(str, Enum):
+class BenchmarkStatus(StrEnum):
     """Whether a company passes or fails a benchmark."""
 
     PASS = "pass"  # nosec B105 - enum value, not a credential
@@ -42,7 +42,7 @@ class BenchmarkStatus(str, Enum):
     NOT_EVALUABLE = "not_evaluable"  # subject to the benchmark, but input data absent
 
 
-class ConsequenceType(str, Enum):
+class ConsequenceType(StrEnum):
     """Consequence of failing a benchmark."""
 
     NONE = "none"

--- a/sbir_etl/models/cet_models.py
+++ b/sbir_etl/models/cet_models.py
@@ -9,12 +9,12 @@ These models represent:
 """
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 
-class ClassificationLevel(str, Enum):
+class ClassificationLevel(StrEnum):
     """Classification confidence levels based on score thresholds."""
 
     HIGH = "High"  # Score ≥ 70

--- a/sbir_etl/models/contract_models.py
+++ b/sbir_etl/models/contract_models.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
 from sbir_etl.models.transition_models import VendorMatch  # noqa: F401 — canonical definition
 
 
-class CompetitionType(str, Enum):
+class CompetitionType(StrEnum):
     """Competition types for federal contracts."""
 
     SOLE_SOURCE = "sole_source"
@@ -18,7 +18,7 @@ class CompetitionType(str, Enum):
     OTHER = "other"
 
 
-class ContractStatus(str, Enum):
+class ContractStatus(StrEnum):
     """Contract status enumeration."""
 
     ACTIVE = "active"

--- a/sbir_etl/models/enrichment.py
+++ b/sbir_etl/models/enrichment.py
@@ -8,13 +8,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
-class EnrichmentStatus(str, Enum):
+class EnrichmentStatus(StrEnum):
     """Status of an enrichment operation."""
 
     SUCCESS = "success"

--- a/sbir_etl/models/quality.py
+++ b/sbir_etl/models/quality.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class QualitySeverity(str, Enum):
+class QualitySeverity(StrEnum):
     """Severity levels for quality issues."""
 
     ERROR = "error"

--- a/sbir_etl/models/sbir_identification.py
+++ b/sbir_etl/models/sbir_identification.py
@@ -15,7 +15,7 @@ References:
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import StrEnum
 from typing import TypedDict
 
 
@@ -24,7 +24,7 @@ from typing import TypedDict
 # ---------------------------------------------------------------------------
 
 
-class SbirResearchCode(str, Enum):
+class SbirResearchCode(StrEnum):
     """FPDS ``research`` field values — exclusively SBIR/STTR identifiers.
 
     Despite the generic field name, the FPDS ``research`` field (Data Dictionary

--- a/sbir_etl/models/sec_edgar.py
+++ b/sbir_etl/models/sec_edgar.py
@@ -7,12 +7,12 @@ and extracted financial data used to enrich SBIR company analysis.
 from __future__ import annotations
 
 from datetime import date, datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
-class FilingType(str, Enum):
+class FilingType(StrEnum):
     """SEC filing types relevant to SBIR analysis."""
 
     FORM_10K = "10-K"
@@ -25,7 +25,7 @@ class FilingType(str, Enum):
     FORM_20F = "20-F"
 
 
-class MAAcquisitionType(str, Enum):
+class MAAcquisitionType(StrEnum):
     """Types of M&A events detected from 8-K filings."""
 
     ACQUISITION = "acquisition"

--- a/sbir_etl/models/statistical_reports.py
+++ b/sbir_etl/models/statistical_reports.py
@@ -8,7 +8,7 @@ report collections for multi-format outputs.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -17,7 +17,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sbir_etl.models.quality import ChangesSummary, DataHygieneMetrics
 
 
-class ReportFormat(str, Enum):
+class ReportFormat(StrEnum):
     """Supported report output formats."""
 
     HTML = "html"

--- a/sbir_etl/models/transition_models.py
+++ b/sbir_etl/models/transition_models.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 from datetime import date, datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
-class ConfidenceLevel(str, Enum):
+class ConfidenceLevel(StrEnum):
     HIGH = "high"
     LIKELY = "likely"
     POSSIBLE = "possible"
 
 
-class CompetitionType(str, Enum):
+class CompetitionType(StrEnum):
     SOLE_SOURCE = "sole_source"
     LIMITED = "limited"
     FULL_AND_OPEN = "full_and_open"

--- a/sbir_etl/models/uspto_models.py
+++ b/sbir_etl/models/uspto_models.py
@@ -23,7 +23,7 @@ Validators:
 
 import re
 from datetime import date
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -44,7 +44,7 @@ def _normalize_name(name: str | None) -> str | None:
 
 
 # ---- Enums ----
-class ConveyanceType(str, Enum):
+class ConveyanceType(StrEnum):
     ASSIGNMENT = "assignment"
     LICENSE = "license"
     SECURITY_INTEREST = "security_interest"

--- a/sbir_etl/utils/monitoring/alerts.py
+++ b/sbir_etl/utils/monitoring/alerts.py
@@ -19,14 +19,14 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
 
-class AlertSeverity(str, Enum):
+class AlertSeverity(StrEnum):
     """Alert severity levels."""
 
     INFO = "INFO"

--- a/tests/utils/pipeline_validator.py
+++ b/tests/utils/pipeline_validator.py
@@ -6,7 +6,7 @@ including extraction, enrichment, and Neo4j graph validation.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 import pandas as pd
@@ -17,7 +17,7 @@ from sbir_graph.loaders import Neo4jClient
 from sbir_etl.models.quality import QualitySeverity
 
 
-class ValidationStage(str, Enum):
+class ValidationStage(StrEnum):
     """Pipeline stages that can be validated."""
 
     EXTRACTION = "extraction"
@@ -27,7 +27,7 @@ class ValidationStage(str, Enum):
     LOADING = "loading"
 
 
-class ValidationStatus(str, Enum):
+class ValidationStatus(StrEnum):
     """Validation result status."""
 
     PASSED = "passed"

--- a/tests/utils/validation_models.py
+++ b/tests/utils/validation_models.py
@@ -6,7 +6,7 @@ test reports, and recommendations for E2E testing.
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from tests.utils.pipeline_validator import (
@@ -17,7 +17,7 @@ from tests.utils.pipeline_validator import (
 )
 
 
-class ValidationScenario(str, Enum):
+class ValidationScenario(StrEnum):
     """E2E test scenarios."""
 
     MINIMAL = "minimal"
@@ -26,7 +26,7 @@ class ValidationScenario(str, Enum):
     EDGE_CASES = "edge_cases"
 
 
-class RecommendationPriority(str, Enum):
+class RecommendationPriority(StrEnum):
     """Priority levels for recommendations."""
 
     LOW = "low"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 of the governance cleanup: kill the false StrEnum standard and unify Python version wording.

### StrEnum (2a — migrate)
- Convert remaining `(str, Enum)` classes in `sbir_etl` models/alerts and test utils to `StrEnum`
- Drop the `UP042` ignore in `pyproject.toml`
- Enforce via targeted `ruff check … --preview --select UP042` in `make lint` and CI (preview rule; not opting into all preview lints)

### Python version (2b)
- One sentence everywhere: **Python 3.11–3.12** (`requires-python >=3.11,<3.13`)
- Touches CLAUDE, README, CONTRIBUTING, `docs/steering/tech.md`, architecture overview

### Testing
- `ruff check sbir_etl packages tests --preview --select UP042` — clean
- `pytest tests/unit/models …` (and related) — 1218 passed

### Non-goals
Phase 1 Make/CI boundary alignment remains [#633](https://github.com/hollomancer/sbir-analytics/pull/633). Evidence-tier contract / CLAUDE dedup are later phases.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0055a-20fb-768e-82dd-bd2a4855079a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0055a-20fb-768e-82dd-bd2a4855079a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

