### PR TITLE
Close review follow-ups from #635 and #649-651

### DIFF
--- a/packages/sbir-graph/sbir_graph/loaders/neo4j/organizations.py
+++ b/packages/sbir-graph/sbir_graph/loaders/neo4j/organizations.py
@@ -1,5 +1,6 @@
 """Neo4j loader for Organization relationships."""
 
+from datetime import UTC, datetime
 from typing import Any
 
 from loguru import logger
@@ -52,9 +53,13 @@ class OrganizationLoader(BaseNeo4jLoader):
             f"(source: {source})"
         )
 
-        # Build relationship list in simplified format
-        relationships: list[tuple[Any, Any, dict[str, Any] | None]] = []
-        for _child_key, child_value, _parent_key, parent_value in subsidiary_pairs:
+        # Source and target may use different keys (e.g. child by organization_id,
+        # parent by UEI), so build the client tuple directly rather than going
+        # through the same-key base helper.
+        full_relationships: list[
+            tuple[str, str, Any, str, str, Any, str, dict[str, Any] | None]
+        ] = []
+        for child_key, child_value, parent_key, parent_value in subsidiary_pairs:
             if not child_value or not parent_value:
                 logger.warning(
                     f"Skipping SUBSIDIARY_OF relationship with missing values: "
@@ -63,47 +68,24 @@ class OrganizationLoader(BaseNeo4jLoader):
                 self.metrics.errors += 1
                 continue
 
-            # Note: We're creating relationships between organizations potentially
-            # matched on different keys (e.g., child by organization_id, parent by UEI)
-            # This requires a more complex query than the base method supports
-            # So we'll use the client directly for this special case
-            from datetime import datetime
-
-            relationships.append(
+            full_relationships.append(
                 (
+                    "Organization",
+                    child_key,
                     str(child_value).strip(),
+                    "Organization",
+                    parent_key,
                     str(parent_value).strip(),
+                    "SUBSIDIARY_OF",
                     {
                         "source": source,
-                        "created_at": datetime.utcnow().isoformat(),
+                        "created_at": datetime.now(UTC).isoformat(),
                     },
                 )
             )
 
-        if not relationships:
+        if not full_relationships:
             return self.metrics
-
-        # For this special case where source and target might use different keys,
-        # we need to use a custom query instead of the base class method
-        full_relationships: list[
-            tuple[str, str, Any, str, str, Any, str, dict[str, Any] | None]
-        ] = []
-
-        for i, (child_key, child_value, parent_key, parent_value) in enumerate(subsidiary_pairs):
-            if i < len(relationships):  # Only include valid relationships
-                _, _, properties = relationships[i - (len(subsidiary_pairs) - len(relationships))]
-                full_relationships.append(
-                    (
-                        "Organization",
-                        child_key,
-                        str(child_value).strip() if child_value else None,
-                        "Organization",
-                        parent_key,
-                        str(parent_value).strip() if parent_value else None,
-                        "SUBSIDIARY_OF",
-                        properties,
-                    )
-                )
 
         # Use client directly for complex relationship creation
         self.metrics = self.client.batch_create_relationships(

--- a/scripts/ci/check_epistemic_tiers.py
+++ b/scripts/ci/check_epistemic_tiers.py
@@ -103,7 +103,7 @@ def _evidence_contract_violations(
             )
         )
     else:
-        amd_text = amendments.read_text(encoding="utf-8")
+        amd_text = _outside_fenced_code(amendments.read_text(encoding="utf-8"))
         if not (SHA256_DIGEST.search(amd_text) or SHA256_FREEZE_LANGUAGE.search(amd_text)):
             violations.append(
                 TierDeclarationViolation(
@@ -118,8 +118,7 @@ def _evidence_contract_violations(
         violations.append(
             TierDeclarationViolation(
                 relative_req,
-                "evidence-tier specs require '**Declared estimand:** …' "
-                "(or '**Estimand:** …')",
+                "evidence-tier specs require '**Declared estimand:** …' (or '**Estimand:** …')",
             )
         )
     return violations

--- a/tests/e2e/test_core_refresh_job.py
+++ b/tests/e2e/test_core_refresh_job.py
@@ -14,11 +14,12 @@ fixture story.
 This module instead provides two complementary, honestly-scoped guarantees:
 
 1. ``test_core_refresh_job_selection_excludes_heavy_assets_and_resolves`` is a *structural*
-   test. It proves the job is wired correctly against the production ``Definitions`` object:
-   the selection resolves without a ``DagsterInvalidSubsetError`` (no missing dependencies or
-   cycles), it selects exactly "all loaded assets minus the heavy ones" (nothing is
-   accidentally included or excluded), and no heavy asset key leaks into the job. It does
-   **not** prove any asset actually executes correctly.
+   test. It pins the advertised all-minus-heavy complement: the job resolves against the
+   production ``Definitions`` object and its executable keys equal
+   ``all_assets - _heavy_keys``. That catches a silent rewrite to ``AssetSelection.all()``
+   or a hardcoded subset. It does **not** independently inventory
+   ``HEAVY_ASSET_PREFIXES``, and missing-dep / cycle failures for an ``all() - heavy``
+   job are already covered by ``Definitions.validate_loadable``.
 
 2. ``test_core_refresh_job_executes_sbir_ingestion_subgraph`` executes a real, connected
    slice of the actual ``core_refresh_job`` object (not a reconstructed copy) end to end via
@@ -34,7 +35,6 @@ This module instead provides two complementary, honestly-scoped guarantees:
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -57,7 +57,6 @@ def test_core_refresh_job_selection_excludes_heavy_assets_and_resolves():
 
     assert selected_keys, "core_refresh_job selected no assets"
     assert selected_keys == expected_keys
-    assert selected_keys.isdisjoint(defs_module._heavy_keys)
 
 
 def test_core_refresh_job_executes_sbir_ingestion_subgraph(
@@ -93,13 +92,14 @@ def test_core_refresh_job_executes_sbir_ingestion_subgraph(
     monkeypatch.chdir(tmp_path)
 
     job = defs_module.defs.resolve_job_def("core_refresh_job")
-    result = job.execute_in_process(
-        asset_selection=[
-            AssetKey("raw_sbir_awards"),
-            AssetKey("validated_sbir_awards"),
-            AssetKey("sbir_validation_report"),
-        ]
-    )
+    ingestion_keys = [
+        AssetKey("raw_sbir_awards"),
+        AssetKey("validated_sbir_awards"),
+        AssetKey("sbir_validation_report"),
+    ]
+    assert job.asset_layer.executable_asset_keys.issuperset(ingestion_keys)
+
+    result = job.execute_in_process(asset_selection=ingestion_keys)
 
     assert result.success
     raw_df = result.output_for_node("raw_sbir_awards")
@@ -119,4 +119,3 @@ def test_core_refresh_job_executes_sbir_ingestion_subgraph(
     report_json = tmp_path / "data" / "validated" / "sbir_validation_report.json"
     assert validated_parquet.is_file()
     assert report_json.is_file()
-    assert os.getenv("SBIR_ETL__PATHS__DATA_ROOT") == str(data_root)

--- a/tests/unit/assets/jobs/test_cet_drift_job_execution.py
+++ b/tests/unit/assets/jobs/test_cet_drift_job_execution.py
@@ -21,10 +21,8 @@ its own lazy numpy/pandas imports inside the function body and its module
 (``sbir_analytics.assets.cet.validation``) only imports the lightweight
 ``.utils`` shim at import time -- so importing it directly and wrapping it in
 an equivalent job keeps this test both fast and representative of what
-``cet_drift_job`` actually runs. If the selection in definitions.py ever
-drifts from this, ``tests/unit/assets/test_asset_discovery.py`` and
-``tests/unit/test_server_schedule_gating.py`` already assert the job is
-discovered/scheduled by name.
+``cet_drift_job`` actually runs. The production job's selection is pinned
+separately in ``tests/unit/assets/test_dagster_definitions.py``.
 
 The asset itself is hermetic by construction: with no
 ``data/processed/cet_award_classifications.{parquet,ndjson}`` present, it

--- a/tests/unit/assets/jobs/test_cet_full_pipeline_job_execution.py
+++ b/tests/unit/assets/jobs/test_cet_full_pipeline_job_execution.py
@@ -37,6 +37,8 @@ trained model or a real Neo4j instance.
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from dagster import Definitions, Output, asset
 
@@ -85,8 +87,11 @@ def _defs(*, award_classifications_asset=_fake_cet_award_classifications):
     )
 
 
-def test_job_wires_all_eight_ops_and_succeeds_with_neo4j_skipped(monkeypatch):
+def test_job_wires_all_eight_ops_and_succeeds_with_neo4j_skipped(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("SKIP_NEO4J_LOADING", "true")
+
+    from sbir_analytics.assets.cet import loading
 
     job = _defs().resolve_job_def("cet_full_pipeline_job")
     node_names = {node.name for node in job.nodes}
@@ -103,9 +108,11 @@ def test_job_wires_all_eight_ops_and_succeeds_with_neo4j_skipped(monkeypatch):
         "loaded_company_cet_relationships",
     }
 
-    result = job.execute_in_process()
+    with patch.object(loading, "_connected_client") as mock_client:
+        result = job.execute_in_process()
 
     assert result.success
+    mock_client.assert_not_called()
     for neo4j_op in (
         "loaded_cet_areas",
         "loaded_award_cet_enrichment",
@@ -119,8 +126,9 @@ def test_job_wires_all_eight_ops_and_succeeds_with_neo4j_skipped(monkeypatch):
         }
 
 
-def test_job_fails_when_an_upstream_compute_asset_fails(monkeypatch):
+def test_job_fails_when_an_upstream_compute_asset_fails(tmp_path, monkeypatch):
     """A failure in the classification stage must fail the whole job, not just skip onward."""
+    monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("SKIP_NEO4J_LOADING", "true")
 
     job = _defs(award_classifications_asset=_failing_cet_award_classifications).resolve_job_def(

--- a/tests/unit/assets/test_dagster_definitions.py
+++ b/tests/unit/assets/test_dagster_definitions.py
@@ -1,7 +1,7 @@
 """Fast contracts for the complete Dagster code location."""
 
 import pytest
-from dagster import DefaultScheduleStatus, Definitions
+from dagster import AssetKey, DefaultScheduleStatus, Definitions
 
 from sbir_analytics import definitions
 
@@ -12,6 +12,15 @@ pytestmark = pytest.mark.fast
 def test_definitions_are_loadable():
     """The registered assets, jobs, checks, schedules, and sensors resolve."""
     Definitions.validate_loadable(definitions.defs)
+
+
+def test_cet_drift_job_selects_only_the_drift_asset():
+    """Keep the reconstructed Layer-3 job in lockstep with the production selection."""
+    assert definitions.cet_drift_job is not None
+    job = definitions.defs.resolve_job_def("cet_drift_job")
+    assert job.asset_layer.executable_asset_keys == {
+        AssetKey(["ml", "validated_cet_drift_detection"])
+    }
 
 
 def test_source_download_schedule_contracts():

--- a/tests/unit/loaders/neo4j/test_organizations.py
+++ b/tests/unit/loaders/neo4j/test_organizations.py
@@ -115,14 +115,6 @@ class TestCreateSubsidiaryRelationships:
         assert "relationships" not in captured
 
     def test_mixed_valid_and_invalid_pairs(self):
-        # NOTE: the source's `full_relationships` construction re-derives which
-        # pairs to include from `len(relationships)` (the count of *valid*
-        # pairs) rather than re-checking validity per index. With one invalid
-        # pair in the middle, this causes the loop to emit the first N pairs
-        # by position (including the invalid one, with a None value) and drop
-        # a later valid pair. This test pins that existing, surprising
-        # behavior rather than the originally-intended one; it is not a test
-        # bug, and fixing the loader logic is out of scope for a coverage PR.
         mock_client, captured = _create_mock_client_with_capture()
         loader = OrganizationLoader(mock_client)
 
@@ -139,10 +131,8 @@ class TestCreateSubsidiaryRelationships:
         assert len(rels) == 2
         assert rels[0][2] == "CHILD-1"
         assert rels[0][5] == "PARENT-1"
-        # The invalid pair is included with a None source value rather than
-        # being dropped, and the trailing valid pair (CHILD-3) is lost.
-        assert rels[1][2] is None
-        assert rels[1][5] == "PARENT-2"
+        assert rels[1][2] == "CHILD-3"
+        assert rels[1][5] == "PARENT-3"
 
     def test_empty_input_returns_metrics_without_client_call(self):
         mock_client, _captured = _create_mock_client_with_capture()

--- a/tests/unit/scripts/test_epistemic_tiers.py
+++ b/tests/unit/scripts/test_epistemic_tiers.py
@@ -82,6 +82,64 @@ def test_evidence_tier_requires_amendments_sha_and_estimand(tmp_path: Path) -> N
     assert "Declared estimand" in messages or "Estimand" in messages
 
 
+def test_evidence_tier_rejects_amendments_without_sha_language(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "# Example\n\n**Target epistemic tier:** evidence\n\n"
+        "**Declared estimand:** the unit-test estimand.\n",
+    )
+    _write(tmp_path, "specs/example/amendments.md", "# Amendments\n\nNo freeze recorded.\n")
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "SHA-256 freeze digest" in violations[0].message
+
+
+def test_evidence_tier_rejects_missing_estimand_when_sha_present(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "# Example\n\n**Target epistemic tier:** evidence\n",
+    )
+    _write(
+        tmp_path,
+        "specs/example/amendments.md",
+        "Frozen file SHA-256: `cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc`\n",
+    )
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "Declared estimand" in violations[0].message or "Estimand" in violations[0].message
+
+
+def test_evidence_tier_ignores_fenced_sha_digest(tmp_path: Path) -> None:
+    spec = tmp_path / "specs" / "example"
+    _write(
+        tmp_path,
+        "specs/example/requirements.md",
+        "# Example\n\n**Target epistemic tier:** evidence\n\n"
+        "**Declared estimand:** the unit-test estimand.\n",
+    )
+    _write(
+        tmp_path,
+        "specs/example/amendments.md",
+        "# Amendments\n\n"
+        "```\n"
+        "SHA-256: `dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd`\n"
+        "```\n",
+    )
+
+    violations = tiers.validate_spec_directory(spec, repository_root=tmp_path)
+
+    assert len(violations) == 1
+    assert "SHA-256 freeze digest" in violations[0].message
+
+
 def test_evidence_tier_accepts_complete_contract(tmp_path: Path) -> None:
     spec = tmp_path / "specs" / "example"
     _write(


### PR DESCRIPTION
## Summary

Follow-ups from the merge-plan review of #635 and #649–#651, now on `main`.

- **#635:** fence-strip `amendments.md` before the SHA paperwork scan; add isolated negatives for SHA-only, estimand-only, and fenced-digest cases.
- **#649:** pin that the SBIR ingestion keys are in `core_refresh_job` before `execute_in_process`; drop the leftover `os.getenv` assert; soften the structural-test docstring.
- **#650:** pin the production `cet_drift_job` selection in `test_dagster_definitions.py` (the Layer-3 file still reconstructs the job for speed); `chdir(tmp_path)` and tripwire `_connected_client` on the CET pipeline skip path.
- **#651:** fix `OrganizationLoader.create_subsidiary_relationships` so a mixed valid/invalid batch writes the valid pairs instead of emitting a `None` child and dropping a later valid pair.

## Testing

- `uv run pytest tests/unit/scripts/test_epistemic_tiers.py tests/unit/loaders/neo4j/test_organizations.py tests/unit/assets/jobs/test_cet_drift_job_execution.py tests/unit/assets/jobs/test_cet_full_pipeline_job_execution.py tests/unit/assets/test_dagster_definitions.py tests/e2e/test_core_refresh_job.py -q` → 38 passed
- `uv run ruff check` / `ruff format --check` on the touched files
- `uv run python scripts/ci/check_epistemic_tiers.py`

## Versioning Impact

- [x] No release impact (internal or unreleased work)