### PR TITLE
Add NIH RePORTER source adapter and CLI (issue #443, PR 2)

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -252,7 +252,7 @@ enrichment_refresh:
       ttl_hours: 168  # 7 days - filings are relatively stable
 
   nih_reporter:
-    # Disabled registry slot for issue #443. No client is implemented here.
+    # Disabled until a hand run succeeds (issue #443). Adapter is wired; do not enable on the live host yet.
     enabled: false
     cadence_days: 7
     sla_staleness_days: 7

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/nih_reporter.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_iii_negative_controls/nih_reporter.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import pandas as pd
 
+from sbir_etl.enrichers.nih_reporter.keys import canonicalize_nih_query_key
 from sbir_etl.identity.exact_awards import IdentityRecoveryError
 from .source_keys import NIH_CORE_PROJECT_ADAPTER, NIH_PROJECT_ADAPTER
 
@@ -31,17 +32,6 @@ _INCLUDE_FIELDS = (
     "CoreProjectNum",
     "Organization",
 )
-
-
-def canonicalize_nih_query_key(value: Any) -> str | None:
-    """Format an SBIR source key for an exact NIH project-number query."""
-
-    if value is None or value is pd.NA:
-        return None
-    text = str(value).strip(" ,").upper()
-    if not text or text in {"<NA>", "NAN", "NONE", "NULL", r"\N"}:
-        return None
-    return "".join(text.split()) or None
 
 
 def _chunks(values: Sequence[str], size: int) -> Iterator[Sequence[str]]:

--- a/sbir_etl/enrichers/nih_reporter/__init__.py
+++ b/sbir_etl/enrichers/nih_reporter/__init__.py
@@ -1,9 +1,11 @@
-"""NIH RePORTER Projects API v2 client and record schema.
+"""NIH RePORTER Projects API v2 client, adapter, and record schema.
 
 Epistemic tier: pipelines. Domain semantics (activity codes, windows,
-``appl_id`` / FY grain) live here. The shared refresh runner is a later PR.
+``appl_id`` / FY grain) live here. The shared refresh runner stays in
+``source_adapter``.
 """
 
+from sbir_etl.enrichers.nih_reporter.adapter import NIHReporterSourceAdapter
 from sbir_etl.enrichers.nih_reporter.client import (
     NIH_ACTIVITY_CODES,
     NIH_PAGE_SIZE,
@@ -18,6 +20,14 @@ from sbir_etl.enrichers.nih_reporter.keys import (
     canonicalize_nih_query_key,
     parse_refresh_window,
 )
+from sbir_etl.enrichers.nih_reporter.persist import (
+    nih_reporter_awards_path,
+    upsert_nih_reporter_awards,
+)
+from sbir_etl.enrichers.nih_reporter.requests import (
+    build_nih_reporter_requests,
+    load_sbir_award_frame,
+)
 from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord, normalize_reporter_result
 
 
@@ -31,9 +41,14 @@ __all__ = [
     "NIHReporterAPIClient",
     "NIHReporterPage",
     "NIHReporterRecord",
+    "NIHReporterSourceAdapter",
     "NIHSearchWindow",
     "NIHWindowKind",
+    "build_nih_reporter_requests",
     "canonicalize_nih_query_key",
+    "load_sbir_award_frame",
+    "nih_reporter_awards_path",
     "normalize_reporter_result",
     "parse_refresh_window",
+    "upsert_nih_reporter_awards",
 ]

--- a/sbir_etl/enrichers/nih_reporter/__init__.py
+++ b/sbir_etl/enrichers/nih_reporter/__init__.py
@@ -1,0 +1,39 @@
+"""NIH RePORTER Projects API v2 client and record schema.
+
+Epistemic tier: pipelines. Domain semantics (activity codes, windows,
+``appl_id`` / FY grain) live here. The shared refresh runner is a later PR.
+"""
+
+from sbir_etl.enrichers.nih_reporter.client import (
+    NIH_ACTIVITY_CODES,
+    NIH_PAGE_SIZE,
+    NIH_REPORTER_CITATION,
+    NIH_REPORTER_ENDPOINT,
+    NIHReporterAPIClient,
+    NIHReporterPage,
+)
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHSearchWindow,
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord, normalize_reporter_result
+
+
+EPISTEMIC_TIER = "pipelines"
+
+__all__ = [
+    "NIH_ACTIVITY_CODES",
+    "NIH_PAGE_SIZE",
+    "NIH_REPORTER_CITATION",
+    "NIH_REPORTER_ENDPOINT",
+    "NIHReporterAPIClient",
+    "NIHReporterPage",
+    "NIHReporterRecord",
+    "NIHSearchWindow",
+    "NIHWindowKind",
+    "canonicalize_nih_query_key",
+    "normalize_reporter_result",
+    "parse_refresh_window",
+]

--- a/sbir_etl/enrichers/nih_reporter/adapter.py
+++ b/sbir_etl/enrichers/nih_reporter/adapter.py
@@ -1,0 +1,178 @@
+"""NIH RePORTER ``SourceAdapter`` wrapping ``NIHReporterAPIClient``.
+
+Epistemic tier: pipelines. Exact ``project_num`` + FY lookup stays on the
+client; this module exposes the shared refresh lifecycle and persists the
+project table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.enrichers.nih_reporter.client import NIH_REPORTER_CITATION, NIHReporterAPIClient
+from sbir_etl.enrichers.nih_reporter.keys import NIHWindowKind, parse_refresh_window
+from sbir_etl.enrichers.nih_reporter.persist import upsert_nih_reporter_awards
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord
+from sbir_etl.enrichers.source_adapter import QualityResult, RawPage, SourceProvenance
+from sbir_etl.utils.async_tools import run_sync
+from sbir_etl.utils.enrichment.freshness import FreshnessStore
+
+
+EPISTEMIC_TIER = "pipelines"
+
+
+class NIHReporterSourceAdapter:
+    """Award-level NIH RePORTER refresh adapter."""
+
+    source_id = "nih_reporter"
+
+    def __init__(
+        self,
+        client: NIHReporterAPIClient | None = None,
+        *,
+        freshness: FreshnessStore | None = None,
+        persist_path: Path | None = None,
+    ) -> None:
+        self._client = client or NIHReporterAPIClient()
+        self._freshness = freshness
+        self._persist_path = persist_path
+
+    def fetch_page(self, request: Mapping[str, Any], cursor: str | None) -> RawPage:
+        del cursor
+        award_id = str(request.get("award_id") or "")
+        project_nums = _project_nums(request)
+        award_year = _award_year(request)
+        if not award_id or not project_nums or award_year is None:
+            return RawPage(
+                payload={
+                    "success": False,
+                    "records": [],
+                    "payload_hash": None,
+                    "delta_detected": True,
+                    "metadata": {},
+                    "error": "NIH RePORTER request needs award_id, project_num, and award_year",
+                },
+                record_id=award_id or "unknown",
+            )
+
+        records = run_sync(
+            self._client.lookup_projects(
+                project_nums,
+                award_year,
+                window=_lookup_window(request.get("window")),
+            )
+        )
+        payload_hash = _payload_hash(self._client, records)
+        previous = None
+        if self._freshness is not None:
+            previous = self._freshness.get_record(award_id, self.source_id)
+        previous_hash = previous.payload_hash if previous is not None else None
+        delta_detected = previous_hash is None or previous_hash != payload_hash
+        if records:
+            upsert_nih_reporter_awards(
+                records,
+                award_id=award_id,
+                path=self._persist_path,
+            )
+        return RawPage(
+            payload={
+                "success": True,
+                "records": [record.to_mapping() for record in records],
+                "payload_hash": payload_hash,
+                "delta_detected": delta_detected,
+                "metadata": {
+                    "match_count": len(records),
+                    "appl_ids": [record.appl_id for record in records],
+                    "award_year": award_year,
+                },
+                "error": None,
+            },
+            record_id=award_id,
+        )
+
+    def normalize(self, raw: RawPage) -> list[Mapping[str, Any]]:
+        payload = raw.payload if isinstance(raw.payload, Mapping) else {}
+        return [
+            {
+                "award_id": raw.record_id,
+                "success": bool(payload.get("success")),
+                "payload": payload.get("records") or [],
+                "payload_hash": payload.get("payload_hash"),
+                "delta_detected": payload.get("delta_detected", True),
+                "metadata": payload.get("metadata") or {},
+                "error": payload.get("error"),
+            }
+        ]
+
+    def validate(self, records: Sequence[Mapping[str, Any]]) -> QualityResult:
+        if not records:
+            return QualityResult(ok=False, errors=("empty page",))
+        first = records[0]
+        if first.get("success"):
+            return QualityResult(ok=True)
+        return QualityResult(ok=False, errors=(str(first.get("error") or "enrichment failed"),))
+
+    def provenance(self, raw: RawPage) -> SourceProvenance:
+        payload = raw.payload if isinstance(raw.payload, Mapping) else {}
+        return SourceProvenance(
+            source_id=self.source_id,
+            retrieved_at=datetime.now(UTC),
+            content_hash=payload.get("payload_hash") if isinstance(payload, Mapping) else None,
+            citation_url=NIH_REPORTER_CITATION,
+        )
+
+
+def _project_nums(request: Mapping[str, Any]) -> list[str]:
+    raw = request.get("project_nums")
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
+        values = [str(item).strip() for item in raw if str(item).strip()]
+        if values:
+            return values
+    single = request.get("project_num") or request.get("core_project_num")
+    if single is None:
+        return []
+    text = str(single).strip()
+    return [text] if text else []
+
+
+def _award_year(request: Mapping[str, Any]) -> int | None:
+    raw = request.get("award_year")
+    if raw is None or raw == "":
+        return None
+    try:
+        year = int(raw)
+    except (TypeError, ValueError):
+        return None
+    if 1900 <= year <= 2100:
+        return year
+    return None
+
+
+def _lookup_window(window: Any) -> str | None:
+    """Pass date windows through; fy windows are already applied to award_year."""
+
+    if window is None:
+        return None
+    parsed = parse_refresh_window(str(window) if not isinstance(window, str) else window)
+    if parsed.kind is NIHWindowKind.PROJECT_START_DATE:
+        return f"{parsed.from_date}:{parsed.to_date}"
+    return None
+
+
+def _payload_hash(client: NIHReporterAPIClient, records: Sequence[NIHReporterRecord]) -> str:
+    page_hashes = tuple(sorted({record.payload_hash for record in records if record.payload_hash}))
+    if len(page_hashes) == 1:
+        return page_hashes[0]
+    if page_hashes:
+        return client.compute_payload_hash({"pages": list(page_hashes)})
+    body = {
+        "appl_ids": [record.appl_id for record in records],
+        "records": [
+            {key: value for key, value in record.to_mapping().items() if key != "last_refreshed_at"}
+            for record in records
+        ],
+    }
+    return client.compute_payload_hash(body)

--- a/sbir_etl/enrichers/nih_reporter/client.py
+++ b/sbir_etl/enrichers/nih_reporter/client.py
@@ -277,14 +277,23 @@ class NIHReporterAPIClient(BaseAsyncAPIClient):
         project_nums: Sequence[str],
         fiscal_year: int,
         *,
