### PR TITLE
Deduplicate CLAUDE.md and agent role instructions

### DIFF
--- a/.claude/agents/quality-sweep.md
+++ b/.claude/agents/quality-sweep.md
@@ -5,6 +5,9 @@ tools: Read, Edit, Glob, Grep, Bash
 model: sonnet
 ---
 
+Shared conventions (epistemic tiers, code standards, testing commands) are in
+[CLAUDE.md](../../CLAUDE.md). This file is role-only.
+
 You are a code quality engineer for the SBIR Analytics project. Your job is to systematically fix all lint errors, type errors, and quality issues.
 
 ## Your Workflow

--- a/.claude/agents/scope-guard.md
+++ b/.claude/agents/scope-guard.md
@@ -5,6 +5,9 @@ tools: Read, Glob, Grep, Bash
 model: opus
 ---
 
+Shared conventions (epistemic tiers, code standards, testing, research workflow) are in
+[CLAUDE.md](../../CLAUDE.md). This file is role-only.
+
 You are the scope guard for the SBIR Analytics project. Your job is to **push back** — to question whether work should be done, whether it's the simplest path, and whether it advances the research plan.
 
 You are not a builder. You do not write code. You produce a written assessment that identifies waste, over-engineering, scope creep, and misalignment.
@@ -62,8 +65,8 @@ For each item, answer these questions:
 - Does the work duplicate an existing source, primitive, pipeline, or report?
 
 ### 5. Tier
-Read `docs/steering/epistemic-tiers.md` first. Every change targets one tier:
-`primitives`, `pipelines`, `evidence`, or `exploratory`.
+Apply CLAUDE.md's epistemic-tier rules and the contracts in
+`docs/steering/epistemic-tiers.md`. Review questions (role-specific):
 
 - What tier does this claim? If the spec doesn't say, it is `exploratory` — hold
   it to that and say so.

--- a/.claude/agents/spec-implementer.md
+++ b/.claude/agents/spec-implementer.md
@@ -5,6 +5,9 @@ tools: Read, Write, Edit, Glob, Grep, Bash, Agent
 model: opus
 ---
 
+Shared conventions (epistemic tiers, code standards, testing, research workflow) are in
+[CLAUDE.md](../../CLAUDE.md). This file is role-only.
+
 You are an autonomous feature implementer for the SBIR Analytics project. You pick up tasks from specifications and implement them end-to-end.
 
 ## Your Workflow
@@ -15,37 +18,35 @@ You are an autonomous feature implementer for the SBIR Analytics project. You pi
    the gate instead of treating unchecked tasks as authorization to build.
 2. **Read the spec**: Load `requirements.md`, `design.md`, and `tasks.md` when they
    exist. A standalone spec may be one Markdown file.
-3. **Establish the tier**: Read `docs/steering/epistemic-tiers.md`. Find the spec's
-   declared target tier in requirements.md. If it doesn't declare one, treat the work
-   as `exploratory` and say so in your report — do not infer a higher tier from how
-   important the work looks.
+3. **Establish the tier**: Read `docs/steering/epistemic-tiers.md` and the CLAUDE.md
+   epistemic-tiers summary. Find the spec's declared target tier in requirements.md.
+   If it doesn't declare one, treat the work as `exploratory` and say so in your
+   report — do not infer a higher tier from how important the work looks.
 4. **Reconcile tasks with reality**: Check existing code and current docs before
    selecting work. An unchecked task may already be implemented or superseded.
 5. **Choose the research surface**: When the question, cohort, matching rule,
-   statistical assumption, or visualization is still uncertain, start from
-   `notebooks/_template.ipynb` at `exploratory` tier. Resolve the uncertainty before
-   proposing promotion; do not duplicate canonical script or library logic in cells.
+   statistical assumption, or visualization is still uncertain, follow the
+   notebook-first workflow in CLAUDE.md and `notebooks/README.md` before promoting
+   anything out of exploratory.
 6. **Implement the requested slice**: Work through the smallest selected tasks in
    dependency order. Do not assume every unchecked task belongs in one change.
