### PR TITLE
Stub semantic fingerprints for transition materializations

### DIFF
--- a/specs/materialization-semantic-fingerprints/design.md
+++ b/specs/materialization-semantic-fingerprints/design.md
@@ -1,0 +1,52 @@
+# Materialization Semantic Fingerprints — Design
+
+## Fingerprint payload
+
+Each stage emits a canonical JSON payload with:
+
+```text
+stage_name
+transformation_contract
+transformation_version
+normalized_config
+upstream[{name, output_sha256, semantic_fingerprint}]
+direct_sources[{name, sha256}]
+```
+
+The semantic fingerprint is SHA-256 over canonical UTF-8 JSON with sorted keys and compact
+separators. Stage code owns a named version constant; a Git SHA and package version can be emitted
+as diagnostics but do not replace that contract.
+
+## Validation flow
+
+1. Resolve and validate every upstream manifest.
+2. Build the expected canonical payload from current configuration and contract versions.
+3. Compare its SHA-256 with the stored fingerprint before accepting a cached output.
+4. Verify the output bytes against the stored output SHA-256.
+5. If any check fails, report the mismatched payload component and require rematerialization.
+
+The validator should be a small shared pipeline utility so stages do not reimplement canonical
+JSON or mismatch reporting. The first consumers are `validated_phase_ii_awards`,
+`validated_phase_iii_contracts`, pair construction, and the survival frame.
+
+## Version-change discipline
+
+Focused tests should pin representative transformation behavior to its declared version. A test
+must fail when a fixture output changes without the expected version bump. This is narrower and
+more reviewable than hashing implementation source files, which would invalidate on comments and
+miss behavior imported from elsewhere.
+
+## Migration and failure behavior
+
+Legacy manifests without a semantic fingerprint are stale by definition. Migration is a local
+rematerialization, not an in-place manifest rewrite. Empty artifacts still publish an output (or
+an explicitly hashed empty representation) and a complete manifest so zero-row results cannot
+escape lineage checks.
+
+## Testing strategy
+
+- Canonical-payload stability across key order and non-semantic path changes.
+- Invalidation on contract version, normalized config, source hash, or upstream fingerprint change.
+- Legacy/missing manifest rejection.
+- Empty-output lineage test.
+- End-to-end fixture across all four transition stages.

--- a/specs/materialization-semantic-fingerprints/requirements.md
+++ b/specs/materialization-semantic-fingerprints/requirements.md
@@ -1,0 +1,84 @@
+# Materialization Semantic Fingerprints — Requirements
+
+> **Lifecycle status:** Maintenance
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **B2–B3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** B2/B3 transition artifacts and their reproducible inputs
+**Answers for:** pipeline engineers and reviewers of materialized transition data
+**RQ complexity tier:** Relational / Inferential downstream; this spec governs lineage only
+
+---
+
+## Done when
+
+Every Phase II, Phase III, pair, and survival materialization is accepted as current only when its
+source bytes, normalized configuration, upstream outputs, and named transformation contract all
+match the adjacent manifest; semantic code changes invalidate stale outputs deterministically.
+
+---
+
+## Background
+
+Transition checks currently record generation time, paths, row counts, and selected source
+provenance, but the Phase III classifier contract is not part of cache validity. A materialization
+created shortly before a classifier correction therefore remained a valid-looking zero-row checks
+artifact after the same input was classifiable. Input hashes alone cannot detect changed semantics.
+
+## Requirements
+
+### Requirement 1 — Named transformation contracts
+
+**User story:** As a pipeline engineer, I want materializations to declare the behavior version
+that produced them, so semantic changes cannot reuse stale outputs.
+
+#### Acceptance Criteria
+
+1. EACH transition stage SHALL declare a stable transformation contract name and version.
+2. A change that can alter row inclusion, identity, dates, or values SHALL require a contract
+   version change enforced by tests or review tooling.
+3. A repository commit SHA MAY be recorded diagnostically but SHALL NOT be the sole semantic
+   version because identical behavior must remain reproducible across builds.
+
+### Requirement 2 — Complete deterministic fingerprint
+
+**User story:** As a reviewer, I want one fingerprint covering every behavior-changing input, so I
+can determine whether an output is reusable without inspecting the working tree.
+
+#### Acceptance Criteria
+
+1. THE fingerprint SHALL include transformation contract/version, normalized configuration,
+   ordered upstream output hashes, and direct source hashes where applicable.
+2. THE normalized payload used to compute the SHA-256 SHALL be emitted in the manifest.
+3. Paths, timestamps, and dictionary insertion order SHALL NOT change the fingerprint unless they
+   change source identity or configured behavior.
+
+### Requirement 3 — Fail-closed cache validation
+
+**User story:** As an operator, I want stale artifacts rejected before downstream use, so a checks
+file cannot certify output produced by different semantics.
+
+#### Acceptance Criteria
+
+1. IF an output or manifest is missing, uses a legacy schema, or has a mismatched fingerprint,
+   THEN cache validation SHALL require rematerialization.
+2. Downstream stages SHALL bind the verified upstream output SHA and semantic fingerprint, not
+   only its filesystem path.
+3. Empty outputs SHALL receive the same fingerprint and validation treatment as non-empty outputs.
+
+## Out of scope
+
+- Making exploratory analyses citable or promoting evidence status.
+- Hashing the entire repository or Python environment as a substitute for named contracts.
+- Retrofitting every Dagster asset in one change; the first bounded slice is the phase-transition
+  chain.
+- Running or rematerializing live assets as part of implementation.
+
+## Dependencies
+
+- Existing transition `.checks.json` manifests — EXISTS
+- Existing file SHA-256 and atomic JSON helpers — EXISTS
+- Phase II, Phase III, pairs, and survival assets — EXISTS

