### PR TITLE
Add job-level execution tests for phase_transition_latency_job, cet_full_pipeline_job, cet_drift_job

### DIFF
--- a/tests/unit/assets/jobs/test_cet_drift_job_execution.py
+++ b/tests/unit/assets/jobs/test_cet_drift_job_execution.py
@@ -1,0 +1,93 @@
+"""Layer-3 execution test for cet_drift_job.
+
+``cet_drift_job`` is defined inline in ``sbir_analytics/definitions.py`` as a
+single-asset selection over ``["ml", "validated_cet_drift_detection"]``,
+conditional on that asset having been discovered:
+
+    cet_drift_job = define_asset_job(
+        name="cet_drift_job",
+        selection=AssetSelection.keys(["ml", "validated_cet_drift_detection"]),
+        description="Run CET drift detection asset",
+    )
+
+Reconstructing that same selection here rather than importing the literal
+``cet_drift_job`` object from ``sbir_analytics.definitions`` is deliberate:
+importing that module forces ``load_assets_from_modules`` over *every*
+discovered asset module (CET/ML/fiscal/NLP included, since
+``DAGSTER_LOAD_HEAVY_ASSETS`` is unset by default in the test env), which
+would make this "simplest of the three" job's test the slowest one in the
+file. ``validated_cet_drift_detection`` itself has no such cost -- it does
+its own lazy numpy/pandas imports inside the function body and its module
+(``sbir_analytics.assets.cet.validation``) only imports the lightweight
+``.utils`` shim at import time -- so importing it directly and wrapping it in
+an equivalent job keeps this test both fast and representative of what
+``cet_drift_job`` actually runs. If the selection in definitions.py ever
+drifts from this, ``tests/unit/assets/test_asset_discovery.py`` and
+``tests/unit/test_server_schedule_gating.py`` already assert the job is
+discovered/scheduled by name.
+
+The asset itself is hermetic by construction: with no
+``data/processed/cet_award_classifications.{parquet,ndjson}`` present, it
+writes a `{"ok": True, "reason": "no_input"}` report and succeeds rather than
+requiring a trained model or Neo4j, so no dependency mocking is needed here.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+from dagster import AssetSelection, Definitions, define_asset_job
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def _defs() -> Definitions:
+    from sbir_analytics.assets.cet.validation import validated_cet_drift_detection
+
+    job = define_asset_job(
+        name="cet_drift_job",
+        selection=AssetSelection.keys(["ml", "validated_cet_drift_detection"]),
+        description="Run CET drift detection asset",
+    )
+    return Definitions(assets=[validated_cet_drift_detection], jobs=[job])
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_job_succeeds_with_no_classifications_present(workspace):
+    """No award classifications materialized yet: the asset must still run and report."""
+    result = _defs().resolve_job_def("cet_drift_job").execute_in_process()
+
+    assert result.success
+    output = result.output_for_node("ml__validated_cet_drift_detection")
+    assert output["ok"] is True
+    assert output["reason"] == "no_input"
+
+    report_path = workspace / "reports/benchmarks/cet_drift_report.json"
+    assert report_path.exists()
+    assert json.loads(report_path.read_text())["reason"] == "no_input"
+
+
+def test_job_writes_a_baseline_candidate_on_first_real_input(workspace):
+    """With classifications present but no stored baseline, it seeds a baseline candidate."""
+    classifications = pd.DataFrame(
+        [
+            {"award_id": "A-1", "primary_cet": "quantum", "primary_score": 82.0},
+            {"award_id": "A-2", "primary_cet": "ai", "primary_score": 45.0},
+        ]
+    )
+    processed_dir = workspace / "data/processed"
+    processed_dir.mkdir(parents=True)
+    classifications.to_parquet(processed_dir / "cet_award_classifications.parquet", index=False)
+
+    result = _defs().resolve_job_def("cet_drift_job").execute_in_process()
+
+    assert result.success
+    baseline_candidate = workspace / "reports/benchmarks/cet_baseline_distributions_current.json"
+    assert baseline_candidate.exists()

--- a/tests/unit/assets/jobs/test_cet_full_pipeline_job_execution.py
+++ b/tests/unit/assets/jobs/test_cet_full_pipeline_job_execution.py
@@ -1,0 +1,136 @@
+"""Layer-3 execution tests for cet_full_pipeline_job.
+
+The job wires 8 ops end-to-end: three CET "compute" assets (taxonomy,
+award classification, company aggregation) feeding five Neo4j loader ops
+(node upsert, two enrichment upserts, two relationship-creation ops). The
+job carries baked-in run config (``config={"ops": {...}}``) supplied at
+``define_asset_job`` time, so ``execute_in_process()`` needs no extra
+run_config from the caller.
+
+Coverage strategy
+------------------
+The three compute assets are out of hermetic-test reach as written: they
+load a trained ``ApplicabilityModel`` pickle off disk
+(``artifacts/models/cet_classifier_v1.pkl``), run real evidence extraction,
+and (for the taxonomy asset) parse ``config/cet/taxonomy.yaml`` through
+Pydantic -- provisioning or faking all of that at the job-execution layer
+would mostly test model-loading plumbing that
+``tests/unit/assets/cet/`` already covers at the asset/unit level, not the
+job's own wiring contract.
+
+What *is* job-specific and otherwise uncovered is (a) whether the 8 ops are
+actually wired together in an executable graph via job's ``AssetSelection``,
+and (b) the Neo4j segment's hermetic-skip contract
+(``SKIP_NEO4J_LOADING=true``, the same convention already pinned per-asset in
+``tests/unit/assets/cet/test_loading_contracts.py``) actually holds when
+those 5 ops run back to back inside one job instead of being invoked one at
+a time via ``build_op_context``.
+
+So these tests substitute lightweight stand-ins for the three compute assets
+(same ``AssetKey``s, trivial bodies) into a job-scoped ``Definitions``, reuse
+the *real* five Neo4j loader assets unmodified, and run with
+``SKIP_NEO4J_LOADING=true`` so no network call is made. This exercises the
+real dependency graph -- including the real ``ins=`` wiring in
+``sbir_analytics/assets/cet/loading.py`` -- for all 8 ops without a real
+trained model or a real Neo4j instance.
+"""
+
+from __future__ import annotations
+
+import pytest
+from dagster import Definitions, Output, asset
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+@asset(name="raw_cet_taxonomy", key_prefix=["ml"])
+def _fake_cet_taxonomy() -> Output:
+    """Stand-in for the real taxonomy asset; see module docstring."""
+    return Output("stub-taxonomy")
+
+
+@asset(name="enriched_cet_award_classifications", key_prefix=["ml"])
+def _fake_cet_award_classifications() -> Output:
+    """Stand-in for the real classification asset; see module docstring."""
+    return Output("stub-classifications")
+
+
+@asset(name="transformed_cet_company_profiles", key_prefix=["ml"])
+def _fake_cet_company_profiles() -> Output:
+    """Stand-in for the real company-profile asset; see module docstring."""
+    return Output("stub-company-profiles")
+
+
+@asset(name="enriched_cet_award_classifications", key_prefix=["ml"])
+def _failing_cet_award_classifications() -> Output:
+    raise RuntimeError("classification model unavailable")
+
+
+def _defs(*, award_classifications_asset=_fake_cet_award_classifications):
+    from sbir_analytics.assets.cet import loading
+    from sbir_analytics.assets.jobs.cet_pipeline_job import cet_full_pipeline_job
+
+    return Definitions(
+        assets=[
+            _fake_cet_taxonomy,
+            award_classifications_asset,
+            _fake_cet_company_profiles,
+            loading.loaded_cet_areas,
+            loading.loaded_award_cet_enrichment,
+            loading.loaded_company_cet_enrichment,
+            loading.loaded_award_cet_relationships,
+            loading.loaded_company_cet_relationships,
+        ],
+        jobs=[cet_full_pipeline_job],
+    )
+
+
+def test_job_wires_all_eight_ops_and_succeeds_with_neo4j_skipped(monkeypatch):
+    monkeypatch.setenv("SKIP_NEO4J_LOADING", "true")
+
+    job = _defs().resolve_job_def("cet_full_pipeline_job")
+    node_names = {node.name for node in job.nodes}
+    # The ``key_prefix=["ml"]`` on the three compute assets becomes a
+    # ``ml__`` node-name prefix; the five Neo4j ops have no key prefix.
+    assert node_names == {
+        "ml__raw_cet_taxonomy",
+        "ml__enriched_cet_award_classifications",
+        "ml__transformed_cet_company_profiles",
+        "loaded_cet_areas",
+        "loaded_award_cet_enrichment",
+        "loaded_company_cet_enrichment",
+        "loaded_award_cet_relationships",
+        "loaded_company_cet_relationships",
+    }
+
+    result = job.execute_in_process()
+
+    assert result.success
+    for neo4j_op in (
+        "loaded_cet_areas",
+        "loaded_award_cet_enrichment",
+        "loaded_company_cet_enrichment",
+        "loaded_award_cet_relationships",
+        "loaded_company_cet_relationships",
+    ):
+        assert result.output_for_node(neo4j_op) == {
+            "status": "skipped",
+            "reason": "explicit_skip",
+        }
+
+
+def test_job_fails_when_an_upstream_compute_asset_fails(monkeypatch):
+    """A failure in the classification stage must fail the whole job, not just skip onward."""
+    monkeypatch.setenv("SKIP_NEO4J_LOADING", "true")
+
+    job = _defs(award_classifications_asset=_failing_cet_award_classifications).resolve_job_def(
+        "cet_full_pipeline_job"
+    )
+
+    result = job.execute_in_process(raise_on_error=False)
+
+    assert not result.success
+    message = result.failure_data_for_node(
+        "ml__enriched_cet_award_classifications"
+    ).error.cause.message
+    assert "classification model unavailable" in message

--- a/tests/unit/assets/jobs/test_phase_transition_latency_job_execution.py
+++ b/tests/unit/assets/jobs/test_phase_transition_latency_job_execution.py
@@ -1,0 +1,139 @@
+"""Layer-3 execution tests for phase_transition_latency_job.
+
+The job's docstring says it "assumes raw_contracts / enriched_sbir_awards are
+already materialized" -- it selects only the four downstream phase_transition
+assets (validated_phase_ii_awards, validated_phase_iii_contracts,
+transformed_phase_ii_iii_pairs, transformed_phase_transition_survival) and
+reads its FPDS/SBIR.gov inputs directly off disk via relative paths (see
+``sbir_analytics.assets.phase_transition.phase_ii.DEFAULT_CONTRACTS_PATH`` and
+``DEFAULT_SBIR_AWARDS_PATH``), rather than depending on upstream asset
+outputs in the Dagster graph.
+
+These tests reproduce that "already materialized" precondition by writing the
+upstream parquet directly at those default relative paths under a tmp cwd,
+then executing the *job itself* end to end via ``execute_in_process`` so the
+Dagster wiring between the four assets (validated_phase_ii_awards /
+validated_phase_iii_contracts feeding transformed_phase_ii_iii_pairs feeding
+transformed_phase_transition_survival) is exercised for real, not just each
+asset function in isolation (that unit coverage already exists in
+tests/unit/phase_transition/test_phase_transition_assets.py).
+
+The job itself is an ``UnresolvedAssetJobDefinition`` (built from asset keys
+via ``build_job_from_spec``), so it must be resolved against a
+``Definitions`` object before it can execute -- a bare
+``phase_transition_latency_job.execute_in_process()`` raises. We build a
+minimal ``Definitions`` scoped to just these four assets (mirroring the
+pattern in test_nih_reporter_iterative_job.py) rather than importing the full
+``sbir_analytics.definitions.defs``, which would pull in every heavy asset
+module.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from dagster import Definitions
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def _defs():
+    from sbir_analytics.assets.jobs.phase_transition_job import phase_transition_latency_job
+    from sbir_analytics.assets.phase_transition import (
+        transformed_phase_ii_iii_pairs,
+        transformed_phase_transition_survival,
+        validated_phase_ii_awards,
+        validated_phase_iii_contracts,
+    )
+
+    return Definitions(
+        assets=[
+            validated_phase_ii_awards,
+            validated_phase_iii_contracts,
+            transformed_phase_ii_iii_pairs,
+            transformed_phase_transition_survival,
+        ],
+        jobs=[phase_transition_latency_job],
+    )
+
+
+def _write_contracts(workspace) -> None:
+    """A minimal Phase II/Phase III pair sharing a recipient UEI."""
+    from sbir_analytics.assets.phase_transition.phase_ii import DEFAULT_CONTRACTS_PATH
+
+    contracts = pd.DataFrame(
+        [
+            {
+                "contract_id": "C_II_1",
+                "piid": "C_II_1",
+                "generated_unique_award_id": "C_II_1",
+                "transaction_unique_id": "TX-C_II_1",
+                "vendor_uei": "AAAAAAAAAAAA",
+                "vendor_duns": "123456789",
+                "vendor_name": "Foo Inc",
+                "awarding_agency_name": "DOD",
+                "action_date": "2020-01-15",
+                "period_of_performance_current_end_date": "2022-06-30",
+                "research": "SR2",
+                "federal_action_obligation": 750_000,
+            },
+            {
+                "contract_id": "C_III_1",
+                "generated_unique_award_id": "C_III_1",
+                "transaction_unique_id": "TX-C_III_1",
+                "vendor_uei": "AAAAAAAAAAAA",
+                "vendor_duns": "123456789",
+                "vendor_name": "Foo Inc",
+                "awarding_agency_name": "DOD",
+                "action_date": "2023-02-01",
+                "period_of_performance_current_end_date": "2024-12-31",
+                "research": "SR3",
+                "federal_action_obligation": 5_000_000,
+            },
+        ]
+    )
+    path = workspace / DEFAULT_CONTRACTS_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    contracts.to_parquet(path, index=False)
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    """Materialize inputs relative to cwd, matching the assets' default paths."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+def test_job_succeeds_with_no_upstream_inputs_materialized(workspace):
+    """Nothing materialized upstream: every asset must still run and emit empty frames.
+
+    This pins the same "run and flag, don't crash" contract that the
+    per-asset unit test (test_validated_phase_ii_awards_runs_on_empty_inputs)
+    pins for a single asset, but at the job-execution level.
+    """
+    result = _defs().resolve_job_def("phase_transition_latency_job").execute_in_process()
+
+    assert result.success
+    survival = result.output_for_node("transformed_phase_transition_survival")
+    assert survival.empty
+
+
+def test_job_wires_phase_ii_and_phase_iii_into_matched_pairs_and_survival(workspace):
+    """End-to-end: a real Phase II/III pair flows through pairs -> survival."""
+    _write_contracts(workspace)
+
+    result = _defs().resolve_job_def("phase_transition_latency_job").execute_in_process()
+
+    assert result.success
+    phase_ii = result.output_for_node("validated_phase_ii_awards")
+    phase_iii = result.output_for_node("validated_phase_iii_contracts")
+    pairs = result.output_for_node("transformed_phase_ii_iii_pairs")
+    survival = result.output_for_node("transformed_phase_transition_survival")
+
+    assert list(phase_ii["award_id"]) == ["C_II_1"]
+    assert list(phase_iii["contract_id"]) == ["C_III_1"]
+    assert len(pairs) == 1
+    assert pairs.iloc[0]["phase_ii_award_id"] == "C_II_1"
+    assert pairs.iloc[0]["phase_iii_contract_id"] == "C_III_1"
+    assert len(survival) == 1
+    assert bool(survival.iloc[0]["event_observed"]) is True


### PR DESCRIPTION
## Description

A repo-wide test-coverage audit found that 4 of the repo's 10 production-scheduled Dagster jobs had zero job-level execution test coverage. `core_refresh_job` is covered separately in #649; this PR covers the remaining three: `phase_transition_latency_job`, `cet_full_pipeline_job`, `cet_drift_job`.

No fix; no dependencies required.

## Approach

Three new "Layer-3" execution test files under `tests/unit/assets/jobs/`, following the existing `test_phase_transition_archive_execution.py` convention (real `job.execute_in_process()`, hermetic monkeypatching, success- and failure-path assertions):

- **`phase_transition_latency_job`**: minimal `Definitions` scoped to its four selected assets, run against both an empty-input case and a real Phase II/III pair flowing end-to-end into a survival row.
- **`cet_full_pipeline_job`**: the 3 CET "compute" ops require a trained model pickle that's out of hermetic reach at the job level (already unit-tested elsewhere), so those are swapped for trivial stand-in assets carrying the same `AssetKey`s. The 5 real, unmodified Neo4j loader assets run alongside them with `SKIP_NEO4J_LOADING=true` — the repo's existing hermetic-skip convention (already pinned per-asset in `tests/unit/assets/cet/test_loading_contracts.py`). This exercises the real dependency wiring across all 8 ops, plus a failure-propagation test. Full docstring in the test file explains the tradeoff.
- **`cet_drift_job`**: the target asset (`validated_cet_drift_detection`) is hermetic by construction (falls back to a no-input report when no classifications parquet exists), so this test wraps it in an equivalent job rather than importing the real `cet_drift_job` from `definitions.py` directly (which would force loading every discovered asset module). `test_asset_discovery.py` / `test_server_schedule_gating.py` already guard that the real selection stays in sync.

## Type of Change

- [x] New feature (non-breaking change which adds functionality — test coverage)

## Versioning Impact

- [x] No release impact (internal or unreleased work)

## Testing

- [x] Unit tests added/updated (`tests/unit/assets/jobs/test_phase_transition_latency_job_execution.py`, `test_cet_full_pipeline_job_execution.py`, `test_cet_drift_job_execution.py`)
- [x] All tests pass locally

Verified: `uv run pytest tests/unit/assets/jobs/ --tb=short -q` (31 passed), `uv run pytest tests/unit/ -m fast -n auto` (4858 passed, 7 skipped, no regressions). `make lint` and `make lint-boundaries` clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sb4ChS5RoErbwa9rUiR2VP)_