### PR TITLE
Add NIH RePORTER API client (issue #443, PR 1)

### DIFF
--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/nih_reporter.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/nih_reporter.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pandas as pd
 
+from sbir_etl.enrichers.nih_reporter.keys import canonicalize_nih_query_key
 from sbir_etl.identity.exact_awards import IdentityRecoveryError
 from .source_keys import NIH_CORE_PROJECT_ADAPTER, NIH_PROJECT_ADAPTER
 
@@ -31,17 +32,6 @@ _INCLUDE_FIELDS = (
     "CoreProjectNum",
     "Organization",
 )
-
-
-def canonicalize_nih_query_key(value: Any) -> str | None:
-    """Format an SBIR source key for an exact NIH project-number query."""
-
-    if value is None or value is pd.NA:
-        return None
-    text = str(value).strip(" ,").upper()
-    if not text or text in {"<NA>", "NAN", "NONE", "NULL", r"\N"}:
-        return None
-    return "".join(text.split()) or None
 
 
 def _chunks(values: Sequence[str], size: int) -> Iterator[Sequence[str]]:

--- a/sbir_etl/enrichers/nih_reporter/__init__.py
+++ b/sbir_etl/enrichers/nih_reporter/__init__.py
@@ -1,0 +1,39 @@
+"""NIH RePORTER Projects API v2 client and record schema.
+
+Epistemic tier: pipelines. Domain semantics (activity codes, windows,
+``appl_id`` / FY grain) live here. The shared refresh runner is a later PR.
+"""
+
+from sbir_etl.enrichers.nih_reporter.client import (
+    NIH_ACTIVITY_CODES,
+    NIH_PAGE_SIZE,
+    NIH_REPORTER_CITATION,
+    NIH_REPORTER_ENDPOINT,
+    NIHReporterAPIClient,
+    NIHReporterPage,
+)
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHSearchWindow,
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord, normalize_reporter_result
+
+
+EPISTEMIC_TIER = "pipelines"
+
+__all__ = [
+    "NIH_ACTIVITY_CODES",
+    "NIH_PAGE_SIZE",
+    "NIH_REPORTER_CITATION",
+    "NIH_REPORTER_ENDPOINT",
+    "NIHReporterAPIClient",
+    "NIHReporterPage",
+    "NIHReporterRecord",
+    "NIHSearchWindow",
+    "NIHWindowKind",
+    "canonicalize_nih_query_key",
+    "normalize_reporter_result",
+    "parse_refresh_window",
+]

--- a/sbir_etl/enrichers/nih_reporter/client.py
+++ b/sbir_etl/enrichers/nih_reporter/client.py
@@ -1,0 +1,300 @@
+"""NIH RePORTER Projects API v2 client.
+
+Epistemic tier: pipelines. Transport, retry, and rate limits come from
+``BaseAsyncAPIClient``. Activity codes, windows, and ``appl_id`` / FY grain
+stay here. No network in unit tests — inject ``http_client``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from sbir_etl.config.loader import get_config
+from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHSearchWindow,
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord, normalize_reporter_result
+from sbir_etl.exceptions import APIError
+from sbir_etl.utils.path_utils import ensure_dir
+
+
+EPISTEMIC_TIER = "pipelines"
+
+NIH_REPORTER_BASE_URL = "https://api.reporter.nih.gov/v2"
+NIH_REPORTER_SEARCH_PATH = "/projects/search"
+NIH_REPORTER_ENDPOINT = f"{NIH_REPORTER_BASE_URL}{NIH_REPORTER_SEARCH_PATH}"
+NIH_REPORTER_CITATION = "https://api.reporter.nih.gov/"
+NIH_ACTIVITY_CODES: tuple[str, ...] = ("R43", "R44", "R41", "R42")
+NIH_PAGE_SIZE = 500
+NIH_INCLUDE_FIELDS: tuple[str, ...] = (
+    "ApplId",
+    "FiscalYear",
+    "ProjectNum",
+    "CoreProjectNum",
+    "ActivityCode",
+    "AgencyIcAdmin",
+    "Organization",
+    "PrincipalInvestigators",
+    "ProjectTitle",
+    "AbstractText",
+    "AwardAmount",
+    "OpportunityNumber",
+    "FullStudySection",
+)
+
+
+@dataclass(frozen=True)
+class NIHReporterPage:
+    """One validated search page plus the raw body used for hashing/cache."""
+
+    total: int
+    offset: int
+    limit: int
+    results: tuple[Mapping[str, Any], ...]
+    raw_body: bytes
+    payload_hash: str
+
+
+class NIHReporterAPIClient(BaseAsyncAPIClient):
+    """Async client for ``POST /v2/projects/search``."""
+
+    api_name = "nih_reporter"
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        cache_dir: Path | str | None = None,
+    ) -> None:
+        super().__init__()
+        if config is None:
+            cfg = get_config()
+            self.config = cfg.enrichment_refresh.nih_reporter.model_dump()
+        else:
+            self.config = config
+
+        self.base_url = str(self.config.get("base_url", NIH_REPORTER_BASE_URL))
+        self.timeout = self.config.get("timeout_seconds", 30)
+        self.rate_limit_per_minute = int(self.config.get("rate_limit_per_minute", 30))
+        cache_setting = cache_dir
+        if cache_setting is None:
+            cache_block = self.config.get("cache") or {}
+            if isinstance(cache_block, Mapping):
+                cache_setting = cache_block.get("cache_dir", "data/cache/nih_reporter")
+            else:
+                cache_setting = "data/cache/nih_reporter"
+        self.cache_dir = Path(str(cache_setting))
+        self._client = http_client or httpx.AsyncClient(timeout=self.timeout)
+        logger.info(
+            f"Initialized NIHReporterAPIClient: base_url={self.base_url}, "
+            f"rate_limit={self.rate_limit_per_minute}/min"
+        )
+
+    def build_search_payload(
+        self,
+        *,
+        offset: int,
+        limit: int = NIH_PAGE_SIZE,
+        project_nums: Sequence[str] | None = None,
+        fiscal_years: Sequence[int] | None = None,
+        window: str | NIHSearchWindow | None = None,
+        activity_codes: Sequence[str] | None = NIH_ACTIVITY_CODES,
+    ) -> dict[str, Any]:
+        """Build a RePORTER search body. Windows become criteria, not filters."""
+
+        if offset < 0:
+            raise ValueError("NIH RePORTER offset must be >= 0")
+        if limit < 1 or limit > NIH_PAGE_SIZE:
+            raise ValueError(f"NIH RePORTER limit must be between 1 and {NIH_PAGE_SIZE}")
+
+        criteria: dict[str, Any] = {}
+        if activity_codes:
+            criteria["activity_codes"] = list(activity_codes)
+        if project_nums:
+            keys = [
+                key
+                for key in (canonicalize_nih_query_key(item) for item in project_nums)
+                if key is not None
+            ]
+            if not keys:
+                raise ValueError("NIH RePORTER project_nums contained no usable keys")
+            criteria["project_nums"] = keys
+        if fiscal_years:
+            criteria["fiscal_years"] = [int(year) for year in fiscal_years]
+
+        parsed = window if isinstance(window, NIHSearchWindow) else parse_refresh_window(window)
+        if parsed.kind is NIHWindowKind.FISCAL_YEARS and "fiscal_years" in criteria:
+            raise ValueError("do not pass both fiscal_years and a fy: window")
+        parsed.apply_to_criteria(criteria)
+
+        return {
+            "criteria": criteria,
+            "include_fields": list(NIH_INCLUDE_FIELDS),
+            "offset": offset,
+            "limit": limit,
+            "sort_field": "appl_id",
+            "sort_order": "asc",
+        }
+
+    def compute_payload_hash(self, payload: Mapping[str, Any] | bytes) -> str:
+        """SHA-256 of a JSON object (sorted) or of raw response bytes."""
+
+        if isinstance(payload, bytes):
+            return hashlib.sha256(payload).hexdigest()
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    async def fetch_page(
+        self,
+        *,
+        offset: int,
+        limit: int = NIH_PAGE_SIZE,
+        project_nums: Sequence[str] | None = None,
+        fiscal_years: Sequence[int] | None = None,
+        window: str | NIHSearchWindow | None = None,
+        activity_codes: Sequence[str] | None = NIH_ACTIVITY_CODES,
+    ) -> NIHReporterPage:
+        """Fetch and validate one search page."""
+
+        body = self.build_search_payload(
+            offset=offset,
+            limit=limit,
+            project_nums=project_nums,
+            fiscal_years=fiscal_years,
+            window=window,
+            activity_codes=activity_codes,
+        )
+        response = await self._request_raw(
+            "POST",
+            NIH_REPORTER_SEARCH_PATH,
+            params=body,
+            headers={"Content-Type": "application/json"},
+        )
+        raw = response.content
+        self._write_raw_cache(raw)
+        return self.parse_page(raw, offset=offset, limit=limit)
+
+    def parse_page(self, raw: bytes, *, offset: int, limit: int) -> NIHReporterPage:
+        """Validate pagination metadata. Fail closed on inconsistency."""
+
+        try:
+            payload = json.loads(raw)
+            meta = payload["meta"]
+            results = payload["results"]
+            total = int(meta["total"])
+            response_offset = int(meta["offset"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            raise APIError(
+                "NIH RePORTER returned an invalid response",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            ) from error
+        if response_offset != offset or not isinstance(results, list):
+            raise APIError(
+                "NIH RePORTER pagination metadata is inconsistent",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            )
+        if len(results) > limit or total < offset + len(results):
+            raise APIError(
+                "NIH RePORTER returned inconsistent result counts",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            )
+        if offset < total and not results:
+            raise APIError(
+                "NIH RePORTER pagination stopped before the declared total",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            )
+        return NIHReporterPage(
+            total=total,
+            offset=offset,
+            limit=limit,
+            results=tuple(results),
+            raw_body=raw,
+            payload_hash=self.compute_payload_hash(raw),
+        )
+
+    async def search_projects(
+        self,
+        *,
+        project_nums: Sequence[str] | None = None,
+        fiscal_years: Sequence[int] | None = None,
+        window: str | NIHSearchWindow | None = None,
+        activity_codes: Sequence[str] | None = NIH_ACTIVITY_CODES,
+        limit: int = NIH_PAGE_SIZE,
+        retrieved_at: datetime | None = None,
+    ) -> list[NIHReporterRecord]:
+        """Walk every page for the given criteria and normalize rows."""
+
+        retrieved = retrieved_at or datetime.now(UTC)
+        records: list[NIHReporterRecord] = []
+        offset = 0
+        while True:
+            page = await self.fetch_page(
+                offset=offset,
+                limit=limit,
+                project_nums=project_nums,
+                fiscal_years=fiscal_years,
+                window=window,
+                activity_codes=activity_codes,
+            )
+            for result in page.results:
+                if not isinstance(result, Mapping):
+                    raise APIError(
+                        "NIH RePORTER result is not an object",
+                        api_name=self.api_name,
+                        endpoint=NIH_REPORTER_SEARCH_PATH,
+                    )
+                records.append(
+                    normalize_reporter_result(
+                        result,
+                        retrieved_at=retrieved,
+                        payload_hash=page.payload_hash,
+                    )
+                )
+            offset += len(page.results)
+            if offset >= page.total:
+                return records
+
+    async def lookup_projects(
+        self,
+        project_nums: Sequence[str],
+        fiscal_year: int,
+        *,
+        limit: int = NIH_PAGE_SIZE,
+        retrieved_at: datetime | None = None,
+    ) -> list[NIHReporterRecord]:
+        """Exact ``project_nums`` + FY lookup, still scoped to SBIR/STTR codes."""
+
+        return await self.search_projects(
+            project_nums=project_nums,
+            fiscal_years=[fiscal_year],
+            activity_codes=NIH_ACTIVITY_CODES,
+            limit=limit,
+            retrieved_at=retrieved_at,
+        )
+
+    def _write_raw_cache(self, raw: bytes) -> None:
+        if not raw:
+            return
+        ensure_dir(self.cache_dir)
+        digest = self.compute_payload_hash(raw)
+        path = self.cache_dir / f"{digest}.json"
+        if not path.exists():
+            path.write_bytes(raw)

--- a/sbir_etl/enrichers/nih_reporter/keys.py
+++ b/sbir_etl/enrichers/nih_reporter/keys.py
@@ -1,0 +1,125 @@
+"""NIH RePORTER query-key and refresh-window helpers.
+
+Epistemic tier: pipelines. Canonicalization is exact-key formatting, not
+company-name identity. Window strings become RePORTER criteria; they are
+never applied as a post-fetch filter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from typing import Any
+
+import pandas as pd
+
+
+EPISTEMIC_TIER = "pipelines"
+
+_NULL_TEXT = frozenset({"<NA>", "NAN", "NONE", "NULL", r"\N"})
+_FY_WINDOW_PREFIX = "fy:"
+
+
+class NIHWindowKind(StrEnum):
+    """How a refresh window maps onto RePORTER search criteria."""
+
+    ALL = "all"
+    PROJECT_START_DATE = "project_start_date"
+    FISCAL_YEARS = "fiscal_years"
+
+
+@dataclass(frozen=True)
+class NIHSearchWindow:
+    """Parsed ``--window`` value ready to attach to a RePORTER criteria object."""
+
+    kind: NIHWindowKind
+    from_date: str | None = None
+    to_date: str | None = None
+    fiscal_years: tuple[int, ...] = ()
+
+    def apply_to_criteria(self, criteria: dict[str, Any]) -> None:
+        """Mutate ``criteria`` with this window. ``ALL`` adds nothing."""
+
+        if self.kind is NIHWindowKind.ALL:
+            return
+        if self.kind is NIHWindowKind.PROJECT_START_DATE:
+            criteria["project_start_date"] = {
+                "from_date": self.from_date,
+                "to_date": self.to_date,
+            }
+            return
+        criteria["fiscal_years"] = list(self.fiscal_years)
+
+
+def canonicalize_nih_query_key(value: Any) -> str | None:
+    """Format an SBIR source key for an exact NIH project-number query.
+
+    Behavior is the Phase III identity-recovery contract: strip surrounding
+    spaces and commas, uppercase, drop interior whitespace, and reject null
+    tokens. Structural punctuation such as ``-`` is preserved.
+    """
+
+    if value is None or value is pd.NA:
+        return None
+    text = str(value).strip(" ,").upper()
+    if not text or text in _NULL_TEXT:
+        return None
+    return "".join(text.split()) or None
+
+
+def parse_refresh_window(window: str | None) -> NIHSearchWindow:
+    """Parse a CLI window into RePORTER criteria.
+
+    Accepted forms:
+
+    - ``None`` / blank — full activity-code snapshot, no date or FY filter
+    - ``YYYY-MM-DD:YYYY-MM-DD`` — inclusive ``project_start_date`` range
+    - ``fy:YYYY-YYYY`` — inclusive fiscal-year range
+
+    Raises:
+        ValueError: If the window is malformed or inverted.
+    """
+
+    if window is None:
+        return NIHSearchWindow(kind=NIHWindowKind.ALL)
+    text = window.strip()
+    if not text:
+        return NIHSearchWindow(kind=NIHWindowKind.ALL)
+
+    lowered = text.lower()
+    if lowered.startswith(_FY_WINDOW_PREFIX):
+        return _parse_fiscal_year_window(text[len(_FY_WINDOW_PREFIX) :])
+    return _parse_project_start_window(text)
+
+
+def _parse_fiscal_year_window(spec: str) -> NIHSearchWindow:
+    parts = spec.split("-")
+    if len(parts) != 2 or not all(part.isdigit() and len(part) == 4 for part in parts):
+        raise ValueError(f"invalid NIH fiscal-year window {spec!r}; expected fy:YYYY-YYYY")
+    start_year = int(parts[0])
+    end_year = int(parts[1])
+    if end_year < start_year:
+        raise ValueError(f"inverted NIH fiscal-year window fy:{start_year}-{end_year}")
+    years = tuple(range(start_year, end_year + 1))
+    return NIHSearchWindow(kind=NIHWindowKind.FISCAL_YEARS, fiscal_years=years)
+
+
+def _parse_project_start_window(spec: str) -> NIHSearchWindow:
+    parts = spec.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"invalid NIH date window {spec!r}; expected YYYY-MM-DD:YYYY-MM-DD")
+    try:
+        start = date.fromisoformat(parts[0])
+        end = date.fromisoformat(parts[1])
+    except ValueError as error:
+        raise ValueError(
+            f"invalid NIH date window {spec!r}; expected YYYY-MM-DD:YYYY-MM-DD"
+        ) from error
+    if end < start:
+        raise ValueError(f"inverted NIH date window {spec}")
+    return NIHSearchWindow(
+        kind=NIHWindowKind.PROJECT_START_DATE,
+        from_date=start.isoformat(),
+        to_date=end.isoformat(),
+    )

