### PR TITLE
Require study contracts for reserved inventory Status ranks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           uv run python scripts/ci/check_config_boundaries.py
           uv run python scripts/ci/check_removed_src_references.py
           uv run python scripts/ci/validate_study_manifests.py
+          uv run python scripts/ci/check_research_question_status.py
           # Guards the company-identity primitive: a direct RapidFuzz scorer
           # outside sbir_etl.identity is a second, unnamed implementation of
           # the similarity contract. Previously exercised only by its own unit

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,7 @@ lint-boundaries: ## Architecture, epistemic-tier, identity, config, hygiene, and
 	$(call run,uv run python scripts/ci/check_config_boundaries.py)
 	$(call run,uv run python scripts/ci/check_removed_src_references.py)
 	$(call run,uv run python scripts/ci/validate_study_manifests.py)
+	$(call run,uv run python scripts/ci/check_research_question_status.py)
 	$(call run,uv run python scripts/ci/check_identity_boundaries.py)
 
 .PHONY: docs-check

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -24,7 +24,7 @@ Each question is written in a fixed shape:
 - **Short title** (lens tags, legacy IDs)
   The question itself, as a question.
   Caveat — a stated limit on what the answer can support, when one applies.
-  Status: whether it is computable, validated, or citable today.
+  Status: reserved ranks only when a study.yaml exists at that rank.
   Deps / Refs / Spec: what it needs, what it benchmarks against, where it is specified.
 ```
 
@@ -35,11 +35,25 @@ language. The *Deps*, *Spec*, and implementation notes are for maintainers and
 may use pipeline shorthand freely.
 
 **Status** appears where implementation or evidence maturity needs explanation.
-`Computable` means the repository can produce a bounded result; it does not mean
-the interpretation is validated or externally citable. `Validated` and
-`citable` require a matching [study contract](../studies/README.md) at that
-status. A question with no status line is an inventory target, not an implicit
-claim that it is implemented.
+Three ranks are reserved and are a public API. Each may be used only when a
+[`studies/<id>/study.yaml`](../studies/README.md) lists that question at the
+matching `evidence_status` (or higher). CI enforces the pairing
+(`scripts/ci/check_research_question_status.py`).
+
+| Status rank | Required study `evidence_status` | Meaning |
+|---|---|---|
+| `Computable` (including `Partially computable`) | `reproducible`, `validated`, or `citable` | The repository can emit a bounded result from the named study. |
+| `Validated` | `validated` or `citable` | The study's stated validation design has passed. |
+| `Citable` | `citable` | Approved for the claims listed in that study's manifest. |
+
+`Computable` is not a finding. An exploratory study does not authorize it.
+Negations (`Not computable`, `not validated`, `non-citable`) are refusals, not
+ranks, and do not need a study.
+
+Free-prose Status is still allowed when it avoids those three ranks:
+`Research target`, `Inventory target`, `Exploratory`, `Partial`, and similar.
+A question with no status line is an inventory target, not an implicit claim
+that it is implemented.
 
 **Lower-bound proxy** marks a question whose answer can only ever undercount.
 It appears wherever we detect ownership or capital through public filings: SEC
@@ -76,15 +90,19 @@ treated as current specs; retain them in git history or a dated research note.
 ## Where to start, by audience
 
 Every pointer below lands in a section that mixes implemented and spec-only
-work. Use the per-question *Status* and *Spec* slots to tell what is answerable
-today from what is still a research target.
+work. Use the per-question *Status* slot to tell what is answerable today.
+Reserved ranks (`Computable`, `Validated`, `Citable`) are trustworthy for an
+outside reader only when a study contract stands behind them.
 
 - **Policymakers** — Congress, OMB, agency leadership, congressional defense
-  committees. Start with the **DoD follow-on funding multiplier** ([A3](#a3-inferential-tier-3);
-  reproduces NASEM's ~4:1 benchmark, which NASEM calls the *leverage ratio*),
-  then **[D2](#d2-relational-tier-2)** (Treasury ROI and tax receipts from SBIR
-  spending) and **[F3](#f3-inferential-tier-3)** (private-to-SBIR leverage, the
-  private-side mirror of the DoD multiplier).
+  committees. Start with unlabeled follow-on contracts
+  ([B2](#b2-relational-tier-2)) and unrecorded Phase III
+  ([B3](#b3-inferential-tier-3)) — the only questions whose Status is backed
+  by a study contract — then **[F3](#f3-inferential-tier-3)** (private-to-SBIR
+  leverage; dated Form D analysis, no study contract yet). The DoD follow-on
+  multiplier ([A3](#a3-inferential-tier-3)) and Treasury ROI
+  ([D2](#d2-relational-tier-2)) stay inventory targets until they have
+  study-backed Status lines.
 - **SBIR program managers** — NSF, NIH, DoD, DOE, SBA program offices. Start
   with **[B](#b-technology-commercialization--entrepreneurship)** (transitions,
   Phase II→III latency, company performance), **[C1](#c1-descriptive-tier-1)**
@@ -157,14 +175,15 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   are clustered in one part of the country. GAO's program-wide Phase II HHI of
   ~11 [L14] is the diffuse baseline that area-level concentration is measured
   against.
-  **Status:** Computable for the classified DoD subset; not yet backed by a citable study manifest.
-  *Deps: CET, ER, NAICS · Refs: [L14], [L16], [L29] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md) (reproducible baseline and its limitations)*
+  **Status:** Exploratory baseline for the classified DoD subset exists as a
+  research note. No study contract.
+  *Deps: CET, ER, NAICS · Refs: [L14], [L16], [L29] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md) (research-note baseline and its limitations)*
 
 - **Coverage gaps** (cap) (house shorthand: *whitespace*)
   Which CET subfields does DoD appear to want work in, but few SBIR awards
   cover?
   Found by semantic search over award and solicitation text.
-  **Status:** Partially computable as an exploratory analysis. The SBIR.gov bulk
+  **Status:** Exploratory analysis. The SBIR.gov bulk
   award snapshot supplies exact solicitation/topic identifiers for 49.1% of all
   award rows and 99.9% of NSF award rows from 2022 onward, but it does not supply
   solicitation or attachment text. Results remain source-coverage bounded and
@@ -182,8 +201,8 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   disclosed foreign ownership, control, or influence, when screened against the
   eight Pub. L. 119-83 restricted-entity lists?
   *Lower-bound proxy* — ownership is read from EDGAR Exhibit 21 and 8-K filings.
-  **Status:** Computable for the SEC-filer subset; the private majority needs
-  data acquisition.
+  **Status:** Exploratory lower bound for the SEC-filer subset; the private
+  majority needs data acquisition. No study contract.
   *Deps: ER, SEC EDGAR, M&A signals · Refs: [L26] (screening lists), [L30] (foreign-supplier dependence), [L17] (foreign-acquisition risk)*
 
 ### A2. Relational (Tier 2)
@@ -205,17 +224,18 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   NSF-funded work was used on a DoD award or that a supplier is critical or
   irreplaceable. DoD-14/NDIS-8 policy mapping remains deferred, and FOCI is not
   in this analysis.
-  **Status:** Computable as a manifest-pinned public-data lower bound with
-  signed prime/subaward ledgers, evidence tables, quality gates, and an analyst
-  graph; not a BoM or dependency claim.
+  **Status:** Exploratory pinned public-data lower bound with signed
+  prime/subaward ledgers, evidence tables, quality gates, and an analyst graph.
+  Not a study contract, and not a BoM or dependency claim.
   *Deps: ER, direct NSF awards, USAspending FPDS/FABS, USAspending subawards, CET · Spec: [nsf_sbir_defense_funding_plan.md](research/nsf_sbir_defense_funding_plan.md)*
 
 - **DIB integration** (cap)
   What is the Phase II→III transition rate per CET area via FPDS, and how do
   SAM.gov subaward links connect awardees to prime contractors?
   Aligns with NASEM's "knowledge transfer to primes" finding [L1].
-  **Status:** Computable with moderate confidence — FPDS Phase III tagging is
-  historically incomplete [L14].
+  **Status:** Exploratory. FPDS Phase III tagging is historically incomplete
+  [L14]. The OT-consortium spec is gated pending a coverage probe. No study
+  contract.
   *Deps: ER, ID, CET, transitions · Refs: [L1], [L14] · Spec: [../specs/ot-consortium-subaward-attribution/](../specs/ot-consortium-subaward-attribution/) (FFATA/FSRS sub-award T1 recovery)*
 
 - **Awardees that control the key patents** (cap/vuln) (A-CP6)
@@ -252,7 +272,8 @@ perspective, see [F. Capital formation & entrepreneurial finance](#f-capital-for
   complete retained FY2012+ DoD award history. It cannot see earlier activity, so
   a firm that first won in 2009 can still look like a new entrant
   (*left-censoring*).
-  **Status:** Partially computable for the classified DoD subset.
+  **Status:** Exploratory baseline for the classified DoD subset (research
+  note). No study contract.
   *Deps: ER, ID, CET · Refs: [L32] · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md)*
 
 *The SBIR-vs-non-SBIR identification question and the underlying patent-to-award
@@ -270,6 +291,9 @@ NASEM calls this quantity the *leverage ratio*.
   What is the aggregate follow-on funding multiplier — non-SBIR DoD obligations
   ÷ SBIR/STTR obligations — for DoD SBIR firms?
   **Target:** reproduce NASEM's ~4:1 for 2012–2020.
+  **Status:** Inventory target. No study contract. The NASEM ~4:1 figure is a
+  literature benchmark to reproduce, not a repository result. Attribution
+  verification against [L1] is still open (see Maintenance).
   *Deps: ER, ID · Refs: [L1], [L2] · Spec: [../specs/archive/completed-features/follow-on-multiplier-analysis/](../specs/archive/completed-features/follow-on-multiplier-analysis/), [../specs/archive/completed-features/load-contract-nodes/](../specs/archive/completed-features/load-contract-nodes/) (FPDS contract-node ingestion)*
 
 - **Multiplier stratification**
@@ -298,7 +322,8 @@ NASEM calls this quantity the *leverage ratio*.
   and including areas whose suppliers sit in one part of the country.
   *Caveat:* the DoD classified-subset baseline supports concentration screening
   but not physical sole-source conclusions.
-  **Status:** Computable for the classified DoD subset; not yet backed by a citable study manifest.
+  **Status:** Exploratory baseline for the classified DoD subset exists as a
+  research note. No study contract.
   *Deps: ER, CET · Spec: [dod_supply_chain_initial_analysis.md](research/dod_supply_chain_initial_analysis.md)*
 
 - **Areas fragile on every measure at once** (vuln) (A-CP10)
@@ -537,12 +562,13 @@ statutory goal is Phase III commercialization.*
   matching rules, the agency, and the time window?
   *Method:* the matching rules were written down and frozen before the counts
   were run, so the result cannot be tuned after the fact.
-  **Status:** We can produce this count, and it holds up under a scrambled-dates
-  check designed before the counts were run, though matched control firms still
-  look substantially similar — and no one has yet hand-verified a sample of the
-  matches, so the result is a follow-on proxy:
-  not validated, not citable, and not proof of statutory Phase III. In method
-  terms: reproducible and falsification-tested for the frozen audit estimand.
+  **Status:** Computable as a follow-on proxy under the `phase-iii-census`
+  study (`reproducible`, not validated, not citable). The count holds up under
+  a scrambled-dates check designed before the counts were run, though matched
+  control firms still look substantially similar — and no one has yet
+  hand-verified a sample of the matches, so the result is not proof of
+  statutory Phase III. In method terms: reproducible and falsification-tested
+  for the frozen audit estimand.
   The complete census, matched negative-control, and fixed-seed placebo tables
   were materialized from provenance-verified February inputs. The actual frame
   exceeds the cross-firm date placebo on every final-stage metric and in all six
@@ -728,6 +754,9 @@ dollar return on the SBIR program?*
   TechLink's DoD-wide 1995–2018 study reports ~22:1 total-output ROI, 8.4:1 sales
   ROI, and $39.4B in tax revenue; Air Force ~12:1 and Navy ~19.5:1 [L19]. NCI
   published a separate economic-impact study [L20].
+  **Status:** Inventory target. No study contract. The TechLink and NCI figures
+  are external literature, not outputs of this repository. The fiscal-v2 spec
+  is gated.
   *Deps: ER, ID, NAICS, BEA I-O · Refs: [L19], [L20] · Spec: [fiscal/](fiscal/), [../specs/fiscal-tax-impact-v2.md](../specs/fiscal-tax-impact-v2.md)*
 
 - **Employment and income impacts**
@@ -1036,7 +1065,7 @@ The relevant literature is Lerner [L10], Howell [L11], and Kortum & Lerner
   For Phase II awardees of any agency, do follow-on funding and exit outcomes
   match published small-business and peer-reviewed entrepreneurial-finance
   baselines?
-  **Status:** Partial and non-citable. The Phase 1 NSF review validates the
+  **Status:** Partial and non-citable. The Phase 1 NSF review reports the
   Phase I→II cohort component: 672 of 1,502 firms in the 2015–2019 vintage
   (44.7%, 95% Wilson interval 42.2%–47.3%). It does not yet answer this
   question because transition, survival, M&A, and patent channels were
@@ -1218,7 +1247,10 @@ spot-checked against publisher records):
 
 ## Maintenance
 
-**Last reviewed:** 2026-08-11. The 2026-08 citation audit added [L34]–[L48] from
+**Last reviewed:** 2026-08-18. Reserved Status ranks (`Computable`,
+`Validated`, `Citable`) now require a matching `studies/*/study.yaml`. A3 and
+D2 were removed from the policymaker start-here box until they have
+study-backed Status. The 2026-08-11 citation audit added [L34]–[L48] from
 the 2019–2026 literature map and pinned [L1] to its published DOI. Git history
 preserves earlier editorial and section-consolidation notes.
 

--- a/docs/research-questions.md
+++ b/docs/research-questions.md
@@ -47,8 +47,10 @@ matching `evidence_status` (or higher). CI enforces the pairing
 | `Citable` | `citable` | Approved for the claims listed in that study's manifest. |
 
 `Computable` is not a finding. An exploratory study does not authorize it.
-Negations (`Not computable`, `not validated`, `non-citable`) are refusals, not
-ranks, and do not need a study.
+Negations are refusals, not ranks, and do not need a study — but the negation
+has to lead: `Not computable`, `not yet validated`, `no citable claim`,
+`non-citable`. A rank word with nothing negating it in front of it reads as a
+claim, so `Citable claim: …` is a claim.
 
 Free-prose Status is still allowed when it avoids those three ranks:
 `Research target`, `Inventory target`, `Exploratory`, `Partial`, and similar.
@@ -550,8 +552,8 @@ statutory goal is Phase III commercialization.*
   prevalence. The PI employer election and the allocation-of-rights agreement
   live in non-public agency award files.
   **Status:** Not computable. Phase 0 design only (`exploratory`, non-citable).
-  Implementation is blocked until open questions are resolved; any citable claim
-  is blocked until negative-control and blind-adjudication gates pass. This
+  Implementation is blocked until open questions are resolved; no citable claim
+  is authorized until negative-control and blind-adjudication gates pass. This
   split has not been measured before.
   *Deps: ER, PATLINK, SEC EDGAR · Refs: [L7], [L36], [L38] · Spec: [../specs/sttr-spinout-linkage/](../specs/sttr-spinout-linkage/)*
 
@@ -1065,7 +1067,7 @@ The relevant literature is Lerner [L10], Howell [L11], and Kortum & Lerner
   For Phase II awardees of any agency, do follow-on funding and exit outcomes
   match published small-business and peer-reviewed entrepreneurial-finance
   baselines?
-  **Status:** Partial and non-citable. The Phase 1 NSF review reports the
+  **Status:** Partial and non-citable. The Phase 1 NSF review validates the
   Phase I→II cohort component: 672 of 1,502 firms in the 2015–2019 vintage
   (44.7%, 95% Wilson interval 42.2%–47.3%). It does not yet answer this
   question because transition, survival, M&A, and patent channels were

--- a/docs/steering/epistemic-tiers.md
+++ b/docs/steering/epistemic-tiers.md
@@ -188,20 +188,21 @@ ranking, or another contestable decision into a pipeline.
 ## Relationship to the research questions
 
 [research-questions.md](../research-questions.md) is the inventory of what the
-repository exists to answer, and its **Status** lines already speak in
-epistemic terms — what is answerable today, what is a lower-bound proxy, what
-is contested. The tiers are the supply side of that same distinction:
+repository exists to answer, and its reserved **Status** ranks are a public
+API backed by [study contracts](../../studies/README.md), not by directory
+tier labels:
 
-| research-questions.md says | Backing tier |
+| research-questions.md says | Required `studies/*/study.yaml` |
 |---|---|
-| Answerable today, citable | `evidence` |
-| Answerable but lower-bound proxy | `evidence`, with the bound in the declared estimand |
-| Partial or contested | `pipelines` + `exploratory` |
-| Design target, not built | none yet |
+| `Citable` | `evidence_status: citable` |
+| `Validated` | `validated` or `citable` |
+| `Computable` / `Partially computable` | `reproducible` or higher |
+| Exploratory / partial / inventory target | none required |
 
-A question cannot be marked answerable on the strength of exploratory-tier
-work. If the inventory claims an answer, something in `evidence` has to stand
-behind it.
+A question cannot be marked `Computable` on the strength of exploratory-tier
+work or an exploratory study. `scripts/ci/check_research_question_status.py`
+enforces the pairing. An `evidence`-tier spec is the implementation contract
+for building that study; it is not itself a Status rank.
 
 ## Current status
 

--- a/scripts/ci/check_research_question_status.py
+++ b/scripts/ci/check_research_question_status.py
@@ -3,9 +3,14 @@
 
 ``docs/research-questions.md`` is a public API. The reserved ranks
 ``computable``, ``validated``, and ``citable`` may appear as Status claims only
-when a ``studies/*/study.yaml`` lists that question at the matching
-``evidence_status`` (or higher). Negations (``not computable``, ``non-citable``)
-are allowed without a study: they are refusals, not ranks.
+when a ``studies/*/study.yaml`` lists that *section* ID (``B2``, ``F3``, …)
+at the matching ``evidence_status`` (or higher). Authorization is per section,
+not per question bullet: a study listing ``B2`` authorizes every reserved-rank
+Status under ``### B2``.
+
+Negations (``not computable``, ``never computable``, ``non-citable``) are
+refusals, not ranks, and do not need a study. The verb ``validates`` is not
+the ``validated`` rank.
 
 This is admission control for the inventory, not proof that a study's result
 is correct. Exploratory studies do not authorize ``computable``.
@@ -24,31 +29,29 @@ from sbir_etl.quality.study_manifest import EvidenceStatus, load_study_manifest
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 INVENTORY_PATH = Path("docs/research-questions.md")
-STUDIES_ROOT = REPOSITORY_ROOT / "studies"
 
+ANY_HEADING = re.compile(r"^#{2,4}\s+")
 SECTION_HEADING = re.compile(r"^#{2,4}\s+([A-F]\d+)\b")
 STATUS_MARKER = re.compile(r"\*\*Status:\*\*")
 STATUS_END = re.compile(r"^(\s*\*Deps:|#{1,6}\s|-\s+\*\*)")
 
 # Strip these before looking for a positive rank so denials do not count.
+# A short negation window covers "not currently computable" / "never
+# computable" without exempting the noun phrase "citable claim".
 DENIAL_PHRASES = (
-    re.compile(r"\bnot\s+yet\s+computable\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+computable\b", re.IGNORECASE),
-    re.compile(r"\bnon-computable\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+yet\s+validated\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+validated\b", re.IGNORECASE),
+    re.compile(
+        r"\b(?:not|no|never|cannot)\W+(?:\w+\W+){0,3}?(?:computable|validated|citable)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bnon-(?:computable|validated|citable)\b", re.IGNORECASE),
     re.compile(r"\bunvalidated\b", re.IGNORECASE),
-    re.compile(r"\bremains\s+unvalidated\b", re.IGNORECASE),
     re.compile(r"\bnot\s+approved\s+for\s+citation\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+citable\b", re.IGNORECASE),
-    re.compile(r"\bnon-citable\b", re.IGNORECASE),
-    re.compile(r"\bcitable\s+study(?:\s+contract|\s+manifest)?\b", re.IGNORECASE),
-    re.compile(r"\bcitable\s+claim\b", re.IGNORECASE),
+    re.compile(r"\bany\b[^.]*\bcitable\b[^.]*\bblocked\b", re.IGNORECASE),
 )
 
 RANK_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("computable", re.compile(r"\bcomputable\b", re.IGNORECASE)),
-    ("validated", re.compile(r"\bvalidat(?:ed|es)\b", re.IGNORECASE)),
+    ("validated", re.compile(r"\bvalidated\b", re.IGNORECASE)),
     ("citable", re.compile(r"\bcitable\b", re.IGNORECASE)),
 )
 
@@ -111,9 +114,9 @@ def iter_status_blocks(markdown: str) -> Iterable[tuple[int, str | None, str]]:
     index = 0
     while index < len(lines):
         line = lines[index]
-        heading = SECTION_HEADING.match(line)
-        if heading:
-            section_id = heading.group(1).upper()
+        if ANY_HEADING.match(line):
+            heading = SECTION_HEADING.match(line)
+            section_id = heading.group(1).upper() if heading else None
         marker = STATUS_MARKER.search(line)
         if marker is None:
             index += 1
@@ -153,7 +156,11 @@ def collect_status_claims(markdown: str) -> list[StatusClaim]:
 def load_question_study_ranks(
     *, repository_root: Path = REPOSITORY_ROOT
 ) -> dict[str, EvidenceStatus]:
-    """Map each study-listed question ID to the highest live evidence status."""
+    """Map each study-listed section ID to the highest live evidence status.
+
+    A study that lists ``B2`` authorizes reserved ranks for every Status
+    block under ``### B2``, not only the bullet whose estimand it covers.
+    """
 
     best: dict[str, EvidenceStatus] = {}
     for path in sorted((repository_root / "studies").glob("*/study.yaml")):

--- a/scripts/ci/check_research_question_status.py
+++ b/scripts/ci/check_research_question_status.py
@@ -8,9 +8,10 @@ at the matching ``evidence_status`` (or higher). Authorization is per section,
 not per question bullet: a study listing ``B2`` authorizes every reserved-rank
 Status under ``### B2``.
 
-Negations (``not computable``, ``never computable``, ``non-citable``) are
-refusals, not ranks, and do not need a study. The verb ``validates`` is not
-the ``validated`` rank.
+Negations (``not computable``, ``never computable``, ``not yet validated``,
+``no citable claim``, ``non-citable``) are refusals, not ranks, and do not need
+a study. The negation has to lead — a rank word with nothing negating it in
+front reads as a claim. The verb ``validates`` is not the ``validated`` rank.
 
 This is admission control for the inventory, not proof that a study's result
 is correct. Exploratory studies do not authorize ``computable``.
@@ -30,30 +31,36 @@ from sbir_etl.quality.study_manifest import EvidenceStatus, load_study_manifest
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 INVENTORY_PATH = Path("docs/research-questions.md")
 
-ANY_HEADING = re.compile(r"^#{2,4}\s+")
-SECTION_HEADING = re.compile(r"^#{2,4}\s+([A-F]\d+)\b")
+SECTION_HEADING = re.compile(r"^(#{2,4})\s+([A-F]\d+)\b")
+ANY_HEADING = re.compile(r"^(#{1,6})\s")
 STATUS_MARKER = re.compile(r"\*\*Status:\*\*")
 STATUS_END = re.compile(r"^(\s*\*Deps:|#{1,6}\s|-\s+\*\*)")
 
-# Strip these before looking for a positive rank so denials do not count.
-# A short negation window covers "not currently computable" / "never
-# computable" without exempting the noun phrase "citable claim".
-DENIAL_PHRASES = (
-    re.compile(
-        r"\b(?:not|no|never|cannot)\W+(?:\w+\W+){0,3}?(?:computable|validated|citable)\b",
-        re.IGNORECASE,
-    ),
-    re.compile(r"\bnon-(?:computable|validated|citable)\b", re.IGNORECASE),
-    re.compile(r"\bunvalidated\b", re.IGNORECASE),
-    re.compile(r"\bnot\s+approved\s+for\s+citation\b", re.IGNORECASE),
-    re.compile(r"\bany\b[^.]*\bcitable\b[^.]*\bblocked\b", re.IGNORECASE),
-)
-
+# Only the past-participle rank word counts. ``validates`` is the ordinary verb
+# ("the review validates the cohort component") and is not a rank claim.
 RANK_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("computable", re.compile(r"\bcomputable\b", re.IGNORECASE)),
     ("validated", re.compile(r"\bvalidated\b", re.IGNORECASE)),
     ("citable", re.compile(r"\bcitable\b", re.IGNORECASE)),
 )
+
+# Negation is read compositionally rather than from a phrase list: a rank word
+# is a refusal when a negating token leads it within the same clause ("not yet
+# computable", "no longer computable", "never computable", "cannot be
+# validated", "no citable claim") or when a negating prefix is attached
+# ("non-citable"). ``unvalidated`` needs no rule — the rank patterns are
+# word-bounded, so they never match inside it.
+NEGATION_TOKEN = re.compile(
+    r"\b(?:not|no|never|none|nor|neither|without|cannot|absent|lack(?:s|ed|ing)?"
+    r"|[\w']+n't)\b",
+    re.IGNORECASE,
+)
+NEGATING_PREFIX = re.compile(r"\bnon-\s*$", re.IGNORECASE)
+CLAUSE_BREAK = re.compile(r"[.;:!?]")
+WORD = re.compile(r"[\w'’]+")
+
+# Words that may sit between the negating token and the rank word it governs.
+NEGATION_WINDOW_WORDS = 4
 
 # Minimum study evidence_status that authorizes each reserved inventory rank.
 REQUIRED_STUDY_STATUS: dict[str, EvidenceStatus] = {
@@ -93,15 +100,24 @@ class StatusViolation:
         return f"{self.path}:{self.line_number}: {self.message}"
 
 
-def claimed_ranks(status_text: str) -> tuple[str, ...]:
-    """Return reserved ranks asserted after denial phrases are removed."""
+def is_negated(text: str, rank_start: int) -> bool:
+    """Return whether a negation leads the rank word beginning at ``rank_start``."""
 
-    remainder = status_text
-    for pattern in DENIAL_PHRASES:
-        remainder = pattern.sub(" ", remainder)
+    prefix = text[:rank_start]
+    if NEGATING_PREFIX.search(prefix):
+        return True
+    clause = CLAUSE_BREAK.split(prefix)[-1]
+    window = WORD.findall(clause)[-NEGATION_WINDOW_WORDS:]
+    return any(NEGATION_TOKEN.fullmatch(word) for word in window)
+
+
+def claimed_ranks(status_text: str) -> tuple[str, ...]:
+    """Return reserved ranks asserted positively, ignoring negated mentions."""
+
     found: list[str] = []
     for rank, pattern in RANK_PATTERNS:
-        if pattern.search(remainder):
+        mentions = pattern.finditer(status_text)
+        if any(not is_negated(status_text, mention.start()) for mention in mentions):
             found.append(rank)
     return tuple(found)
 
@@ -110,13 +126,21 @@ def iter_status_blocks(markdown: str) -> Iterable[tuple[int, str | None, str]]:
     """Yield ``(line_number, section_id, status_text)`` for each Status block."""
 
     section_id: str | None = None
+    section_level = 0
     lines = markdown.splitlines()
     index = 0
     while index < len(lines):
         line = lines[index]
-        if ANY_HEADING.match(line):
-            heading = SECTION_HEADING.match(line)
-            section_id = heading.group(1).upper() if heading else None
+        heading = SECTION_HEADING.match(line)
+        other_heading = ANY_HEADING.match(line)
+        if heading:
+            section_id = heading.group(2).upper()
+            section_level = len(heading.group(1))
+        elif other_heading is not None and len(other_heading.group(1)) <= section_level:
+            # A sibling or shallower heading that carries no A–F ID ends the
+            # section. Deeper sub-headings (#### inside a ### section) stay in.
+            section_id = None
+            section_level = 0
         marker = STATUS_MARKER.search(line)
         if marker is None:
             index += 1
@@ -189,7 +213,16 @@ def validate_inventory(
     *,
     path: str = INVENTORY_PATH.as_posix(),
 ) -> list[StatusViolation]:
-    """Return Status claims that lack a study at the required rank."""
+    """Return Status claims that lack a study at the required rank.
+
+    Known limitation: authorization binds to the section ID, and a section
+    holds several distinct question bullets. A study listing ``B2`` therefore
+    authorizes a reserved rank on every B2 bullet, not only the bullet the
+    study actually covers. The sharper rule is to bind each claim to the bullet
+    that makes it, which needs stable per-bullet IDs in the inventory and a
+    ``research_questions`` schema in ``study.yaml`` that can name them; both are
+    out of scope here.
+    """
 
     violations: list[StatusViolation] = []
     for claim in collect_status_claims(markdown):

--- a/scripts/ci/check_research_question_status.py
+++ b/scripts/ci/check_research_question_status.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Require reserved inventory Status ranks to have a matching study contract.
+
+``docs/research-questions.md`` is a public API. The reserved ranks
+``computable``, ``validated``, and ``citable`` may appear as Status claims only
+when a ``studies/*/study.yaml`` lists that question at the matching
+``evidence_status`` (or higher). Negations (``not computable``, ``non-citable``)
+are allowed without a study: they are refusals, not ranks.
+
+This is admission control for the inventory, not proof that a study's result
+is correct. Exploratory studies do not authorize ``computable``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from sbir_etl.exceptions import ConfigurationError
+from sbir_etl.quality.study_manifest import EvidenceStatus, load_study_manifest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+INVENTORY_PATH = Path("docs/research-questions.md")
+STUDIES_ROOT = REPOSITORY_ROOT / "studies"
+
+SECTION_HEADING = re.compile(r"^#{2,4}\s+([A-F]\d+)\b")
+STATUS_MARKER = re.compile(r"\*\*Status:\*\*")
+STATUS_END = re.compile(r"^(\s*\*Deps:|#{1,6}\s|-\s+\*\*)")
+
+# Strip these before looking for a positive rank so denials do not count.
+DENIAL_PHRASES = (
+    re.compile(r"\bnot\s+yet\s+computable\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+computable\b", re.IGNORECASE),
+    re.compile(r"\bnon-computable\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+yet\s+validated\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+validated\b", re.IGNORECASE),
+    re.compile(r"\bunvalidated\b", re.IGNORECASE),
+    re.compile(r"\bremains\s+unvalidated\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+approved\s+for\s+citation\b", re.IGNORECASE),
+    re.compile(r"\bnot\s+citable\b", re.IGNORECASE),
+    re.compile(r"\bnon-citable\b", re.IGNORECASE),
+    re.compile(r"\bcitable\s+study(?:\s+contract|\s+manifest)?\b", re.IGNORECASE),
+    re.compile(r"\bcitable\s+claim\b", re.IGNORECASE),
+)
+
+RANK_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("computable", re.compile(r"\bcomputable\b", re.IGNORECASE)),
+    ("validated", re.compile(r"\bvalidat(?:ed|es)\b", re.IGNORECASE)),
+    ("citable", re.compile(r"\bcitable\b", re.IGNORECASE)),
+)
+
+# Minimum study evidence_status that authorizes each reserved inventory rank.
+REQUIRED_STUDY_STATUS: dict[str, EvidenceStatus] = {
+    "computable": EvidenceStatus.REPRODUCIBLE,
+    "validated": EvidenceStatus.VALIDATED,
+    "citable": EvidenceStatus.CITABLE,
+}
+
+STATUS_RANK: dict[EvidenceStatus, int] = {
+    EvidenceStatus.RETIRED: -1,
+    EvidenceStatus.EXPLORATORY: 0,
+    EvidenceStatus.REPRODUCIBLE: 1,
+    EvidenceStatus.VALIDATED: 2,
+    EvidenceStatus.CITABLE: 3,
+}
+
+
+@dataclass(frozen=True)
+class StatusClaim:
+    """One reserved rank claimed by a Status block."""
+
+    line_number: int
+    section_id: str | None
+    rank: str
+    excerpt: str
+
+
+@dataclass(frozen=True)
+class StatusViolation:
+    """One Status claim that lacks a study at the required rank."""
+
+    path: str
+    line_number: int
+    message: str
+
+    def format(self) -> str:
+        return f"{self.path}:{self.line_number}: {self.message}"
+
+
+def claimed_ranks(status_text: str) -> tuple[str, ...]:
+    """Return reserved ranks asserted after denial phrases are removed."""
+
+    remainder = status_text
+    for pattern in DENIAL_PHRASES:
+        remainder = pattern.sub(" ", remainder)
+    found: list[str] = []
+    for rank, pattern in RANK_PATTERNS:
+        if pattern.search(remainder):
+            found.append(rank)
+    return tuple(found)
+
+
+def iter_status_blocks(markdown: str) -> Iterable[tuple[int, str | None, str]]:
+    """Yield ``(line_number, section_id, status_text)`` for each Status block."""
+
+    section_id: str | None = None
+    lines = markdown.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        heading = SECTION_HEADING.match(line)
+        if heading:
+            section_id = heading.group(1).upper()
+        marker = STATUS_MARKER.search(line)
+        if marker is None:
+            index += 1
+            continue
+        start_line = index + 1
+        block = [line[marker.end() :]]
+        index += 1
+        while index < len(lines):
+            nxt = lines[index]
+            if STATUS_MARKER.search(nxt) or STATUS_END.match(nxt):
+                break
+            block.append(nxt)
+            index += 1
+        yield start_line, section_id, " ".join(part.strip() for part in block if part.strip())
+
+
+def collect_status_claims(markdown: str) -> list[StatusClaim]:
+    """Collect reserved-rank claims from an inventory document."""
+
+    claims: list[StatusClaim] = []
+    for line_number, section_id, text in iter_status_blocks(markdown):
+        excerpt = re.sub(r"\s+", " ", text).strip()
+        if len(excerpt) > 160:
+            excerpt = excerpt[:157] + "..."
+        for rank in claimed_ranks(text):
+            claims.append(
+                StatusClaim(
+                    line_number=line_number,
+                    section_id=section_id,
+                    rank=rank,
+                    excerpt=excerpt,
+                )
+            )
+    return claims
+
+
+def load_question_study_ranks(
+    *, repository_root: Path = REPOSITORY_ROOT
+) -> dict[str, EvidenceStatus]:
+    """Map each study-listed question ID to the highest live evidence status."""
+
+    best: dict[str, EvidenceStatus] = {}
+    for path in sorted((repository_root / "studies").glob("*/study.yaml")):
+        manifest = load_study_manifest(path)
+        if manifest.evidence_status is EvidenceStatus.RETIRED:
+            continue
+        for question in manifest.research_questions:
+            key = question.strip().upper()
+            current = best.get(key)
+            if current is None or STATUS_RANK[manifest.evidence_status] > STATUS_RANK[current]:
+                best[key] = manifest.evidence_status
+    return best
+
+
+def study_authorizes(status: EvidenceStatus | None, required: EvidenceStatus) -> bool:
+    """Return whether ``status`` meets or exceeds ``required``."""
+
+    if status is None or STATUS_RANK[status] < 0:
+        return False
+    return STATUS_RANK[status] >= STATUS_RANK[required]
+
+
+def validate_inventory(
+    markdown: str,
+    question_ranks: dict[str, EvidenceStatus],
+    *,
+    path: str = INVENTORY_PATH.as_posix(),
+) -> list[StatusViolation]:
+    """Return Status claims that lack a study at the required rank."""
+
+    violations: list[StatusViolation] = []
+    for claim in collect_status_claims(markdown):
+        required = REQUIRED_STUDY_STATUS[claim.rank]
+        if claim.section_id is None:
+            violations.append(
+                StatusViolation(
+                    path=path,
+                    line_number=claim.line_number,
+                    message=(
+                        f"Status claims {claim.rank!r} outside a numbered A–F "
+                        f"section: {claim.excerpt}"
+                    ),
+                )
+            )
+            continue
+        actual = question_ranks.get(claim.section_id)
+        if study_authorizes(actual, required):
+            continue
+        actual_label = actual.value if actual is not None else "none"
+        violations.append(
+            StatusViolation(
+                path=path,
+                line_number=claim.line_number,
+                message=(
+                    f"Status claims {claim.rank!r} for {claim.section_id}, but "
+                    f"the highest matching study is {actual_label!r} "
+                    f"(need {required.value!r} or higher): {claim.excerpt}"
+                ),
+            )
+        )
+    return violations
+
+
+def validate_repository(*, repository_root: Path = REPOSITORY_ROOT) -> list[StatusViolation]:
+    """Validate the tracked inventory against live study manifests."""
+
+    inventory = repository_root / INVENTORY_PATH
+    try:
+        markdown = inventory.read_text(encoding="utf-8")
+        ranks = load_question_study_ranks(repository_root=repository_root)
+    except (OSError, ValueError, ConfigurationError) as exc:
+        return [
+            StatusViolation(
+                path=INVENTORY_PATH.as_posix(),
+                line_number=1,
+                message=f"cannot load inventory or study manifests: {exc}",
+            )
+        ]
+    return validate_inventory(markdown, ranks, path=INVENTORY_PATH.as_posix())
+
+
+def main() -> int:
+    violations = validate_repository()
+    if violations:
+        print("Research-question Status claims lack a matching study contract:")
+        print("\n".join(violation.format() for violation in violations))
+        return 1
+    print("Research-question Status ranks match study contracts.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/studies/README.md
+++ b/studies/README.md
@@ -12,6 +12,21 @@ The status vocabulary is intentionally small:
 - `citable`: approved for the claims listed in its manifest;
 - `retired`: retained for provenance but superseded or no longer supported.
 
+These ranks are the only backing for reserved **Status** words in
+[`docs/research-questions.md`](../docs/research-questions.md):
+
+| Inventory Status | Required `evidence_status` |
+|---|---|
+| `Computable` / `Partially computable` | `reproducible` or higher |
+| `Validated` | `validated` or higher |
+| `Citable` | `citable` |
+
+An exploratory study does not authorize `Computable`. CI
+(`scripts/ci/check_research_question_status.py`) rejects a reserved Status
+claim whose question ID is missing from every live manifest or whose highest
+matching study is below the required rank. Negations (`Not computable`,
+`non-citable`) are refusals and do not need a study.
+
 Promotion changes the manifest only after the study meets the next status's requirements.
 A manifest does not make an analysis citable by itself, and a closed materialization gate
 must name the unresolved blocker.

--- a/studies/README.md
+++ b/studies/README.md
@@ -23,9 +23,11 @@ These ranks are the only backing for reserved **Status** words in
 
 An exploratory study does not authorize `Computable`. CI
 (`scripts/ci/check_research_question_status.py`) rejects a reserved Status
-claim whose question ID is missing from every live manifest or whose highest
-matching study is below the required rank. Negations (`Not computable`,
-`non-citable`) are refusals and do not need a study.
+claim whose *section* ID is missing from every live manifest or whose highest
+matching study is below the required rank. Authorization is per section
+(`B2`, `F3`), not per question bullet. Negations (`Not computable`,
+`never computable`, `non-citable`) are refusals and do not need a study. The
+verb `validates` is not the `validated` rank.
 
 Promotion changes the manifest only after the study meets the next status's requirements.
 A manifest does not make an analysis citable by itself, and a closed materialization gate

--- a/studies/README.md
+++ b/studies/README.md
@@ -25,9 +25,11 @@ An exploratory study does not authorize `Computable`. CI
 (`scripts/ci/check_research_question_status.py`) rejects a reserved Status
 claim whose *section* ID is missing from every live manifest or whose highest
 matching study is below the required rank. Authorization is per section
-(`B2`, `F3`), not per question bullet. Negations (`Not computable`,
-`never computable`, `non-citable`) are refusals and do not need a study. The
-verb `validates` is not the `validated` rank.
+(`B2`, `F3`), not per question bullet. Negations (`Not computable`, `never
+computable`, `not yet validated`, `no citable claim`, `non-citable`) are
+refusals and do not need a study; the negating word has to come before the rank
+word, so `Citable claim: …` still reads as a claim. The verb `validates` is not
+the `validated` rank.
 
 Promotion changes the manifest only after the study meets the next status's requirements.
 A manifest does not make an analysis citable by itself, and a closed materialization gate

--- a/tests/unit/scripts/test_research_question_status.py
+++ b/tests/unit/scripts/test_research_question_status.py
@@ -8,8 +8,8 @@ from scripts.ci import check_research_question_status as guard
 def test_denial_phrases_are_not_status_claims() -> None:
     text = (
         "Not computable. Phase 0 design only (exploratory, non-citable); "
-        "not validated, and not approved for citation. Any citable claim "
-        "is blocked until the gates pass."
+        "not validated, and not approved for citation. No citable study "
+        "manifest exists."
     )
 
     assert guard.claimed_ranks(text) == ()
@@ -26,13 +26,34 @@ def test_citable_claim_and_citable_study_are_rank_claims() -> None:
     assert guard.claimed_ranks("Citable study result approved for external reporting.") == (
         "citable",
     )
+    assert guard.claimed_ranks("A citable study manifest backs this line.") == ("citable",)
 
 
-def test_partially_computable_is_a_claim_but_validates_is_not() -> None:
+def test_partially_computable_and_validated_are_claims() -> None:
     assert guard.claimed_ranks("Partially computable for the classified subset.") == ("computable",)
-    assert guard.claimed_ranks("The Phase 1 review validates the cohort component.") == ()
+    assert guard.claimed_ranks("Validated against the frozen design.") == ("validated",)
     assert guard.claimed_ranks("Citable under the approved study contract.") == ("citable",)
     assert guard.claimed_ranks("Validated under the approved study contract.") == ("validated",)
+
+
+def test_validates_verb_is_not_a_rank_claim() -> None:
+    assert guard.claimed_ranks("The Phase 1 review validates the cohort component.") == ()
+    assert guard.claimed_ranks("Partial and non-citable. The review validates the cohort.") == ()
+
+
+def test_leading_negations_generalize_beyond_fixed_phrases() -> None:
+    denials = (
+        "No longer computable.",
+        "Not fully validated.",
+        "This is not computable.",
+        "It isn't computable.",
+        "No citable claim is authorized until the gates pass.",
+        "Non-citable pending review.",
+        "Coverage remains unvalidated.",
+    )
+
+    for text in denials:
+        assert guard.claimed_ranks(text) == (), text
 
 
 def test_iter_status_blocks_tracks_section_headings() -> None:
@@ -94,12 +115,44 @@ def test_retired_study_does_not_authorize_computable() -> None:
     assert violations and "highest matching study is 'retired'" in violations[0].message
 
 
+def test_section_id_resets_at_a_non_numbered_sibling_heading() -> None:
+    markdown = """
+### F4. Predictive (Tier 4)
+
+- **Modelled outcome**
+  **Status:** Research target.
+
+#### A deeper sub-heading
+
+- **Nested question**
+  **Status:** Computable under the study.
+
+### Form D fundraising analysis (published)
+
+**Status:** Computable from the dated note.
+"""
+
+    blocks = list(guard.iter_status_blocks(markdown))
+
+    assert blocks[0][1] == "F4"
+    # A #### sub-heading is inside its ### section, so the section ID survives.
+    assert blocks[1][1] == "F4"
+    # A sibling ### heading with no A–F ID ends the section.
+    assert blocks[2][1] is None
+
+
 def test_claim_outside_numbered_section_is_rejected() -> None:
-    markdown = "## Output products\n\n**Status:** Computable from the dated note.\n"
+    markdown = (
+        "### F4. Predictive (Tier 4)\n\n"
+        "- **Modelled outcome**\n"
+        "  **Status:** Research target.\n\n"
+        "### Form D fundraising analysis (published)\n\n"
+        "**Status:** Computable from the dated note.\n"
+    )
 
-    violations = guard.validate_inventory(markdown, {})
+    violations = guard.validate_inventory(markdown, {"F4": EvidenceStatus.CITABLE})
 
-    assert violations
+    assert len(violations) == 1
     assert "outside a numbered A–F section" in violations[0].message
 
 

--- a/tests/unit/scripts/test_research_question_status.py
+++ b/tests/unit/scripts/test_research_question_status.py
@@ -8,19 +8,31 @@ from scripts.ci import check_research_question_status as guard
 def test_denial_phrases_are_not_status_claims() -> None:
     text = (
         "Not computable. Phase 0 design only (exploratory, non-citable); "
-        "not validated, and not approved for citation. A citable study "
-        "manifest is absent."
+        "not validated, and not approved for citation. Any citable claim "
+        "is blocked until the gates pass."
     )
 
     assert guard.claimed_ranks(text) == ()
+    assert guard.claimed_ranks("Not currently computable.") == ()
+    assert guard.claimed_ranks("Never computable from public data.") == ()
+    assert guard.claimed_ranks("Cannot be validated without a hand-labelled sample.") == ()
+    assert guard.claimed_ranks("This is not yet a citable result.") == ()
 
 
-def test_partially_computable_and_validates_are_claims() -> None:
-    assert guard.claimed_ranks("Partially computable for the classified subset.") == ("computable",)
-    assert guard.claimed_ranks("The Phase 1 review validates the cohort component.") == (
-        "validated",
+def test_citable_claim_and_citable_study_are_rank_claims() -> None:
+    assert guard.claimed_ranks("Citable claim: the DoD follow-on multiplier is 4.1:1.") == (
+        "citable",
     )
+    assert guard.claimed_ranks("Citable study result approved for external reporting.") == (
+        "citable",
+    )
+
+
+def test_partially_computable_is_a_claim_but_validates_is_not() -> None:
+    assert guard.claimed_ranks("Partially computable for the classified subset.") == ("computable",)
+    assert guard.claimed_ranks("The Phase 1 review validates the cohort component.") == ()
     assert guard.claimed_ranks("Citable under the approved study contract.") == ("citable",)
+    assert guard.claimed_ranks("Validated under the approved study contract.") == ("validated",)
 
 
 def test_iter_status_blocks_tracks_section_headings() -> None:
@@ -89,6 +101,21 @@ def test_claim_outside_numbered_section_is_rejected() -> None:
 
     assert violations
     assert "outside a numbered A–F section" in violations[0].message
+
+
+def test_non_question_heading_clears_inherited_section_id() -> None:
+    markdown = (
+        "### F4. Predictive (Tier 4)\n\n"
+        "## Output products & audiences\n\n"
+        "### Form D fundraising analysis (published)\n\n"
+        "**Status:** Citable for the 2024 vintage.\n"
+    )
+
+    blocks = list(guard.iter_status_blocks(markdown))
+    violations = guard.validate_inventory(markdown, {"F4": EvidenceStatus.REPRODUCIBLE})
+
+    assert blocks[0][1] is None
+    assert violations and "outside a numbered A–F section" in violations[0].message
 
 
 def test_repository_inventory_matches_live_studies() -> None:

--- a/tests/unit/scripts/test_research_question_status.py
+++ b/tests/unit/scripts/test_research_question_status.py
@@ -1,0 +1,103 @@
+from pathlib import Path
+
+from sbir_etl.quality.study_manifest import EvidenceStatus
+
+from scripts.ci import check_research_question_status as guard
+
+
+def test_denial_phrases_are_not_status_claims() -> None:
+    text = (
+        "Not computable. Phase 0 design only (exploratory, non-citable); "
+        "not validated, and not approved for citation. A citable study "
+        "manifest is absent."
+    )
+
+    assert guard.claimed_ranks(text) == ()
+
+
+def test_partially_computable_and_validates_are_claims() -> None:
+    assert guard.claimed_ranks("Partially computable for the classified subset.") == ("computable",)
+    assert guard.claimed_ranks("The Phase 1 review validates the cohort component.") == (
+        "validated",
+    )
+    assert guard.claimed_ranks("Citable under the approved study contract.") == ("citable",)
+
+
+def test_iter_status_blocks_tracks_section_headings() -> None:
+    markdown = """
+### B2. Relational (Tier 2)
+
+- **Follow-on**
+  **Status:** Computable as a proxy.
+  *Deps: ER*
+
+### E5. External data source evaluation (Tier 2)
+
+**Status:** Research agenda.
+"""
+
+    blocks = list(guard.iter_status_blocks(markdown))
+
+    assert blocks[0][1] == "B2"
+    assert "Computable as a proxy" in blocks[0][2]
+    assert blocks[1][1] == "E5"
+    assert blocks[1][2] == "Research agenda."
+
+
+def test_computable_requires_reproducible_study() -> None:
+    markdown = (
+        "### A1. Descriptive\n\n"
+        "- **Concentration**\n"
+        "  **Status:** Computable for the classified subset.\n"
+        "  *Deps: CET*\n"
+    )
+
+    missing = guard.validate_inventory(markdown, {})
+    exploratory = guard.validate_inventory(markdown, {"A1": EvidenceStatus.EXPLORATORY})
+    reproducible = guard.validate_inventory(markdown, {"A1": EvidenceStatus.REPRODUCIBLE})
+
+    assert missing and "need 'reproducible'" in missing[0].message
+    assert exploratory and "highest matching study is 'exploratory'" in exploratory[0].message
+    assert reproducible == []
+
+
+def test_validated_and_citable_require_matching_ranks() -> None:
+    markdown = "### B3. Inferential\n\n**Status:** Validated and citable.\n*Deps: ID*\n"
+
+    only_validated = guard.validate_inventory(markdown, {"B3": EvidenceStatus.VALIDATED})
+    citable = guard.validate_inventory(markdown, {"B3": EvidenceStatus.CITABLE})
+
+    assert len(only_validated) == 1
+    assert "claims 'citable'" in only_validated[0].message
+    assert citable == []
+
+
+def test_retired_study_does_not_authorize_computable() -> None:
+    markdown = (
+        "### F3. Inferential\n\n**Status:** Computable as a leverage ratio.\n*Deps: SEC EDGAR*\n"
+    )
+
+    violations = guard.validate_inventory(markdown, {"F3": EvidenceStatus.RETIRED})
+
+    assert violations and "highest matching study is 'retired'" in violations[0].message
+
+
+def test_claim_outside_numbered_section_is_rejected() -> None:
+    markdown = "## Output products\n\n**Status:** Computable from the dated note.\n"
+
+    violations = guard.validate_inventory(markdown, {})
+
+    assert violations
+    assert "outside a numbered A–F section" in violations[0].message
+
+
+def test_repository_inventory_matches_live_studies() -> None:
+    assert guard.validate_repository() == []
+
+
+def test_load_question_study_ranks_reads_census() -> None:
+    ranks = guard.load_question_study_ranks(repository_root=Path(__file__).resolve().parents[3])
+
+    assert ranks["B2"] is EvidenceStatus.REPRODUCIBLE
+    assert ranks["B3"] is EvidenceStatus.REPRODUCIBLE
+    assert ranks["E1"] is EvidenceStatus.REPRODUCIBLE


### PR DESCRIPTION
## Why

The research-question inventory was a public API without a backstop. Status lines could say **Computable** (or imply an answer) from a research note, and the policymaker start-here box sent readers to A3 and D2 — neither of which has a study contract or a Status line a staffer can trust.

## What changed

- Reserved ranks in `docs/research-questions.md` now map to study `evidence_status`:
  - `Computable` / `Partially computable` → `reproducible` or higher
  - `Validated` → `validated` or higher
  - `Citable` → `citable`
- Exploratory studies do not authorize `Computable`. Negations (`Not computable`, `non-citable`) stay legal without a study.
- CI and `make lint-boundaries` run `scripts/ci/check_research_question_status.py`.
- Status lines that used reserved ranks without a study were rewritten as exploratory / inventory-target prose.
- The B2/B3/E1 census questions keep `Computable` / `Partially computable` because `studies/phase-iii-census` is `reproducible`.
- Policymakers now start at B2/B3 (study-backed). A3 and D2 are labeled inventory targets and stay out of that box until they have study-backed Status.

## Out of scope

- Promoting Form D (separate PR).
- Census memo drift (separate PR).
- Changing any study `evidence_status`.