### PR TITLE
Stub multi-FY USAspending contract archive union

### DIFF
--- a/specs/status.md
+++ b/specs/status.md
@@ -170,6 +170,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   stays gated on the decoy/estimand work in `phase3-transition-groundtruth` and a
   `studies/transition-scoring/` promotion. No GitHub-runner execution, no
   committed corpus bytes, no server schedule.
+- **`usaspending-multi-fy-archive-union` — Maintenance.** Pipelines-tier remediation for
+  the transition source layer's scalar archive selection. Resolve one declared revision per
+  requested fiscal year, union at transaction grain, and bind the complete archive set to the
+  output manifest; no transition classification or analysis is in scope.
 - **`weekly-awards-report-refactor` — Maintenance.** Monolith is already split
   into weekly reporting modules. Remaining work is injection, coverage, and
   alias cleanup.

--- a/specs/usaspending-multi-fy-archive-union/design.md
+++ b/specs/usaspending-multi-fy-archive-union/design.md
@@ -1,0 +1,42 @@
+# USAspending Multi-FY Contract Archive Union — Design
+
+## Current flow
+
+The transition asset calls `find_latest_local_contract_archive`, which sorts all matching archive
+filenames by update date and returns one path. The extractor and manifest consequently model the
+source as a scalar even when the local directory contains multiple fiscal partitions.
+
+## Proposed flow
+
+1. Resolve the configured fiscal-year set before extraction.
+2. Group valid `Contracts_Full` filenames by fiscal year and choose the latest revision inside
+   each group.
+3. Stream each selected archive through `AwardArchiveContractExtractor` in deterministic order.
+4. Reconcile repeated transaction IDs across archives, retaining identical repeats and rejecting
+   conflicts.
+5. Publish one Parquet output and one manifest bound to the complete ordered archive set.
+
+The resolver should return a typed sequence carrying fiscal year, revision date, and path rather
+than infer those values repeatedly from strings. The asset should accept an explicit fiscal-year
+configuration; implicit "all files currently present" behavior would make the cut unstable.
+
+## Failure behavior
+
+- Missing requested fiscal year: fail before scanning.
+- Multiple same-date revisions for one year: require byte identity or fail as ambiguous.
+- Repeated transaction ID with different canonical content: fail and emit the conflicting archive
+  names and transaction identifier.
+- Existing scalar-cache manifest: invalidate and rebuild; do not reinterpret it as a set.
+
+## Provenance and migration
+
+The manifest schema gains an ordered `award_archives` collection and an archive-set SHA-256.
+During one compatibility release, the existing singular `award_archive_file` may be emitted only
+when the set contains one item. Consumers must use the set-level fingerprint for cache validity.
+
+## Testing strategy
+
+- Resolver fixtures with two fiscal years and multiple revisions within one year.
+- Missing-year and ambiguous-revision failure tests.
+- Two tiny ZIP fixtures containing a repeated identical transaction and a conflicting transaction.
+- Asset test proving input order does not change output bytes or manifest order.