--- a/sbir_etl/enrichers/nih_reporter/schema.py
+++ b/sbir_etl/enrichers/nih_reporter/schema.py
@@ -1,0 +1,207 @@
+"""Normalized NIH RePORTER project record.
+
+Epistemic tier: pipelines. ``appl_id`` is the official row id. Award-level
+upsert uses ``(canonical project_num, fy)``. Multiple ``appl_id``s or
+organization identifiers for one upsert key are retained, not collapsed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sbir_etl.enrichers.nih_reporter.keys import canonicalize_nih_query_key
+
+
+EPISTEMIC_TIER = "pipelines"
+
+NIH_SOURCE_ID = "nih_reporter"
+
+
+@dataclass(frozen=True)
+class NIHReporterRecord:
+    """One RePORTER project row after field extraction.
+
+    ``org_uei`` / ``org_duns`` are the primary identifiers when present.
+    ``org_ueis`` / ``org_duns_values`` keep the full official sets so a later
+    identity consumer can expand pairs without a second fetch.
+    """
+
+    appl_id: str
+    fy: int
+    project_num: str | None = None
+    core_project_num: str | None = None
+    activity_code: str | None = None
+    agency_ic_admin: str | None = None
+    org_name: str | None = None
+    org_uei: str | None = None
+    org_duns: str | None = None
+    org_ueis: tuple[str, ...] = ()
+    org_duns_values: tuple[str, ...] = ()
+    pi_names: tuple[str, ...] = ()
+    project_title: str | None = None
+    abstract_text: str | None = None
+    award_amount: float | None = None
+    foa_number: str | None = None
+    study_section: str | None = None
+    source: str = NIH_SOURCE_ID
+    last_refreshed_at: datetime | None = None
+    payload_hash: str | None = None
+
+    def upsert_key(self) -> tuple[str, int] | None:
+        """Award-level key, or ``None`` when the project number is unusable."""
+
+        canonical = canonicalize_nih_query_key(self.project_num)
+        if canonical is None:
+            return None
+        return (canonical, self.fy)
+
+    def to_mapping(self) -> dict[str, Any]:
+        """JSON/Parquet-friendly record."""
+
+        return {
+            "appl_id": self.appl_id,
+            "fy": self.fy,
+            "project_num": self.project_num,
+            "core_project_num": self.core_project_num,
+            "activity_code": self.activity_code,
+            "agency_ic_admin": self.agency_ic_admin,
+            "org_name": self.org_name,
+            "org_uei": self.org_uei,
+            "org_duns": self.org_duns,
+            "org_ueis": list(self.org_ueis),
+            "org_duns_values": list(self.org_duns_values),
+            "pi_names": list(self.pi_names),
+            "project_title": self.project_title,
+            "abstract_text": self.abstract_text,
+            "award_amount": self.award_amount,
+            "foa_number": self.foa_number,
+            "study_section": self.study_section,
+            "source": self.source,
+            "last_refreshed_at": (
+                self.last_refreshed_at.isoformat() if self.last_refreshed_at else None
+            ),
+            "payload_hash": self.payload_hash,
+        }
+
+
+def normalize_reporter_result(
+    result: Mapping[str, Any],
+    *,
+    retrieved_at: datetime | None = None,
+    payload_hash: str | None = None,
+) -> NIHReporterRecord:
+    """Extract a typed record from one RePORTER ``results[]`` object.
+
+    Raises:
+        ValueError: If ``appl_id`` or ``fiscal_year`` is missing or unusable.
+    """
+
+    try:
+        appl_id = str(result["appl_id"]).strip()
+        fy = int(result["fiscal_year"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("NIH RePORTER project lacks appl_id or fiscal_year") from error
+    if not appl_id:
+        raise ValueError("NIH RePORTER project lacks appl_id or fiscal_year")
+
+    raw_org = result.get("organization")
+    organization = raw_org if isinstance(raw_org, Mapping) else {}
+    ueis = _identifier_values(organization, "org_ueis", "primary_uei")
+    duns_values = _identifier_values(organization, "org_duns", "primary_duns")
+    return NIHReporterRecord(
+        appl_id=appl_id,
+        fy=fy,
+        project_num=_optional_str(result.get("project_num")),
+        core_project_num=_optional_str(result.get("core_project_num")),
+        activity_code=_optional_str(result.get("activity_code")),
+        agency_ic_admin=_optional_str(result.get("agency_ic_admin")),
+        org_name=_optional_str(organization.get("org_name")),
+        org_uei=ueis[0] if ueis else None,
+        org_duns=duns_values[0] if duns_values else None,
+        org_ueis=ueis,
+        org_duns_values=duns_values,
+        pi_names=_pi_names(result.get("principal_investigators")),
+        project_title=_optional_str(result.get("project_title")),
+        abstract_text=_optional_str(result.get("abstract_text")),
+        award_amount=_optional_float(result.get("award_amount")),
+        foa_number=_opportunity_number(result.get("opportunity_number")),
+        study_section=_study_section(result.get("full_study_section")),
+        last_refreshed_at=retrieved_at,
+        payload_hash=payload_hash,
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _identifier_values(
+    organization: Mapping[str, Any],
+    plural_key: str,
+    primary_key: str,
+) -> tuple[str, ...]:
+    raw = organization.get(plural_key)
+    values: list[str] = []
+    if isinstance(raw, list):
+        for item in raw:
+            text = str(item).strip() if item is not None else ""
+            if text:
+                values.append(text)
+    primary = _optional_str(organization.get(primary_key))
+    if primary and primary not in values:
+        values.insert(0, primary)
+    return tuple(dict.fromkeys(values))
+
+
+def _pi_names(raw: Any) -> tuple[str, ...]:
+    if not isinstance(raw, list):
+        return ()
+    names: list[str] = []
+    for investigator in raw:
+        if not isinstance(investigator, Mapping):
+            continue
+        full = _optional_str(investigator.get("full_name"))
+        if full:
+            names.append(full)
+            continue
+        first = _optional_str(investigator.get("first_name")) or ""
+        last = _optional_str(investigator.get("last_name")) or ""
+        joined = " ".join(part for part in (first, last) if part)
+        if joined:
+            names.append(joined)
+    return tuple(names)
+
+
+def _opportunity_number(raw: Any) -> str | None:
+    if isinstance(raw, list):
+        for item in raw:
+            text = _optional_str(item)
+            if text:
+                return text
+        return None
+    return _optional_str(raw)
+
+
+def _study_section(raw: Any) -> str | None:
+    if isinstance(raw, Mapping):
+        for key in ("srg_code", "name", "srg_name"):
+            text = _optional_str(raw.get(key))
+            if text:
+                return text
+        return None
+    return _optional_str(raw)

--- a/specs/iterative-api-enrichment/tasks.md
+++ b/specs/iterative-api-enrichment/tasks.md
@@ -80,3 +80,25 @@ Optional Phase 2 expansion (6.1, 6.2) is **not** required to close #442.
   - Verify: CLI `--help` and a mocked dry-run
 - [x] 7.5 Update `docs/enrichment/usaspending-iterative-refresh.md`.
   - Verify: `make docs-check`
+
+## Issue #443 — NIH RePORTER source adapter
+
+Per-source adapter for R43/R44/R41/R42. Shared lifecycle stays in
+`SourceAdapter` / `SourceRefreshRunner`. Grain: exact `project_num` /
+`core_project_num` + FY on known SBIR.gov NIH/HHS awards; windows become
+RePORTER criteria. Out of scope: STTR `research_hospitals`, live schedule,
+rewriting the Phase III urllib extractor.
+
+- [x] 8.1 Add `sbir_etl/enrichers/nih_reporter/` client, key canonicalizer,
+      and normalized record schema. Move `canonicalize_nih_query_key` here;
+      Phase III re-exports it.
+  - Verify: `tests/unit/enrichers/nih_reporter/` (pagination, windows,
+    duplicates, retries) and `tests/unit/phase_iii_negative_controls/test_nih_reporter.py`
+- [ ] 8.2 Adapter + SBIR.gov request builder + `refresh-enrichment --source nih_reporter`.
+  - Verify: mocked CLI dry-run; disabled source exits; no USAspending parquet dependency
+- [ ] 8.3 Dagster ledger / stale set / refresh batch and job. No sensor.
+      Keep `enabled: false`.
+  - Verify: job selection includes the refresh asset; hermetic fake adapter
+- [ ] 8.4 Docs (`docs/enrichment/nih-reporter-refresh.md`) and E3 freshness
+      mention only after a hand run has written a freshness row.
+  - Verify: `make docs-check`

--- a/tests/unit/enrichers/nih_reporter/fixtures/search_page.json
+++ b/tests/unit/enrichers/nih_reporter/fixtures/search_page.json
@@ -1,0 +1,28 @@
+{
+  "meta": {"total": 1, "offset": 0, "limit": 500},
+  "results": [
+    {
+      "appl_id": 10824314,
+      "fiscal_year": 2024,
+      "project_num": "1R43AI123456-01",
+      "core_project_num": "R43AI123456",
+      "activity_code": "R43",
+      "agency_ic_admin": "NIAID",
+      "organization": {
+        "org_name": "Example Biotech Inc",
+        "org_ueis": ["DPMGH9MG1X67"],
+        "org_duns": ["076580745"],
+        "primary_uei": "DPMGH9MG1X67",
+        "primary_duns": "076580745"
+      },
+      "principal_investigators": [
+        {"first_name": "Ada", "last_name": "Lovelace", "full_name": "Ada Lovelace"}
+      ],
+      "project_title": "Example SBIR project",
+      "abstract_text": "An abstract.",
+      "award_amount": 275000,
+      "opportunity_number": "PA-22-176",
+      "full_study_section": {"srg_code": "ZRG1", "name": "Special Emphasis Panel"}
+    }
+  ]
+}

--- a/tests/unit/enrichers/nih_reporter/test_client.py
+++ b/tests/unit/enrichers/nih_reporter/test_client.py
@@ -1,0 +1,246 @@
+"""Hermetic tests for NIHReporterAPIClient. No live network."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.client import (
+    NIH_ACTIVITY_CODES,
+    NIH_INCLUDE_FIELDS,
+    NIH_PAGE_SIZE,
+    NIHReporterAPIClient,
+)
+from sbir_etl.exceptions import APIError
+
+
+pytestmark = pytest.mark.fast
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search_page.json"
+
+
+def _client(
+    handler: httpx.MockTransport | Any,
+    tmp_path: Path,
+) -> NIHReporterAPIClient:
+    transport = (
+        handler if isinstance(handler, httpx.MockTransport) else httpx.MockTransport(handler)
+    )
+    return NIHReporterAPIClient(
+        config={
+            "timeout_seconds": 5,
+            "rate_limit_per_minute": 120,
+            "cache": {"cache_dir": str(tmp_path / "cache")},
+        },
+        http_client=httpx.AsyncClient(transport=transport),
+        cache_dir=tmp_path / "cache",
+    )
+
+
+def test_build_payload_omitted_window_is_activity_code_snapshot() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(offset=0)
+    assert payload["criteria"] == {"activity_codes": list(NIH_ACTIVITY_CODES)}
+    assert "project_start_date" not in payload["criteria"]
+    assert "fiscal_years" not in payload["criteria"]
+    assert payload["limit"] == NIH_PAGE_SIZE
+    assert payload["include_fields"] == list(NIH_INCLUDE_FIELDS)
+
+
+def test_build_payload_date_window_is_api_criteria() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(offset=0, window="2020-01-01:2021-12-31")
+    assert payload["criteria"]["project_start_date"] == {
+        "from_date": "2020-01-01",
+        "to_date": "2021-12-31",
+    }
+    assert payload["criteria"]["activity_codes"] == list(NIH_ACTIVITY_CODES)
+
+
+def test_build_payload_fy_window_is_api_criteria() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(offset=0, window="fy:2023-2024")
+    assert payload["criteria"]["fiscal_years"] == [2023, 2024]
+
+
+def test_build_payload_exact_lookup_canonicalizes_keys() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(
+        offset=0,
+        project_nums=[" 1 R43 AI123456-01, "],
+        fiscal_years=[2024],
+    )
+    assert payload["criteria"]["project_nums"] == ["1R43AI123456-01"]
+    assert payload["criteria"]["fiscal_years"] == [2024]
+
+
+def test_build_payload_rejects_fy_window_and_explicit_years() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    with pytest.raises(ValueError, match="fy: window"):
+        client.build_search_payload(offset=0, fiscal_years=[2024], window="fy:2023-2024")
+
+
+def test_payload_hash_is_deterministic() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    first = client.compute_payload_hash({"b": 1, "a": 2})
+    second = client.compute_payload_hash({"a": 2, "b": 1})
+    assert first == second
+    assert len(first) == 64
+
+
+@pytest.mark.asyncio
+async def test_search_uses_recorded_fixture(tmp_path: Path) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, content=FIXTURE.read_bytes())
+
+    client = _client(handler, tmp_path)
+    records = await client.search_projects(window="fy:2024-2024", limit=500)
+    assert len(records) == 1
+    assert records[0].project_num == "1R43AI123456-01"
+    assert captured[0]["criteria"]["fiscal_years"] == [2024]
+    assert captured[0]["criteria"]["activity_codes"] == list(NIH_ACTIVITY_CODES)
+    cached = list((tmp_path / "cache").glob("*.json"))
+    assert len(cached) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_paginates_to_declared_total(tmp_path: Path) -> None:
+    offsets: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        offset = int(body["offset"])
+        offsets.append(offset)
+        result = {
+            "appl_id": 100 + offset,
+            "fiscal_year": 2024,
+            "project_num": "1R43AI123456-01",
+            "activity_code": "R43",
+        }
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 2, "offset": offset, "limit": 1}, "results": [result]},
+        )
+
+    client = _client(handler, tmp_path)
+    records = await client.search_projects(limit=1)
+    assert offsets == [0, 1]
+    assert [record.appl_id for record in records] == ["100", "101"]
+    assert {record.upsert_key() for record in records} == {("1R43AI123456-01", 2024)}
+
+
+@pytest.mark.asyncio
+async def test_partial_last_page_when_next_offset_equals_total(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        offset = int(body["offset"])
+        if offset == 0:
+            results = [
+                {"appl_id": 1, "fiscal_year": 2024, "project_num": "1R43AA000001-01"},
+                {"appl_id": 2, "fiscal_year": 2024, "project_num": "1R44AA000002-01"},
+            ]
+        else:
+            results = [{"appl_id": 3, "fiscal_year": 2024, "project_num": "1R41AA000003-01"}]
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 3, "offset": offset, "limit": 2}, "results": results},
+        )
+
+    records = await _client(handler, tmp_path).search_projects(limit=2)
+    assert [record.appl_id for record in records] == ["1", "2", "3"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_project_num_keeps_both_appl_ids(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "meta": {"total": 2, "offset": 0, "limit": 500},
+                "results": [
+                    {"appl_id": 10, "fiscal_year": 2024, "project_num": "1R43AI123456-01"},
+                    {"appl_id": 11, "fiscal_year": 2024, "project_num": "1R43AI123456-01"},
+                ],
+            },
+        )
+
+    records = await _client(handler, tmp_path).search_projects()
+    assert [record.appl_id for record in records] == ["10", "11"]
+    assert records[0].upsert_key() == records[1].upsert_key()
+
+
+@pytest.mark.asyncio
+async def test_offset_mismatch_fails_closed(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 1, "offset": 99, "limit": 500}, "results": []},
+        )
+
+    with pytest.raises(APIError, match="pagination metadata"):
+        await _client(handler, tmp_path).fetch_page(offset=0)
+
+
+@pytest.mark.asyncio
+async def test_empty_page_before_total_fails_closed(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 4, "offset": 0, "limit": 500}, "results": []},
+        )
+
+    with pytest.raises(APIError, match="stopped before the declared total"):
+        await _client(handler, tmp_path).fetch_page(offset=0)
+
+
+@pytest.mark.asyncio
+async def test_oversized_page_fails_closed(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "meta": {"total": 2, "offset": 0, "limit": 1},
+                "results": [
+                    {"appl_id": 1, "fiscal_year": 2024},
+                    {"appl_id": 2, "fiscal_year": 2024},
+                ],
+            },
+        )
+
+    with pytest.raises(APIError, match="inconsistent result counts"):
+        await _client(handler, tmp_path).fetch_page(offset=0, limit=1)
+
+
+@pytest.mark.asyncio
+async def test_server_error_then_success_is_retried(tmp_path: Path) -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(503, text="unavailable")
+        return httpx.Response(200, content=FIXTURE.read_bytes())
+
+    records = await _client(handler, tmp_path).lookup_projects(["1R43AI123456-01"], 2024)
+    assert attempts["count"] == 2
+    assert records[0].appl_id == "10824314"
+
+
+@pytest.mark.asyncio
+async def test_client_error_is_not_retried(tmp_path: Path) -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(400, text="bad request")
+
+    with pytest.raises(APIError, match="HTTP 400"):
+        await _client(handler, tmp_path).fetch_page(offset=0)
+    assert attempts["count"] == 1

