### PR TITLE
Align Phase III census docs with the study file

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -52,14 +52,28 @@ brief count as maintainer-facing.
 
 The Phase III census has its own formal study record. The
 [study file](../../studies/phase-iii-census/study.yaml) is the clock:
-`reproducible`, not validated or citable. The 2026-08-03
+`reproducible`, not validated or citable. The
+[February 2026 data-build record](../../studies/phase-iii-census/materialization-2026-02-06.md)
+holds the census ladder, the sensitivity grid, and the blocking one-factor check. The
+2026-08-03
 [identity-eligibility](../../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md),
 [exact-match balance](../../studies/phase-iii-census/control-matching-audit-2026-08-03.md),
 and [fixed-seed placebo](../../studies/phase-iii-census/placebo-results-2026-08-03.md)
 audits are recorded. [Matched negative-control outcomes](../../studies/phase-iii-census/negative-control-outcomes-2026-08-03.md)
-are descriptive only (about 2.10× clearing with 0.853 overlap). The placebo is
-one preregistered falsification, not labeled validation. Hand-labeled
-validation remains the open gate.
+are descriptive only, and only within the frozen exact-match common-support subset: SBIR
+firms clear the full criteria set about 2.10× as often as controls, with a 0.853 overlap
+coefficient, computed on 712 of 12,042 exact-UEI SBIR firms (5.91%) and 1,029 of 843,777
+screened-negative controls — 4,827 of the 5,539 match-eligible treated firms matched zero
+controls. That ratio is not a population-wide rate. The placebo is one preregistered
+falsification, not labeled validation.
+
+The study file records four standing limitations, not one. The materialized placebo is a
+single non-uniform cyclic derangement rather than an inferential permutation distribution,
+and labeled validation remains unresolved, so no headline census cell, undercount claim, or
+statutory Phase III interpretation is authorized. Negative-control inference is restricted
+to the frozen exact-match common-support subset and does not generalize to unmatched Phase
+II firms. Exact UEI matching misses acquisitions, successors, and UEI changes. And an
+uncoded lineage proxy is not proof of a statutory Phase III award.
 
 ## Economic and fiscal methods
 

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,7 +1,7 @@
 ---
 Type: Overview
 Maintainer: Conrad Hollomon
-Last-Reviewed: 2026-08-03
+Last-Reviewed: 2026-08-18
 Status: active
 ---
 
@@ -50,12 +50,16 @@ brief count as maintainer-facing.
 | [Commercialization benchmark method](../commercialization-benchmark-methodology.md) | B3 | Method is documented; this repository cannot recreate the local audit | FY2026 local audit described in the document |
 | [Monthly procurement-transition report](../procurement-transition-report.md) | B4, E6 | Instructions for producing a report; not research evidence | Current public-source pipeline |
 
-The Phase III census has its own formal study record: the
-[study file](../../studies/phase-iii-census/study.yaml),
-[February 2026 data-build review](../../studies/phase-iii-census/materialization-2026-02-06.md),
-and [August 2026 control-group identity review](../../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md).
-The work can be repeated, but it is not yet approved for citation. The comparison
-group, matching, and placebo test are not finished.
+The Phase III census has its own formal study record. The
+[study file](../../studies/phase-iii-census/study.yaml) is the clock:
+`reproducible`, not validated or citable. The 2026-08-03
+[identity-eligibility](../../studies/phase-iii-census/identity-eligibility-audit-2026-08-03.md),
+[exact-match balance](../../studies/phase-iii-census/control-matching-audit-2026-08-03.md),
+and [fixed-seed placebo](../../studies/phase-iii-census/placebo-results-2026-08-03.md)
+audits are recorded. [Matched negative-control outcomes](../../studies/phase-iii-census/negative-control-outcomes-2026-08-03.md)
+are descriptive only (about 2.10× clearing with 0.853 overlap). The placebo is
+one preregistered falsification, not labeled validation. Hand-labeled
+validation remains the open gate.
 
 ## Economic and fiscal methods
 

--- a/studies/phase-iii-census/materialization-2026-02-06.md
+++ b/studies/phase-iii-census/materialization-2026-02-06.md
@@ -4,9 +4,15 @@
 
 This is the complete Phase 1 deterministic census audit, not a validated count of
 statutory Phase III awards. Every row and sensitivity cell is reported; no cell is a
