### PR TITLE
Relocate the #371 M&A discovery toolkit into sbir_etl

### DIFF
--- a/sbir_etl/enrichers/ma_discovery/__init__.py
+++ b/sbir_etl/enrichers/ma_discovery/__init__.py
@@ -1,0 +1,27 @@
+"""M&A discovery toolkit: query generation, verification, and press merge.
+
+Epistemic tier: pipelines. Relocated from the paused #371 scripts. This
+package does not include a live search-API client or an LLM extractor.
+"""
+
+from sbir_etl.enrichers.ma_discovery.orchestrator import process_batch
+from sbir_etl.enrichers.ma_discovery.press import enrich_ma_events, merge_press_signals
+from sbir_etl.enrichers.ma_discovery.queries import generate_queries, query_rows_from_events
+from sbir_etl.enrichers.ma_discovery.search import MockSearchTool, SearchTool
+from sbir_etl.enrichers.ma_discovery.verifier import VerificationResult, verify_acquisition
+
+
+EPISTEMIC_TIER = "pipelines"
+
+__all__ = [
+    "EPISTEMIC_TIER",
+    "MockSearchTool",
+    "SearchTool",
+    "VerificationResult",
+    "enrich_ma_events",
+    "generate_queries",
+    "merge_press_signals",
+    "process_batch",
+    "query_rows_from_events",
+    "verify_acquisition",
+]

--- a/sbir_etl/enrichers/ma_discovery/orchestrator.py
+++ b/sbir_etl/enrichers/ma_discovery/orchestrator.py
@@ -1,0 +1,89 @@
+"""Run search queries for M&A candidates and verify the snippets.
+
+Reads the candidate query CSV emitted by ``queries``, runs each query
+through a pluggable ``SearchTool``, and feeds snippets into
+``verify_acquisition``. Confirmed hits are written as JSONL.
+
+This PR ships only ``MockSearchTool``. A live search-API client is a
+later step.
+
+Usage::
+
+    python -m sbir_etl.enrichers.ma_discovery.orchestrator
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.enrichers.ma_discovery.search import MockSearchTool, SearchTool
+from sbir_etl.enrichers.ma_discovery.verifier import verify_acquisition
+
+
+DEFAULT_QUERIES_PATH = Path("data/ma_search_queries.csv")
+DEFAULT_OUTPUT_PATH = Path("data/discovered_acquisitions.jsonl")
+
+
+async def process_batch(
+    queries: list[dict[str, str]], search_tool: SearchTool
+) -> list[dict[str, Any]]:
+    """Run a batch of (company, acquirer, query) rows and return verified events."""
+    verified: list[dict[str, Any]] = []
+    for row in queries:
+        company = row["company_name"]
+        acquirer = row["acquirer"]
+        query = row["query"]
+        results = await search_tool.search(query)
+        for res in results:
+            snippet = res.get("snippet", "")
+            verification = verify_acquisition(company, acquirer, snippet)
+            if verification["confirmed"]:
+                verified.append(
+                    {
+                        "company_name": company,
+                        "acquirer": acquirer,
+                        "date": verification["date"],
+                        "value": verification["value"],
+                        "source": res.get("link", "Unknown"),
+                        "evidence": snippet,
+                    }
+                )
+                break  # one hit per (company, acquirer) is enough
+    return verified
+
+
+def load_query_csv(path: Path) -> list[dict[str, str]]:
+    """Load search-query CSV rows."""
+    with path.open() as handle:
+        return list(csv.DictReader(handle))
+
+
+def write_verified_jsonl(path: Path, rows: Sequence[dict[str, Any]]) -> None:
+    """Write verified acquisition rows as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify M&A search-query snippets")
+    parser.add_argument("--input", type=Path, default=DEFAULT_QUERIES_PATH)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args(argv)
+
+    queries = load_query_csv(args.input)
+    verified = asyncio.run(process_batch(queries, MockSearchTool()))
+    write_verified_jsonl(args.output, verified)
+    print(f"Found {len(verified)} verified acquisitions. Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sbir_etl/enrichers/ma_discovery/press.py
+++ b/sbir_etl/enrichers/ma_discovery/press.py
@@ -1,0 +1,115 @@
+"""Enrich existing SBIR M&A events with press-wire signals.
+
+Wraps ``SyncPressWireClient``. Library functions take an injected client
+so tests never poll the network.
+
+Usage::
+
+    python -m sbir_etl.enrichers.ma_discovery.press
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.enrichers.press_wire import PressRelease
+from sbir_etl.enrichers.sync_wrappers import SyncPressWireClient
+
+
+DEFAULT_EVENTS_PATH = Path("data/sbir_ma_events.jsonl")
+DEFAULT_OUTPUT_PATH = Path("data/enriched_sbir_ma_events.jsonl")
+
+
+def load_ma_events(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL M&A event rows, skipping malformed lines."""
+    events: list[dict[str, Any]] = []
+    with path.open() as handle:
+        for line in handle:
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def watchlist_from_events(events: Iterable[Mapping[str, Any]]) -> list[str]:
+    """Unique ``company_name`` values, preserving first-seen order."""
+    names: list[str] = []
+    seen: set[str] = set()
+    for event in events:
+        name = event.get("company_name")
+        if name and name not in seen:
+            seen.add(name)
+            names.append(name)
+    return names
+
+
+def merge_press_signals(
+    events: Sequence[Mapping[str, Any]],
+    hits: Sequence[PressRelease],
+) -> list[dict[str, Any]]:
+    """Attach matching press hits to events; unmatched events stay unenriched."""
+    company_press: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for hit in hits:
+        company_press[hit.matched_company].append(
+            {
+                "title": hit.title,
+                "link": hit.link,
+                "published": hit.published,
+                "summary": hit.summary,
+                "source": hit.source,
+            }
+        )
+
+    enriched_events: list[dict[str, Any]] = []
+    for event in events:
+        merged = dict(event)
+        company = merged.get("company_name")
+        if company in company_press:
+            merged["press_wire_signals"] = company_press[company]
+            merged["signal_count"] = merged.get("signal_count", 0) + 1
+            merged["enriched"] = True
+        else:
+            merged["press_wire_signals"] = []
+            merged["enriched"] = False
+        enriched_events.append(merged)
+    return enriched_events
+
+
+def enrich_ma_events(events: Sequence[Mapping[str, Any]], client: Any) -> list[dict[str, Any]]:
+    """Poll ``client`` for the event watchlist and merge press-wire signals."""
+    client.set_watchlist(watchlist_from_events(events))
+    hits = client.poll()
+    return merge_press_signals(events, hits)
+
+
+def write_enriched_jsonl(path: Path, events: Sequence[Mapping[str, Any]]) -> None:
+    """Write enriched event rows as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as handle:
+        for event in events:
+            handle.write(json.dumps(event) + "\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Enrich M&A events with press-wire hits")
+    parser.add_argument("--input", type=Path, default=DEFAULT_EVENTS_PATH)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT_PATH)
+    args = parser.parse_args(argv)
+
+    events = load_ma_events(args.input)
+    with SyncPressWireClient() as client:
+        enriched = enrich_ma_events(events, client)
+    write_enriched_jsonl(args.output, enriched)
+    enriched_count = sum(1 for event in enriched if event["enriched"])
+    print(f"Enriched {enriched_count} of {len(events)} events. Wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sbir_etl/enrichers/ma_discovery/queries.py
+++ b/sbir_etl/enrichers/ma_discovery/queries.py
@@ -1,0 +1,117 @@
+"""Generate web-search queries for Form-D-missing M&A candidates.
+
+Company names are normalized through ``sbir_etl.identity`` with
+``CompanyNameProfile.RECIPIENT_V1`` (suffix-stripping) so query strings
+do not carry Inc/LLC/Corp tokens.
+
+Usage::
+
+    python -m sbir_etl.enrichers.ma_discovery.queries
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+
+
+DEFAULT_EVENTS_PATH = Path("data/sbir_ma_events.jsonl")
+DEFAULT_QUERIES_PATH = Path("data/ma_search_queries.csv")
+QUERY_CSV_FIELDS = ("company_name", "acquirer", "query")
+
+
+def _clean_name(name: str | None) -> str:
+    """Normalize a company name with the suffix-stripping recipient profile."""
+    if not name:
+        return ""
+    return normalize_company_name(name, profile=CompanyNameProfile.RECIPIENT_V1)
+
+
+def generate_queries(company_name: str | None, acquirer: str | None) -> list[str]:
+    """Return four web-search query strings for the (company, acquirer) pair."""
+    if not company_name or not acquirer:
+        return []
+    c_name = _clean_name(company_name)
+    a_name = _clean_name(acquirer)
+    if not c_name or not a_name:
+        return []
+    return [
+        f'"{c_name}" acquired by "{a_name}" press release',
+        f'"{c_name}" "{a_name}" merger announcement',
+        f'"{c_name}" bought by "{a_name}"',
+        f'"{a_name}" announces acquisition of "{c_name}"',
+    ]
+
+
+def is_query_candidate(event: Mapping[str, Any]) -> bool:
+    """True when the event has an acquirer and no Form D detail."""
+    return bool(event.get("acquirer")) and not event.get("form_d_detail")
+
+
+def query_rows_from_events(events: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
+    """Build CSV rows for Form-D-missing events that name an acquirer."""
+    rows: list[dict[str, str]] = []
+    for event in events:
+        if not is_query_candidate(event):
+            continue
+        company_name = event.get("company_name")
+        acquirer = event.get("acquirer")
+        for query in generate_queries(company_name, acquirer):
+            rows.append(
+                {
+                    "company_name": str(company_name),
+                    "acquirer": str(acquirer),
+                    "query": query,
+                }
+            )
+    return rows
+
+
+def load_ma_events(path: Path) -> list[dict[str, Any]]:
+    """Load JSONL M&A event rows, skipping malformed lines."""
+    events: list[dict[str, Any]] = []
+    with path.open() as handle:
+        for line in handle:
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+def write_query_csv(path: Path, rows: Sequence[Mapping[str, str]]) -> None:
+    """Write ``company_name,acquirer,query`` rows to ``path``."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(QUERY_CSV_FIELDS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row[field] for field in QUERY_CSV_FIELDS})
+
+
+def build_query_csv(events: Iterable[Mapping[str, Any]], output_path: Path) -> int:
+    """Select candidates, generate queries, and write a CSV. Return row count."""
+    rows = query_rows_from_events(events)
+    write_query_csv(output_path, rows)
+    return len(rows)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate M&A search-query CSV rows")
+    parser.add_argument("--input", type=Path, default=DEFAULT_EVENTS_PATH)
+    parser.add_argument("--output", type=Path, default=DEFAULT_QUERIES_PATH)
+    args = parser.parse_args(argv)
+    events = load_ma_events(args.input)
+    count = build_query_csv(events, args.output)
+    print(f"Wrote {count} queries to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sbir_etl/enrichers/ma_discovery/search.py
+++ b/sbir_etl/enrichers/ma_discovery/search.py
@@ -1,0 +1,31 @@
+"""Pluggable search interface for M&A discovery.
+
+Real search-API clients (Tavily / Brave / Bing) are out of scope here.
+``MockSearchTool`` is the Physical Optics / Mercury Systems fixture used
+by tests and the optional CLI.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class SearchTool(Protocol):
+    async def search(self, query: str) -> list[dict[str, Any]]: ...
+
+
+class MockSearchTool:
+    """In-memory fixture that confirms Physical Optics / Mercury Systems."""
+
+    async def search(self, query: str) -> list[dict[str, Any]]:
+        if "Physical Optics" in query and "Mercury Systems" in query:
+            return [
+                {
+                    "snippet": (
+                        "Mercury Systems announced the acquisition of "
+                        "Physical Optics Corporation."
+                    ),
+                    "link": "http://example.com",
+                }
+            ]
+        return []

--- a/sbir_etl/enrichers/ma_discovery/search.py
+++ b/sbir_etl/enrichers/ma_discovery/search.py
@@ -22,8 +22,7 @@ class MockSearchTool:
             return [
                 {
                     "snippet": (
-                        "Mercury Systems announced the acquisition of "
-                        "Physical Optics Corporation."
+                        "Mercury Systems announced the acquisition of Physical Optics Corporation."
                     ),
                     "link": "http://example.com",
                 }

--- a/sbir_etl/enrichers/ma_discovery/verifier.py
+++ b/sbir_etl/enrichers/ma_discovery/verifier.py
@@ -1,0 +1,41 @@
+"""Heuristic verifier for M&A acquisition signals in text snippets.
+
+Both names must appear in the text and a recognized acquisition verb must
+be present. Date extraction is out of scope for this heuristic (always
+``"Unknown"`` on confirm). An LLM extractor is a later replacement.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class VerificationResult(TypedDict):
+    confirmed: bool
+    date: str | None
+    value: float | None
+    reason: str
+
+
+def verify_acquisition(company: str, acquirer: str, snippet: str) -> VerificationResult:
+    """Return whether ``snippet`` confirms ``company`` was acquired by ``acquirer``."""
+    text = snippet.lower()
+    c = company.lower()
+    a = acquirer.lower()
+
+    keywords = ["acquired", "acquisition", "bought", "merger", "merged", "purchase"]
+
+    if c in text and a in text and any(k in text for k in keywords):
+        return {
+            "confirmed": True,
+            "date": "Unknown",  # LLM would extract; heuristic cannot
+            "value": None,
+            "reason": "Confirmed via keyword match",
+        }
+
+    return {
+        "confirmed": False,
+        "date": None,
+        "value": None,
+        "reason": "No clear acquisition signal found",
+    }

--- a/specs/ma-discovery-integration/design.md
+++ b/specs/ma-discovery-integration/design.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft for review.
 **Date:** 2026-06-26.
-**Relates to:** [`specs/archive/completed-features/merger_acquisition_detection/`](../archive/completed-features/merger_acquisition_detection/design.md) (existing Form D + EFTS detection), [`sbir_etl/capital_events/sources/ma_events.py`](../../sbir_etl/capital_events/sources/ma_events.py) (downstream consumer), and the unmerged toolkit scaffold preserved in draft PR [#371](https://github.com/hollomancer/sbir-analytics/pull/371).
+**Relates to:** [`specs/archive/completed-features/merger_acquisition_detection/`](../archive/completed-features/merger_acquisition_detection/design.md) (existing Form D + EFTS detection), [`sbir_etl/capital_events/sources/ma_events.py`](../../sbir_etl/capital_events/sources/ma_events.py) (downstream consumer), and the toolkit now at [`sbir_etl/enrichers/ma_discovery/`](../../sbir_etl/enrichers/ma_discovery/) (relocated from draft PR [#371](https://github.com/hollomancer/sbir-analytics/pull/371); issue [#446](https://github.com/hollomancer/sbir-analytics/issues/446)).
 
 ## Why
 
@@ -14,16 +14,16 @@ A web-search-based discovery path can recover some of those, but only if the row
 
 The capital-events builder at `sbir_etl/capital_events/sources/ma_events.py:13-55` reads `data/enriched_sbir_ma_events.jsonl` and filters on `confidence in {"high", "medium"}` (string tier, not a numeric score). The pipeline shape is fixed; discovery must conform to it.
 
-Note: `detect_sbir_ma_events.py` writes `data/sbir_ma_events.jsonl`; the builder reads `data/enriched_sbir_ma_events.jsonl`. **No committed script produces the enriched file** — the press-wire enrichment step (`SyncPressWireClient` in `sbir_etl/enrichers/press_wire.py`) exists as a library but is not wired into a standalone CLI. The diagram below treats `enrich_ma_with_press.py` as a **to-be-added** component; discovery integration assumes this enrichment glue lands as part of (or before) the discovery implementation PR.
+Note: `detect_sbir_ma_events.py` writes `data/sbir_ma_events.jsonl`; the builder reads `data/enriched_sbir_ma_events.jsonl`. Press-wire enrichment lives at `sbir_etl.enrichers.ma_discovery.press` and wraps `SyncPressWireClient`. Discovery integration still assumes that glue runs before the builder.
 
 **Adopted: option C with collision rule C3.**
 
 ```
 detect_sbir_ma_events.py ─► sbir_ma_events.jsonl ─┐
-                                                  ├─► [TODO] enrich_ma_with_press.py ─► enriched_sbir_ma_events.jsonl ─► capital_events.parquet (MA_EVENT)
-ma_discovery_orchestrator ────────────────────────┘                                     ▲
-       ▲                                                                                │
-       └── runs only on Form-D-missing rows surfaced by detect_sbir_ma_events           └── filter: confidence in {high, medium}
+                                                  ├─► ma_discovery.press ─► enriched_sbir_ma_events.jsonl ─► capital_events.parquet (MA_EVENT)
+ma_discovery.orchestrator ────────────────────────┘                          ▲
+       ▲                                                                     │
+       └── runs only on Form-D-missing rows surfaced by detect_sbir_ma_events └── filter: confidence in {high, medium}
 ```
 
 Discovery is a candidate-expansion step that fires only for firms detect_sbir_ma_events emitted *without* Form D backing. Its output joins `sbir_ma_events.jsonl` before press enrichment, so discovered rows pick up press-wire signals the same way Form D-backed rows do. Until the press-enrichment CLI is wired up, discovery output can be concatenated directly into `enriched_sbir_ma_events.jsonl` (the file the builder reads); the field contract is the same.
@@ -89,7 +89,7 @@ class MAEvent(BaseModel):
 ## Out of scope for v1
 
 - Auto-tuning the confidence thresholds against a labeled set. Use the boundary thresholds above and revisit after the first manual run.
-- Press-release scraping beyond the existing `SyncPressWireClient` (in `sbir_etl/enrichers/press_wire.py`). The to-be-added `enrich_ma_with_press.py` CLI is expected to wrap this client and stay in the pipeline as a sibling step.
+- Press-release scraping beyond the existing `SyncPressWireClient` (in `sbir_etl/enrichers/press_wire.py`). `sbir_etl.enrichers.ma_discovery.press` wraps this client and stays in the pipeline as a sibling step.
 - Discovery for non-Form-D-missing firms ("would discovery surface a *better* signal for a row Form D already covered?"). Adds cost without clearly improving recall.
 - A graph loader for discovered M&A events. They flow into `capital_events.parquet` like every other source; the Neo4j path picks them up at the existing `MAEventLoader`.
 
@@ -107,7 +107,7 @@ These are choices the design intentionally does *not* pin, because they're indep
 ## Implementation sequencing (after this design is approved)
 
 1. **Fix `MAEvent.confidence`** as a `@computed_field` and align the score-to-tier cutoffs with this design (or replace both with calibrated thresholds). Standalone PR; small, safe, lands first.
-2. **Move toolkit scripts to a module path** (`sbir_etl/enrichers/ma_discovery/`) and fix relative imports. No behavior change.
+2. **Move toolkit scripts to a module path** (`sbir_etl/enrichers/ma_discovery/`) and fix relative imports. No behavior change. Done (issue #446, toolkit relocation).
 3. **Implement a real `SearchTool`** against the chosen backend, with config + credentials in `.env.example` and `OTConsortiumConfig`-style schema entry.
 4. **Replace keyword verifier with LLM extractor.** Structured output: `{matched_company, matched_acquirer, acquisition_date, value_usd, citation_url}`.
 5. **Wire collision-detection / C3 promotion logic** between discovery output and existing `sbir_ma_events.jsonl`.

--- a/specs/status.md
+++ b/specs/status.md
@@ -78,9 +78,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   as the reference adapter, and `usaspending_refresh_batch` on the job.
   Per-source adapters stay split (#443 NIH RePORTER, then SAM/PatentsView).
   Tasks 6.1–6.2 remain optional Phase 2 expansion.
-- **`ma-discovery-integration` — Deferred.** The design depends on an unmerged
-  discovery toolkit and missing press-enrichment glue. Revisit only when M&A
-  recall becomes a selected research priority.
+- **`ma-discovery-integration` — Deferred.** The #371 toolkit now lives at
+  `sbir_etl/enrichers/ma_discovery/` (issue #446, toolkit relocation). Search
+  backend, LLM extractor, and collision policy remain unbuilt. Revisit only
+  when M&A recall becomes a selected research priority.
 - **`modular-analysis-platform` — Maintenance.** Pipelines-tier contracts
   and registry so a new tech-census or transition-cohort profile is
   YAML-only (issue #441). HTTP is out of scope per ADR-004. Weekly awards

--- a/tests/unit/enrichers/ma_discovery/test_orchestrator.py
+++ b/tests/unit/enrichers/ma_discovery/test_orchestrator.py
@@ -1,0 +1,41 @@
+"""Tests for the M&A discovery orchestrator."""
+
+from __future__ import annotations
+
+import pytest
+
+from sbir_etl.enrichers.ma_discovery.orchestrator import process_batch
+from sbir_etl.enrichers.ma_discovery.search import MockSearchTool
+
+
+pytestmark = pytest.mark.fast
+
+
+@pytest.mark.asyncio
+async def test_process_batch_confirms_physical_optics_mercury_systems() -> None:
+    queries = [
+        {
+            "company_name": "Physical Optics Corporation",
+            "acquirer": "Mercury Systems",
+            "query": '"Physical Optics" acquired by "Mercury Systems" press release',
+        }
+    ]
+    verified = await process_batch(queries, MockSearchTool())
+    assert len(verified) == 1
+    assert verified[0]["company_name"] == "Physical Optics Corporation"
+    assert verified[0]["acquirer"] == "Mercury Systems"
+    assert verified[0]["date"] == "Unknown"
+    assert verified[0]["source"] == "http://example.com"
+
+
+@pytest.mark.asyncio
+async def test_process_batch_rejects_unrelated_query() -> None:
+    queries = [
+        {
+            "company_name": "Unrelated Labs",
+            "acquirer": "Other Holdings",
+            "query": "unrelated labs other holdings",
+        }
+    ]
+    verified = await process_batch(queries, MockSearchTool())
+    assert verified == []

--- a/tests/unit/enrichers/ma_discovery/test_press.py
+++ b/tests/unit/enrichers/ma_discovery/test_press.py
@@ -31,9 +31,7 @@ def test_enrich_ma_events_merges_mocked_poll_hit() -> None:
 
     enriched = enrich_ma_events(events, client)
 
-    client.set_watchlist.assert_called_once_with(
-        ["Physical Optics Corporation", "Unrelated Labs"]
-    )
+    client.set_watchlist.assert_called_once_with(["Physical Optics Corporation", "Unrelated Labs"])
     client.poll.assert_called_once_with()
 
     matched, other = enriched

--- a/tests/unit/enrichers/ma_discovery/test_press.py
+++ b/tests/unit/enrichers/ma_discovery/test_press.py
@@ -1,0 +1,53 @@
+"""Tests for press-wire merge onto M&A events."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from sbir_etl.enrichers.ma_discovery.press import enrich_ma_events
+from sbir_etl.enrichers.press_wire import PressRelease
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_enrich_ma_events_merges_mocked_poll_hit() -> None:
+    events = [
+        {"company_name": "Physical Optics Corporation", "signal_count": 1},
+        {"company_name": "Unrelated Labs"},
+    ]
+    hit = PressRelease(
+        title="Mercury Systems Completes Acquisition of Physical Optics",
+        link="http://example.com/poc",
+        published="2018-01-01",
+        summary="Mercury Systems announced the acquisition.",
+        source="PRNewswire",
+        matched_company="Physical Optics Corporation",
+    )
+    client = Mock()
+    client.poll.return_value = [hit]
+
+    enriched = enrich_ma_events(events, client)
+
+    client.set_watchlist.assert_called_once_with(
+        ["Physical Optics Corporation", "Unrelated Labs"]
+    )
+    client.poll.assert_called_once_with()
+
+    matched, other = enriched
+    assert matched["enriched"] is True
+    assert matched["signal_count"] == 2
+    assert matched["press_wire_signals"] == [
+        {
+            "title": hit.title,
+            "link": hit.link,
+            "published": hit.published,
+            "summary": hit.summary,
+            "source": hit.source,
+        }
+    ]
+    assert other["enriched"] is False
+    assert other["press_wire_signals"] == []
+    assert "signal_count" not in other

--- a/tests/unit/enrichers/ma_discovery/test_queries.py
+++ b/tests/unit/enrichers/ma_discovery/test_queries.py
@@ -1,0 +1,81 @@
+"""Tests for M&A search-query generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sbir_etl.enrichers.ma_discovery.queries import (
+    build_query_csv,
+    generate_queries,
+    query_rows_from_events,
+)
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_generate_queries_empty_names_return_nothing() -> None:
+    assert generate_queries(None, "Mercury Systems") == []
+    assert generate_queries("Physical Optics", None) == []
+    assert generate_queries("", "Mercury Systems") == []
+    assert generate_queries("Physical Optics", "") == []
+    assert generate_queries("Inc.", "LLC") == []
+
+
+def test_generate_queries_uses_suffix_stripped_identity_names() -> None:
+    company = "Physical Optics Corporation"
+    acquirer = "Mercury Systems, Inc."
+    queries = generate_queries(company, acquirer)
+
+    cleaned_company = normalize_company_name(company, profile=CompanyNameProfile.RECIPIENT_V1)
+    cleaned_acquirer = normalize_company_name(acquirer, profile=CompanyNameProfile.RECIPIENT_V1)
+    assert cleaned_company == "physical optics"
+    assert cleaned_acquirer == "mercury systems"
+    assert len(queries) == 4
+
+    blob = " ".join(queries)
+    assert cleaned_company in blob
+    assert cleaned_acquirer in blob
+    assert "corporation" not in blob
+    assert "inc" not in blob
+    assert company not in blob
+    assert acquirer not in blob
+
+
+def test_query_rows_only_include_acquirer_without_form_d(tmp_path: Path) -> None:
+    events = [
+        {
+            "company_name": "Physical Optics Corporation",
+            "acquirer": "Mercury Systems, Inc.",
+        },
+        {
+            "company_name": "Form D Firm Inc",
+            "acquirer": "Big Buyer Corp",
+            "form_d_detail": {"accession": "0001"},
+        },
+        {
+            "company_name": "No Buyer LLC",
+            "acquirer": None,
+        },
+        {
+            "company_name": "Empty Buyer LLC",
+            "acquirer": "",
+        },
+    ]
+
+    rows = query_rows_from_events(events)
+    assert {row["company_name"] for row in rows} == {"Physical Optics Corporation"}
+    assert all(row["acquirer"] == "Mercury Systems, Inc." for row in rows)
+    assert len(rows) == 4
+    assert all("query" in row and row["query"] for row in rows)
+
+    output = tmp_path / "ma_search_queries.csv"
+    written = build_query_csv(events, output)
+    assert written == 4
+    text = output.read_text()
+    assert "Physical Optics Corporation" in text
+    assert "Form D Firm Inc" not in text
+    assert "No Buyer LLC" not in text

--- a/tests/unit/enrichers/ma_discovery/test_verifier.py
+++ b/tests/unit/enrichers/ma_discovery/test_verifier.py
@@ -1,0 +1,41 @@
+"""Tests for the keyword M&A verifier."""
+
+from __future__ import annotations
+
+import pytest
+
+from sbir_etl.enrichers.ma_discovery.verifier import verify_acquisition
+
+
+pytestmark = pytest.mark.fast
+
+
+def test_verify_acquisition_confirms_when_names_and_verb_present() -> None:
+    result = verify_acquisition(
+        "Physical Optics",
+        "Mercury Systems",
+        "Mercury Systems announced the acquisition of Physical Optics Corporation.",
+    )
+    assert result["confirmed"] is True
+    assert result["date"] == "Unknown"
+    assert result["value"] is None
+
+
+def test_verify_acquisition_rejects_when_verb_missing() -> None:
+    result = verify_acquisition(
+        "Physical Optics",
+        "Mercury Systems",
+        "Mercury Systems and Physical Optics announced a joint research contract.",
+    )
+    assert result["confirmed"] is False
+    assert result["date"] is None
+
+
+def test_verify_acquisition_rejects_when_a_name_is_missing() -> None:
+    result = verify_acquisition(
+        "Physical Optics",
+        "Mercury Systems",
+        "Mercury Systems announced the acquisition of an unnamed optics firm.",
+    )
+    assert result["confirmed"] is False
+    assert result["date"] is None


### PR DESCRIPTION
Closes nothing yet; this is step 1 of 3 for #446 (move → search tools → LLM eval).

Relocates the paused #371 toolkit into `sbir_etl/enrichers/ma_discovery/` as an importable, tested pipelines-tier module. Company-name cleaning now goes through `sbir_etl.identity` with `CompanyNameProfile.RECIPIENT_V1`. Press enrichment wraps the existing `SyncPressWireClient` and is mocked in tests.

Deliberately out of scope:
- no search-API client (Tavily/Brave/Bing)
- no LLM extractor (`verify_acquisition` stays the keyword heuristic)
- no `MAEvent.confidence` rewrite
- no live network, Dagster assets, or schedules

The `ma-discovery-integration` spec remains **Deferred**. This PR only notes that the toolkit now lives at the new package path.