--- a/tests/unit/enrichers/nih_reporter/test_keys.py
+++ b/tests/unit/enrichers/nih_reporter/test_keys.py
@@ -1,0 +1,66 @@
+"""Tests for NIH RePORTER key canonicalization and window parsing."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_canonicalize_preserves_structural_punctuation() -> None:
+    assert canonicalize_nih_query_key(" 5 F32 DK132864-03, ") == "5F32DK132864-03"
+
+
+def test_canonicalize_rejects_null_tokens() -> None:
+    assert canonicalize_nih_query_key(None) is None
+    assert canonicalize_nih_query_key(pd.NA) is None
+    assert canonicalize_nih_query_key("nan") is None
+    assert canonicalize_nih_query_key("  ") is None
+
+
+def test_blank_window_is_full_snapshot() -> None:
+    parsed = parse_refresh_window(None)
+    assert parsed.kind is NIHWindowKind.ALL
+    criteria: dict[str, object] = {"activity_codes": ["R43"]}
+    parsed.apply_to_criteria(criteria)
+    assert criteria == {"activity_codes": ["R43"]}
+
+
+def test_iso_date_window_becomes_project_start_date() -> None:
+    parsed = parse_refresh_window("2020-01-01:2024-12-31")
+    assert parsed.kind is NIHWindowKind.PROJECT_START_DATE
+    criteria: dict[str, object] = {}
+    parsed.apply_to_criteria(criteria)
+    assert criteria == {"project_start_date": {"from_date": "2020-01-01", "to_date": "2024-12-31"}}
+
+
+def test_fiscal_year_window_is_inclusive() -> None:
+    parsed = parse_refresh_window("fy:2022-2024")
+    assert parsed.fiscal_years == (2022, 2023, 2024)
+    criteria: dict[str, object] = {}
+    parsed.apply_to_criteria(criteria)
+    assert criteria == {"fiscal_years": [2022, 2023, 2024]}
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        "2020-01-01",
+        "fy:2024",
+        "fy:2024-20",
+        "not-a-window",
+        "2024-12-31:2020-01-01",
+        "fy:2024-2022",
+    ],
+)
+def test_malformed_or_inverted_windows_fail_closed(window: str) -> None:
+    with pytest.raises(ValueError):
+        parse_refresh_window(window)

--- a/tests/unit/enrichers/nih_reporter/test_schema.py
+++ b/tests/unit/enrichers/nih_reporter/test_schema.py
@@ -1,0 +1,53 @@
+"""Tests for NIH RePORTER record normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.schema import normalize_reporter_result
+
+
+pytestmark = pytest.mark.fast
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search_page.json"
+
+
+def test_normalize_recorded_fixture() -> None:
+    payload = json.loads(FIXTURE.read_text())
+    record = normalize_reporter_result(payload["results"][0], payload_hash="abc")
+    assert record.appl_id == "10824314"
+    assert record.fy == 2024
+    assert record.upsert_key() == ("1R43AI123456-01", 2024)
+    assert record.org_uei == "DPMGH9MG1X67"
+    assert record.org_duns == "076580745"
+    assert record.pi_names == ("Ada Lovelace",)
+    assert record.foa_number == "PA-22-176"
+    assert record.study_section == "ZRG1"
+    assert record.award_amount == 275000.0
+    assert record.source == "nih_reporter"
+    assert record.payload_hash == "abc"
+
+
+def test_normalize_keeps_multiple_org_identifiers() -> None:
+    record = normalize_reporter_result(
+        {
+            "appl_id": 1,
+            "fiscal_year": 2023,
+            "project_num": "1R44CA000001-01",
+            "organization": {
+                "org_ueis": ["UEIAAAA11111", "UEIBBBB22222"],
+                "primary_duns": "123456789",
+            },
+        }
+    )
+    assert record.org_ueis == ("UEIAAAA11111", "UEIBBBB22222")
+    assert record.org_duns == "123456789"
+    assert record.org_duns_values == ("123456789",)
+
+
+def test_normalize_requires_appl_id_and_fy() -> None:
+    with pytest.raises(ValueError, match="appl_id or fiscal_year"):
+        normalize_reporter_result({"project_num": "1R43AI123456-01"})


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

