### PR TITLE
Stub canonical contract source-field preservation

### DIFF
--- a/specs/contract-source-field-preservation/design.md
+++ b/specs/contract-source-field-preservation/design.md
@@ -1,0 +1,42 @@
+# Contract Source-Field Preservation — Design
+
+## Field contract
+
+The source layer should carry these concepts independently:
+
+| Concept | USAspending archive field | Canonical destination |
+|---|---|---|
+| Research code | `research_code` | `research_code` |
+| Research label | `research` | existing `research` during migration |
+| Awarding top tier | `awarding_agency_name` | existing `agency` |
+| Awarding sub-tier | `awarding_sub_agency_name` | existing `sub_agency` |
+| Funding top tier | `funding_agency_name` | `funding_agency` |
+| Funding sub-tier | `funding_sub_agency_name` | `funding_sub_agency` |
+| Transaction narrative | `transaction_description` | existing `description` |
+| Base-award narrative | `prime_award_base_transaction_description` | `base_award_description` |
+
+Exact source headers must be verified against the schema-extraction fixture before implementation;
+aliases must be explicit rather than fuzzy header matching.
+
+## Component changes
+
+1. Expand `CONTRACT_ARCHIVE_COLUMNS` and `_map_row` with the required raw fields.
+2. Extend `FederalContract` with stable optional fields where they are broadly consumed. Critical
+   scope fields should not be buried in an opaque metadata blob.
+3. Update Parquet serialization and source-provenance checks to carry the expanded schema.
+4. Add named compatibility accessors only where an existing consumer cannot migrate atomically.
+
+## Failure and migration behavior
+
+An archive governed by the new contract fails schema verification when a required header is
+absent. An older cached Parquet without the new schema must be invalidated, not padded with copied
+values. Existing fields keep their current definitions until downstream consumers have migrated;
+the change must not redefine `description` as the base-award description in place.
+
+## Testing strategy
+
+- One-row CSV fixture with deliberately different values in every paired field.
+- Round-trip test through `FederalContract` and Parquet.
+- Null fixture proving no cross-field fallback.
+- Schema-drift test for a missing required header.
+- Downstream compatibility tests for existing contract consumers.

--- a/specs/contract-source-field-preservation/requirements.md
+++ b/specs/contract-source-field-preservation/requirements.md
@@ -1,0 +1,88 @@
+# Contract Source-Field Preservation — Requirements
+
+> **Lifecycle status:** Maintenance
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **B2–B3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** B2 award-to-contract transition and B3 unrecorded Phase III work
+**Answers for:** pipeline engineers maintaining canonical procurement inputs
+**RQ complexity tier:** Relational / Inferential downstream; this spec preserves source semantics
+
+---
+
+## Done when
+
+The canonical contract artifact preserves the distinct USAspending fields required to reconstruct
+research coding, awarding and funding organization scope, and award- versus transaction-level
+descriptions without consulting the raw archive again.
+
+---
+
+## Background
+
+The narrow award-archive projection currently keeps descriptive `research`, funding top-tier
+agency, and `transaction_description`, but drops raw `research_code`, funding sub-agency, and
+`prime_award_base_transaction_description`. Downstream consumers therefore cannot distinguish
+Element 10Q codes from labels, implement funding-subtier scope, or tell modification text from the
+base award narrative. These are source-fidelity defects, not study-specific filters.
+
+## Requirements
+
+### Requirement 1 — Preserve distinct source semantics
+
+**User story:** As a pipeline engineer, I want semantically different source fields represented
+separately, so downstream code cannot substitute one field for another accidentally.
+
+#### Acceptance Criteria
+
+1. THE canonical projection SHALL preserve raw `research_code` separately from the descriptive
+   `research` label.
+2. THE projection SHALL preserve awarding and funding top-tier and sub-tier agency names in
+   separate fields.
+3. THE projection SHALL preserve transaction description separately from the prime-award base
+   transaction description.
+4. Missing optional source values SHALL remain null and SHALL NOT be copied from a neighboring
+   semantic field.
+
+### Requirement 2 — Canonical schema and compatibility
+
+**User story:** As a downstream consumer, I want stable named fields and an explicit migration,
+so existing readers do not silently change meaning.
+
+#### Acceptance Criteria
+
+1. THE `FederalContract` model and Parquet schema SHALL expose unambiguous names for every added
+   field or document an intentionally metadata-only field.
+2. Existing `research`, `agency`, `sub_agency`, and `description` fields SHALL retain their current
+   meaning during a documented compatibility period.
+3. THE schema or extraction contract version SHALL change when the new fields are introduced.
+
+### Requirement 3 — Source-fidelity checks
+
+**User story:** As a reviewer, I want field-level provenance and coverage checks, so a future
+archive-schema drift cannot recreate the same loss silently.
+
+#### Acceptance Criteria
+
+1. Archive schema verification SHALL require the added raw headers when the configured archive
+   contract declares them required.
+2. Checks SHALL report non-null coverage for each preserved field and bind the ordered source
+   column projection to the output manifest.
+3. Fixture tests SHALL prove that research code/label, agency tier, and description grain remain
+   distinct after CSV→model→Parquet round-trip.
+
+## Out of scope
+
+- Deciding whether a contract is Phase III.
+- Agency-specific inclusion filters or matching rules.
+- Narrative-quality thresholds, text scoring, or imputation of missing descriptions.
+- Expanding the projection to unrelated USAspending columns without a named consumer.
+
+## Dependencies
+
+- `AwardArchiveContractExtractor` — EXISTS
+- `FederalContract` canonical model — EXISTS
+- Transition contract-ingestion manifest and coverage checks — EXISTS

