### PR TITLE
Align glossary and requirements template with owners

### DIFF
--- a/docs/development/spec-workflow-guide.md
+++ b/docs/development/spec-workflow-guide.md
@@ -35,7 +35,9 @@ specs/<feature>/
 
 ### Requirements
 
-Begin `requirements.md` with a compact context block:
+Start from [`specs/REQUIREMENTS_TEMPLATE.md`](../../specs/REQUIREMENTS_TEMPLATE.md).
+Design and tasks shapes live in this guide (there are no separate DESIGN/TASKS template
+files). Begin `requirements.md` with a compact context block:
 
 ```markdown
 # <Feature> Requirements

--- a/docs/steering/glossary.md
+++ b/docs/steering/glossary.md
@@ -1,12 +1,25 @@
 # Glossary
 
-## Confidence Levels (Enrichment)
+Short definitions for recurring pipeline and enrichment terms. Method-specific
+thresholds and tier contracts live in their owner docs — do not treat this file
+as a universal scoring standard.
 
-| Level | Range | Sources | Use Case |
-|-------|-------|---------|----------|
-| High | ≥0.80 | Exact matches, API lookups | Production ready |
-| Medium | 0.60-0.79 | Fuzzy matches, validated proximity | Review recommended |
-| Low | <0.60 | Agency defaults, sector fallbacks | Manual review required |
+## Confidence (method-scoped)
+
+There is **no repository-wide High / Medium / Low band**. A confidence value is
+meaningful only with its method and calibration population; see
+[enrichment-patterns.md](enrichment-patterns.md#confidence).
+
+Owners (read the config or doc; do not copy numbers here):
+
+| Method | Owner |
+|--------|--------|
+| Enrichment doctrine | [enrichment-patterns.md](enrichment-patterns.md) |
+| Fuzzy-match thresholds | `config/base.yaml` (`high_confidence_threshold` / `low_confidence_threshold`) |
+| Transition HIGH / LIKELY / POSSIBLE | `config/transition/detection.yaml`, [detection-algorithm.md](../transition/detection-algorithm.md) |
+| CET High / Medium / Low | `config/cet/classification.yaml` |
+| Form D confidence tiers | [form-d-data-dictionary.md](../research/form-d-data-dictionary.md) |
+| Company-categorization bands | `config/base.yaml` (award-count knobs) |
 
 ## Key Terms
 
@@ -15,7 +28,15 @@
 - Incremental mode: Process only new/changed data while preserving previous outputs.
 - Chunked processing: Split large datasets into bounded-size chunks to manage memory.
 - Fallback chain: Ordered sequence of enrichment sources, moving to the next on failure.
-- Evidence: Metadata supporting an enrichment decision (e.g., similarity scores, API info).
-- Confidence: Numeric score (0.0–1.0) indicating reliability of an enrichment result.
+- Enrichment evidence: Metadata supporting an enrichment decision (e.g., similarity
+  scores, API info). Not the epistemic tier named `evidence` — see
+  [epistemic-tiers.md](epistemic-tiers.md).
+- Confidence: Numeric score produced by a named method (often 0.0–1.0). Gate on that
+  method's contract, not a context-free band from this glossary.
+- Epistemic tier: Admission control for how much weight an artifact can carry
+  (`primitives` / `pipelines` / `evidence` / `exploratory`). Defined in
+  [epistemic-tiers.md](epistemic-tiers.md) and summarized in [CLAUDE.md](../../CLAUDE.md).
+- RQ complexity tier: Descriptive / Relational / Inferential / Predictive labels in
+  [research-questions.md](../research-questions.md). Not an epistemic tier.
 - Batch size: Number of records processed per operation (API call, DB write, etc.).
 - Env var override: `SBIR_ETL__...` environment variable that overrides YAML config at runtime.

--- a/specs/REQUIREMENTS_TEMPLATE.md
+++ b/specs/REQUIREMENTS_TEMPLATE.md
@@ -1,11 +1,32 @@
 # [Feature Name] — Requirements
 
-> **Status:** [Not yet started | In progress | Partially implemented | Complete]
+<!--
+Before writing: read specs/status.md (lifecycle), docs/development/spec-workflow-guide.md
+(shapes), docs/steering/epistemic-tiers.md (contracts), and CLAUDE.md (conventions).
+Design and tasks shapes live in the workflow guide — there are no separate DESIGN/TASKS
+template files.
+-->
+
+> **Lifecycle status:** [see `specs/status.md` — Active | Maintenance | Gated backlog |
+> Deferred | Archive candidate]
+> **Spec-file progress (optional):** [Not yet started | In progress | Partially implemented | Complete]
 > Anchors inventory question(s) **[RQ IDs]** in [docs/research-questions.md](../docs/research-questions.md).
+
+**Target epistemic tier:** [`primitives` | `pipelines` | `evidence` | `exploratory`]
+(see [epistemic-tiers.md](../docs/steering/epistemic-tiers.md))
 
 **Research question anchor:** [e.g., A3 — DoD leverage ratio]
 **Answers for:** [audiences from the RQ inventory — e.g., policy analysts, SBIR program managers]
-**Complexity tier:** [Descriptive | Relational | Inferential | Predictive]
+**RQ complexity tier:** [Descriptive | Relational | Inferential | Predictive]
+(not epistemic tier; see [research-questions.md](../docs/research-questions.md))
+
+<!--
+Evidence-tier only — omit for other tiers. Required when Target epistemic tier is `evidence`:
+**Declared estimand:** [what quantity is estimated, and what would make it wrong]
+Plus an amendments.md freeze log with a SHA-256 digest and/or raw-byte freeze language.
+See docs/steering/epistemic-tiers.md. Default to pipelines or exploratory when the
+four-item evidence contract is not yet in place.
+-->
 
 ---
 
@@ -30,7 +51,8 @@ tractable. Cite the relevant RQ section. Do not repeat the glossary or the requi
 ## Glossary
 
 [Optional. Define only terms that are ambiguous in context or that have project-specific
-meanings. Omit standard terms like "award" or "agency".]
+meanings. Omit standard terms like "award" or "agency". Do not redefine confidence bands —
+link the owning config or doc from [glossary.md](../docs/steering/glossary.md).]
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 5 of the rules-cleanup plan: stop treating the steering glossary and requirements template as competing standards.

- **`docs/steering/glossary.md`**: remove the false universal High/Medium/Low enrichment bands; point at method owners (enrichment patterns, fuzzy-match config, transition detection, CET, Form D, company categorization). Rename enrichment “Evidence” so it does not collide with the epistemic `evidence` tier; add short epistemic vs RQ-complexity pointers.
- **`specs/REQUIREMENTS_TEMPLATE.md`**: lifecycle status → `specs/status.md`; add `Target epistemic tier`; relabel complexity as **RQ complexity tier**; evidence-only estimand comment; glossary note not to redefine confidence bands; before-writing pointer block.
- **`docs/development/spec-workflow-guide.md`**: one-liner that requirements start from the template and design/tasks shapes live in the guide.

Overlaps the template hunks in #635 (Phase 3); rebase whichever lands second.

## Verify

- `make docs-check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0055a-20fb-768e-82dd-bd2a4855079a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0055a-20fb-768e-82dd-bd2a4855079a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