--- a/specs/usaspending-multi-fy-archive-union/requirements.md
+++ b/specs/usaspending-multi-fy-archive-union/requirements.md
@@ -1,0 +1,81 @@
+# USAspending Multi-FY Contract Archive Union — Requirements
+
+> **Lifecycle status:** Maintenance
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **B2–B3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** B2 award-to-contract transition and B3 Phase II→III latency
+**Answers for:** pipeline engineers maintaining transition inputs
+**RQ complexity tier:** Relational / Inferential downstream; this spec only moves source data
+
+---
+
+## Done when
+
+Given an explicit set of federal fiscal years, the transition source layer deterministically
+materializes the union of the latest USAspending `Contracts_Full` revision for every requested
+year, binds every archive to the output manifest, and refuses incomplete or conflicting cuts.
+
+---
+
+## Background
+
+`find_latest_local_contract_archive` currently returns one archive by its global update date.
+When FY2025 and FY2026 archives coexist, the transition asset therefore reads only one fiscal
+partition; a later download can silently replace rather than extend the materialized time span.
+Multi-year transition and latency consumers need an explicit, reproducible fiscal partition set.
+
+## Requirements
+
+### Requirement 1 — Explicit archive-set resolution
+
+**User story:** As a pipeline engineer, I want archive discovery to resolve one declared revision
+per requested fiscal year, so that a rerun cannot silently change the temporal population.
+
+#### Acceptance Criteria
+
+1. WHEN fiscal years are requested, THE System SHALL select the latest valid archive revision
+   independently within each requested year.
+2. IF any requested year is absent or has an unparseable archive name, THEN THE System SHALL fail
+   before extraction and identify the missing or invalid partition.
+3. THE System SHALL return archives in deterministic fiscal-year and filename order.
+
+### Requirement 2 — Transaction-faithful union
+
+**User story:** As a transition consumer, I want all requested fiscal partitions assembled at the
+canonical transaction grain, so that counts and first-event dates use the complete declared cut.
+
+#### Acceptance Criteria
+
+1. THE System SHALL extract every selected archive through the same schema-verified projection.
+2. WHEN a transaction identifier occurs in more than one partition, THE System SHALL deduplicate
+   byte-equivalent records and fail closed on conflicting records.
+3. THE System SHALL expose per-year scanned, matched, and emitted row counts in quality checks.
+
+### Requirement 3 — Set-level provenance
+
+**User story:** As a reviewer, I want the output bound to every selected archive, so that the
+declared multi-year cut can be independently reproduced.
+
+#### Acceptance Criteria
+
+1. THE adjacent checks manifest SHALL record fiscal year, filename, size, SHA-256, and source
+   revision date for every selected archive.
+2. Cache reuse SHALL require the ordered archive-set fingerprint, vendor-frame fingerprint, and
+   extractor contract version to match.
+3. A one-year request SHALL remain supported as a one-element archive set.
+
+## Out of scope
+
+- Downloading every historical USAspending partition automatically.
+- Agency- or study-specific filtering beyond the existing vendor frame.
+- Transition matching, classification, or statistical estimation.
+
+## Dependencies
+
+- `AwardArchiveContractExtractor` — EXISTS
+- `raw_contracts` transition asset and source-provenance checks — EXISTS
+- Local USAspending annual contract archives — OPERATOR-PROVIDED

--- a/specs/usaspending-multi-fy-archive-union/tasks.md
+++ b/specs/usaspending-multi-fy-archive-union/tasks.md
@@ -1,0 +1,21 @@
+# USAspending Multi-FY Contract Archive Union — Tasks
+
+- [ ] 1. Add fiscal-year-aware archive resolution and typed archive metadata.
+  - Verify: resolver unit tests cover ordering, revision selection, and missing years.
+  - Requirements: 1.1–1.3
+
+- [ ] 2. Extend archive extraction to stream a declared archive sequence.
+  - Verify: two-partition fixture emits the union at transaction grain.
+  - Requirements: 2.1
+
+- [ ] 3. Add deterministic cross-partition transaction reconciliation.
+  - Verify: identical repeats collapse and conflicting repeats fail closed.
+  - Requirements: 2.2–2.3
+
+- [ ] 4. Version the manifest and bind the complete archive set to cache validity.
+  - Verify: adding, removing, or replacing one fiscal partition invalidates the cache.
+  - Requirements: 3.1–3.3
+
+- [ ] 5. Document the fiscal-year configuration and scalar-manifest migration.
+  - Verify: focused tests, `make docs-check`, and `make lint-boundaries` pass.
+  - Requirements: 3.2–3.3


### PR DESCRIPTION
## Description

Adds a pipelines-tier maintenance spec for replacing scalar USAspending archive selection with an explicit, provenance-bound fiscal-year set. This is a planning stub only; implementation remains unchecked in `tasks.md`.

## Type of Change

- [x] Documentation update
- [ ] Bug fix

## Versioning Impact

- [x] No release impact

## Testing

- [x] `make docs-check`
- [x] `git diff --check`

## Scope

The future implementation will select one revision per requested fiscal year, union at transaction grain, fail on conflicting duplicate transactions, and bind every archive hash to cache validity. Transition classification and analysis are out of scope.