--- a/specs/contract-source-field-preservation/tasks.md
+++ b/specs/contract-source-field-preservation/tasks.md
@@ -1,0 +1,21 @@
+# Contract Source-Field Preservation — Tasks
+
+- [ ] 1. Verify and fixture the exact USAspending raw headers.
+  - Verify: the fixture contains distinct research code/label, agency tiers, and descriptions.
+  - Requirements: 1.1–1.4
+
+- [ ] 2. Extend the canonical contract model and version its schema contract.
+  - Verify: model serialization preserves each optional field without fallback.
+  - Requirements: 2.1–2.3
+
+- [ ] 3. Expand award-archive projection and row mapping.
+  - Verify: CSV→model tests preserve all fields byte-for-byte after normalization.
+  - Requirements: 1.1–1.4, 3.1
+
+- [ ] 4. Bind projection and coverage metadata into source checks.
+  - Verify: missing headers fail and coverage is emitted for every added field.
+  - Requirements: 3.1–3.3
+
+- [ ] 5. Migrate downstream readers without redefining legacy fields.
+  - Verify: focused integration tests, `make docs-check`, and `make lint-boundaries` pass.
+  - Requirements: 2.1–2.3

--- a/specs/status.md
+++ b/specs/status.md
@@ -39,6 +39,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`company-categorization` — Maintenance.** About 80% complete. Evaluate the
   remaining Neo4j loader and docs against the current `:Organization` graph
   schema before implementation.
+- **`contract-source-field-preservation` — Maintenance.** Pipelines-tier repair for lossy
+  USAspending contract projection. Preserve research code versus label, awarding versus funding
+  agency tiers, and transaction versus base-award descriptions without adding classification or
+  study-specific filters.
 - **`cross-agency-taxonomy` — Gated backlog.** M3 research target. Prerequisite
   classifier/tools exist, but this spec's batch run, report, and Dagster wiring
   are not implemented.


### PR DESCRIPTION
## Description

Adds a pipelines-tier maintenance spec for repairing lossy USAspending contract projection. This is a planning stub only; implementation remains unchecked in `tasks.md`.

## Type of Change

- [x] Documentation update
- [ ] Bug fix

## Versioning Impact

- [x] No release impact

## Testing

- [x] `make docs-check`
- [x] `git diff --check`

## Scope

The future implementation will preserve research code versus label, awarding versus funding agency tiers, and transaction versus base-award descriptions as distinct canonical fields. Phase III classification, text scoring, and agency-specific filters are out of scope.