First slice of issue #443: a typed NIH RePORTER Projects API v2 client, shared project-key canonicalizer, and documented project record. No adapter, CLI, or Dagster job yet.

Fixes part of #443.

**Grain (locked for the rest of #443):**
- Official row id: `appl_id`
- Award upsert key: `(canonical project_num, fy)`
- `--window` becomes RePORTER criteria (`project_start_date` or `fiscal_years`), never a post-fetch filter
- Default activity codes: R43 / R44 / R41 / R42
- Pagination fails closed on offset mismatch, empty page before `total`, or `len(results) > limit`

Phase III `canonicalize_nih_query_key` now re-exports the shared helper so there is one canonicalizer. The Phase III urllib extractor is unchanged.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Versioning Impact

- [x] MINOR: new capability, deprecation, or breaking change during `0.x`

## Testing

- `uv run pytest tests/unit/enrichers/nih_reporter tests/unit/phase_iii_negative_controls/test_nih_reporter.py` — 32 passed
- `uv run ruff check` on the new package
- `uv run python -m mypy sbir_etl/enrichers/nih_reporter`
- `uv run python scripts/ci/check_tier_boundaries.py`

## Remaining #443 slices

- 8.2 Adapter + SBIR.gov request builder + `refresh-enrichment --source nih_reporter`
- 8.3 Dagster job (no sensor); keep `enabled: false`
- 8.4 Docs; E3 freshness mention only after a hand run

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51d513e6-97b1-44f8-a000-6b9cd092d414?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51d513e6-97b1-44f8-a000-6b9cd092d414&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

