### PR TITLE
Add a weekly literature-map refresh (OpenAlex + grey RSS)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,7 @@ USPTO_ODP_API_KEY=
 # BEA API Key (required for fiscal analysis I-O tables)
 # Register at https://apps.bea.gov/API/signup/
 BEA_API_KEY=
+
+# OpenAlex polite-pool contact (optional). Used by author lookup and the
+# weekly literature-map refresh. No key required; mailto gets a better rate limit.
+OPENALEX_MAILTO=

--- a/.github/workflows/literature-map.yml
+++ b/.github/workflows/literature-map.yml
@@ -1,0 +1,66 @@
+name: Literature map
+
+# Weekly OpenAlex refresh of docs/research/literature-map/sbir_literature_map.csv.
+# Opens a PR when the CSV or refresh_status.md change. Does not push to main
+# and does not rewrite authored memos. Exploratory; not a citable update.
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    # Monday 09:17 UTC — distinct from Saturday's ci.yml full suite.
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: literature-map
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh OpenAlex literature map
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Python and UV
+        uses: ./.github/actions/setup-python-uv
+        with:
+          python-version: "3.11"
+          install-dev-deps: "true"
+
+      - name: Refresh the map
+        env:
+          OPENALEX_MAILTO: ${{ secrets.OPENALEX_MAILTO }}
+        run: uv run python scripts/data/update_literature_map.py
+
+      - name: Open or update a refresh PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/literature-map-refresh
+          delete-branch: true
+          commit-message: |
+            chore: refresh SBIR literature map from OpenAlex
+
+            Weekly OpenAlex metadata refresh and deterministic intake of new
+            core/adjacent works. Authored memos are unchanged.
+          title: "chore: refresh SBIR literature map from OpenAlex"
+          body: |
+            Automated weekly refresh of `docs/research/literature-map/sbir_literature_map.csv`
+            and `refresh_status.md` from the OpenAlex works API.
+
+            Existing rows keep their stored relevance/area labels; citation counts and
+            bibliographic fields are updated. New works are classified with title
+            keywords only (exploratory, not an LLM re-score).
+
+            `sbir_literature_map.md` and `citation_gap_memo.md` are **not** rewritten.
+            Review new rows before merging. This does not change study Status or
+            `[L#]` entries.
+
+            Trigger: schedule (Monday 09:17 UTC) or `workflow_dispatch`.
+          add-paths: |
+            docs/research/literature-map/sbir_literature_map.csv
+            docs/research/literature-map/refresh_status.md

--- a/.github/workflows/literature-map.yml
+++ b/.github/workflows/literature-map.yml
@@ -1,8 +1,9 @@
 name: Literature map
 
-# Weekly OpenAlex refresh of docs/research/literature-map/sbir_literature_map.csv.
-# Opens a PR when the CSV or refresh_status.md change. Does not push to main
-# and does not rewrite authored memos. Exploratory; not a citable update.
+# Weekly refresh of docs/research/literature-map/sbir_literature_map.csv
+# (OpenAlex journals/NAP books + GAO/NAP/CRS/ITIF RSS). Opens a PR when the
+# CSV or refresh_status.md change. Does not push to main and does not rewrite
+# authored memos. Exploratory; not a citable update.
 
 permissions:
   contents: write
@@ -20,7 +21,7 @@ concurrency:
 
 jobs:
   refresh:
-    name: Refresh OpenAlex literature map
+    name: Refresh literature map
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -43,18 +44,20 @@ jobs:
           branch: chore/literature-map-refresh
           delete-branch: true
           commit-message: |
-            chore: refresh SBIR literature map from OpenAlex
+            chore: refresh SBIR literature map
 
-            Weekly OpenAlex metadata refresh and deterministic intake of new
-            core/adjacent works. Authored memos are unchanged.
-          title: "chore: refresh SBIR literature map from OpenAlex"
+            Weekly OpenAlex metadata refresh, NASEM Press source pull, and
+            GAO/NAP/CRS/ITIF RSS intake. Authored memos are unchanged.
+          title: "chore: refresh SBIR literature map"
           body: |
             Automated weekly refresh of `docs/research/literature-map/sbir_literature_map.csv`
-            and `refresh_status.md` from the OpenAlex works API.
+            and `refresh_status.md` from OpenAlex plus grey-literature RSS/Atom feeds
+            (GAO, National Academies Press, EveryCRSReport, ITIF).
 
             Existing rows keep their stored relevance/area labels; citation counts and
             bibliographic fields are updated. New works are classified with title
-            keywords only (exploratory, not an LLM re-score).
+            keywords only (exploratory, not an LLM re-score). Grey rows without an
+            OpenAlex id use synthetic keys (`gao:…`, `nap:…`, `crs:…`, `itif:…`).
 
             `sbir_literature_map.md` and `citation_gap_memo.md` are **not** rewritten.
             Review new rows before merging. This does not change study Status or

--- a/Makefile
+++ b/Makefile
@@ -178,8 +178,8 @@ test: ## Run all tests
 	$(call run,uv run pytest -v --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-branch --cov-fail-under=70)
 
 .PHONY: literature-map
-literature-map: ## Refresh the OpenAlex literature map (CSV + refresh_status.md)
-	@$(call info,Refreshing literature map from OpenAlex)
+literature-map: ## Refresh the literature map from OpenAlex + grey RSS (CSV + refresh_status.md)
+	@$(call info,Refreshing literature map from OpenAlex and grey-literature feeds)
 	$(call run,uv run python scripts/data/update_literature_map.py)
 
 .PHONY: test-unit

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,11 @@ test: ## Run all tests
 	@$(call info,Running tests)
 	$(call run,uv run pytest -v --cov=sbir_etl --cov=packages/sbir-analytics/sbir_analytics --cov=packages/sbir-ml/sbir_ml --cov=packages/sbir-graph/sbir_graph --cov-branch --cov-fail-under=70)
 
+.PHONY: literature-map
+literature-map: ## Refresh the OpenAlex literature map (CSV + refresh_status.md)
+	@$(call info,Refreshing literature map from OpenAlex)
+	$(call run,uv run python scripts/data/update_literature_map.py)
+
 .PHONY: test-unit
 test-unit: ## Run unit tests only
 	@$(call info,Running unit tests)

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -97,7 +97,8 @@ explain how firms were selected and what the results cannot show.
 ## Research planning and communication
 
 - [Literature map and citation audit](literature-map/README.md) — research published
-  from 2019–2026 and missing coverage across question areas A–F.
+  from 2019–2026 and missing coverage across question areas A–F. The CSV is
+  refreshed weekly from OpenAlex (`make literature-map`); authored memos are not.
 - [Solicitation document and requirement evidence plan](solicitation_document_evidence_plan.md) —
   bounded acquisition, linkage, attachment parsing, and classifier gates for A1 and E5; Phase 1 is
   implemented, but this remains a plan rather than research evidence.

--- a/docs/research/literature-map/README.md
+++ b/docs/research/literature-map/README.md
@@ -35,10 +35,12 @@ connector), covering 2019–2026.
 
 Pooled ~989 OpenAlex works via thematic A–F keyword searches, direct SBIR/STTR searches, and
 forward-citation pulls from two anchor papers (Howell 2017, Myers & Lanahan 2022), then