--- a/specs/materialization-semantic-fingerprints/tasks.md
+++ b/specs/materialization-semantic-fingerprints/tasks.md
@@ -1,0 +1,21 @@
+# Materialization Semantic Fingerprints — Tasks
+
+- [ ] 1. Add canonical semantic-fingerprint payload and validation helpers.
+  - Verify: unit tests cover stable hashing and component-level mismatch reporting.
+  - Requirements: 2.1–2.3
+
+- [ ] 2. Declare and test transformation contracts for Phase II and Phase III assets.
+  - Verify: a classifier-behavior fixture requires a version bump when output changes.
+  - Requirements: 1.1–1.3
+
+- [ ] 3. Bind Phase II/III manifests to source and configuration fingerprints.
+  - Verify: stale, legacy, and empty-output cases fail closed or rematerialize.
+  - Requirements: 2.1–2.3, 3.1, 3.3
+
+- [ ] 4. Propagate verified lineage through pairs and survival outputs.
+  - Verify: changing either upstream output invalidates both downstream stages.
+  - Requirements: 3.1–3.2
+
+- [ ] 5. Document migration without performing a live materialization.
+  - Verify: focused tests, `make docs-check`, and `make lint-boundaries` pass.
+  - Requirements: 3.1–3.3

--- a/specs/status.md
+++ b/specs/status.md
@@ -82,6 +82,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   `sbir_etl/enrichers/ma_discovery/` (issue #446, toolkit relocation). Search
   backend, LLM extractor, and collision policy remain unbuilt. Revisit only
   when M&A recall becomes a selected research priority.
+- **`materialization-semantic-fingerprints` — Maintenance.** Pipelines-tier lineage repair
+  for the phase-transition chain. Bind outputs to named transformation contracts, normalized
+  configuration, and verified upstream hashes so semantic code changes invalidate stale artifacts;
+  no live rematerialization or evidence promotion is authorized by the spec.
 - **`modular-analysis-platform` — Maintenance.** Pipelines-tier contracts
   and registry so a new tech-census or transition-cohort profile is
   YAML-only (issue #441). HTTP is out of scope per ADR-004. Weekly awards


### PR DESCRIPTION
## Description

Adds a pipelines-tier maintenance spec for invalidating transition artifacts when transformation semantics change. This is a planning stub only; implementation remains unchecked in `tasks.md`.

## Type of Change

- [x] Documentation update
- [ ] Bug fix

## Versioning Impact

- [x] No release impact

## Testing

- [x] `make docs-check`
- [x] `git diff --check`

## Scope

The future implementation will bind Phase II, Phase III, pair, and survival outputs to named transformation versions, normalized configuration, and verified upstream hashes. It does not authorize a live materialization or evidence-tier promotion.