### PR TITLE
chore: prepare release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ version.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-08-18
+
+### Added
+
+- Reserved inventory Status ranks (`Computable`, `Validated`, `Citable`) now
+  require a matching `studies/*/study.yaml`. CI enforces the pairing
+  (`scripts/ci/check_research_question_status.py`) (#654, #657).
+- `studies/form-d-fundraising` at `reproducible`: frozen Form D leverage
+  estimand, restored `scripts/data/bootstrap_form_d_leverage_ci.py`, and
+  F3 Status may say Computable. Not validated or citable (#658).
+
+### Changed
+
+- Audience start-here lists only reserved Status ranks or explicit refusals.
+  F3 is split into the Form D leverage estimand and causal questions that
+  design cannot answer. E4–E6 are marked operational. Unbacked F1 M&A point
+  estimates were removed from the inventory (#657).
+- Phase III census research-outputs index now treats `study.yaml` as the
+  clock: August identity, matching, outcomes, and placebo memos are
+  recorded; hand-labeled validation remains open (#656).
+
 ## [0.7.1] — 2026-08-18
 
 ### Added
@@ -245,7 +266,8 @@ across the root project and the three packages under `packages/`.
 `vMAJOR.MINOR.PATCH` form it requires. Per that policy published tags are never
 moved or reused, so they remain as historical markers.
 
-[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.5.1...v0.6.0

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.7.1"
+  version: "0.8.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.7.1"
+version = "0.8.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.7.1"
+version = "0.8.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.7.1"
+version = "0.8.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.7.1"
+version = "0.8.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2810,7 +2810,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2834,7 +2834,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -2985,7 +2985,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3004,7 +3004,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Increment

**0.8.0 (MINOR).** Since `v0.7.1` the user-visible work is new research capability and a public Status API, not a patch:

- new `reproducible` study (`form-d-fundraising`) and restored bootstrap CLI
- reserved inventory Status ranks are now a CI-enforced public API
- start-here / F3 / E4–E6 / census-doc alignment

No Dagster asset-key, job-name, configuration-key, or persisted-schema breaks.

## Checklist

- [x] Four `pyproject.toml` versions, `sbir_etl.__version__`, and `config/base.yaml` `pipeline.version` are `0.8.0`
- [x] `uv lock`
- [x] `uv run python scripts/ci/check_versioning.py --tag v0.8.0` passed

After merge: annotated tag `v0.8.0` and GitHub release.