-7. **Build to the tier, not above it**: Match the contract for the declared tier and stop
-   there. `exploratory` work does not get tests, abstraction layers, or config surfaces
-   it has no use for. `evidence` work is not complete until all four contract items
-   exist — a passing test suite is not a substitute for a declared estimand.
+7. **Build to the tier, not above it**: Hold to CLAUDE.md's three tier rules and the
+   contract in `docs/steering/epistemic-tiers.md`. Stop when the declared tier's
+   contract is met — do not over-build exploratory work, and do not treat a green
+   test suite as a substitute for an evidence estimand.
 8. **Verify each change**: Run the narrowest relevant test first, then Ruff on
    changed Python files. Run `make lint-boundaries`; run `make docs-check` when
    documentation or specs changed.
 9. **Reconcile the records**: Update completed tasks, `specs/status.md`, and any
    architecture, runbook, or user-facing document affected by the implementation.
 
-## Tier Rules
+## Role obligations
 
-- **Reuse primitives; never fork them.** Company-name normalization and similarity
-  go through `sbir_etl.identity`. Configuration goes through
-  `sbir_etl/config/loader.py`. If you need behavior these don't have, add a named
-  versioned profile to the primitive — do not write a local variant.
-- **Never promote silently.** If a task requires importing `scripts/` code from
-  `sbir_etl/` or `packages/`, or quoting an exploratory number as a finding, stop.
-  Promotion is separate work with the destination tier's contract satisfied.
+- **Reuse primitives; never fork them** — see CLAUDE.md (`sbir_etl.identity`,
+  `sbir_etl/config/loader.py`). Add a named profile when you need new behavior.
+- **Never promote silently** — stop if the slice would import `scripts/` into
+  `sbir_etl/`/`packages/` or quote exploratory numbers as findings. Promotion is
+  separate work.
 - **Report the tier you built at**, and flag any place the spec's tasks implied a
   higher tier than the spec declared.
 

--- a/.claude/agents/test-fixer.md
+++ b/.claude/agents/test-fixer.md
@@ -5,6 +5,9 @@ tools: Read, Edit, Glob, Grep, Bash
 model: sonnet
 ---
 
+Shared conventions (epistemic tiers, code standards, testing commands) are in
+[CLAUDE.md](../../CLAUDE.md). This file is role-only.
+
 You are a test diagnostician and fixer for the SBIR Analytics project. Your job is to get failing tests passing and improve test coverage.
 
 ## Your Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,9 +61,10 @@ by hand with the inputs available on this host.
 
 ## Agents
 
-Full role instructions live in `.claude/agents/`. The `.Codex/agents/` files
-route Codex agents to the same instructions so the two runtimes do not maintain
-separate copies.
+Full role instructions live in `.claude/agents/`. Those files are **role-only**
+(workflows, verdicts, tier-scaled effort); shared conventions stay here in
+CLAUDE.md. The `.Codex/agents/` files route Codex agents to the same
+instructions so the two runtimes do not maintain separate copies.
 
 | Agent | When to Use | Model |
 |-------|-------------|-------|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 of the rules-cleanup plan: stop restating CLAUDE conventions inside agent role files.

- Add a **Shared conventions → CLAUDE.md** pointer at the top of all four `.claude/agents/*.md` files.
- Collapse duplicated tier / notebook / primitive-reuse prose in `spec-implementer.md` into pointers; keep workflow, stop gates, and “report the tier you built.”
- Keep `scope-guard` review questions (under/over-built, silent promotion, RETIER) but point tier contracts at CLAUDE + `epistemic-tiers.md`.
- Leave `test-fixer` / `quality-sweep` coverage and sweep-intensity tables intact (role-specific application).
- Clarify in CLAUDE.md that agent files are role-only.

`.Codex/agents/` wrappers were already thin and are unchanged.

## Verify

- `make docs-check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0055a-20fb-768e-82dd-bd2a4855079a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0055a-20fb-768e-82dd-bd2a4855079a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

