### PR TITLE
Report each D4 direction on its own status

### DIFF
--- a/scripts/sttr_spinout_linkage/d4_scorer.py
+++ b/scripts/sttr_spinout_linkage/d4_scorer.py
@@ -567,31 +567,23 @@ def score_d4_money_trail(
     subaward_client: SubawardClient | None = None,
     form_d_index: dict[str, tuple[str, ...]] | None = None,
 ) -> D4MoneyTrail:
-    """Score both D4 directions and combine them into one `D4MoneyTrail`.
+    """Score both D4 directions and report each one on its own status.
 
-    `kernel.D4MoneyTrail` (prerequisite code, not modified by this PR) has a
-    single `status`/`reason` pair covering both directions, but
-    `kernel.classify_linkage` reads each direction's own field
-    (`ri_subaward_share`, `form_d_officer_ri_affiliated`) independently --
-    Order 3 checks `status == MEASURED and ri_subaward_share > 0`, Order 2's
-    corroboration checks `status == MEASURED and form_d_officer_ri_affiliated`.
-    Setting the shared `status` from only one direction would wrongly block
-    the cascade from crediting the *other* direction's real result (e.g. a
-    contract-instrument award, correctly `NOT_APPLICABLE` for the subaward
-    share, must not also suppress a real Form D officer match) -- exactly
-    the class of directional bug this module's docstring opens with.
+    `kernel.D4MoneyTrail` carries a separate status and absence reason per
+    direction, and `kernel.classify_linkage` reads them independently:
+    Order 2's corroboration checks `form_d_status is MEASURED and
+    form_d_officer_ri_affiliated`, Order 3 checks `subaward_status is
+    MEASURED and ri_subaward_share > 0`. Each direction is therefore passed
+    straight through, with no attempt to reconcile the two into a single
+    shared status.
 
-    Combining policy, in priority order:
-    1. `MEASURED` if **either** direction produced a real measured value --
-       the other direction's own field already defaults to a safe negative
-       (`False` / `None`), so this never manufactures a false positive.
-    2. `NOT_APPLICABLE` if the subaward direction confirmed a non-grant
-       instrument (the more specific, more informative state).
-    3. `EVALUATION_FAILED` if either direction hit an unexpected runtime
-       error (as opposed to a typed absence).
-    4. Otherwise, the more specific of the two directions' typed-absence
-       states (preferring a status that is not `NOT_EVALUATED`, since
-       "not yet queried" is the least informative outcome to report).
+    That reconciliation is precisely what the dataclass split removed. A
+    contract-instrument award is correctly `NOT_APPLICABLE` on the subaward
+    side while saying nothing about whether a Form D officer is
+    RI-affiliated; collapsing both into one status let either direction's
+    typed absence suppress the other's measured signal, or -- in the
+    opposite direction -- let one direction's `MEASURED` advertise a
+    measurement the other never made.
     """
 
     subaward_status, share, subaward_reason = score_ri_subaward_share(
@@ -606,27 +598,11 @@ def score_d4_money_trail(
         form_d_index=form_d_index,
     )
 
-    if subaward_status is DimensionStatus.MEASURED or form_d_status is DimensionStatus.MEASURED:
-        return D4MoneyTrail(
-            status=DimensionStatus.MEASURED,
-            ri_subaward_share=share,
-            form_d_officer_ri_affiliated=officer_match,
-        )
-    if subaward_status is DimensionStatus.NOT_APPLICABLE:
-        return D4MoneyTrail(
-            status=DimensionStatus.NOT_APPLICABLE,
-            ri_subaward_share=share,
-            form_d_officer_ri_affiliated=officer_match,
-            reason=subaward_reason,
-        )
-    if (
-        subaward_status is DimensionStatus.EVALUATION_FAILED
-        or form_d_status is DimensionStatus.EVALUATION_FAILED
-    ):
-        return D4MoneyTrail(status=DimensionStatus.EVALUATION_FAILED)
-
-    if subaward_status is DimensionStatus.NOT_EVALUATED and form_d_status is not (
-        DimensionStatus.NOT_EVALUATED
-    ):
-        return D4MoneyTrail(status=form_d_status, reason=form_d_reason)
-    return D4MoneyTrail(status=subaward_status, reason=subaward_reason)
+    return D4MoneyTrail(
+        subaward_status=subaward_status,
+        form_d_status=form_d_status,
+        ri_subaward_share=share,
+        form_d_officer_ri_affiliated=officer_match,
+        subaward_reason=subaward_reason,
+        form_d_reason=form_d_reason,
+    )

--- a/tests/unit/sttr_spinout_linkage/test_d4_scorer.py
+++ b/tests/unit/sttr_spinout_linkage/test_d4_scorer.py
@@ -1,8 +1,10 @@
 """Probes for the D4 money/paper-trail scorer.
 
-Exploratory tier: covers instrument-type classification, the two D4
-directions independently, and the `D4MoneyTrail` combining policy -- not a
-comprehensive matrix over every real-world `Contract` field format. No
+Exploratory tier: covers instrument-type classification and the two D4
+directions independently, including that each direction reports its own
+status and absence reason without either suppressing or borrowing from the
+other -- not a comprehensive matrix over every real-world `Contract` field
+format. No
 network call: `score_ri_subaward_share` / `score_d4_money_trail` are always
 exercised against a fake `SubawardClient`, never `UsaspendingSubawardClient`.
 """
@@ -380,11 +382,12 @@ class TestScoreD4MoneyTrail:
             subaward_client=client,
             form_d_index={key: ("Jane Smith",)},
         )
-        assert trail.status is DimensionStatus.MEASURED
+        assert trail.subaward_status is DimensionStatus.MEASURED
+        assert trail.form_d_status is DimensionStatus.MEASURED
         assert trail.ri_subaward_share == 1.0
         assert trail.form_d_officer_ri_affiliated is True
 
-    def test_pi_name_only_match_drives_the_combined_trail(self) -> None:
+    def test_pi_name_only_match_is_measured_on_the_form_d_direction(self) -> None:
         """A contract-instrument award where only the PI (not the RI POC)
         shows up as a Form D officer -- the classic professor-founder pattern
         this direction was extended to catch."""
@@ -402,8 +405,10 @@ class TestScoreD4MoneyTrail:
             subaward_client=FakeSubawardClient(),
             form_d_index={key: ("Frances Arnold",)},
         )
-        assert trail.status is DimensionStatus.MEASURED
+        assert trail.form_d_status is DimensionStatus.MEASURED
         assert trail.form_d_officer_ri_affiliated is True
+        assert trail.subaward_status is DimensionStatus.NOT_APPLICABLE
+        assert trail.subaward_reason is SignalAbsentReason.NON_GRANT_INSTRUMENT
         assert trail.ri_subaward_share is None
 
     def test_contract_instrument_with_form_d_match_is_measured_not_suppressed(self) -> None:
@@ -424,8 +429,9 @@ class TestScoreD4MoneyTrail:
             subaward_client=FakeSubawardClient(),
             form_d_index={key: ("Jane Smith",)},
         )
-        assert trail.status is DimensionStatus.MEASURED
+        assert trail.form_d_status is DimensionStatus.MEASURED
         assert trail.form_d_officer_ri_affiliated is True
+        assert trail.subaward_status is DimensionStatus.NOT_APPLICABLE
         assert trail.ri_subaward_share is None
 
     def test_contract_instrument_with_no_form_d_match_is_not_applicable(self) -> None:
@@ -438,8 +444,10 @@ class TestScoreD4MoneyTrail:
             subaward_client=FakeSubawardClient(),
             form_d_index={},
         )
-        assert trail.status is DimensionStatus.NOT_APPLICABLE
-        assert trail.reason is SignalAbsentReason.NON_GRANT_INSTRUMENT
+        assert trail.subaward_status is DimensionStatus.NOT_APPLICABLE
+        assert trail.subaward_reason is SignalAbsentReason.NON_GRANT_INSTRUMENT
+        assert trail.form_d_status is DimensionStatus.NOT_EVALUATED
+        assert trail.form_d_reason is SignalAbsentReason.SOURCE_NOT_QUERIED
 
     def test_evaluation_failure_propagates(self) -> None:
         trail = score_d4_money_trail(
@@ -451,9 +459,11 @@ class TestScoreD4MoneyTrail:
             subaward_client=FakeSubawardClient(raise_on_find=True),
             form_d_index={},
         )
-        assert trail.status is DimensionStatus.EVALUATION_FAILED
+        assert trail.subaward_status is DimensionStatus.EVALUATION_FAILED
+        assert trail.form_d_status is DimensionStatus.NOT_MEASURABLE
+        assert trail.form_d_reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE
 
-    def test_neither_direction_evaluated_prefers_the_more_specific_status(self) -> None:
+    def test_each_direction_reports_its_own_typed_absence(self) -> None:
         trail = score_d4_money_trail(
             ri_name="University of North Dakota",
             company_name="Unlisted Firm LLC",
@@ -463,5 +473,7 @@ class TestScoreD4MoneyTrail:
             subaward_client=None,  # NOT_EVALUATED / SOURCE_NOT_QUERIED
             form_d_index={},
         )
-        assert trail.status is DimensionStatus.NOT_MEASURABLE
-        assert trail.reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE
+        assert trail.subaward_status is DimensionStatus.NOT_EVALUATED
+        assert trail.subaward_reason is SignalAbsentReason.SOURCE_NOT_QUERIED
+        assert trail.form_d_status is DimensionStatus.NOT_MEASURABLE
+        assert trail.form_d_reason is SignalAbsentReason.SOURCE_FIELD_UNAVAILABLE


### PR DESCRIPTION
## Description

Fixes a `TypeError` on `main` that fails 6 tests and turns the `Fast Tests` shards red on **every open PR in the repository**.

`score_d4_money_trail` still constructed `D4MoneyTrail` with a single `status=`/`reason=` pair, but the dataclass in `scripts/sttr_spinout_linkage/kernel.py` had been split into `subaward_status`/`form_d_status` with per-direction reasons. `kernel.py` was updated for the split; its caller was not:

```
TypeError: D4MoneyTrail.__init__() got an unexpected keyword argument 'status'
```

### Why this isn't a mechanical rename

Translating `status=X` into `subaward_status=X, form_d_status=X` would compile and go green while preserving the exact defect the split was made to remove.

`kernel.classify_linkage` already reads the two directions independently — Order 2's corroboration checks `form_d_status is MEASURED and form_d_officer_ri_affiliated`, Order 3 checks `subaward_status is MEASURED and ri_subaward_share > 0`. The scorer's four-step "combining policy" collapsed both into one status, which is what the dataclass docstring warns against:

> A single shared status would let one direction's typed absence suppress the other's measured signal.

The scorer's own docstring already argued the same point, describing the collapse as a workaround for a kernel it noted was "not modified by this PR". The kernel has since been modified, so the workaround is obsolete. Each direction is now passed straight through and the combining policy is deleted.

### Behavior changes

Two cases get strictly more accurate:

- **Contract-instrument award with a Form D officer match** now reports `subaward_status = NOT_APPLICABLE` / `NON_GRANT_INSTRUMENT` *and* `form_d_status = MEASURED`. Previously the whole trail was relabelled `MEASURED`, erasing the fact that the subaward direction was never applicable.
- **An evaluation failure on one direction no longer discards the other.** The old `return D4MoneyTrail(status=EVALUATION_FAILED)` dropped `ri_subaward_share` and `form_d_officer_ri_affiliated` entirely; both are now retained.

Net effect is a 74→50 line reduction in the scorer — the policy was the bulk of it.

### Tests

Updated to assert per-direction status and reason. Two were renamed because the behavior they named no longer exists:

| Before | After |
|---|---|
| `test_pi_name_only_match_drives_the_combined_trail` | `test_pi_name_only_match_is_measured_on_the_form_d_direction` |
| `test_neither_direction_evaluated_prefers_the_more_specific_status` | `test_each_direction_reports_its_own_typed_absence` |

Every test's original intent is preserved. `test_contract_instrument_with_form_d_match_is_measured_not_suppressed` — the case the module exists to protect — gets stronger: no-suppression is now structural rather than dependent on a policy branch ordering.

Both `scripts/sttr_spinout_linkage/` and its tests are `exploratory` tier, so nothing contract-bound is affected. No production module imports the scorer.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

`exploratory`-tier code under `scripts/`, not reachable from any packaged module or public interface.

## Testing

Confirmed the failure reproduces on `main` at `5d2b750b` before changing anything (6 failed, 38 passed in the affected file), then verified the fix:

- `make test-unit` — **6241 passed, 7 skipped, 0 failed** (was 6 failed)
- `tests/unit/sttr_spinout_linkage/` — 141 passed, including the 11 `classify_linkage` cases in `test_kernel.py` that already used the two-status form
- `make lint` — ruff check, `ruff format --check` (939 files), UP042, and mypy over 316 source files all clean
- `make lint-boundaries` — all seven guards pass

Also grepped for other consumers of the old contract: the only production construction site is the one fixed here, and the remaining `trail.status` references belong to `D2PersonTrail` and `D5TextTrail`, which legitimately still carry a single status.

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests pass locally

Existing tests updated rather than added; the file already covered these cases and could not compile against the current dataclass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Em9voSGzWZ8dp2uQTm4Br1)_