-headline result. The matched negative-control study, placebo test, and labeled validation
-remain unresolved, so this record does not establish that the frozen proxy discriminates
-Phase III work from ordinary follow-on federal contracting.
+headline result. As of this February run, the matched negative-control study, placebo
+test, and labeled validation were not part of the materialization, so this record does
+not establish that the frozen proxy discriminates Phase III work from ordinary follow-on
+federal contracting.
+
+Later record (do not back-date this run): the 2026-08-03 identity, matching, outcomes,
+and placebo memos, and the [study file](study.yaml), supersede the "remain unresolved"
+clause for those three audits. Labeled validation is still unresolved. The study file is
+the clock.
 
 ## Run and freeze record
 

--- a/studies/phase-iii-census/materialization-2026-02-06.md
+++ b/studies/phase-iii-census/materialization-2026-02-06.md
@@ -4,15 +4,22 @@
 
 This is the complete Phase 1 deterministic census audit, not a validated count of
 statutory Phase III awards. Every row and sensitivity cell is reported; no cell is a
-headline result. As of this February run, the matched negative-control study, placebo
-test, and labeled validation were not part of the materialization, so this record does
-not establish that the frozen proxy discriminates Phase III work from ordinary follow-on
-federal contracting.
+headline result. The matched negative-control study, placebo test, and labeled validation
+remain unresolved, so this record does not establish that the frozen proxy discriminates
+Phase III work from ordinary follow-on federal contracting.
 
-Later record (do not back-date this run): the 2026-08-03 identity, matching, outcomes,
-and placebo memos, and the [study file](study.yaml), supersede the "remain unresolved"
-clause for those three audits. Labeled validation is still unresolved. The study file is
-the clock.
+**Later record, added 2026-08-18 — do not back-date this run.** The paragraph above stands
+as written on 2026-02-06. Two of the three items it lists as unresolved have since been run
+and recorded outside this materialization: the matched negative-control study
+([matching audit](control-matching-audit-2026-08-03.md),
+[outcomes](negative-control-outcomes-2026-08-03.md)) and the
+[placebo test](placebo-results-2026-08-03.md), both dated 2026-08-03. Labeled validation is
+not in that set and remains unresolved. Those later memos are descriptive: the placebo is
+one non-uniform cyclic derangement, not an inferential permutation distribution, and
+negative-control inference is restricted to the frozen exact-match common-support subset.
+They therefore do not establish the discrimination this February record declines to claim.
+The [study file](study.yaml) is the clock, and it records the study as `reproducible` —
+not validated, not citable.
 
 ## Run and freeze record
 

--- a/studies/phase-iii-census/negative-control-outcomes-2026-08-03.md
+++ b/studies/phase-iii-census/negative-control-outcomes-2026-08-03.md
@@ -12,7 +12,11 @@ distinguish SBIR firms from otherwise similar federal contractors.
 This is an unweighted empirical comparison of 712 retained SBIR firms and 1,029 retained
 screened-negative controls. It is not a matched-set causal estimate, does not generalize to
 the unmatched Phase II population, and does not validate any contract as statutory Phase
-III. The placebo test and hand-labelled validation remain unresolved.
+III. This outcomes run did not invoke the placebo (see Frozen run). The preregistered
+placebo was run separately and is recorded in
+[placebo-results-2026-08-03.md](placebo-results-2026-08-03.md). Hand-labelled validation
+remains unresolved. The [study file](study.yaml) is the clock: the placebo is descriptive
+falsification evidence, not labeled validation.
 
 ## Frozen run
 


### PR DESCRIPTION
## Why

Three documents disagreed about whether the Phase III census comparison group, matching, and placebo were done:

- `docs/research/README.md` said they were not finished.
- `studies/phase-iii-census/negative-control-outcomes-2026-08-03.md` said the placebo remained unresolved — but that run set `Placebo invoked: false`, and `placebo-results-2026-08-03.md` already records the separate preregistered run.
- `studies/phase-iii-census/study.yaml` already treats the placebo as descriptive falsification evidence, not labeled validation, and keeps the study at `reproducible`.

## What changed

- The research-outputs index now treats `study.yaml` as the clock and links the August identity, matching, outcomes, and placebo memos.
- The August outcomes memo keeps its run table (`Placebo invoked: false`) and points at the companion placebo memo. Only hand-labeled validation stays unresolved.
- The February materialization memo keeps its original freeze record and adds a later-record note so August work is not back-dated into that run.

No study status, SHA, or permitted claim changed.