### PR TITLE
chore: prepare release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,75 @@ version.
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-08-18
+
+### Added
+
+- `SourceAdapter` protocol and `SourceRefreshRunner`, with `USAspendingAPIClient`
+  wrapped as the reference adapter, restoring `uv run refresh-enrichment
+  --source usaspending` (#619).
+- Pipelines-tier `AnalysisSpec` / `AnalysisRun` platform with a registry-driven
+  runner, snapshot compare, and `scripts/data/run_analysis.py --profile`; the
+  prior hard-coded tech-area builder CLIs remain as deprecated shims (#619).
+- STTR spinout-linkage exploratory kernel: identity resolution, generic-token
+  guard, typed dimension-absence reasons, and the frozen Order 0–4 linkage
+  cascade (#623), its D1 award-spine loader and design freeze-hash guard
+  (#627), and a D4 money/paper-trail scorer scoring the subcontract and
+  spinout signals as two independent directions (#632).
+- STTR spinout-linkage partner-type seed lists: FFRDC, IPEDS, new-model-org,
+  fiscal-sponsor, and IRS nonprofit-registry data captured; the
+  research-hospitals list is left honestly pending on two dead-end sources
+  (#624).
+- `evidence-auditor` and `deployment-safety-reviewer` specialist review
+  agents, cross-checked against the actual evidence-tier contract and
+  self-hosted server runbook they enforce (#646).
+- A crosswalk from the canonical 21-area CET taxonomy to the 14 national
+  security CET areas in Appendix A of the August 2026 National Security
+  Science and Technology Strategy, with Appendix B's priority-need alignment
+  and a `docs/nssts-2026-alignment.md` explainer of what the strategy does
+  and does not license (#647).
+
+### Changed
+
+- `specs/sttr-spinout-linkage` frozen as Revision 1: all 12 open design
+  questions resolved, including a second research pass confirming no public
+  or paid source directly supplies Bayh-Dole research-institution-to-SBC
+  license records (#620, #626).
+- `make lint-boundaries` now runs the same eight guard scripts as the CI
+  quality job, including two that were previously CI-only (#633).
+- Remaining `(str, Enum)` classes migrated to `StrEnum`, enforced by a
+  targeted `UP042` check in `make lint` and CI; Python version wording
+  unified to 3.11–3.12 throughout (#634).
+- CLAUDE.md and agent role instructions deduplicated behind a single shared
+  pointer (#636).
+- The steering glossary and requirements template point confidence bands at
+  their owning config or doc instead of restating them, and disambiguate
+  enrichment "evidence" from the epistemic `evidence` tier (#637).
+- Steering checklists that read as CI gates but were not enforced anywhere
+  are relabeled as guidance, with the genuinely CI-enforced contracts kept
+  in their own table (#638).
+- Per-spec glossaries scrubbed of confidence bands they never owned;
+  archived specs keep only glossary terms still used in their own
+  requirements text (#639).
+
+### Fixed
+
+- The USAspending refresh pipeline: requests carried only `award_id` and
+  could never match an award, the runner checkpoint was never cleared so an
+  award refreshed once was skipped forever, and NaN identifiers reached the
+  API as the literal string `"nan"` (#621).
+- The analysis platform: `run_analysis.py --profile` wrote no census
+  artifacts, the calibration-drift gate was unreachable from the CLI, and a
+  malformed analysis registry could crash the entire Dagster definitions
+  load instead of just the affected cohort assets (#622).
+- The STTR linkage kernel: a generic-token guard bypass on the exact-match
+  identity path, a guard failure that collapsed into a measured negative
+  instead of blocking the label, `D4MoneyTrail`'s single shared status
+  letting one direction's typed absence suppress the other's real signal,
+  and an unreachable cascade branch (#628).
+- `D4MoneyTrail` construction after the kernel's status-field split, which
+  had been failing `Fast Tests` on every open pull request (#647).
+
 ## [0.6.0] — 2026-08-15
 
 ### Added
@@ -150,7 +219,8 @@ across the root project and the three packages under `packages/`.
 `vMAJOR.MINOR.PATCH` form it requires. Per that policy published tags are never
 moved or reused, so they remain as historical markers.
 
-[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.4.0...v0.5.0

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.6.0"
+  version: "0.7.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.6.0"
+version = "0.7.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.6.0"
+version = "0.7.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.6.0"
+version = "0.7.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.6.0"
+version = "0.7.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2834,7 +2834,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2985,7 +2985,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3004,7 +3004,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Description

Synchronizes package, runtime, config, and lockfile versions and rolls the post-v0.6.0 changelog into 0.7.0, per [docs/steering/versioning.md](docs/steering/versioning.md).

This is a MINOR release: several new capabilities landed since v0.6.0 (source-adapter and analysis-run platforms, the STTR spinout-linkage exploratory module, the NSSTS crosswalk, two new review agents), none of them a declared-stable public-surface change, consistent with the `0.x` MINOR criteria in CLAUDE.md.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

(This PR is the release-prep chore itself — see `CHANGELOG.md` for the full classification of what it packages.)

## Versioning Impact

- [x] MINOR: new capability, deprecation, or breaking change during `0.x`

## Testing

```
uv run python scripts/ci/check_versioning.py --tag v0.7.0   # passed
uv run pytest tests/unit                                     # 6247 passed, 7 skipped
make lint                                                     # ruff, format, UP042, mypy — clean
```

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

No behavioral code changes — this PR only touches `CHANGELOG.md`, the four `pyproject.toml` files, `config/base.yaml`'s `pipeline.version`, `sbir_etl/__init__.py`'s `__version__`, and `uv.lock`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

### Next steps after merge

Tag `main` at the merge commit as `v0.7.0` (annotated), push the tag, and create the GitHub release from it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sb4ChS5RoErbwa9rUiR2VP)_