-machine-classified each for relevance and policy area. OpenAlex covers journals and NBER/SSRN
-working papers well but is thin on the GAO/CSIS/NASEM grey literature that dominates `[L#]` —
-those institutional sources are best tracked directly. Abstracts were largely license-gated;
-thematic summaries rest on titles, venues, topics, and citation context.
+machine-classified each for relevance and policy area. The weekly refresh also pulls National
+Academies Press books from OpenAlex (source `S4306463641`) and recent GAO / NAP / CRS / ITIF
+items from public RSS/Atom feeds, filtered to SBIR/STTR and a short industrial-base/FOCI
+keyword list. CSIS web analysis is still thin in both OpenAlex and CSIS's public RSS (the
+feed is mostly old events); those `[L#]` entries stay hand-tracked. Abstracts were largely
+license-gated; thematic summaries rest on titles, venues, topics, and citation context.
 
 ## Refresh
 
@@ -52,6 +54,13 @@ make literature-map
 That updates `sbir_literature_map.csv` (citation counts and new keyword-classified works)
 and overwrites `refresh_status.md`. It does **not** rewrite this README, `sbir_literature_map.md`,
 or `citation_gap_memo.md`. Existing rows keep their stored relevance/area labels.
+
+Grey-literature rows without an OpenAlex work id use a synthetic key in `openalex_id`
+(`gao:GAO-24-106398`, `nap:29329`, `crs:R43695`, `itif:…`). A later OpenAlex hit with the
+same title or DOI is merged onto that row and the key is upgraded to `W…`. RSS feeds are
+recency windows, not a full corpus — historical GAO/CRS reports already in `[L#]` are not
+backfilled. CRS is read from the unofficial EveryCRSReport mirror. One failed feed does
+not abort the OpenAlex half of the run.
 
 `.github/workflows/literature-map.yml` runs the same command weekly (Monday 09:17 UTC) and
 opens `chore/literature-map-refresh` when those two files change. Optional secret:

--- a/docs/research/literature-map/README.md
+++ b/docs/research/literature-map/README.md
@@ -39,3 +39,22 @@ machine-classified each for relevance and policy area. OpenAlex covers journals 
 working papers well but is thin on the GAO/CSIS/NASEM grey literature that dominates `[L#]` —
 those institutional sources are best tracked directly. Abstracts were largely license-gated;
 thematic summaries rest on titles, venues, topics, and citation context.
+
+## Refresh
+
+The CSV is exploratory. Re-run locally or wait for the Monday GitHub Action:
+
+```bash
+make literature-map
+# or: uv run python scripts/data/update_literature_map.py
+```
+
+That updates `sbir_literature_map.csv` (citation counts and new keyword-classified works)
+and overwrites `refresh_status.md`. It does **not** rewrite this README, `sbir_literature_map.md`,
+or `citation_gap_memo.md`. Existing rows keep their stored relevance/area labels.
+
+`.github/workflows/literature-map.yml` runs the same command weekly (Monday 09:17 UTC) and
+opens `chore/literature-map-refresh` when those two files change. Optional secret:
+`OPENALEX_MAILTO` (OpenAlex polite pool). No API key is required.
+
+The workflow is not a study promotion and does not edit `[L#]` entries.

--- a/docs/testing/test-scheduling.md
+++ b/docs/testing/test-scheduling.md
@@ -8,8 +8,10 @@
 
 **Status**: Active
 
-`.github/workflows/ci.yml` is the repository's only GitHub Actions workflow. In addition to pull
+`.github/workflows/ci.yml` is the quality and test workflow. In addition to pull
 requests and pushes to `main`, it runs a weekly regression suite at 08:17 UTC each Saturday.
+`.github/workflows/literature-map.yml` is a separate Monday job that refreshes the
+OpenAlex literature map and opens a PR when the CSV changes.
 
 ## Pull requests
 

--- a/sbir_etl/enrichers/openalex_client.py
+++ b/sbir_etl/enrichers/openalex_client.py
@@ -200,13 +200,12 @@ class OpenAlexClient(BaseAsyncAPIClient):
         """GET ``/works`` with caller-supplied query params.
 
         Used by the exploratory literature-map refresh. Returns the raw JSON
-        object (``results``, ``meta``). Empty ``results`` on 4xx; propagates
-        :class:`APIError` on 5xx.
+        object (``results``, ``meta``). A 404 is an empty page; other 4xx/5xx
+        errors propagate so malformed filters are not reported as zero hits.
         """
         try:
             return await self._make_request("GET", "works", params=self._with_mailto(params))
         except APIError as e:
-            status = e.details.get("http_status")
-            if status and 400 <= status < 500:
+            if e.details.get("http_status") == 404:
                 return {"results": [], "meta": {}}
             raise

--- a/sbir_etl/enrichers/openalex_client.py
+++ b/sbir_etl/enrichers/openalex_client.py
@@ -195,3 +195,18 @@ class OpenAlexClient(BaseAsyncAPIClient):
             return None
 
         return _parse_author(profile)
+
+    async def search_works(self, params: dict[str, Any]) -> dict[str, Any]:
+        """GET ``/works`` with caller-supplied query params.
+
+        Used by the exploratory literature-map refresh. Returns the raw JSON
+        object (``results``, ``meta``). Empty ``results`` on 4xx; propagates
+        :class:`APIError` on 5xx.
+        """
+        try:
+            return await self._make_request("GET", "works", params=self._with_mailto(params))
+        except APIError as e:
+            status = e.details.get("http_status")
+            if status and 400 <= status < 500:
+                return {"results": [], "meta": {}}
+            raise