+        window: str | NIHSearchWindow | None = None,
         limit: int = NIH_PAGE_SIZE,
         retrieved_at: datetime | None = None,
     ) -> list[NIHReporterRecord]:
-        """Exact ``project_nums`` + FY lookup, still scoped to SBIR/STTR codes."""
+        """Exact ``project_nums`` + FY lookup, still scoped to SBIR/STTR codes.
 
+        A date window becomes ``project_start_date`` criteria. A ``fy:`` window
+        is rejected here because ``fiscal_year`` already sets ``fiscal_years``.
+        """
+
+        parsed = window if isinstance(window, NIHSearchWindow) else parse_refresh_window(window)
+        if parsed.kind is NIHWindowKind.FISCAL_YEARS:
+            raise ValueError("lookup_projects takes fiscal_year; do not also pass a fy: window")
         return await self.search_projects(
             project_nums=project_nums,
             fiscal_years=[fiscal_year],
+            window=window if parsed.kind is NIHWindowKind.PROJECT_START_DATE else None,
             activity_codes=NIH_ACTIVITY_CODES,
             limit=limit,
             retrieved_at=retrieved_at,

--- a/sbir_etl/enrichers/nih_reporter/client.py
+++ b/sbir_etl/enrichers/nih_reporter/client.py
@@ -1,0 +1,300 @@
+"""NIH RePORTER Projects API v2 client.
+
+Epistemic tier: pipelines. Transport, retry, and rate limits come from
+``BaseAsyncAPIClient``. Activity codes, windows, and ``appl_id`` / FY grain
+stay here. No network in unit tests — inject ``http_client``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+from loguru import logger
+
+from sbir_etl.config.loader import get_config
+from sbir_etl.enrichers.base_client import BaseAsyncAPIClient
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHSearchWindow,
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord, normalize_reporter_result
+from sbir_etl.exceptions import APIError
+from sbir_etl.utils.path_utils import ensure_dir
+
+
+EPISTEMIC_TIER = "pipelines"
+
+NIH_REPORTER_BASE_URL = "https://api.reporter.nih.gov/v2"
+NIH_REPORTER_SEARCH_PATH = "/projects/search"
+NIH_REPORTER_ENDPOINT = f"{NIH_REPORTER_BASE_URL}{NIH_REPORTER_SEARCH_PATH}"
+NIH_REPORTER_CITATION = "https://api.reporter.nih.gov/"
+NIH_ACTIVITY_CODES: tuple[str, ...] = ("R43", "R44", "R41", "R42")
+NIH_PAGE_SIZE = 500
+NIH_INCLUDE_FIELDS: tuple[str, ...] = (
+    "ApplId",
+    "FiscalYear",
+    "ProjectNum",
+    "CoreProjectNum",
+    "ActivityCode",
+    "AgencyIcAdmin",
+    "Organization",
+    "PrincipalInvestigators",
+    "ProjectTitle",
+    "AbstractText",
+    "AwardAmount",
+    "OpportunityNumber",
+    "FullStudySection",
+)
+
+
+@dataclass(frozen=True)
+class NIHReporterPage:
+    """One validated search page plus the raw body used for hashing/cache."""
+
+    total: int
+    offset: int
+    limit: int
+    results: tuple[Mapping[str, Any], ...]
+    raw_body: bytes
+    payload_hash: str
+
+
+class NIHReporterAPIClient(BaseAsyncAPIClient):
+    """Async client for ``POST /v2/projects/search``."""
+
+    api_name = "nih_reporter"
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+        cache_dir: Path | str | None = None,
+    ) -> None:
+        super().__init__()
+        if config is None:
+            cfg = get_config()
+            self.config = cfg.enrichment_refresh.nih_reporter.model_dump()
+        else:
+            self.config = config
+
+        self.base_url = str(self.config.get("base_url", NIH_REPORTER_BASE_URL))
+        self.timeout = self.config.get("timeout_seconds", 30)
+        self.rate_limit_per_minute = int(self.config.get("rate_limit_per_minute", 30))
+        cache_setting = cache_dir
+        if cache_setting is None:
+            cache_block = self.config.get("cache") or {}
+            if isinstance(cache_block, Mapping):
+                cache_setting = cache_block.get("cache_dir", "data/cache/nih_reporter")
+            else:
+                cache_setting = "data/cache/nih_reporter"
+        self.cache_dir = Path(str(cache_setting))
+        self._client = http_client or httpx.AsyncClient(timeout=self.timeout)
+        logger.info(
+            f"Initialized NIHReporterAPIClient: base_url={self.base_url}, "
+            f"rate_limit={self.rate_limit_per_minute}/min"
+        )
+
+    def build_search_payload(
+        self,
+        *,
+        offset: int,
+        limit: int = NIH_PAGE_SIZE,
+        project_nums: Sequence[str] | None = None,
+        fiscal_years: Sequence[int] | None = None,
+        window: str | NIHSearchWindow | None = None,
+        activity_codes: Sequence[str] | None = NIH_ACTIVITY_CODES,
+    ) -> dict[str, Any]:
+        """Build a RePORTER search body. Windows become criteria, not filters."""
+
+        if offset < 0:
+            raise ValueError("NIH RePORTER offset must be >= 0")
+        if limit < 1 or limit > NIH_PAGE_SIZE:
+            raise ValueError(f"NIH RePORTER limit must be between 1 and {NIH_PAGE_SIZE}")
+
+        criteria: dict[str, Any] = {}
+        if activity_codes:
+            criteria["activity_codes"] = list(activity_codes)
+        if project_nums:
+            keys = [
+                key
+                for key in (canonicalize_nih_query_key(item) for item in project_nums)
+                if key is not None
+            ]
+            if not keys:
+                raise ValueError("NIH RePORTER project_nums contained no usable keys")
+            criteria["project_nums"] = keys
+        if fiscal_years:
+            criteria["fiscal_years"] = [int(year) for year in fiscal_years]
+
+        parsed = window if isinstance(window, NIHSearchWindow) else parse_refresh_window(window)
+        if parsed.kind is NIHWindowKind.FISCAL_YEARS and "fiscal_years" in criteria:
+            raise ValueError("do not pass both fiscal_years and a fy: window")
+        parsed.apply_to_criteria(criteria)
+
+        return {
+            "criteria": criteria,
+            "include_fields": list(NIH_INCLUDE_FIELDS),
+            "offset": offset,
+            "limit": limit,
+            "sort_field": "appl_id",
+            "sort_order": "asc",
+        }
+
+    def compute_payload_hash(self, payload: Mapping[str, Any] | bytes) -> str:
+        """SHA-256 of a JSON object (sorted) or of raw response bytes."""
+
+        if isinstance(payload, bytes):
+            return hashlib.sha256(payload).hexdigest()
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+        return hashlib.sha256(encoded).hexdigest()
+
+    async def fetch_page(
+        self,
+        *,
+        offset: int,
+        limit: int = NIH_PAGE_SIZE,
+        project_nums: Sequence[str] | None = None,
+        fiscal_years: Sequence[int] | None = None,
+        window: str | NIHSearchWindow | None = None,
+        activity_codes: Sequence[str] | None = NIH_ACTIVITY_CODES,
+    ) -> NIHReporterPage:
+        """Fetch and validate one search page."""
+
+        body = self.build_search_payload(
+            offset=offset,
+            limit=limit,
+            project_nums=project_nums,
+            fiscal_years=fiscal_years,
+            window=window,
+            activity_codes=activity_codes,
+        )
+        response = await self._request_raw(
+            "POST",
+            NIH_REPORTER_SEARCH_PATH,
+            params=body,
+            headers={"Content-Type": "application/json"},
+        )
+        raw = response.content
+        self._write_raw_cache(raw)
+        return self.parse_page(raw, offset=offset, limit=limit)
+
+    def parse_page(self, raw: bytes, *, offset: int, limit: int) -> NIHReporterPage:
+        """Validate pagination metadata. Fail closed on inconsistency."""
+
+        try:
+            payload = json.loads(raw)
+            meta = payload["meta"]
+            results = payload["results"]
+            total = int(meta["total"])
+            response_offset = int(meta["offset"])
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+            raise APIError(
+                "NIH RePORTER returned an invalid response",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            ) from error
+        if response_offset != offset or not isinstance(results, list):
+            raise APIError(
+                "NIH RePORTER pagination metadata is inconsistent",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            )
+        if len(results) > limit or total < offset + len(results):
+            raise APIError(
+                "NIH RePORTER returned inconsistent result counts",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            )
+        if offset < total and not results:
+            raise APIError(
+                "NIH RePORTER pagination stopped before the declared total",
+                api_name=self.api_name,
+                endpoint=NIH_REPORTER_SEARCH_PATH,
+            )
+        return NIHReporterPage(
+            total=total,
+            offset=offset,
+            limit=limit,
+            results=tuple(results),
+            raw_body=raw,
+            payload_hash=self.compute_payload_hash(raw),
+        )
+
+    async def search_projects(
+        self,
+        *,
+        project_nums: Sequence[str] | None = None,
+        fiscal_years: Sequence[int] | None = None,
+        window: str | NIHSearchWindow | None = None,
+        activity_codes: Sequence[str] | None = NIH_ACTIVITY_CODES,
+        limit: int = NIH_PAGE_SIZE,
+        retrieved_at: datetime | None = None,
+    ) -> list[NIHReporterRecord]:
+        """Walk every page for the given criteria and normalize rows."""
+
+        retrieved = retrieved_at or datetime.now(UTC)
+        records: list[NIHReporterRecord] = []
+        offset = 0
+        while True:
+            page = await self.fetch_page(
+                offset=offset,
+                limit=limit,
+                project_nums=project_nums,
+                fiscal_years=fiscal_years,
+                window=window,
+                activity_codes=activity_codes,
+            )
+            for result in page.results:
+                if not isinstance(result, Mapping):
+                    raise APIError(
+                        "NIH RePORTER result is not an object",
+                        api_name=self.api_name,
+                        endpoint=NIH_REPORTER_SEARCH_PATH,
+                    )
+                records.append(
+                    normalize_reporter_result(
+                        result,
+                        retrieved_at=retrieved,
+                        payload_hash=page.payload_hash,
+                    )
+                )
+            offset += len(page.results)
+            if offset >= page.total:
+                return records
+
+    async def lookup_projects(
+        self,
+        project_nums: Sequence[str],
+        fiscal_year: int,
+        *,
+        limit: int = NIH_PAGE_SIZE,
+        retrieved_at: datetime | None = None,
+    ) -> list[NIHReporterRecord]:
+        """Exact ``project_nums`` + FY lookup, still scoped to SBIR/STTR codes."""
+
+        return await self.search_projects(
+            project_nums=project_nums,
+            fiscal_years=[fiscal_year],
+            activity_codes=NIH_ACTIVITY_CODES,
+            limit=limit,
+            retrieved_at=retrieved_at,
+        )
+
+    def _write_raw_cache(self, raw: bytes) -> None:
+        if not raw:
+            return
+        ensure_dir(self.cache_dir)
+        digest = self.compute_payload_hash(raw)
+        path = self.cache_dir / f"{digest}.json"
+        if not path.exists():
+            path.write_bytes(raw)

--- a/sbir_etl/enrichers/nih_reporter/keys.py
+++ b/sbir_etl/enrichers/nih_reporter/keys.py
@@ -1,0 +1,125 @@
+"""NIH RePORTER query-key and refresh-window helpers.
+
+Epistemic tier: pipelines. Canonicalization is exact-key formatting, not
+company-name identity. Window strings become RePORTER criteria; they are
+never applied as a post-fetch filter.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from enum import StrEnum
+from typing import Any
+
+import pandas as pd
+
+
+EPISTEMIC_TIER = "pipelines"
+
+_NULL_TEXT = frozenset({"<NA>", "NAN", "NONE", "NULL", r"\N"})
+_FY_WINDOW_PREFIX = "fy:"
+
+
+class NIHWindowKind(StrEnum):
+    """How a refresh window maps onto RePORTER search criteria."""
+
+    ALL = "all"
+    PROJECT_START_DATE = "project_start_date"
+    FISCAL_YEARS = "fiscal_years"
+
+
+@dataclass(frozen=True)
+class NIHSearchWindow:
+    """Parsed ``--window`` value ready to attach to a RePORTER criteria object."""
+
+    kind: NIHWindowKind
+    from_date: str | None = None
+    to_date: str | None = None
+    fiscal_years: tuple[int, ...] = ()
+
+    def apply_to_criteria(self, criteria: dict[str, Any]) -> None:
+        """Mutate ``criteria`` with this window. ``ALL`` adds nothing."""
+
+        if self.kind is NIHWindowKind.ALL:
+            return
+        if self.kind is NIHWindowKind.PROJECT_START_DATE:
+            criteria["project_start_date"] = {
+                "from_date": self.from_date,
+                "to_date": self.to_date,
+            }
+            return
+        criteria["fiscal_years"] = list(self.fiscal_years)
+
+
+def canonicalize_nih_query_key(value: Any) -> str | None:
+    """Format an SBIR source key for an exact NIH project-number query.
+
+    Behavior is the Phase III identity-recovery contract: strip surrounding
+    spaces and commas, uppercase, drop interior whitespace, and reject null
+    tokens. Structural punctuation such as ``-`` is preserved.
+    """
+
+    if value is None or value is pd.NA:
+        return None
+    text = str(value).strip(" ,").upper()
+    if not text or text in _NULL_TEXT:
+        return None
+    return "".join(text.split()) or None
+
+
+def parse_refresh_window(window: str | None) -> NIHSearchWindow:
+    """Parse a CLI window into RePORTER criteria.
+
+    Accepted forms:
+
+    - ``None`` / blank — full activity-code snapshot, no date or FY filter
+    - ``YYYY-MM-DD:YYYY-MM-DD`` — inclusive ``project_start_date`` range
+    - ``fy:YYYY-YYYY`` — inclusive fiscal-year range
+
+    Raises:
+        ValueError: If the window is malformed or inverted.
+    """
+
+    if window is None:
+        return NIHSearchWindow(kind=NIHWindowKind.ALL)
+    text = window.strip()
+    if not text:
+        return NIHSearchWindow(kind=NIHWindowKind.ALL)
+
+    lowered = text.lower()
+    if lowered.startswith(_FY_WINDOW_PREFIX):
+        return _parse_fiscal_year_window(text[len(_FY_WINDOW_PREFIX) :])
+    return _parse_project_start_window(text)
+
+
+def _parse_fiscal_year_window(spec: str) -> NIHSearchWindow:
+    parts = spec.split("-")
+    if len(parts) != 2 or not all(part.isdigit() and len(part) == 4 for part in parts):
+        raise ValueError(f"invalid NIH fiscal-year window {spec!r}; expected fy:YYYY-YYYY")
+    start_year = int(parts[0])
+    end_year = int(parts[1])
+    if end_year < start_year:
+        raise ValueError(f"inverted NIH fiscal-year window fy:{start_year}-{end_year}")
+    years = tuple(range(start_year, end_year + 1))
+    return NIHSearchWindow(kind=NIHWindowKind.FISCAL_YEARS, fiscal_years=years)
+
+
+def _parse_project_start_window(spec: str) -> NIHSearchWindow:
+    parts = spec.split(":")
+    if len(parts) != 2:
+        raise ValueError(f"invalid NIH date window {spec!r}; expected YYYY-MM-DD:YYYY-MM-DD")
+    try:
+        start = date.fromisoformat(parts[0])
+        end = date.fromisoformat(parts[1])
+    except ValueError as error:
+        raise ValueError(
+            f"invalid NIH date window {spec!r}; expected YYYY-MM-DD:YYYY-MM-DD"
+        ) from error
+    if end < start:
+        raise ValueError(f"inverted NIH date window {spec}")
+    return NIHSearchWindow(
+        kind=NIHWindowKind.PROJECT_START_DATE,
+        from_date=start.isoformat(),
+        to_date=end.isoformat(),
+    )

--- a/sbir_etl/enrichers/nih_reporter/persist.py
+++ b/sbir_etl/enrichers/nih_reporter/persist.py
@@ -1,0 +1,81 @@
+"""Persist NIH RePORTER project rows to the derived award table.
+
+Epistemic tier: pipelines. Official row id is ``appl_id``. Award-level
+replace uses ``(canonical project_num, fy)``; multiple ``appl_id``s for one
+upsert key are retained, not collapsed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord
+from sbir_etl.utils.cloud_storage import get_data_root
+from sbir_etl.utils.data.file_io import save_dataframe_parquet
+from sbir_etl.utils.path_utils import ensure_parent_dir
+
+
+EPISTEMIC_TIER = "pipelines"
+
+NIH_REPORTER_AWARDS_NAME = "nih_reporter_awards.parquet"
+
+
+def nih_reporter_awards_path() -> Path:
+    """Canonical location of the persisted RePORTER project table."""
+
+    return get_data_root() / "derived" / NIH_REPORTER_AWARDS_NAME
+
+
+def upsert_key_text(canonical_project_num: str, fy: int) -> str:
+    """Stable string form of the award-level upsert key."""
+
+    return f"{canonical_project_num}|{fy}"
+
+
+def upsert_nih_reporter_awards(
+    records: Sequence[NIHReporterRecord],
+    *,
+    award_id: str,
+    path: Path | None = None,
+) -> Path | None:
+    """Replace persisted rows for each upsert key present in ``records``.
+
+    An empty fetch does not delete existing rows. Returns the path written,
+    or ``None`` when there is nothing to persist.
+    """
+
+    rows: list[dict[str, Any]] = []
+    keys: set[str] = set()
+    for record in records:
+        key = record.upsert_key()
+        if key is None:
+            continue
+        mapping = record.to_mapping()
+        mapping["award_id"] = award_id
+        mapping["project_num_canonical"] = key[0]
+        mapping["upsert_key"] = upsert_key_text(key[0], key[1])
+        rows.append(mapping)
+        keys.add(mapping["upsert_key"])
+    if not rows:
+        return None
+
+    dest = path or nih_reporter_awards_path()
+    ensure_parent_dir(dest)
+    existing = _load_existing(dest)
+    if not existing.empty and "upsert_key" in existing.columns:
+        existing = existing.loc[~existing["upsert_key"].isin(keys)].copy()
+    combined = pd.concat([existing, pd.DataFrame(rows)], ignore_index=True)
+    return save_dataframe_parquet(combined, dest, index=False)
+
+
+def _load_existing(path: Path) -> pd.DataFrame:
+    if not path.is_file():
+        return pd.DataFrame()
+    try:
+        return pd.read_parquet(path)
+    except Exception:
+        return pd.DataFrame()

--- a/sbir_etl/enrichers/nih_reporter/persist.py
+++ b/sbir_etl/enrichers/nih_reporter/persist.py
@@ -75,7 +75,4 @@ def upsert_nih_reporter_awards(
 def _load_existing(path: Path) -> pd.DataFrame:
     if not path.is_file():
         return pd.DataFrame()
-    try:
-        return pd.read_parquet(path)
-    except Exception:
-        return pd.DataFrame()
+    return pd.read_parquet(path)

--- a/sbir_etl/enrichers/nih_reporter/requests.py
+++ b/sbir_etl/enrichers/nih_reporter/requests.py
@@ -1,0 +1,200 @@
+"""Build NIH RePORTER refresh requests from the SBIR.gov award frame.
+
+Epistemic tier: pipelines. Exact ``project_num`` / ``core_project_num`` + FY
+on known NIH/HHS awards. Windows become RePORTER criteria, not a local
+award-date filter. Company name is never a join key.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from collections.abc import Mapping
+from typing import Any
+
+import pandas as pd
+
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHSearchWindow,
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+from sbir_etl.extractors.sbir_public_awards import load_sbir_awards_csv
+from sbir_etl.utils.cloud_storage import find_latest_sbir_awards
+
+
+EPISTEMIC_TIER = "pipelines"
+
+NIH_REPORTER_AGENCIES = frozenset({"HHS", "NIH"})
+NIH_IC_LABELS = frozenset(
+    {
+        "NCI",
+        "NIAID",
+        "NHLBI",
+        "NIGMS",
+        "NINDS",
+        "NIMH",
+        "NIDA",
+        "NIA",
+        "NICHD",
+        "NIDDK",
+        "NEI",
+        "NHGRI",
+        "NIEHS",
+        "NIAMS",
+        "NIDCR",
+        "NIDCD",
+        "NIAAA",
+        "NIBIB",
+        "NIMHD",
+        "NCCIH",
+        "NINR",
+        "NLM",
+        "FIC",
+        "NCATS",
+        "CIT",
+        "OD",
+        "NCRR",
+        "NCCAM",
+        "CSR",
+        "CC",
+    }
+)
+PROJECT_KEY_COLUMNS = ("contract_number", "agency_tracking_number")
+
+
+def sbir_awards_path() -> Path | None:
+    """Canonical SBIR.gov award CSV, or ``None`` when no vintage exists."""
+
+    found = find_latest_sbir_awards()
+    return Path(found) if found else None
+
+
+def load_sbir_award_frame(path: Path | None = None) -> pd.DataFrame:
+    """Load the SBIR.gov award frame used to build RePORTER lookups.
+
+    Raises:
+        FileNotFoundError: If the SBIR.gov CSV is missing. Callers must not
+            treat a missing frame as an empty refresh.
+    """
+
+    src = path if path is not None else sbir_awards_path()
+    if src is None or not Path(src).is_file():
+        raise FileNotFoundError(
+            "SBIR.gov award CSV is unavailable; NIH RePORTER refresh needs "
+            "data/raw/sbir/award_data.csv (or a history/ vintage). "
+            "Download the public awards file before running "
+            "refresh-enrichment --source nih_reporter."
+        )
+    return load_sbir_awards_csv(Path(src))
+
+
+def is_nih_reporter_agency(agency: Any, branch: Any = None) -> bool:
+    """True when agency or branch is NIH, HHS, or a known NIH institute label."""
+
+    for raw in (agency, branch):
+        token = _token(raw)
+        if not token:
+            continue
+        if token in NIH_REPORTER_AGENCIES or token in NIH_IC_LABELS or token.startswith("NIH"):
+            return True
+    return False
+
+
+def four_digit_award_year(value: Any) -> int | None:
+    """Return a four-digit award year, or ``None`` when the cell is unusable."""
+
+    if value is None or value is pd.NA:
+        return None
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    try:
+        year = int(value)
+    except (TypeError, ValueError):
+        text = str(value).strip()
+        if len(text) >= 4 and text[:4].isdigit():
+            year = int(text[:4])
+        else:
+            return None
+    if 1900 <= year <= 2100:
+        return year
+    return None
+
+
+def project_keys_for_row(row: pd.Series | Mapping[str, Any]) -> list[str]:
+    """Canonical project keys from contract and agency tracking number."""
+
+    keys: list[str] = []
+    for column in PROJECT_KEY_COLUMNS:
+        key = canonicalize_nih_query_key(_cell(row, column))
+        if key and key not in keys:
+            keys.append(key)
+    return keys
+
+
+def build_nih_reporter_requests(
+    awards: pd.DataFrame,
+    window: str | NIHSearchWindow | None = None,
+) -> tuple[list[dict[str, Any]], int]:
+    """Map an SBIR.gov frame to runner requests.
+
+    Returns:
+        ``(requests, skipped)`` where ``skipped`` is the number of NIH/HHS
+        rows dropped for a missing project key or four-digit award year.
+        A ``fy:`` window restricts ``award_year`` so we do not look up years
+        the API would reject; a date window is attached as criteria only.
+    """
+
+    parsed = window if isinstance(window, NIHSearchWindow) else parse_refresh_window(window)
+    skipped = 0
+    requests: list[dict[str, Any]] = []
+    if awards.empty:
+        return requests, skipped
+
+    for _, row in awards.iterrows():
+        if not is_nih_reporter_agency(row.get("agency"), row.get("branch")):
+            continue
+        keys = project_keys_for_row(row)
+        year = four_digit_award_year(row.get("award_year"))
+        if not keys or year is None:
+            skipped += 1
+            continue
+        if parsed.kind is NIHWindowKind.FISCAL_YEARS and year not in parsed.fiscal_years:
+            continue
+        award_id = row.get("award_id")
+        if award_id is None or (isinstance(award_id, float) and pd.isna(award_id)):
+            skipped += 1
+            continue
+        request: dict[str, Any] = {
+            "award_id": str(award_id),
+            "project_num": keys[0],
+            "project_nums": keys,
+            "award_year": year,
+        }
+        if parsed.kind is NIHWindowKind.PROJECT_START_DATE:
+            request["window"] = f"{parsed.from_date}:{parsed.to_date}"
+        requests.append(request)
+    return requests, skipped
+
+
+def _token(value: Any) -> str:
+    if value is None or value is pd.NA:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except (TypeError, ValueError):
+        pass
+    return str(value).strip().upper()
+
+
+def _cell(row: pd.Series | Mapping[str, Any], column: str) -> Any:
+    if hasattr(row, "index") and column not in row.index:
+        return None
+    try:
+        return row[column]
+    except (KeyError, TypeError, IndexError):
+        return row.get(column) if hasattr(row, "get") else None

--- a/sbir_etl/enrichers/nih_reporter/schema.py
+++ b/sbir_etl/enrichers/nih_reporter/schema.py
@@ -1,0 +1,207 @@
+"""Normalized NIH RePORTER project record.
+
+Epistemic tier: pipelines. ``appl_id`` is the official row id. Award-level
+upsert uses ``(canonical project_num, fy)``. Multiple ``appl_id``s or
+organization identifiers for one upsert key are retained, not collapsed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sbir_etl.enrichers.nih_reporter.keys import canonicalize_nih_query_key
+
+
+EPISTEMIC_TIER = "pipelines"
+
+NIH_SOURCE_ID = "nih_reporter"
+
+
+@dataclass(frozen=True)
+class NIHReporterRecord:
+    """One RePORTER project row after field extraction.
+
+    ``org_uei`` / ``org_duns`` are the primary identifiers when present.
+    ``org_ueis`` / ``org_duns_values`` keep the full official sets so a later
+    identity consumer can expand pairs without a second fetch.
+    """
+
+    appl_id: str
+    fy: int
+    project_num: str | None = None
+    core_project_num: str | None = None
+    activity_code: str | None = None
+    agency_ic_admin: str | None = None
+    org_name: str | None = None
+    org_uei: str | None = None
+    org_duns: str | None = None
+    org_ueis: tuple[str, ...] = ()
+    org_duns_values: tuple[str, ...] = ()
+    pi_names: tuple[str, ...] = ()
+    project_title: str | None = None
+    abstract_text: str | None = None
+    award_amount: float | None = None
+    foa_number: str | None = None
+    study_section: str | None = None
+    source: str = NIH_SOURCE_ID
+    last_refreshed_at: datetime | None = None
+    payload_hash: str | None = None
+
+    def upsert_key(self) -> tuple[str, int] | None:
+        """Award-level key, or ``None`` when the project number is unusable."""
+
+        canonical = canonicalize_nih_query_key(self.project_num)
+        if canonical is None:
+            return None
+        return (canonical, self.fy)
+
+    def to_mapping(self) -> dict[str, Any]:
+        """JSON/Parquet-friendly record."""
+
+        return {
+            "appl_id": self.appl_id,
+            "fy": self.fy,
+            "project_num": self.project_num,
+            "core_project_num": self.core_project_num,
+            "activity_code": self.activity_code,
+            "agency_ic_admin": self.agency_ic_admin,
+            "org_name": self.org_name,
+            "org_uei": self.org_uei,
+            "org_duns": self.org_duns,
+            "org_ueis": list(self.org_ueis),
+            "org_duns_values": list(self.org_duns_values),
+            "pi_names": list(self.pi_names),
+            "project_title": self.project_title,
+            "abstract_text": self.abstract_text,
+            "award_amount": self.award_amount,
+            "foa_number": self.foa_number,
+            "study_section": self.study_section,
+            "source": self.source,
+            "last_refreshed_at": (
+                self.last_refreshed_at.isoformat() if self.last_refreshed_at else None
+            ),
+            "payload_hash": self.payload_hash,
+        }
+
+
+def normalize_reporter_result(
+    result: Mapping[str, Any],
+    *,
+    retrieved_at: datetime | None = None,
+    payload_hash: str | None = None,
+) -> NIHReporterRecord:
+    """Extract a typed record from one RePORTER ``results[]`` object.
+
+    Raises:
+        ValueError: If ``appl_id`` or ``fiscal_year`` is missing or unusable.
+    """
+
+    try:
+        appl_id = str(result["appl_id"]).strip()
+        fy = int(result["fiscal_year"])
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("NIH RePORTER project lacks appl_id or fiscal_year") from error
+    if not appl_id:
+        raise ValueError("NIH RePORTER project lacks appl_id or fiscal_year")
+
+    raw_org = result.get("organization")
+    organization = raw_org if isinstance(raw_org, Mapping) else {}
+    ueis = _identifier_values(organization, "org_ueis", "primary_uei")
+    duns_values = _identifier_values(organization, "org_duns", "primary_duns")
+    return NIHReporterRecord(
+        appl_id=appl_id,
+        fy=fy,
+        project_num=_optional_str(result.get("project_num")),
+        core_project_num=_optional_str(result.get("core_project_num")),
+        activity_code=_optional_str(result.get("activity_code")),
+        agency_ic_admin=_optional_str(result.get("agency_ic_admin")),
+        org_name=_optional_str(organization.get("org_name")),
+        org_uei=ueis[0] if ueis else None,
+        org_duns=duns_values[0] if duns_values else None,
+        org_ueis=ueis,
+        org_duns_values=duns_values,
+        pi_names=_pi_names(result.get("principal_investigators")),
+        project_title=_optional_str(result.get("project_title")),
+        abstract_text=_optional_str(result.get("abstract_text")),
+        award_amount=_optional_float(result.get("award_amount")),
+        foa_number=_opportunity_number(result.get("opportunity_number")),
+        study_section=_study_section(result.get("full_study_section")),
+        last_refreshed_at=retrieved_at,
+        payload_hash=payload_hash,
+    )
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _identifier_values(
+    organization: Mapping[str, Any],
+    plural_key: str,
+    primary_key: str,
+) -> tuple[str, ...]:
+    raw = organization.get(plural_key)
+    values: list[str] = []
+    if isinstance(raw, list):
+        for item in raw:
+            text = str(item).strip() if item is not None else ""
+            if text:
+                values.append(text)
+    primary = _optional_str(organization.get(primary_key))
+    if primary and primary not in values:
+        values.insert(0, primary)
+    return tuple(dict.fromkeys(values))
+
+
+def _pi_names(raw: Any) -> tuple[str, ...]:
+    if not isinstance(raw, list):
+        return ()
+    names: list[str] = []
+    for investigator in raw:
+        if not isinstance(investigator, Mapping):
+            continue
+        full = _optional_str(investigator.get("full_name"))
+        if full:
+            names.append(full)
+            continue
+        first = _optional_str(investigator.get("first_name")) or ""
+        last = _optional_str(investigator.get("last_name")) or ""
+        joined = " ".join(part for part in (first, last) if part)
+        if joined:
+            names.append(joined)
+    return tuple(names)
+
+
+def _opportunity_number(raw: Any) -> str | None:
+    if isinstance(raw, list):
+        for item in raw:
+            text = _optional_str(item)
+            if text:
+                return text
+        return None
+    return _optional_str(raw)
+
+
+def _study_section(raw: Any) -> str | None:
+    if isinstance(raw, Mapping):
+        for key in ("srg_code", "name", "srg_name"):
+            text = _optional_str(raw.get(key))
+            if text:
+                return text
+        return None
+    return _optional_str(raw)

--- a/sbir_etl/enrichers/refresh_cli.py
+++ b/sbir_etl/enrichers/refresh_cli.py
@@ -11,6 +11,13 @@ from collections.abc import Sequence
 from typing import Any
 
 from sbir_etl.config.loader import get_config
+from sbir_etl.enrichers.nih_reporter.adapter import NIHReporterSourceAdapter
+from sbir_etl.enrichers.nih_reporter.keys import parse_refresh_window
+from sbir_etl.enrichers.nih_reporter.requests import (
+    build_nih_reporter_requests,
+    load_sbir_award_frame,
+    sbir_awards_path,
+)
 from sbir_etl.enrichers.source_adapter import SourceRefreshRunner
 from sbir_etl.enrichers.usaspending.adapter import USAspendingSourceAdapter
 from sbir_etl.enrichers.usaspending.requests import (
@@ -28,14 +35,24 @@ from sbir_etl.utils.enrichment.freshness import FreshnessStore
 
 EPISTEMIC_TIER = "pipelines"
 
+REGISTERED_SOURCES = ("usaspending", "nih_reporter")
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Refresh one enrichment source")
-    parser.add_argument("--source", required=True, help="Registered enrichment source id")
+    parser.add_argument(
+        "--source",
+        required=True,
+        help="Registered enrichment source id (usaspending, nih_reporter)",
+    )
     parser.add_argument(
         "--window",
         default=None,
-        help="Optional START:END window (ISO dates) applied to the award date column.",
+        help=(
+            "Optional refresh window. USAspending: START:END ISO dates on the "
+            "award date column. NIH RePORTER: START:END becomes project_start_date "
+            "criteria, or fy:YYYY-YYYY for fiscal years — not a post-fetch filter."
+        ),
     )
     parser.add_argument(
         "--award-id",
@@ -47,20 +64,38 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _requests_for_source(
-    source: str,
-    award_ids: Sequence[str] | None,
-    window: str | None = None,
-) -> list[dict[str, Any]]:
+def _source_config(source: str) -> Any:
     config = get_config()
     source_config = getattr(config.enrichment_refresh, source, None)
     if source_config is None:
         raise SystemExit(f"unknown enrichment source: {source}")
     if not source_config.enabled:
         raise SystemExit(f"enrichment source {source} is disabled")
+    return source_config
+
+
+def _requests_for_source(
+    source: str,
+    award_ids: Sequence[str] | None,
+    window: str | None = None,
+) -> list[dict[str, Any]]:
+    source_config = _source_config(source)
+    if source == "nih_reporter":
+        return _nih_reporter_requests(award_ids, window, source_config.sla_staleness_days)
+    if source != "usaspending":
+        raise SystemExit(f"unknown enrichment source: {source}")
+    return _usaspending_requests(award_ids, window, source_config.sla_staleness_days)
+
+
+def _usaspending_requests(
+    award_ids: Sequence[str] | None,
+    window: str | None,
+    sla: int,
+) -> list[dict[str, Any]]:
     store = FreshnessStore()
-    sla = source_config.sla_staleness_days
-    stale = store.get_awards_needing_refresh(source, sla, list(award_ids) if award_ids else None)
+    stale = store.get_awards_needing_refresh(
+        "usaspending", sla, list(award_ids) if award_ids else None
+    )
     if not stale:
         return []
 
@@ -101,6 +136,67 @@ def _requests_for_source(
     return usable
 
 
+def _nih_reporter_requests(
+    award_ids: Sequence[str] | None,
+    window: str | None,
+    sla: int,
+) -> list[dict[str, Any]]:
+    try:
+        parse_refresh_window(window)
+    except ValueError as exc:
+        raise SystemExit(f"invalid NIH refresh window: {exc}") from exc
+    try:
+        awards = load_sbir_award_frame()
+    except FileNotFoundError as exc:
+        raise SystemExit(str(exc)) from exc
+    except Exception as exc:
+        location = sbir_awards_path()
+        raise SystemExit(f"failed to load SBIR.gov awards from {location}: {exc}") from exc
+
+    requests, skipped = build_nih_reporter_requests(awards, window=window)
+    if skipped:
+        print(
+            f"skipping {skipped} NIH/HHS award(s) with no usable project key or year",
+            file=sys.stderr,
+        )
+    if award_ids:
+        wanted = {str(award_id) for award_id in award_ids}
+        eligible = {request["award_id"] for request in requests}
+        missing = wanted - eligible
+        if missing:
+            print(
+                f"skipping {len(missing)} award(s) absent from the SBIR.gov NIH/HHS frame",
+                file=sys.stderr,
+            )
+        requests = [request for request in requests if request["award_id"] in wanted]
+
+    selected = _nih_ids_needing_refresh(
+        FreshnessStore(),
+        [request["award_id"] for request in requests],
+        sla,
+    )
+    return [request for request in requests if request["award_id"] in selected]
+
+
+def _nih_ids_needing_refresh(
+    store: FreshnessStore,
+    eligible_ids: Sequence[str],
+    sla: int,
+) -> set[str]:
+    """First run includes every eligible id; later runs add unseen + stale."""
+
+    wanted = {str(award_id) for award_id in eligible_ids}
+    if not wanted:
+        return set()
+    ledger = store.load_all()
+    if ledger.empty or "source" not in ledger.columns:
+        return wanted
+    nih = ledger.loc[ledger["source"].astype(str) == "nih_reporter"]
+    known = set(nih["award_id"].astype(str)) if not nih.empty else set()
+    stale = set(store.get_awards_needing_refresh("nih_reporter", sla, list(wanted)))
+    return stale | (wanted - known)
+
+
 def run_refresh(
     *,
     source: str,
@@ -109,18 +205,24 @@ def run_refresh(
     runner: SourceRefreshRunner | None = None,
     adapter: Any = None,
 ) -> dict[str, Any]:
-    if source != "usaspending":
+    if source not in REGISTERED_SOURCES:
         raise SystemExit(
             f"source {source!r} has no adapter yet; implement SourceAdapter to join the runner"
         )
     requests = _requests_for_source(source, award_ids, window)
     freshness = FreshnessStore()
-    active_adapter = adapter or USAspendingSourceAdapter(freshness=freshness)
+    source_config = getattr(get_config().enrichment_refresh, source)
+    if adapter is not None:
+        active_adapter = adapter
+    elif source == "nih_reporter":
+        active_adapter = NIHReporterSourceAdapter(freshness=freshness)
+    else:
+        active_adapter = USAspendingSourceAdapter(freshness=freshness)
     active_runner = runner or SourceRefreshRunner(
         freshness=freshness,
         checkpoints=CheckpointStore(),
         partition_id=f"{source}-cli",
-        checkpoint_interval=get_config().enrichment_refresh.usaspending.checkpoint_interval,
+        checkpoint_interval=source_config.checkpoint_interval,
     )
     return active_runner.refresh_records(active_adapter, requests).as_dict()
 

--- a/specs/iterative-api-enrichment/tasks.md
+++ b/specs/iterative-api-enrichment/tasks.md
@@ -94,8 +94,14 @@ rewriting the Phase III urllib extractor.
       Phase III re-exports it.
   - Verify: `tests/unit/enrichers/nih_reporter/` (pagination, windows,
     duplicates, retries) and `tests/unit/phase_iii_negative_controls/test_nih_reporter.py`
-- [ ] 8.2 Adapter + SBIR.gov request builder + `refresh-enrichment --source nih_reporter`.
+- [x] 8.2 Adapter + SBIR.gov request builder + `refresh-enrichment --source nih_reporter`.
   - Verify: mocked CLI dry-run; disabled source exits; no USAspending parquet dependency
+  - Notes: `NIHReporterSourceAdapter` + `requests.py` build exact-key lookups
+    from the SBIR.gov award frame. `--window` is RePORTER criteria (date or
+    `fy:`), not a local award-date filter. First run treats an empty freshness
+    ledger as "all eligible NIH/HHS awards." Persist grain is `appl_id` at
+    `data/derived/nih_reporter_awards.parquet`. `enabled: false` until a hand
+    run succeeds.
 - [ ] 8.3 Dagster ledger / stale set / refresh batch and job. No sensor.
       Keep `enabled: false`.
   - Verify: job selection includes the refresh asset; hermetic fake adapter

--- a/specs/iterative-api-enrichment/tasks.md
+++ b/specs/iterative-api-enrichment/tasks.md
@@ -80,3 +80,25 @@ Optional Phase 2 expansion (6.1, 6.2) is **not** required to close #442.
   - Verify: CLI `--help` and a mocked dry-run
 - [x] 7.5 Update `docs/enrichment/usaspending-iterative-refresh.md`.
   - Verify: `make docs-check`
+
+## Issue #443 — NIH RePORTER source adapter
+
+Per-source adapter for R43/R44/R41/R42. Shared lifecycle stays in
+`SourceAdapter` / `SourceRefreshRunner`. Grain: exact `project_num` /
+`core_project_num` + FY on known SBIR.gov NIH/HHS awards; windows become
+RePORTER criteria. Out of scope: STTR `research_hospitals`, live schedule,
+rewriting the Phase III urllib extractor.
+
+- [x] 8.1 Add `sbir_etl/enrichers/nih_reporter/` client, key canonicalizer,
+      and normalized record schema. Move `canonicalize_nih_query_key` here;
+      Phase III re-exports it.
+  - Verify: `tests/unit/enrichers/nih_reporter/` (pagination, windows,
+    duplicates, retries) and `tests/unit/phase_iii_negative_controls/test_nih_reporter.py`
+- [ ] 8.2 Adapter + SBIR.gov request builder + `refresh-enrichment --source nih_reporter`.
+  - Verify: mocked CLI dry-run; disabled source exits; no USAspending parquet dependency
+- [ ] 8.3 Dagster ledger / stale set / refresh batch and job. No sensor.
+      Keep `enabled: false`.
+  - Verify: job selection includes the refresh asset; hermetic fake adapter
+- [ ] 8.4 Docs (`docs/enrichment/nih-reporter-refresh.md`) and E3 freshness
+      mention only after a hand run has written a freshness row.
+  - Verify: `make docs-check`

--- a/tests/unit/enrichers/nih_reporter/fixtures/search_page.json
+++ b/tests/unit/enrichers/nih_reporter/fixtures/search_page.json
@@ -1,0 +1,28 @@
+{
+  "meta": {"total": 1, "offset": 0, "limit": 500},
+  "results": [
+    {
+      "appl_id": 10824314,
+      "fiscal_year": 2024,
+      "project_num": "1R43AI123456-01",
+      "core_project_num": "R43AI123456",
+      "activity_code": "R43",
+      "agency_ic_admin": "NIAID",
+      "organization": {
+        "org_name": "Example Biotech Inc",
+        "org_ueis": ["DPMGH9MG1X67"],
+        "org_duns": ["076580745"],
+        "primary_uei": "DPMGH9MG1X67",
+        "primary_duns": "076580745"
+      },
+      "principal_investigators": [
+        {"first_name": "Ada", "last_name": "Lovelace", "full_name": "Ada Lovelace"}
+      ],
+      "project_title": "Example SBIR project",
+      "abstract_text": "An abstract.",
+      "award_amount": 275000,
+      "opportunity_number": "PA-22-176",
+      "full_study_section": {"srg_code": "ZRG1", "name": "Special Emphasis Panel"}
+    }
+  ]
+}

--- a/tests/unit/enrichers/nih_reporter/test_adapter.py
+++ b/tests/unit/enrichers/nih_reporter/test_adapter.py
@@ -1,0 +1,153 @@
+"""Hermetic tests for NIHReporterSourceAdapter. No live network."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.adapter import NIHReporterSourceAdapter
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord
+from sbir_etl.models.enrichment import EnrichmentFreshnessRecord, EnrichmentStatus
+from sbir_etl.utils.enrichment.freshness import FreshnessStore
+
+
+pytestmark = pytest.mark.fast
+
+
+class _FakeClient:
+    def __init__(self, records: list[NIHReporterRecord] | None = None) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.records = (
+            list(records)
+            if records is not None
+            else [
+                NIHReporterRecord(
+                    appl_id="10824314",
+                    fy=2024,
+                    project_num="1R43AI123456-01",
+                    payload_hash="pagehash",
+                )
+            ]
+        )
+
+    async def lookup_projects(self, project_nums, fiscal_year, *, window=None, **kwargs):
+        del kwargs
+        self.calls.append(
+            {
+                "project_nums": list(project_nums),
+                "fiscal_year": fiscal_year,
+                "window": window,
+            }
+        )
+        return list(self.records)
+
+    def compute_payload_hash(self, payload: Any) -> str:
+        return "computed-hash"
+
+
+def test_adapter_lookup_and_persist(tmp_path: Path) -> None:
+    client = _FakeClient()
+    dest = tmp_path / "nih_reporter_awards.parquet"
+    adapter = NIHReporterSourceAdapter(client=client, persist_path=dest)
+
+    raw = adapter.fetch_page(
+        {
+            "award_id": "AW-1",
+            "project_num": "1R43AI123456-01",
+            "project_nums": ["1R43AI123456-01"],
+            "award_year": 2024,
+        },
+        None,
+    )
+    records = adapter.normalize(raw)
+    quality = adapter.validate(records)
+    proven = adapter.provenance(raw)
+
+    assert quality.ok
+    assert records[0]["success"] is True
+    assert records[0]["payload_hash"] == "pagehash"
+    assert proven.citation_url == "https://api.reporter.nih.gov/"
+    assert client.calls == [
+        {"project_nums": ["1R43AI123456-01"], "fiscal_year": 2024, "window": None}
+    ]
+    stored = pd.read_parquet(dest)
+    assert list(stored["appl_id"]) == ["10824314"]
+    assert list(stored["award_id"]) == ["AW-1"]
+    assert list(stored["upsert_key"]) == ["1R43AI123456-01|2024"]
+
+
+def test_date_window_is_passed_to_client(tmp_path: Path) -> None:
+    client = _FakeClient()
+    adapter = NIHReporterSourceAdapter(client=client, persist_path=tmp_path / "out.parquet")
+    adapter.fetch_page(
+        {
+            "award_id": "AW-1",
+            "project_num": "1R43AI123456-01",
+            "award_year": 2024,
+            "window": "2024-01-01:2024-12-31",
+        },
+        None,
+    )
+    assert client.calls[0]["window"] == "2024-01-01:2024-12-31"
+
+
+def test_missing_request_fields_fail_without_client_call(tmp_path: Path) -> None:
+    client = _FakeClient()
+    adapter = NIHReporterSourceAdapter(client=client, persist_path=tmp_path / "out.parquet")
+    raw = adapter.fetch_page({"award_id": "AW-1"}, None)
+    records = adapter.normalize(raw)
+    assert adapter.validate(records).ok is False
+    assert client.calls == []
+    assert records[0]["error"]
+
+
+def test_empty_lookup_is_success_and_does_not_wipe_table(tmp_path: Path) -> None:
+    dest = tmp_path / "nih_reporter_awards.parquet"
+    first = NIHReporterSourceAdapter(
+        client=_FakeClient(),
+        persist_path=dest,
+    )
+    first.fetch_page(
+        {"award_id": "AW-1", "project_num": "1R43AI123456-01", "award_year": 2024},
+        None,
+    )
+    empty = NIHReporterSourceAdapter(
+        client=_FakeClient(records=[]),
+        persist_path=dest,
+    )
+    raw = empty.fetch_page(
+        {"award_id": "AW-1", "project_num": "1R43AI123456-01", "award_year": 2024},
+        None,
+    )
+    records = empty.normalize(raw)
+    assert records[0]["success"] is True
+    assert records[0]["metadata"]["match_count"] == 0
+    assert list(pd.read_parquet(dest)["appl_id"]) == ["10824314"]
+
+
+def test_delta_compares_freshness_hash(tmp_path: Path) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    store.save_record(
+        EnrichmentFreshnessRecord(
+            award_id="AW-1",
+            source="nih_reporter",
+            last_attempt_at=datetime(2020, 1, 1),
+            last_success_at=datetime(2020, 1, 1),
+            status=EnrichmentStatus.SUCCESS,
+            payload_hash="pagehash",
+        )
+    )
+    adapter = NIHReporterSourceAdapter(
+        _FakeClient(),
+        freshness=store,
+        persist_path=tmp_path / "out.parquet",
+    )
+    raw = adapter.fetch_page(
+        {"award_id": "AW-1", "project_num": "1R43AI123456-01", "award_year": 2024},
+        None,
+    )
+    assert adapter.normalize(raw)[0]["delta_detected"] is False

--- a/tests/unit/enrichers/nih_reporter/test_client.py
+++ b/tests/unit/enrichers/nih_reporter/test_client.py
@@ -234,6 +234,38 @@ async def test_server_error_then_success_is_retried(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_lookup_date_window_is_api_criteria(tmp_path: Path) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, content=FIXTURE.read_bytes())
+
+    await _client(handler, tmp_path).lookup_projects(
+        ["1R43AI123456-01"],
+        2024,
+        window="2024-01-01:2024-12-31",
+    )
+    criteria = captured[0]["criteria"]
+    assert criteria["project_nums"] == ["1R43AI123456-01"]
+    assert criteria["fiscal_years"] == [2024]
+    assert criteria["project_start_date"] == {"from_date": "2024-01-01", "to_date": "2024-12-31"}
+
+
+@pytest.mark.asyncio
+async def test_lookup_rejects_fy_window(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=FIXTURE.read_bytes())
+
+    with pytest.raises(ValueError, match="fy: window"):
+        await _client(handler, tmp_path).lookup_projects(
+            ["1R43AI123456-01"],
+            2024,
+            window="fy:2024-2024",
+        )
+
+
+@pytest.mark.asyncio
 async def test_client_error_is_not_retried(tmp_path: Path) -> None:
     attempts = {"count": 0}
 

--- a/tests/unit/enrichers/nih_reporter/test_client.py
+++ b/tests/unit/enrichers/nih_reporter/test_client.py
@@ -1,0 +1,246 @@
+"""Hermetic tests for NIHReporterAPIClient. No live network."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.client import (
+    NIH_ACTIVITY_CODES,
+    NIH_INCLUDE_FIELDS,
+    NIH_PAGE_SIZE,
+    NIHReporterAPIClient,
+)
+from sbir_etl.exceptions import APIError
+
+
+pytestmark = pytest.mark.fast
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search_page.json"
+
+
+def _client(
+    handler: httpx.MockTransport | Any,
+    tmp_path: Path,
+) -> NIHReporterAPIClient:
+    transport = (
+        handler if isinstance(handler, httpx.MockTransport) else httpx.MockTransport(handler)
+    )
+    return NIHReporterAPIClient(
+        config={
+            "timeout_seconds": 5,
+            "rate_limit_per_minute": 120,
+            "cache": {"cache_dir": str(tmp_path / "cache")},
+        },
+        http_client=httpx.AsyncClient(transport=transport),
+        cache_dir=tmp_path / "cache",
+    )
+
+
+def test_build_payload_omitted_window_is_activity_code_snapshot() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(offset=0)
+    assert payload["criteria"] == {"activity_codes": list(NIH_ACTIVITY_CODES)}
+    assert "project_start_date" not in payload["criteria"]
+    assert "fiscal_years" not in payload["criteria"]
+    assert payload["limit"] == NIH_PAGE_SIZE
+    assert payload["include_fields"] == list(NIH_INCLUDE_FIELDS)
+
+
+def test_build_payload_date_window_is_api_criteria() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(offset=0, window="2020-01-01:2021-12-31")
+    assert payload["criteria"]["project_start_date"] == {
+        "from_date": "2020-01-01",
+        "to_date": "2021-12-31",
+    }
+    assert payload["criteria"]["activity_codes"] == list(NIH_ACTIVITY_CODES)
+
+
+def test_build_payload_fy_window_is_api_criteria() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(offset=0, window="fy:2023-2024")
+    assert payload["criteria"]["fiscal_years"] == [2023, 2024]
+
+
+def test_build_payload_exact_lookup_canonicalizes_keys() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    payload = client.build_search_payload(
+        offset=0,
+        project_nums=[" 1 R43 AI123456-01, "],
+        fiscal_years=[2024],
+    )
+    assert payload["criteria"]["project_nums"] == ["1R43AI123456-01"]
+    assert payload["criteria"]["fiscal_years"] == [2024]
+
+
+def test_build_payload_rejects_fy_window_and_explicit_years() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    with pytest.raises(ValueError, match="fy: window"):
+        client.build_search_payload(offset=0, fiscal_years=[2024], window="fy:2023-2024")
+
+
+def test_payload_hash_is_deterministic() -> None:
+    client = NIHReporterAPIClient(config={"rate_limit_per_minute": 30}, cache_dir=".")
+    first = client.compute_payload_hash({"b": 1, "a": 2})
+    second = client.compute_payload_hash({"a": 2, "b": 1})
+    assert first == second
+    assert len(first) == 64
+
+
+@pytest.mark.asyncio
+async def test_search_uses_recorded_fixture(tmp_path: Path) -> None:
+    captured: list[dict[str, Any]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content))
+        return httpx.Response(200, content=FIXTURE.read_bytes())
+
+    client = _client(handler, tmp_path)
+    records = await client.search_projects(window="fy:2024-2024", limit=500)
+    assert len(records) == 1
+    assert records[0].project_num == "1R43AI123456-01"
+    assert captured[0]["criteria"]["fiscal_years"] == [2024]
+    assert captured[0]["criteria"]["activity_codes"] == list(NIH_ACTIVITY_CODES)
+    cached = list((tmp_path / "cache").glob("*.json"))
+    assert len(cached) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_paginates_to_declared_total(tmp_path: Path) -> None:
+    offsets: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        offset = int(body["offset"])
+        offsets.append(offset)
+        result = {
+            "appl_id": 100 + offset,
+            "fiscal_year": 2024,
+            "project_num": "1R43AI123456-01",
+            "activity_code": "R43",
+        }
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 2, "offset": offset, "limit": 1}, "results": [result]},
+        )
+
+    client = _client(handler, tmp_path)
+    records = await client.search_projects(limit=1)
+    assert offsets == [0, 1]
+    assert [record.appl_id for record in records] == ["100", "101"]
+    assert {record.upsert_key() for record in records} == {("1R43AI123456-01", 2024)}
+
+
+@pytest.mark.asyncio
+async def test_partial_last_page_when_next_offset_equals_total(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        offset = int(body["offset"])
+        if offset == 0:
+            results = [
+                {"appl_id": 1, "fiscal_year": 2024, "project_num": "1R43AA000001-01"},
+                {"appl_id": 2, "fiscal_year": 2024, "project_num": "1R44AA000002-01"},
+            ]
+        else:
+            results = [{"appl_id": 3, "fiscal_year": 2024, "project_num": "1R41AA000003-01"}]
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 3, "offset": offset, "limit": 2}, "results": results},
+        )
+
+    records = await _client(handler, tmp_path).search_projects(limit=2)
+    assert [record.appl_id for record in records] == ["1", "2", "3"]
+
+
+@pytest.mark.asyncio
+async def test_duplicate_project_num_keeps_both_appl_ids(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "meta": {"total": 2, "offset": 0, "limit": 500},
+                "results": [
+                    {"appl_id": 10, "fiscal_year": 2024, "project_num": "1R43AI123456-01"},
+                    {"appl_id": 11, "fiscal_year": 2024, "project_num": "1R43AI123456-01"},
+                ],
+            },
+        )
+
+    records = await _client(handler, tmp_path).search_projects()
+    assert [record.appl_id for record in records] == ["10", "11"]
+    assert records[0].upsert_key() == records[1].upsert_key()
+
+
+@pytest.mark.asyncio
+async def test_offset_mismatch_fails_closed(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 1, "offset": 99, "limit": 500}, "results": []},
+        )
+
+    with pytest.raises(APIError, match="pagination metadata"):
+        await _client(handler, tmp_path).fetch_page(offset=0)
+
+
+@pytest.mark.asyncio
+async def test_empty_page_before_total_fails_closed(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"meta": {"total": 4, "offset": 0, "limit": 500}, "results": []},
+        )
+
+    with pytest.raises(APIError, match="stopped before the declared total"):
+        await _client(handler, tmp_path).fetch_page(offset=0)
+
+
+@pytest.mark.asyncio
+async def test_oversized_page_fails_closed(tmp_path: Path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "meta": {"total": 2, "offset": 0, "limit": 1},
+                "results": [
+                    {"appl_id": 1, "fiscal_year": 2024},
+                    {"appl_id": 2, "fiscal_year": 2024},
+                ],
+            },
+        )
+
+    with pytest.raises(APIError, match="inconsistent result counts"):
+        await _client(handler, tmp_path).fetch_page(offset=0, limit=1)
+
+
+@pytest.mark.asyncio
+async def test_server_error_then_success_is_retried(tmp_path: Path) -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            return httpx.Response(503, text="unavailable")
+        return httpx.Response(200, content=FIXTURE.read_bytes())
+
+    records = await _client(handler, tmp_path).lookup_projects(["1R43AI123456-01"], 2024)
+    assert attempts["count"] == 2
+    assert records[0].appl_id == "10824314"
+
+
+@pytest.mark.asyncio
+async def test_client_error_is_not_retried(tmp_path: Path) -> None:
+    attempts = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["count"] += 1
+        return httpx.Response(400, text="bad request")
+
+    with pytest.raises(APIError, match="HTTP 400"):
+        await _client(handler, tmp_path).fetch_page(offset=0)
+    assert attempts["count"] == 1

--- a/tests/unit/enrichers/nih_reporter/test_keys.py
+++ b/tests/unit/enrichers/nih_reporter/test_keys.py
@@ -1,0 +1,66 @@
+"""Tests for NIH RePORTER key canonicalization and window parsing."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.keys import (
+    NIHWindowKind,
+    canonicalize_nih_query_key,
+    parse_refresh_window,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_canonicalize_preserves_structural_punctuation() -> None:
+    assert canonicalize_nih_query_key(" 5 F32 DK132864-03, ") == "5F32DK132864-03"
+
+
+def test_canonicalize_rejects_null_tokens() -> None:
+    assert canonicalize_nih_query_key(None) is None
+    assert canonicalize_nih_query_key(pd.NA) is None
+    assert canonicalize_nih_query_key("nan") is None
+    assert canonicalize_nih_query_key("  ") is None
+
+
+def test_blank_window_is_full_snapshot() -> None:
+    parsed = parse_refresh_window(None)
+    assert parsed.kind is NIHWindowKind.ALL
+    criteria: dict[str, object] = {"activity_codes": ["R43"]}
+    parsed.apply_to_criteria(criteria)
+    assert criteria == {"activity_codes": ["R43"]}
+
+
+def test_iso_date_window_becomes_project_start_date() -> None:
+    parsed = parse_refresh_window("2020-01-01:2024-12-31")
+    assert parsed.kind is NIHWindowKind.PROJECT_START_DATE
+    criteria: dict[str, object] = {}
+    parsed.apply_to_criteria(criteria)
+    assert criteria == {"project_start_date": {"from_date": "2020-01-01", "to_date": "2024-12-31"}}
+
+
+def test_fiscal_year_window_is_inclusive() -> None:
+    parsed = parse_refresh_window("fy:2022-2024")
+    assert parsed.fiscal_years == (2022, 2023, 2024)
+    criteria: dict[str, object] = {}
+    parsed.apply_to_criteria(criteria)
+    assert criteria == {"fiscal_years": [2022, 2023, 2024]}
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        "2020-01-01",
+        "fy:2024",
+        "fy:2024-20",
+        "not-a-window",
+        "2024-12-31:2020-01-01",
+        "fy:2024-2022",
+    ],
+)
+def test_malformed_or_inverted_windows_fail_closed(window: str) -> None:
+    with pytest.raises(ValueError):
+        parse_refresh_window(window)

--- a/tests/unit/enrichers/nih_reporter/test_persist.py
+++ b/tests/unit/enrichers/nih_reporter/test_persist.py
@@ -46,3 +46,15 @@ def test_empty_records_do_not_write(tmp_path: Path) -> None:
     dest = tmp_path / "nih_reporter_awards.parquet"
     assert upsert_nih_reporter_awards([], award_id="AW-1", path=dest) is None
     assert not dest.exists()
+
+
+def test_unreadable_existing_file_raises_instead_of_silently_wiping(tmp_path: Path) -> None:
+    """A corrupt/unreadable prior file must fail loudly, not be treated as
+
+    empty -- silently swallowing the read error would replace `dest` with
+    only the current batch, discarding every previously persisted row.
+    """
+    dest = tmp_path / "nih_reporter_awards.parquet"
+    dest.write_text("not a parquet file")
+    with pytest.raises(Exception):  # noqa: B017 - pandas' parquet engine error type
+        upsert_nih_reporter_awards([_record("99")], award_id="AW-1", path=dest)

--- a/tests/unit/enrichers/nih_reporter/test_persist.py
+++ b/tests/unit/enrichers/nih_reporter/test_persist.py
@@ -1,0 +1,48 @@
+"""Tests for the NIH RePORTER derived project table."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.persist import upsert_nih_reporter_awards
+from sbir_etl.enrichers.nih_reporter.schema import NIHReporterRecord
+
+
+pytestmark = pytest.mark.fast
+
+
+def _record(
+    appl_id: str, project_num: str = "1R43AI123456-01", fy: int = 2024
+) -> NIHReporterRecord:
+    return NIHReporterRecord(appl_id=appl_id, fy=fy, project_num=project_num)
+
+
+def test_upsert_replaces_one_key_and_keeps_other_appl_ids(tmp_path: Path) -> None:
+    dest = tmp_path / "nih_reporter_awards.parquet"
+    upsert_nih_reporter_awards(
+        [_record("10"), _record("11")],
+        award_id="AW-1",
+        path=dest,
+    )
+    upsert_nih_reporter_awards(
+        [_record("12")],
+        award_id="AW-1",
+        path=dest,
+    )
+    upsert_nih_reporter_awards(
+        [_record("20", project_num="1R44CA000001-01")],
+        award_id="AW-2",
+        path=dest,
+    )
+    stored = pd.read_parquet(dest)
+    assert set(stored["appl_id"]) == {"12", "20"}
+    assert set(stored["upsert_key"]) == {"1R43AI123456-01|2024", "1R44CA000001-01|2024"}
+
+
+def test_empty_records_do_not_write(tmp_path: Path) -> None:
+    dest = tmp_path / "nih_reporter_awards.parquet"
+    assert upsert_nih_reporter_awards([], award_id="AW-1", path=dest) is None
+    assert not dest.exists()

--- a/tests/unit/enrichers/nih_reporter/test_requests.py
+++ b/tests/unit/enrichers/nih_reporter/test_requests.py
@@ -1,0 +1,118 @@
+"""Tests for SBIR.gov → NIH RePORTER request building."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.requests import (
+    build_nih_reporter_requests,
+    is_nih_reporter_agency,
+    load_sbir_award_frame,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+def _award(**overrides: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "award_id": "AW-NIH-1",
+        "agency": "HHS",
+        "branch": "NIAID",
+        "contract_number": "1 R43 AI123456-01",
+        "agency_tracking_number": "R43AI123456",
+        "award_year": 2024,
+        "company": "Example Biotech",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_build_requests_canonicalizes_keys_and_keeps_year() -> None:
+    requests, skipped = build_nih_reporter_requests(pd.DataFrame([_award()]))
+
+    assert skipped == 0
+    assert requests == [
+        {
+            "award_id": "AW-NIH-1",
+            "project_num": "1R43AI123456-01",
+            "project_nums": ["1R43AI123456-01", "R43AI123456"],
+            "award_year": 2024,
+        }
+    ]
+
+
+def test_non_nih_agencies_are_ignored() -> None:
+    requests, skipped = build_nih_reporter_requests(
+        pd.DataFrame([_award(agency="DOD", branch="NAVY", award_id="AW-DOD")])
+    )
+    assert requests == []
+    assert skipped == 0
+
+
+def test_rows_without_project_key_or_year_are_skipped() -> None:
+    frame = pd.DataFrame(
+        [
+            _award(contract_number=None, agency_tracking_number=None, award_id="AW-NO-KEY"),
+            _award(award_year=None, award_id="AW-NO-YEAR"),
+            _award(agency="NIH", branch=None, award_id="AW-OK"),
+        ]
+    )
+    requests, skipped = build_nih_reporter_requests(frame)
+    assert skipped == 2
+    assert [request["award_id"] for request in requests] == ["AW-OK"]
+
+
+def test_fy_window_restricts_award_year_not_calendar_dates() -> None:
+    frame = pd.DataFrame(
+        [
+            _award(award_id="AW-2024", award_year=2024),
+            _award(award_id="AW-2019", award_year=2019),
+        ]
+    )
+    requests, skipped = build_nih_reporter_requests(frame, window="fy:2023-2024")
+    assert skipped == 0
+    assert [request["award_id"] for request in requests] == ["AW-2024"]
+    assert "window" not in requests[0]
+
+
+def test_date_window_is_attached_as_criteria_not_a_local_filter() -> None:
+    frame = pd.DataFrame(
+        [
+            _award(award_id="AW-2024", award_year=2024),
+            _award(award_id="AW-2019", award_year=2019),
+        ]
+    )
+    requests, skipped = build_nih_reporter_requests(frame, window="2024-01-01:2024-12-31")
+    assert skipped == 0
+    assert [request["award_id"] for request in requests] == ["AW-2024", "AW-2019"]
+    assert all(request["window"] == "2024-01-01:2024-12-31" for request in requests)
+
+
+def test_company_name_is_not_a_join_key() -> None:
+    requests, _skipped = build_nih_reporter_requests(
+        pd.DataFrame([_award(company="Totally Different Name LLC")])
+    )
+    assert "company" not in requests[0]
+
+
+@pytest.mark.parametrize(
+    ("agency", "branch", "expected"),
+    [
+        ("HHS", "NIAID", True),
+        ("NIH", None, True),
+        ("DOD", "NAVY", False),
+        ("NSF", None, False),
+        ("HHS", "NCI", True),
+    ],
+)
+def test_agency_allowlist(agency: str | None, branch: str | None, expected: bool) -> None:
+    assert is_nih_reporter_agency(agency, branch) is expected
+
+
+def test_missing_sbir_frame_fails_clearly(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="SBIR.gov award CSV"):
+        load_sbir_award_frame(tmp_path / "missing.csv")

--- a/tests/unit/enrichers/nih_reporter/test_schema.py
+++ b/tests/unit/enrichers/nih_reporter/test_schema.py
@@ -1,0 +1,53 @@
+"""Tests for NIH RePORTER record normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sbir_etl.enrichers.nih_reporter.schema import normalize_reporter_result
+
+
+pytestmark = pytest.mark.fast
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search_page.json"
+
+
+def test_normalize_recorded_fixture() -> None:
+    payload = json.loads(FIXTURE.read_text())
+    record = normalize_reporter_result(payload["results"][0], payload_hash="abc")
+    assert record.appl_id == "10824314"
+    assert record.fy == 2024
+    assert record.upsert_key() == ("1R43AI123456-01", 2024)
+    assert record.org_uei == "DPMGH9MG1X67"
+    assert record.org_duns == "076580745"
+    assert record.pi_names == ("Ada Lovelace",)
+    assert record.foa_number == "PA-22-176"
+    assert record.study_section == "ZRG1"
+    assert record.award_amount == 275000.0
+    assert record.source == "nih_reporter"
+    assert record.payload_hash == "abc"
+
+
+def test_normalize_keeps_multiple_org_identifiers() -> None:
+    record = normalize_reporter_result(
+        {
+            "appl_id": 1,
+            "fiscal_year": 2023,
+            "project_num": "1R44CA000001-01",
+            "organization": {
+                "org_ueis": ["UEIAAAA11111", "UEIBBBB22222"],
+                "primary_duns": "123456789",
+            },
+        }
+    )
+    assert record.org_ueis == ("UEIAAAA11111", "UEIBBBB22222")
+    assert record.org_duns == "123456789"
+    assert record.org_duns_values == ("123456789",)
+
+
+def test_normalize_requires_appl_id_and_fy() -> None:
+    with pytest.raises(ValueError, match="appl_id or fiscal_year"):
+        normalize_reporter_result({"project_num": "1R43AI123456-01"})

--- a/tests/unit/enrichers/test_refresh_cli.py
+++ b/tests/unit/enrichers/test_refresh_cli.py
@@ -59,6 +59,8 @@ def test_parser_help_lists_source() -> None:
     help_text = parser.format_help()
     assert "--source" in help_text
     assert "--window" in help_text
+    assert "nih_reporter" in help_text
+    assert "fy:YYYY-YYYY" in help_text
 
 
 def _stale_store(tmp_path, award_id: str = "AW-CLI") -> FreshnessStore:
@@ -197,3 +199,166 @@ def test_stale_ids_absent_from_enriched_are_reported(tmp_path, monkeypatch, caps
     assert adapter.requests == []
     assert stats["total"] == 0
     assert "absent from enriched awards" in capsys.readouterr().err
+
+
+class _NIHAdapter:
+    source_id = "nih_reporter"
+
+    def __init__(self) -> None:
+        self.requests: list[dict] = []
+
+    def fetch_page(self, request, cursor):
+        del cursor
+        self.requests.append(dict(request))
+        return RawPage(
+            payload={"success": True, "payload_hash": "x"}, record_id=request["award_id"]
+        )
+
+    def normalize(self, raw):
+        return [
+            {"award_id": raw.record_id, "success": True, "delta_detected": True, "metadata": {}}
+        ]
+
+    def validate(self, records):
+        del records
+        return QualityResult(ok=True)
+
+    def provenance(self, raw):
+        return SourceProvenance(
+            source_id=self.source_id,
+            retrieved_at=datetime.now(),
+            content_hash="x",
+            citation_url="https://api.reporter.nih.gov/",
+        )
+
+
+def _nih_awards() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "award_id": "AW-NIH-1",
+                "agency": "HHS",
+                "branch": "NIAID",
+                "contract_number": "1R43AI123456-01",
+                "agency_tracking_number": None,
+                "award_year": 2024,
+            },
+            {
+                "award_id": "AW-NIH-OLD",
+                "agency": "NIH",
+                "branch": None,
+                "contract_number": "1R44CA000001-01",
+                "agency_tracking_number": None,
+                "award_year": 2019,
+            },
+        ]
+    )
+
+
+def _enable_nih(monkeypatch) -> None:
+    config = get_config()
+    monkeypatch.setattr(config.enrichment_refresh.nih_reporter, "enabled", True)
+    monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.get_config", lambda: config)
+
+
+def _patch_nih_cli(monkeypatch, store: FreshnessStore, awards: pd.DataFrame) -> None:
+    _enable_nih(monkeypatch)
+    monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.FreshnessStore", lambda: store)
+    monkeypatch.setattr(
+        "sbir_etl.enrichers.refresh_cli.load_sbir_award_frame", lambda *a, **k: awards
+    )
+    monkeypatch.setattr(
+        "sbir_etl.enrichers.refresh_cli.load_enriched_awards",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("NIH must not load USAspending")),
+    )
+
+
+def test_nih_help_and_disabled_source_exits(tmp_path, monkeypatch) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.FreshnessStore", lambda: store)
+    with pytest.raises(SystemExit, match="disabled"):
+        run_refresh(source="nih_reporter", adapter=_NIHAdapter(), runner=_runner(tmp_path, store))
+
+
+def test_nih_first_run_refreshes_all_eligible_awards(tmp_path, monkeypatch) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    _patch_nih_cli(monkeypatch, store, _nih_awards())
+    adapter = _NIHAdapter()
+
+    stats = run_refresh(source="nih_reporter", adapter=adapter, runner=_runner(tmp_path, store))
+
+    assert [request["award_id"] for request in adapter.requests] == ["AW-NIH-1", "AW-NIH-OLD"]
+    assert stats["success"] == 2
+
+
+def test_nih_date_window_is_criteria_not_a_local_date_filter(tmp_path, monkeypatch) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    _patch_nih_cli(monkeypatch, store, _nih_awards())
+    adapter = _NIHAdapter()
+
+    run_refresh(
+        source="nih_reporter",
+        window="2024-01-01:2024-12-31",
+        adapter=adapter,
+        runner=_runner(tmp_path, store),
+    )
+
+    assert [request["award_id"] for request in adapter.requests] == ["AW-NIH-1", "AW-NIH-OLD"]
+    assert all(request["window"] == "2024-01-01:2024-12-31" for request in adapter.requests)
+
+
+def test_nih_missing_sbir_frame_fails_fast(tmp_path, monkeypatch) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    _enable_nih(monkeypatch)
+    monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.FreshnessStore", lambda: store)
+
+    def _missing(*_args, **_kwargs):
+        raise FileNotFoundError("SBIR.gov award CSV is unavailable")
+
+    monkeypatch.setattr("sbir_etl.enrichers.refresh_cli.load_sbir_award_frame", _missing)
+
+    with pytest.raises(SystemExit, match="SBIR.gov award CSV"):
+        run_refresh(source="nih_reporter", adapter=_NIHAdapter(), runner=_runner(tmp_path, store))
+
+
+def test_nih_skips_fresh_ledger_rows_but_includes_unseen(tmp_path, monkeypatch) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    store.save_record(
+        EnrichmentFreshnessRecord(
+            award_id="AW-NIH-1",
+            source="nih_reporter",
+            last_attempt_at=datetime.now(),
+            last_success_at=datetime.now(),
+            status=EnrichmentStatus.SUCCESS,
+        )
+    )
+    _patch_nih_cli(monkeypatch, store, _nih_awards())
+    adapter = _NIHAdapter()
+
+    run_refresh(source="nih_reporter", adapter=adapter, runner=_runner(tmp_path, store))
+
+    assert [request["award_id"] for request in adapter.requests] == ["AW-NIH-OLD"]
+
+
+def test_nih_rows_without_project_key_are_reported(tmp_path, monkeypatch, capsys) -> None:
+    store = FreshnessStore(tmp_path / "freshness.parquet")
+    awards = pd.DataFrame(
+        [
+            {
+                "award_id": "AW-NO-KEY",
+                "agency": "HHS",
+                "branch": "NIH",
+                "contract_number": None,
+                "agency_tracking_number": None,
+                "award_year": 2024,
+            }
+        ]
+    )
+    _patch_nih_cli(monkeypatch, store, awards)
+    adapter = _NIHAdapter()
+
+    stats = run_refresh(source="nih_reporter", adapter=adapter, runner=_runner(tmp_path, store))
+
+    assert adapter.requests == []
+    assert stats["total"] == 0
+    assert "no usable project key" in capsys.readouterr().err


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Second slice of #443. Operators can run `uv run refresh-enrichment --source nih_reporter` against the SBIR.gov award frame (not the USAspending parquet), persist a documented project table, and write freshness/checkpoints. The source stays `enabled: false` until a hand run succeeds.

Stacked on #640 (client + key canonicalizer).

Fixes part of #443 (task 8.2). Remaining: Dagster job without a sensor (8.3), then docs after a hand run (8.4).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Versioning Impact

- [x] No release impact (internal or unreleased work)

## What this adds

- `NIHReporterSourceAdapter` — exact `project_num` + FY lookup via the 8.1 client; runner contract matches USAspending (`award_id`, `success`, `payload_hash`, `delta_detected`, `metadata`, `error`)
- Request builder from SBIR.gov NIH/HHS awards (`contract_number` / `agency_tracking_number` + four-digit `award_year`). Company name is never a join key. Missing project key/year rows are skipped with a count on stderr
- `--window` becomes RePORTER criteria (`YYYY-MM-DD:YYYY-MM-DD` → `project_start_date`; `fy:YYYY-YYYY` restricts `award_year` and is not also sent as a second `fiscal_years` predicate). Not a local award-date filter
- First run with an empty freshness ledger refreshes every eligible NIH/HHS award instead of silently no-oping
- Persist grain: official row id is `appl_id`; award upsert replaces `(canonical project_num, fy)` at `data/derived/nih_reporter_awards.parquet`. Multiple `appl_id`s are retained. An empty lookup does not wipe existing rows
- Missing SBIR.gov CSV fails with a clear error, not `None`
- `enabled: false` is still the kill switch

## Out of scope (later PRs)

- Dagster ledger / stale set / refresh job (8.3)
- Docs and E3 freshness mention (8.4, only after a hand run)
- Live schedule, enabling on the live host, STTR hospitals, Phase III extractor rewrite

## Testing

- [x] Unit tests added/updated
- [x] All targeted tests pass locally

```text
uv run pytest tests/unit/enrichers/nih_reporter \
  tests/unit/enrichers/test_refresh_cli.py \
  tests/unit/phase_iii_negative_controls/test_nih_reporter.py
# 67 passed
uv run mypy sbir_etl/enrichers/nih_reporter sbir_etl/enrichers/refresh_cli.py
uv run python scripts/ci/check_tier_boundaries.py
```

Existing USAspending CLI tests stay green. NIH CLI tests do not load the USAspending enriched parquet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51d513e6-97b1-44f8-a000-6b9cd092d414?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51d513e6-97b1-44f8-a000-6b9cd092d414&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

