### PR TITLE
chore: prepare release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,32 @@ version.
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-08-18
+
+### Added
+
+- Hermetic end-to-end coverage for `core_refresh_job` (#649).
+- Job-level execution tests for `phase_transition_latency_job`,
+  `cet_full_pipeline_job`, and `cet_drift_job` (#650).
+- Unit tests for the previously untested Neo4j categorization, SEC EDGAR,
+  organization, and patent-loading paths, plus weekly-report LLM digest
+  builders (#651).
+
+### Changed
+
+- Specs that declared `evidence` without the four-item contract were
+  retiered; `phase-iii-census` remains the only evidence target, and CI now
+  requires amendments SHA paperwork plus a declared estimand (#635).
+- The evidence-tier checker fence-strips `amendments.md` before the SHA
+  scan. The new job tests pin `core_refresh_job` membership, the production
+  `cet_drift_job` selection, and the CET pipeline skip path (#652).
+
+### Fixed
+
+- `OrganizationLoader.create_subsidiary_relationships` kept an invalid pair
+  (with a `None` child) and dropped a later valid pair when a mixed batch
+  contained a hole (#652).
+
 ## [0.7.0] — 2026-08-18
 
 ### Added
@@ -219,7 +245,8 @@ across the root project and the three packages under `packages/`.
 `vMAJOR.MINOR.PATCH` form it requires. Per that policy published tags are never
 moved or reused, so they remain as historical markers.
 
-[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.0...v0.5.1

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.7.0"
+  version: "0.7.1"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.7.0"
+version = "0.7.1"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.7.0"
+version = "0.7.1"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.7.0"
+version = "0.7.1"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.7.0"
+version = "0.7.1"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2834,7 +2834,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2985,7 +2985,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3004,7 +3004,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Description

Synchronizes package, runtime, config, and lockfile versions and rolls the post-v0.7.0 changelog into 0.7.1, per [docs/steering/versioning.md](docs/steering/versioning.md).

This is a PATCH release: a backward-compatible `OrganizationLoader` indexing fix, evidence-tier paperwork enforcement, and job/loader test coverage. No new public compatibility surface.

`uv run python scripts/ci/check_versioning.py --tag v0.7.1` passed locally.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

(This PR is the release-prep metadata bump.)

## Versioning Impact

- [x] Patch (bug fixes, documentation, internal maintenance)