--- a/scripts/data/update_literature_map.py
+++ b/scripts/data/update_literature_map.py
@@ -474,6 +474,20 @@ def merge_rows(
     return list(by_id.values()), added
 
 
+async def resolve_doi_work_id(client: OpenAlexClient, doi: str) -> str:
+    """Resolve a DOI to an OpenAlex work id (``W…``).
+
+    The ``cites`` filter only accepts work ids, not ``doi:`` values.
+    """
+    data = await client.search_works({"filter": f"doi:{doi}", "per_page": 1})
+    results = data.get("results") or []
+    first = results[0] if results and isinstance(results[0], dict) else None
+    oid = _last_path_segment((first or {}).get("id")) or ""
+    if not is_openalex_work_id(oid):
+        raise RuntimeError(f"OpenAlex returned no work id for DOI {doi}")
+    return oid
+
+
 async def _works_pages(
     client: OpenAlexClient,
     params: dict[str, Any],
@@ -560,12 +574,13 @@ async def refresh(
             added_total += added
 
         for doi in ANCHOR_DOIS:
+            work_id = await resolve_doi_work_id(client, doi)
             cited = await _works_pages(
                 client,
-                {"filter": f"cites:doi:{doi},{year_filter}"},
+                {"filter": f"cites:{work_id},{year_filter}"},
             )
             parsed = [parse_work(w) for w in cited]
-            query_counts[f"cites:{doi}"] = len(parsed)
+            query_counts[f"cites:{work_id}"] = len(parsed)
             existing, added = merge_rows(existing, parsed)
             added_total += added
 

--- a/scripts/data/update_literature_map.py
+++ b/scripts/data/update_literature_map.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Refresh the committed OpenAlex literature map (exploratory, non-citable).
+
+Epistemic tier: exploratory. Regenerates ``sbir_literature_map.csv`` and a
+machine-written ``refresh_status.md``. Does **not** rewrite the authored
+narrative memos (``sbir_literature_map.md``, ``citation_gap_memo.md``).
+
+Existing rows keep their human/machine relevance and area labels. New works
+are classified with deterministic title keywords only.
+
+Usage::
+
+    uv run python scripts/data/update_literature_map.py
+    uv run python scripts/data/update_literature_map.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import re
+from collections import Counter
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.enrichers.openalex_client import OpenAlexClient, _last_path_segment
+
+EPISTEMIC_TIER = "exploratory"
+
+MAP_COLUMNS = (
+    "relevance",
+    "area",
+    "year",
+    "first_author",
+    "n_authors",
+    "title",
+    "venue",
+    "type",
+    "citations",
+    "fwci",
+    "open_access",
+    "doi",
+    "openalex_id",
+)
+
+DEFAULT_MAP = Path("docs/research/literature-map/sbir_literature_map.csv")
+DEFAULT_STATUS = Path("docs/research/literature-map/refresh_status.md")
+YEAR_START = 2019
+PER_PAGE = 50
+MAX_PAGES_PER_QUERY = 4  # 200 hits/query ceiling for CI
+ID_BATCH = 50
+
+ANCHOR_DOIS = (
+    "10.1257/aer.20150491",  # Howell 2017
+    "10.1257/aer.20201851",  # Myers & Lanahan 2022
+)
+
+# Direct SBIR/STTR searches plus one query per research-question area A–F.
+SEARCH_QUERIES: tuple[tuple[str, str], ...] = (
+    ("direct", "SBIR STTR"),
+    ("direct", '"Small Business Innovation Research"'),
+    ("direct", '"Small Business Technology Transfer"'),
+    ("A", "defense innovation SBIR OR FOCI acquisition small business"),
+    ("B", "SBIR commercialization OR SBIR Phase III"),
+    ("C", "R&D subsidy spillover patent government"),
+    ("D", "SBIR employment jobs public R&D"),
+    ("E", "SBIR evaluation procurement contest"),
+    ("F", "SBIR venture capital entrepreneurial finance"),
+)
+
+CORE_RE = re.compile(
+    r"\bsbir\b|\bsttr\b|small business innovation research|"
+    r"small business technology transfer",
+    re.IGNORECASE,
+)
+AREA_KEYWORDS: dict[str, tuple[str, ...]] = {
+    "A": (
+        "defense",
+        "defence",
+        "foci",
+        "industrial base",
+        "procurement",
+        "military",
+        "national security",
+    ),
+    "B": ("commercializ", "phase iii", "phase 3", "transition", "spinoff", "spin-off"),
+    "C": ("spillover", "patent", "knowledge", "citation"),
+    "D": ("employment", "jobs", "wage", "economic impact", "gdp"),
+    "E": ("evaluat", "contest", "program management", "award mill"),
+    "F": ("venture", "form d", "private capital", "entrepreneurial finance", "ipo"),
+}
+
+
+def parse_work(work: dict[str, Any]) -> dict[str, Any]:
+    """Flatten one OpenAlex work into the map CSV schema (labels empty)."""
+    authorships = work.get("authorships") or []
+    first = ""
+    if authorships:
+        first = str((authorships[0].get("author") or {}).get("display_name") or "")
+    source = (work.get("primary_location") or {}).get("source") or {}
+    doi_raw = work.get("doi") or ""
+    doi = str(doi_raw).replace("https://doi.org/", "").strip()
+    oa = work.get("open_access") or {}
+    fwci = work.get("fwci")
+    year = work.get("publication_year")
+    return {
+        "relevance": "",
+        "area": "",
+        "year": "" if year is None else str(int(year)),
+        "first_author": first,
+        "n_authors": str(len(authorships)),
+        "title": str(work.get("display_name") or work.get("title") or ""),
+        "venue": str(source.get("display_name") or ""),
+        "type": str(work.get("type") or ""),
+        "citations": str(int(work.get("cited_by_count") or 0)),
+        "fwci": "" if fwci is None else str(fwci),
+        "open_access": str(bool(oa.get("is_oa"))),
+        "doi": doi,
+        "openalex_id": _last_path_segment(work.get("id")) or "",
+    }
+
+
+def classify_new_work(title: str, hint_area: str | None = None) -> tuple[str, str] | None:
+    """Return (relevance, area) for a previously unseen work, or None to drop."""
+    text = title or ""
+    if not text.strip():
+        return None
+    is_core = CORE_RE.search(text) is not None
+    hits = {area: sum(1 for kw in kws if kw in text.lower()) for area, kws in AREA_KEYWORDS.items()}
+    scored = [area for area, n in hits.items() if n > 0]
+    if hint_area in AREA_KEYWORDS and hint_area not in scored:
+        scored.append(hint_area)
+    if not is_core and not scored:
+        return None
+    if hint_area in scored:
+        area = hint_area
+    else:
+        area = max(hits, key=lambda a: (hits[a], -ord(a))) if scored else "E"
+    return ("core" if is_core else "adjacent", area)
+
+
+def load_map(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def write_map(path: Path, rows: list[dict[str, str]]) -> None:
+    ordered = sorted(
+        rows,
+        key=lambda r: (
+            r.get("relevance", ""),
+            r.get("area", ""),
+            r.get("year", ""),
+            r.get("openalex_id", ""),
+        ),
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(MAP_COLUMNS), extrasaction="ignore")
+        writer.writeheader()
+        for row in ordered:
+            writer.writerow({col: row.get(col, "") for col in MAP_COLUMNS})
+
+
+def merge_rows(
+    existing: list[dict[str, str]],
+    incoming: list[dict[str, str]],
+    *,
+    hint_area: str | None = None,
+) -> tuple[list[dict[str, str]], int]:
+    """Update metadata for known IDs; append newly classified works."""
+    by_id = {row["openalex_id"]: dict(row) for row in existing if row.get("openalex_id")}
+    added = 0
+    meta_fields = (
+        "year",
+        "first_author",
+        "n_authors",
+        "title",
+        "venue",
+        "type",
+        "citations",
+        "fwci",
+        "open_access",
+        "doi",
+    )
+    for work in incoming:
+        oid = work.get("openalex_id") or ""
+        if not oid:
+            continue
+        if oid in by_id:
+            for field in meta_fields:
+                if work.get(field) not in {None, ""}:
+                    by_id[oid][field] = work[field]
+            continue
+        labels = classify_new_work(work.get("title") or "", hint_area=hint_area)
+        if labels is None:
+            continue
+        relevance, area = labels
+        work["relevance"] = relevance
+        work["area"] = area
+        by_id[oid] = work
+        added += 1
+    return list(by_id.values()), added
+
+
+async def _works_pages(
+    client: OpenAlexClient,
+    params: dict[str, Any],
+    *,
+    max_pages: int = MAX_PAGES_PER_QUERY,
+) -> list[dict[str, Any]]:
+    pages: list[dict[str, Any]] = []
+    cursor = "*"
+    for _ in range(max_pages):
+        payload = dict(params)
+        payload["per_page"] = PER_PAGE
+        payload["cursor"] = cursor
+        data = await client.search_works(payload)
+        results = data.get("results") or []
+        pages.extend(work for work in results if isinstance(work, dict))
+        cursor = (data.get("meta") or {}).get("next_cursor")
+        if not results or not cursor:
+            break
+    return pages
+
+
+async def refresh(
+    *,
+    map_path: Path,
+    status_path: Path,
+    year_end: int,
+    mailto: str | None,
+    dry_run: bool,
+) -> dict[str, Any]:
+    existing = load_map(map_path)
+    year_filter = f"publication_year:{YEAR_START}-{year_end}"
+    query_counts: dict[str, int] = {}
+    added_total = 0
+
+    client = OpenAlexClient(mailto=mailto)
+    try:
+        for hint, query in SEARCH_QUERIES:
+            works = await _works_pages(
+                client,
+                {"search": query, "filter": year_filter},
+            )
+            parsed = [parse_work(w) for w in works]
+            query_counts[f"search:{hint}:{query[:40]}"] = len(parsed)
+            existing, added = merge_rows(
+                existing, parsed, hint_area=hint if hint in AREA_KEYWORDS else None
+            )
+            added_total += added
+
+        for doi in ANCHOR_DOIS:
+            cited = await _works_pages(
+                client,
+                {"filter": f"cites:doi:{doi},{year_filter}"},
+            )
+            parsed = [parse_work(w) for w in cited]
+            query_counts[f"cites:{doi}"] = len(parsed)
+            existing, added = merge_rows(existing, parsed)
+            added_total += added
+
+        known_ids = [row["openalex_id"] for row in existing if row.get("openalex_id")]
+        refreshed = 0
+        for i in range(0, len(known_ids), ID_BATCH):
+            batch = known_ids[i : i + ID_BATCH]
+            joined = "|".join(batch)
+            data = await client.search_works(
+                {"filter": f"openalex_id:{joined}", "per_page": min(len(batch), PER_PAGE)}
+            )
+            parsed = [parse_work(w) for w in (data.get("results") or []) if isinstance(w, dict)]
+            existing, _ = merge_rows(existing, parsed)
+            refreshed += len(parsed)
+    finally:
+        await client.aclose()
+
+    status = {
+        "generated_at": datetime.now(UTC).isoformat(timespec="seconds"),
+        "existing_before": len(load_map(map_path)) if map_path.exists() else 0,
+        "existing_after": len(existing),
+        "new_works_classified": added_total,
+        "ids_refreshed": refreshed,
+        "query_counts": query_counts,
+        "year_window": f"{YEAR_START}-{year_end}",
+    }
+    if not dry_run:
+        write_map(map_path, existing)
+        _write_status(status_path, status, existing)
+    return status
+
+
+def _write_status(path: Path, status: dict[str, Any], rows: list[dict[str, str]]) -> None:
+    counts = Counter((row.get("relevance", ""), row.get("area", "")) for row in rows)
+    lines = [
+        "# Literature map refresh status",
+        "",
+        "Machine-written by `scripts/data/update_literature_map.py`. Exploratory.",
+        "Does not replace `sbir_literature_map.md` or `citation_gap_memo.md`.",
+        "",
+        f"- Generated at: `{status['generated_at']}`",
+        f"- Year window: `{status['year_window']}`",
+        f"- Rows after merge: **{status['existing_after']}**",
+        f"- New works classified this run: **{status['new_works_classified']}**",
+        f"- Existing OpenAlex IDs metadata-refreshed: **{status['ids_refreshed']}**",
+        "",
+        "## Counts by relevance × area",
+        "",
+        "| relevance | area | n |",
+        "|---|---|---|",
+    ]
+    for (relevance, area), n in sorted(counts.items()):
+        lines.append(f"| {relevance} | {area} | {n} |")
+    lines.extend(["", "## Query hit counts", "", "| query | hits |", "|---|---|"])
+    for name, n in status["query_counts"].items():
+        lines.append(f"| `{name}` | {n} |")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("--map", type=Path, default=DEFAULT_MAP)
+    parser.add_argument("--status", type=Path, default=DEFAULT_STATUS)
+    parser.add_argument("--year-end", type=int, default=datetime.now(UTC).year)
+    parser.add_argument(
+        "--mailto", default=None, help="OpenAlex polite-pool email (else OPENALEX_MAILTO)"
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+    status = asyncio.run(
+        refresh(
+            map_path=args.map,
+            status_path=args.status,
+            year_end=args.year_end,
+            mailto=args.mailto,
+            dry_run=args.dry_run,
+        )
+    )
+    print(
+        f"literature map: {status['existing_after']} rows, "
+        f"{status['new_works_classified']} new, "
+        f"{status['ids_refreshed']} refreshed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/update_literature_map.py
+++ b/scripts/data/update_literature_map.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Refresh the committed OpenAlex literature map (exploratory, non-citable).
+"""Refresh the committed literature map (exploratory, non-citable).
 
 Epistemic tier: exploratory. Regenerates ``sbir_literature_map.csv`` and a
 machine-written ``refresh_status.md``. Does **not** rewrite the authored
@@ -7,6 +7,10 @@ narrative memos (``sbir_literature_map.md``, ``citation_gap_memo.md``).
 
 Existing rows keep their human/machine relevance and area labels. New works
 are classified with deterministic title keywords only.
+
+OpenAlex covers journals well and National Academies Press books when they
+are indexed. GAO, CRS, ITIF, and other grey sources are pulled from public
+RSS/Atom feeds and stored under synthetic ids (``gao:…``, ``nap:…``, …).
 
 Usage::
 
@@ -20,10 +24,17 @@ import argparse
 import asyncio
 import csv
 import re
+import sys
+import xml.etree.ElementTree as ET
 from collections import Counter
 from datetime import UTC, datetime
+from email.utils import parsedate_to_datetime
+from html import unescape
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
+from urllib.parse import urlparse
+
+import httpx
 
 from sbir_etl.enrichers.openalex_client import OpenAlexClient, _last_path_segment
 
@@ -51,6 +62,9 @@ YEAR_START = 2019
 PER_PAGE = 50
 MAX_PAGES_PER_QUERY = 4  # 200 hits/query ceiling for CI
 ID_BATCH = 50
+USER_AGENT = (
+    "sbir-analytics-literature-map (https://github.com/hollomancer/sbir-analytics; exploratory)"
+)
 
 ANCHOR_DOIS = (
     "10.1257/aer.20150491",  # Howell 2017
@@ -70,9 +84,72 @@ SEARCH_QUERIES: tuple[tuple[str, str], ...] = (
     ("F", "SBIR venture capital entrepreneurial finance"),
 )
 
+# OpenAlex source ids for grey publishers that actually index SBIR titles.
+# NASEM Press eBooks: S4306463641. GAO/CRS/CSIS/ITIF have no usable recent
+# SBIR coverage in OpenAlex (checked 2026-08); those use RSS instead.
+OPENALEX_SOURCE_QUERIES: tuple[tuple[str, str, str], ...] = (("E", "NASEM", "S4306463641"),)
+
+
+class RssSource(NamedTuple):
+    prefix: str
+    venue: str
+    hint_area: str
+    url: str
+    first_author: str
+    work_type: str
+
+
+RSS_SOURCES: tuple[RssSource, ...] = (
+    RssSource(
+        prefix="gao",
+        venue="U.S. Government Accountability Office",
+        hint_area="E",
+        url="https://www.gao.gov/rss/reports.xml",
+        first_author="GAO",
+        work_type="report",
+    ),
+    RssSource(
+        prefix="nap",
+        venue="National Academies Press",
+        hint_area="E",
+        url="https://nap.nationalacademies.org/rss/",
+        first_author="NASEM",
+        work_type="book",
+    ),
+    RssSource(
+        prefix="crs",
+        venue="Congressional Research Service",
+        hint_area="E",
+        url="https://www.everycrsreport.com/rss.xml",
+        first_author="CRS",
+        work_type="report",
+    ),
+    RssSource(
+        prefix="itif",
+        venue="Information Technology and Innovation Foundation",
+        hint_area="D",
+        url="https://itif.org/feed",
+        first_author="ITIF",
+        work_type="report",
+    ),
+)
+
 CORE_RE = re.compile(
     r"\bsbir\b|\bsttr\b|small business innovation research|"
-    r"small business technology transfer",
+    r"small business technology transfer|"
+    r"small business research program",
+    re.IGNORECASE,
+)
+# RSS feeds are unfiltered institutional streams; keep only SBIR-adjacent titles.
+GREY_KEEP_RE = re.compile(
+    r"\bsbir\b|\bsttr\b|"
+    r"small business innovation research|"
+    r"small business technology transfer|"
+    r"small business research program|"
+    r"\bphase iii\b|"
+    r"\bfoci\b|foreign ownership|"
+    r"defense industrial base|defence industrial base|"
+    r"award mill",
     re.IGNORECASE,
 )
 AREA_KEYWORDS: dict[str, tuple[str, ...]] = {
@@ -91,6 +168,18 @@ AREA_KEYWORDS: dict[str, tuple[str, ...]] = {
     "E": ("evaluat", "contest", "program management", "award mill"),
     "F": ("venture", "form d", "private capital", "entrepreneurial finance", "ipo"),
 }
+_HTML_RE = re.compile(r"<[^>]+>")
+_WS_RE = re.compile(r"\s+")
+_OPENALEX_WORK_ID_RE = re.compile(r"^W\d+$")
+
+
+def is_openalex_work_id(oid: str) -> bool:
+    return _OPENALEX_WORK_ID_RE.fullmatch(oid or "") is not None
+
+
+def openalex_ids_for_refresh(rows: list[dict[str, str]]) -> list[str]:
+    """IDs that OpenAlex can resolve; skip synthetic grey keys (gao:, nap:, …)."""
+    return [row["openalex_id"] for row in rows if is_openalex_work_id(row.get("openalex_id") or "")]
 
 
 def parse_work(work: dict[str, Any]) -> dict[str, Any]:
@@ -141,6 +230,132 @@ def classify_new_work(title: str, hint_area: str | None = None) -> tuple[str, st
     return ("core" if is_core else "adjacent", area)
 
 
+def _plain(text: str) -> str:
+    return _WS_RE.sub(" ", _HTML_RE.sub(" ", unescape(text or ""))).strip()
+
+
+def parse_feed_year(raw: str) -> str:
+    """Year from RSS pubDate or Atom published/updated; empty if unparseable."""
+    text = (raw or "").strip()
+    if not text:
+        return ""
+    try:
+        return str(parsedate_to_datetime(text).year)
+    except (TypeError, ValueError, OverflowError):
+        pass
+    try:
+        return str(datetime.fromisoformat(text).year)
+    except ValueError:
+        pass
+    match = re.search(r"(?:19|20)\d{2}", text)
+    return match.group(0) if match else ""
+
+
+def synthetic_id(prefix: str, link: str, title: str) -> str:
+    """Stable grey-literature key stored in the openalex_id column."""
+    if prefix == "gao":
+        match = re.search(r"gao-\d{2}-\d+", link, re.I)
+        if match:
+            return f"gao:{match.group(0).upper()}"
+    if prefix == "crs":
+        match = re.search(r"/reports/([A-Za-z]{1,3}\d+)\.html", link)
+        if match:
+            return f"crs:{match.group(1).upper()}"
+    if prefix == "nap":
+        match = re.search(r"/catalog/(\d+)", link)
+        if match:
+            return f"nap:{match.group(1)}"
+    slug = urlparse(link).path.rstrip("/").rsplit("/", 1)[-1]
+    slug = re.sub(r"[^a-z0-9-]+", "-", slug.lower()).strip("-")[:80]
+    if not slug:
+        slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")[:80]
+    return f"{prefix}:{slug or 'unknown'}"
+
+
+def _local_tag(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def parse_feed(xml_text: str) -> list[dict[str, str]]:
+    """Parse RSS 2.0 or Atom XML into title/link/description/published dicts."""
+    text = xml_text.lstrip("\ufeff")
+    text = re.sub(r"^<\?xml[^?]*\?>", "", text, count=1).lstrip()
+    root = ET.fromstring(text)
+    return [_parse_feed_entry(el) for el in root.iter() if _local_tag(el.tag) in {"item", "entry"}]
+
+
+def _parse_feed_entry(el: ET.Element) -> dict[str, str]:
+    fields = {
+        "title": "",
+        "link": "",
+        "description": "",
+        "published": "",
+        "guid": "",
+        "creator": "",
+    }
+    for child in el:
+        local = _local_tag(child.tag)
+        text = (child.text or "").strip()
+        if local == "title" and text:
+            fields["title"] = text
+        elif local == "link":
+            href = (child.attrib.get("href") or text).strip()
+            rel = child.attrib.get("rel", "alternate")
+            if href and (not fields["link"] or rel == "alternate"):
+                fields["link"] = href
+        elif local in {"description", "summary", "content"} and text:
+            if not fields["description"]:
+                fields["description"] = text
+        elif local in {"pubDate", "published", "updated", "date"} and text:
+            if not fields["published"]:
+                fields["published"] = text
+        elif local in {"guid", "id"} and text:
+            fields["guid"] = text
+        elif local in {"creator", "author"}:
+            name = text
+            if not name:
+                for sub in child:
+                    if _local_tag(sub.tag) == "name" and (sub.text or "").strip():
+                        name = sub.text.strip()
+                        break
+            if name and not fields["creator"]:
+                fields["creator"] = name
+    return fields
+
+
+def feed_entry_to_row(entry: dict[str, str], source: RssSource) -> dict[str, str] | None:
+    """Classify one RSS/Atom entry; drop off-topic or pre-window items."""
+    title = _plain(entry.get("title") or "")
+    # Title only: GAO abstracts often mention "defense industrial base" in passing.
+    if not title or GREY_KEEP_RE.search(title) is None:
+        return None
+    year = parse_feed_year(entry.get("published") or "")
+    if year and int(year) < YEAR_START:
+        return None
+    labels = classify_new_work(title)
+    if labels is None:
+        area = source.hint_area if source.hint_area in AREA_KEYWORDS else "E"
+        labels = ("adjacent", area)
+    link = entry.get("link") or ""
+    first = (entry.get("creator") or "").strip() or source.first_author
+    relevance, area = labels
+    return {
+        "relevance": relevance,
+        "area": area,
+        "year": year,
+        "first_author": first,
+        "n_authors": "1",
+        "title": title,
+        "venue": source.venue,
+        "type": source.work_type,
+        "citations": "",
+        "fwci": "",
+        "open_access": "True",
+        "doi": "",
+        "openalex_id": synthetic_id(source.prefix, link, title),
+    }
+
+
 def load_map(path: Path) -> list[dict[str, str]]:
     with path.open(newline="", encoding="utf-8") as handle:
         return list(csv.DictReader(handle))
@@ -164,14 +379,45 @@ def write_map(path: Path, rows: list[dict[str, str]]) -> None:
             writer.writerow({col: row.get(col, "") for col in MAP_COLUMNS})
 
 
+def _norm_doi(value: str | None) -> str:
+    return (value or "").replace("https://doi.org/", "").strip().lower()
+
+
+def _norm_title(value: str | None) -> str:
+    return _WS_RE.sub(" ", (value or "").strip().lower())
+
+
 def merge_rows(
     existing: list[dict[str, str]],
     incoming: list[dict[str, str]],
     *,
     hint_area: str | None = None,
 ) -> tuple[list[dict[str, str]], int]:
-    """Update metadata for known IDs; append newly classified works."""
-    by_id = {row["openalex_id"]: dict(row) for row in existing if row.get("openalex_id")}
+    """Update metadata for known IDs; append newly classified works.
+
+    Dedupes on OpenAlex/synthetic id, DOI, and normalized title so a later
+    OpenAlex hit can attach to a grey RSS stub without creating a second row.
+    """
+    by_id: dict[str, dict[str, str]] = {}
+    doi_index: dict[str, str] = {}
+    title_index: dict[str, str] = {}
+
+    def remember(row: dict[str, str]) -> None:
+        oid = row.get("openalex_id") or ""
+        if not oid:
+            return
+        by_id[oid] = row
+        doi = _norm_doi(row.get("doi"))
+        if doi:
+            doi_index[doi] = oid
+        title = _norm_title(row.get("title"))
+        if title:
+            title_index[title] = oid
+
+    for row in existing:
+        if row.get("openalex_id"):
+            remember(dict(row))
+
     added = 0
     meta_fields = (
         "year",
@@ -186,21 +432,44 @@ def merge_rows(
         "doi",
     )
     for work in incoming:
+        work = dict(work)
         oid = work.get("openalex_id") or ""
         if not oid:
             continue
-        if oid in by_id:
+        doi = _norm_doi(work.get("doi"))
+        title = _norm_title(work.get("title"))
+        target = oid if oid in by_id else None
+        if target is None and doi:
+            target = doi_index.get(doi)
+        if target is None and title:
+            target = title_index.get(title)
+        if target is not None:
+            stored = by_id[target]
+            fill_blanks_only = not is_openalex_work_id(oid) and is_openalex_work_id(target)
             for field in meta_fields:
-                if work.get(field) not in {None, ""}:
-                    by_id[oid][field] = work[field]
+                value = work.get(field)
+                if value in {None, ""}:
+                    continue
+                if fill_blanks_only and stored.get(field) not in {None, ""}:
+                    continue
+                stored[field] = value
+            if is_openalex_work_id(oid) and not is_openalex_work_id(target):
+                stored["openalex_id"] = oid
+                del by_id[target]
+                remember(stored)
             continue
-        labels = classify_new_work(work.get("title") or "", hint_area=hint_area)
+        incoming_rel = work.get("relevance") or ""
+        incoming_area = work.get("area") or ""
+        if incoming_rel and incoming_area:
+            labels: tuple[str, str] | None = (incoming_rel, incoming_area)
+        else:
+            labels = classify_new_work(work.get("title") or "", hint_area=hint_area)
         if labels is None:
             continue
         relevance, area = labels
         work["relevance"] = relevance
         work["area"] = area
-        by_id[oid] = work
+        remember(work)
         added += 1
     return list(by_id.values()), added
 
@@ -224,6 +493,30 @@ async def _works_pages(
         if not results or not cursor:
             break
     return pages
+
+
+async def fetch_rss_rows() -> list[tuple[RssSource, list[dict[str, str]]]]:
+    """Download grey-literature feeds. One dead feed does not abort the run."""
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml",
+    }
+    out: list[tuple[RssSource, list[dict[str, str]]]] = []
+    async with httpx.AsyncClient(timeout=30.0, headers=headers, follow_redirects=True) as http:
+        for source in RSS_SOURCES:
+            try:
+                response = await http.get(source.url)
+                response.raise_for_status()
+                rows = [
+                    row
+                    for entry in parse_feed(response.text)
+                    if (row := feed_entry_to_row(entry, source)) is not None
+                ]
+                out.append((source, rows))
+            except (httpx.HTTPError, ET.ParseError, OSError) as exc:
+                print(f"warning: {source.prefix} RSS failed: {exc}", file=sys.stderr)
+                out.append((source, []))
+    return out
 
 
 async def refresh(
@@ -253,6 +546,19 @@ async def refresh(
             )
             added_total += added
 
+        for hint, label, source_id in OPENALEX_SOURCE_QUERIES:
+            works = await _works_pages(
+                client,
+                {
+                    "search": "SBIR",
+                    "filter": f"primary_location.source.id:{source_id},{year_filter}",
+                },
+            )
+            parsed = [parse_work(w) for w in works]
+            query_counts[f"source:{label}:{source_id}"] = len(parsed)
+            existing, added = merge_rows(existing, parsed, hint_area=hint)
+            added_total += added
+
         for doi in ANCHOR_DOIS:
             cited = await _works_pages(
                 client,
@@ -263,7 +569,12 @@ async def refresh(
             existing, added = merge_rows(existing, parsed)
             added_total += added
 
-        known_ids = [row["openalex_id"] for row in existing if row.get("openalex_id")]
+        for source, rows in await fetch_rss_rows():
+            query_counts[f"rss:{source.prefix}"] = len(rows)
+            existing, added = merge_rows(existing, rows, hint_area=source.hint_area)
+            added_total += added
+
+        known_ids = openalex_ids_for_refresh(existing)
         refreshed = 0
         for i in range(0, len(known_ids), ID_BATCH):
             batch = known_ids[i : i + ID_BATCH]

--- a/tests/unit/scripts/test_update_literature_map.py
+++ b/tests/unit/scripts/test_update_literature_map.py
@@ -11,10 +11,16 @@ from sbir_etl.enrichers.openalex_client import OpenAlexClient
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "data"))
 
 from update_literature_map import (  # noqa: E402
+    RssSource,
     classify_new_work,
+    feed_entry_to_row,
+    is_openalex_work_id,
     load_map,
     merge_rows,
+    openalex_ids_for_refresh,
+    parse_feed,
     parse_work,
+    synthetic_id,
     write_map,
 )
 
@@ -101,6 +107,190 @@ def test_write_and_load_round_trip(tmp_path: Path) -> None:
     rows = load_map(path)
     assert len(rows) == 1
     assert rows[0]["openalex_id"] == "W123"
+
+
+GAO_RSS = """<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="/scripts/rss.xsl" ?>
+<rss version="2.0">
+  <channel>
+    <title>Reports News from the GAO</title>
+    <item>
+      <title>Small Business Research Programs: Increased Performance Standards</title>
+      <link>https://www.gao.gov/products/gao-24-106398</link>
+      <description>GAO reviewed SBIR/STTR multiple-award performance standards.</description>
+      <pubDate>Wed, 15 May 2024 08:00:00 -0400</pubDate>
+    </item>
+    <item>
+      <title>Defense Industrial Base: Dependence on Foreign Suppliers</title>
+      <link>https://www.gao.gov/products/gao-25-107283</link>
+      <description>DoD supplier visibility past the prime-contractor tier.</description>
+      <pubDate>Tue, 11 Mar 2025 08:00:00 -0400</pubDate>
+    </item>
+    <item>
+      <title>Defense Health Care: Blast Exposures</title>
+      <link>https://www.gao.gov/products/gao-26-107829</link>
+      <description>Cognitive assessments for service members.</description>
+      <pubDate>Tue, 18 Aug 2026 06:59:03 -0400</pubDate>
+    </item>
+    <item>
+      <title>International Agreements: DOD Oversight</title>
+      <link>https://www.gao.gov/products/gao-26-108249</link>
+      <description>Goals for cost-sharing and defense industrial base improvements.</description>
+      <pubDate>Mon, 17 Aug 2026 08:00:00 -0400</pubDate>
+    </item>
+  </channel>
+</rss>
+"""
+
+NAP_ATOM = """<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="https://www.w3.org/2005/Atom">
+  <title>New Titles from the National Academies Press</title>
+  <entry>
+    <title>Review of the SBIR and STTR Programs at the Department of Defense</title>
+    <link rel="alternate" href="https://www.nap.edu/catalog/29329"/>
+    <id>tag:nap.edu,2026:https://www.nap.edu/catalog/29329#final</id>
+    <published>2026-01-15T00:00:00-05:00</published>
+    <content type="html">Final Book Now Available</content>
+  </entry>
+  <entry>
+    <title>Report of the Treasurer For the Year Ended December 31, 2025</title>
+    <link rel="alternate" href="https://www.nap.edu/catalog/29521"/>
+    <published>2026-07-31T10:45:12-04:00</published>
+  </entry>
+</feed>
+"""
+
+GAO_SOURCE = RssSource(
+    prefix="gao",
+    venue="U.S. Government Accountability Office",
+    hint_area="E",
+    url="https://www.gao.gov/rss/reports.xml",
+    first_author="GAO",
+    work_type="report",
+)
+NAP_SOURCE = RssSource(
+    prefix="nap",
+    venue="National Academies Press",
+    hint_area="E",
+    url="https://nap.nationalacademies.org/rss/",
+    first_author="NASEM",
+    work_type="book",
+)
+
+
+def test_synthetic_ids_from_canonical_urls() -> None:
+    assert (
+        synthetic_id("gao", "https://www.gao.gov/products/gao-25-107283", "x")
+        == "gao:GAO-25-107283"
+    )
+    assert (
+        synthetic_id("crs", "https://www.EveryCRSReport.com/reports/R43695.html", "x")
+        == "crs:R43695"
+    )
+    assert synthetic_id("nap", "https://www.nap.edu/catalog/29329", "x") == "nap:29329"
+
+
+def test_parse_gao_rss_keeps_sbir_and_dib_drops_unrelated() -> None:
+    entries = parse_feed(GAO_RSS)
+    rows = [feed_entry_to_row(entry, GAO_SOURCE) for entry in entries]
+    kept = {row["openalex_id"]: row for row in rows if row is not None}
+    assert set(kept) == {"gao:GAO-24-106398", "gao:GAO-25-107283"}
+    assert kept["gao:GAO-24-106398"]["relevance"] == "core"
+    assert kept["gao:GAO-24-106398"]["year"] == "2024"
+    assert kept["gao:GAO-25-107283"]["relevance"] == "adjacent"
+    assert kept["gao:GAO-25-107283"]["area"] == "A"
+
+
+def test_parse_nap_atom_keeps_sbir_book() -> None:
+    entries = parse_feed(NAP_ATOM)
+    rows = [feed_entry_to_row(entry, NAP_SOURCE) for entry in entries]
+    kept = [row for row in rows if row is not None]
+    assert len(kept) == 1
+    assert kept[0]["openalex_id"] == "nap:29329"
+    assert kept[0]["relevance"] == "core"
+    assert kept[0]["year"] == "2026"
+
+
+def test_merge_dedupes_grey_stub_onto_openalex_id() -> None:
+    existing = [
+        {
+            "relevance": "core",
+            "area": "E",
+            "year": "2026",
+            "first_author": "NASEM",
+            "n_authors": "1",
+            "title": "Review of the SBIR and STTR Programs at the Department of Defense",
+            "venue": "National Academies Press",
+            "type": "book",
+            "citations": "",
+            "fwci": "",
+            "open_access": "True",
+            "doi": "",
+            "openalex_id": "nap:29329",
+        }
+    ]
+    incoming = [
+        parse_work(
+            {
+                **SAMPLE_WORK,
+                "id": "https://openalex.org/W555",
+                "display_name": "Review of the SBIR and STTR Programs at the Department of Defense",
+                "cited_by_count": 12,
+                "doi": "https://doi.org/10.17226/29329",
+            }
+        )
+    ]
+    merged, added = merge_rows(existing, incoming)
+    assert added == 0
+    assert len(merged) == 1
+    assert merged[0]["openalex_id"] == "W555"
+    assert merged[0]["relevance"] == "core"
+    assert merged[0]["citations"] == "12"
+    assert merged[0]["doi"] == "10.17226/29329"
+
+
+def test_grey_rss_does_not_clobber_openalex_citations() -> None:
+    existing = [
+        parse_work(SAMPLE_WORK)
+        | {
+            "relevance": "core",
+            "area": "B",
+            "title": "An SBIR commercialization study",
+        }
+    ]
+    incoming = [
+        {
+            "relevance": "core",
+            "area": "B",
+            "year": "2024",
+            "first_author": "GAO",
+            "n_authors": "1",
+            "title": "An SBIR commercialization study",
+            "venue": "U.S. Government Accountability Office",
+            "type": "report",
+            "citations": "0",
+            "fwci": "",
+            "open_access": "True",
+            "doi": "",
+            "openalex_id": "gao:GAO-24-1",
+        }
+    ]
+    merged, added = merge_rows(existing, incoming)
+    assert added == 0
+    assert merged[0]["openalex_id"] == "W123"
+    assert merged[0]["citations"] == "4"
+
+
+def test_openalex_refresh_skips_synthetic_ids() -> None:
+    rows = [
+        {"openalex_id": "W123"},
+        {"openalex_id": "gao:GAO-24-106398"},
+        {"openalex_id": "nap:29329"},
+        {"openalex_id": ""},
+    ]
+    assert openalex_ids_for_refresh(rows) == ["W123"]
+    assert is_openalex_work_id("W123")
+    assert not is_openalex_work_id("gao:GAO-24-106398")
 
 
 def test_search_works_passes_mailto(monkeypatch) -> None:

--- a/tests/unit/scripts/test_update_literature_map.py
+++ b/tests/unit/scripts/test_update_literature_map.py
@@ -6,7 +6,10 @@ import asyncio
 import sys
 from pathlib import Path
 
+import pytest
+
 from sbir_etl.enrichers.openalex_client import OpenAlexClient
+from sbir_etl.exceptions import APIError
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "data"))
 
@@ -20,6 +23,7 @@ from update_literature_map import (  # noqa: E402
     openalex_ids_for_refresh,
     parse_feed,
     parse_work,
+    resolve_doi_work_id,
     synthetic_id,
     write_map,
 )
@@ -309,3 +313,43 @@ def test_search_works_passes_mailto(monkeypatch) -> None:
     assert captured["endpoint"] == "works"
     assert captured["params"]["mailto"] == "map@example.com"
     assert captured["params"]["search"] == "SBIR"
+
+
+def test_resolve_doi_work_id_uses_doi_filter(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_search(self, params):  # noqa: ANN001
+        captured["params"] = params
+        return {"results": [{"id": "https://openalex.org/W2741809807"}], "meta": {}}
+
+    monkeypatch.setattr(OpenAlexClient, "search_works", fake_search)
+    oid = asyncio.run(resolve_doi_work_id(OpenAlexClient(), "10.1257/aer.20150491"))
+    assert oid == "W2741809807"
+    assert captured["params"] == {"filter": "doi:10.1257/aer.20150491", "per_page": 1}
+
+
+def test_resolve_doi_work_id_raises_when_missing(monkeypatch) -> None:
+    async def fake_search(self, params):  # noqa: ANN001
+        return {"results": [], "meta": {}}
+
+    monkeypatch.setattr(OpenAlexClient, "search_works", fake_search)
+    with pytest.raises(RuntimeError, match="no work id"):
+        asyncio.run(resolve_doi_work_id(OpenAlexClient(), "10.0/missing"))
+
+
+def test_search_works_propagates_malformed_filter(monkeypatch) -> None:
+    async def fake_request(self, method, endpoint, params=None):  # noqa: ANN001
+        raise APIError("bad filter", api_name="openalex", http_status=400)
+
+    monkeypatch.setattr(OpenAlexClient, "_make_request", fake_request)
+    with pytest.raises(APIError):
+        asyncio.run(OpenAlexClient().search_works({"filter": "cites:doi:10.1257/aer.20150491"}))
+
+
+def test_search_works_404_is_empty(monkeypatch) -> None:
+    async def fake_request(self, method, endpoint, params=None):  # noqa: ANN001
+        raise APIError("gone", api_name="openalex", http_status=404)
+
+    monkeypatch.setattr(OpenAlexClient, "_make_request", fake_request)
+    data = asyncio.run(OpenAlexClient().search_works({"filter": "openalex_id:W0"}))
+    assert data["results"] == []

--- a/tests/unit/scripts/test_update_literature_map.py
+++ b/tests/unit/scripts/test_update_literature_map.py
@@ -1,0 +1,121 @@
+"""Unit tests for the exploratory literature-map refresh."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from sbir_etl.enrichers.openalex_client import OpenAlexClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "data"))
+
+from update_literature_map import (  # noqa: E402
+    classify_new_work,
+    load_map,
+    merge_rows,
+    parse_work,
+    write_map,
+)
+
+
+SAMPLE_WORK = {
+    "id": "https://openalex.org/W123",
+    "display_name": "An SBIR commercialization study",
+    "publication_year": 2024,
+    "type": "article",
+    "cited_by_count": 4,
+    "fwci": 1.2,
+    "doi": "https://doi.org/10.1/example",
+    "open_access": {"is_oa": True},
+    "authorships": [{"author": {"display_name": "Ada Lovelace"}}],
+    "primary_location": {"source": {"display_name": "Research Policy"}},
+}
+
+
+def test_parse_work_flattens_openalex_fields() -> None:
+    row = parse_work(SAMPLE_WORK)
+    assert row["openalex_id"] == "W123"
+    assert row["first_author"] == "Ada Lovelace"
+    assert row["n_authors"] == "1"
+    assert row["doi"] == "10.1/example"
+    assert row["open_access"] == "True"
+    assert row["citations"] == "4"
+    assert row["year"] == "2024"
+
+
+def test_classify_core_sbir_title() -> None:
+    assert classify_new_work("Evaluating the SBIR program") == ("core", "E")
+
+
+def test_classify_adjacent_defense_without_sbir() -> None:
+    assert classify_new_work("Defense industrial base procurement reform") == ("adjacent", "A")
+
+
+def test_classify_drops_off_topic() -> None:
+    assert classify_new_work("A cookbook of pasta sauces") is None
+
+
+def test_merge_preserves_existing_labels_and_adds_new() -> None:
+    existing = [
+        {
+            "relevance": "core",
+            "area": "B",
+            "year": "2020",
+            "first_author": "Old",
+            "n_authors": "1",
+            "title": "Old title",
+            "venue": "X",
+            "type": "article",
+            "citations": "1",
+            "fwci": "0.1",
+            "open_access": "False",
+            "doi": "10.old",
+            "openalex_id": "W123",
+        }
+    ]
+    incoming = [
+        parse_work(SAMPLE_WORK),
+        parse_work(
+            {
+                **SAMPLE_WORK,
+                "id": "https://openalex.org/W999",
+                "display_name": "Venture capital after Form D offerings",
+            }
+        ),
+    ]
+    merged, added = merge_rows(existing, incoming)
+    by_id = {row["openalex_id"]: row for row in merged}
+    assert added == 1
+    assert by_id["W123"]["relevance"] == "core"
+    assert by_id["W123"]["area"] == "B"
+    assert by_id["W123"]["citations"] == "4"
+    assert by_id["W123"]["title"] == "An SBIR commercialization study"
+    assert by_id["W999"]["relevance"] == "adjacent"
+    assert by_id["W999"]["area"] == "F"
+
+
+def test_write_and_load_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "map.csv"
+    write_map(path, [parse_work(SAMPLE_WORK) | {"relevance": "core", "area": "B"}])
+    rows = load_map(path)
+    assert len(rows) == 1
+    assert rows[0]["openalex_id"] == "W123"
+
+
+def test_search_works_passes_mailto(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_request(self, method, endpoint, params=None):  # noqa: ANN001
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["params"] = params
+        return {"results": [], "meta": {}}
+
+    monkeypatch.setattr(OpenAlexClient, "_make_request", fake_request)
+    client = OpenAlexClient(mailto="map@example.com")
+    data = asyncio.run(client.search_works({"search": "SBIR", "per_page": 2}))
+    assert data["results"] == []
+    assert captured["endpoint"] == "works"
+    assert captured["params"]["mailto"] == "map@example.com"
+    assert captured["params"]["search"] == "SBIR"

--- a/tests/unit/test_ci_test_contract.py
+++ b/tests/unit/test_ci_test_contract.py
@@ -22,6 +22,22 @@ def test_ci_has_a_weekly_full_suite_schedule() -> None:
     assert workflow["jobs"]["test-full"]["if"] == "github.event_name != 'pull_request'"
 
 
+def test_literature_map_refresh_is_a_monday_pr_job() -> None:
+    workflow = yaml.load(
+        (REPOSITORY_ROOT / ".github/workflows/literature-map.yml").read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    assert workflow["on"]["schedule"] == [{"cron": "17 9 * * 1"}]
+    assert workflow["permissions"]["contents"] == "write"
+    assert workflow["permissions"]["pull-requests"] == "write"
+    run_step = next(
+        step
+        for step in workflow["jobs"]["refresh"]["steps"]
+        if step.get("name") == "Refresh the map"
+    )
+    assert run_step["run"] == "uv run python scripts/data/update_literature_map.py"
+
+
 def test_pull_requests_run_the_hermetic_e2e_selection() -> None:
     job = _workflow()["jobs"]["test-e2e"]
     run_step = next(step for step in job["steps"] if step.get("name") == "Run hermetic E2E tests")


### PR DESCRIPTION
## Description

The literature map in `docs/research/literature-map/` was a one-shot OpenAlex snapshot with no refresh path. This adds:

- `scripts/data/update_literature_map.py` (exploratory): re-search OpenAlex, pull National Academies Press books by source id, ingest recent GAO / NAP / CRS / ITIF items from public RSS/Atom feeds, refresh citation/OA metadata for existing OpenAlex IDs, classify **new** titles with deterministic keywords, write `sbir_literature_map.csv` + `refresh_status.md`.
- `.github/workflows/literature-map.yml`: Monday 09:17 UTC (and `workflow_dispatch`). Opens `chore/literature-map-refresh` when those files change. Does **not** push to `main`.
- `OpenAlexClient.search_works` for the works API (polite-pool `mailto` via optional `OPENALEX_MAILTO`).

Grey rows without an OpenAlex work id use synthetic keys (`gao:…`, `nap:…`, `crs:…`, `itif:…`). A later OpenAlex hit with the same title or DOI is merged onto that row. RSS is a recency window, not a backfill of `[L#]`. CSIS's public RSS is mostly old events and is not ingested; those `[L#]` entries stay hand-tracked.

Existing rows keep their stored relevance/area labels. Authored memos (`sbir_literature_map.md`, `citation_gap_memo.md`) are not rewritten. This does not promote the map, edit `[L#]`, or change study Status.

**Operator setup:** optional repo secret `OPENALEX_MAILTO` for OpenAlex's polite pool. No API key. Grey feeds are unauthenticated.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes the issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

`uv run pytest tests/unit/scripts/test_update_literature_map.py tests/unit/test_ci_test_contract.py -n0 -q` — 17 passed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes