### PR TITLE
chore: prepare release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ version.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-08-19
+
+### Added
+
+- Importable M&A discovery toolkit at `sbir_etl.enrichers.ma_discovery`
+  (query generation, keyword verifier, mock search, press-wire merge, and
+  optional CLIs). Name cleaning goes through `sbir_etl.identity`. Search
+  backends and the LLM extractor are not in this release (#661).
+
+### Changed
+
+- `make ci-local` now reproduces pull-request CI (lint, guards, Dagster
+  validate, compose, Bandit, pinned `detect-secrets`, unit `-m "not slow"`,
+  hermetic e2e) instead of the post-merge coverage suite (#660).
+- Phase III PR canary no longer claims to be the ≥85% HIGH-precision
+  benchmark. A mixed-signal slice fails if retrospective weights are
+  swapped; the S3-corpus number stays a manual run (#660).
+
 ## [0.8.0] — 2026-08-18
 
 ### Added
@@ -266,7 +284,8 @@ across the root project and the three packages under `packages/`.
 `vMAJOR.MINOR.PATCH` form it requires. Per that policy published tags are never
 moved or reused, so they remain as historical markers.
 
-[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/hollomancer/sbir-analytics/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.1...v0.8.0
 [0.7.1]: https://github.com/hollomancer/sbir-analytics/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/hollomancer/sbir-analytics/compare/v0.6.0...v0.7.0

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.8.0"
+  version: "0.9.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.8.0"
+version = "0.9.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.8.0"
+version = "0.9.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.8.0"
+version = "0.9.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.8.0"
+version = "0.9.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/uv.lock
+++ b/uv.lock
@@ -2823,7 +2823,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2847,7 +2847,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -3001,7 +3001,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3020,7 +3020,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Description

Prepare synchronized release **v0.9.0**.

**Increment:** MINOR (`0.8.0` → `0.9.0`). Largest required bump since `v0.8.0` is the new importable `sbir_etl.enrichers.ma_discovery` surface (#661). `#660` is CI/docs hygiene and does not add a compatibility surface.

`uv run python scripts/ci/check_versioning.py --tag v0.9.0` passed locally.

The annotated tag and GitHub release will be created on the squash-merge commit, not this branch tip.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [ ] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [x] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

`uv run python scripts/ci/check_versioning.py --tag v0.9.0` — passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes