### PR TITLE
Stub shared phase-transition report grain repair

### DIFF
--- a/specs/phase-transition-report-grain/design.md
+++ b/specs/phase-transition-report-grain/design.md
@@ -1,0 +1,51 @@
+# Phase-Transition Report Grain — Design
+
+## Current flow
+
+`phase_transition_analysis` reads both `pairs` and `survival`. Percentiles, histograms, and agency
+median latency query all pair rows; transition rates query survival rows. This makes the report a
+mixture of pair-weighted and award-weighted summaries.
+
+## Proposed reporting contract
+
+The survival/follow-up artifact becomes the only headline analysis table:
+
+- grain: one row per canonical Phase II award;
+- event fields: observed flag, selected first-event contract/action, signed time from the declared
+  origin;
+- censor fields: cut date and follow-up time when no event is observed;
+- strata: Phase II agency and cohort attributes copied from the same award row.
+
+Headline incidence, event-conditional latency, agency summaries, and cohort summaries query this
+table. The pairs table remains an input to construction and an output for link diagnostics only.
+
+## Multiplicity audit
+
+Before report generation, compute and emit:
+
+1. candidate Phase III contracts per Phase II award;
+2. Phase II assignments per selected Phase III contract;
+3. counts with multiplicity greater than one and each maximum;
+4. row totals at pair, Phase II award, and distinct selected-contract grain.
+
+These diagnostics explain linkage ambiguity without changing the chosen headline unit.
+
+## Failure behavior
+
+Duplicate Phase II identifiers, incomplete event/censor fields, or inconsistent observed flags are
+blocking schema errors. Signed negative event times may be retained as diagnostics when the source
+contract permits them, but the reporter must not call the resulting event-only distribution a
+survival estimate.
+
+## Migration
+
+Version the report schema. Rename pair-based legacy fields if they must be retained temporarily;
+do not silently overwrite their semantics under the same key. Update downstream fixtures and docs
+to name the award-grain denominator.
+
+## Testing strategy
+
+- One firm with several Phase II awards and several candidate contracts.
+- One selected contract reused by multiple Phase II assignments.
+- Duplicate-award and incomplete event/censor failure fixtures.
+- Invariance test: adding a non-selected candidate pair leaves headline metrics unchanged.

--- a/specs/phase-transition-report-grain/requirements.md
+++ b/specs/phase-transition-report-grain/requirements.md
@@ -1,0 +1,83 @@
+# Phase-Transition Report Grain — Requirements
+
+> **Lifecycle status:** Maintenance
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **B2–B3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** B2 transition linkage and B3 Phase II→III latency/survival
+**Answers for:** pipeline engineers and analysts consuming shared transition reports
+**RQ complexity tier:** Relational / Inferential downstream; this spec enforces reporting grain
+
+---
+
+## Done when
+
+The shared transition reporter derives rates, agency summaries, and event-conditional latency from
+one documented row-per-Phase-II follow-up frame, while candidate-pair multiplicity is emitted only
+as a separately labeled diagnostic.
+
+---
+
+## Background
+
+The current reporter calculates latency percentiles and histograms over the raw `pairs` table but
+calculates transition rates from the one-row-per-Phase-II `survival` table. Firms with several
+Phase II awards or Phase III contracts therefore receive extra weight in latency summaries, and
+the report combines statistics with different denominators under one transition vocabulary.
+
+## Requirements
+
+### Requirement 1 — One declared headline grain
+
+**User story:** As a report consumer, I want every headline transition measure tied to a declared
+unit of observation, so multiplicity cannot silently change weighting.
+
+#### Acceptance Criteria
+
+1. THE headline follow-up frame SHALL contain exactly one row per canonical Phase II award.
+2. Transition incidence SHALL use that frame's explicit event indicator and declared follow-up cut.
+3. Event-conditional latency SHALL use only observed-event rows from the same frame and SHALL state
+   its denominator and signed time origin.
+4. Agency and cohort summaries SHALL aggregate the same frame rather than joining back to all raw
+   pairs.
+
+### Requirement 2 — Pair diagnostics remain diagnostic
+
+**User story:** As a pipeline engineer, I want candidate-link multiplicity visible but separated,
+so it helps debug matching without being mistaken for transition incidence.
+
+#### Acceptance Criteria
+
+1. Raw candidate pairs SHALL NOT feed headline latency or rate fields.
+2. Checks SHALL report Phase II awards with multiple candidate Phase III contracts, contracts
+   reused across Phase II assignments, and maximum multiplicity.
+3. Every pair-derived output SHALL be labeled `candidate_pair` or equivalent and non-citable.
+
+### Requirement 3 — Schema and semantic guards
+
+**User story:** As a reviewer, I want automated grain assertions, so future schema changes fail
+instead of quietly reintroducing mixed denominators.
+
+#### Acceptance Criteria
+
+1. THE reporter SHALL fail when the follow-up frame contains duplicate Phase II award identifiers.
+2. THE reporter SHALL fail when an observed event lacks its event date/time or when a censored row
+   lacks its censoring time.
+3. Synthetic one-to-many fixtures SHALL prove that adding candidate pairs does not change a Phase
+   II award's headline weight.
+
+## Out of scope
+
+- Choosing or validating the Phase II↔Phase III matching rule.
+- Kaplan–Meier estimation or resolving negative completion-relative event times.
+- Agency-specific cohort filters or Navy-specific reporting.
+- Promoting the report beyond its current non-citable tier.
+
+## Dependencies
+
+- Phase II↔Phase III candidate-pairs asset — EXISTS
+- One-row-per-Phase-II survival/follow-up asset — EXISTS
+- Shared `phase_transition_analysis` reporter — EXISTS

--- a/specs/phase-transition-report-grain/tasks.md
+++ b/specs/phase-transition-report-grain/tasks.md
@@ -1,0 +1,21 @@
+# Phase-Transition Report Grain — Tasks
+
+- [ ] 1. Define and validate the row-per-Phase-II follow-up schema.
+  - Verify: duplicate identifiers and incomplete event/censor rows fail closed.
+  - Requirements: 1.1–1.3, 3.1–3.2
+
+- [ ] 2. Move all headline reporter queries onto the follow-up frame.
+  - Verify: incidence, latency, agency, and cohort fixtures share one denominator.
+  - Requirements: 1.1–1.4
+
+- [ ] 3. Add candidate-pair multiplicity diagnostics.
+  - Verify: one-to-many and reused-contract fixtures emit the expected audit counts.
+  - Requirements: 2.1–2.3
+
+- [ ] 4. Version report keys and migrate downstream readers.
+  - Verify: no pair-weighted metric remains under a headline transition label.
+  - Requirements: 1.3–1.4, 2.3
+
+- [ ] 5. Reconcile transition reporting documentation.
+  - Verify: focused tests, `make docs-check`, and `make lint-boundaries` pass.
+  - Requirements: 1.1–3.3

--- a/specs/status.md
+++ b/specs/status.md
@@ -111,6 +111,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`phase-iii-source-materialization` — Maintenance.** The schema-verified
   USAspending and SBIR.gov source layer is implemented. Keep it aligned with the
   census and other transition consumers rather than extending it with scoring policy.
+- **`phase-transition-report-grain` — Maintenance.** Pipelines-tier correction for the
+  shared transition reporter's mixed pair- and award-grain summaries. Use one row per Phase II
+  award for headline rates and event-conditional latency, with pair multiplicity retained only as
+  an explicitly labeled diagnostic; matching-policy and survival-estimator changes are out of scope.
 - **`phase-iii-hand-label-validation` — Gated backlog.** Design and estimand
   are written but the spec is not yet frozen. Do not implement until the design
   is approved and frozen per the evidence-tier contract.


### PR DESCRIPTION
## Description

Adds a pipelines-tier maintenance spec for removing mixed pair- and award-grain statistics from the shared transition report. This is a planning stub only; implementation remains unchecked in `tasks.md`.

## Type of Change

- [x] Documentation update
- [ ] Bug fix

## Versioning Impact

- [x] No release impact

## Testing

- [x] `make docs-check`
- [x] `git diff --check`

## Scope

The future implementation will use a one-row-per-Phase-II follow-up frame for headline incidence and event-conditional latency, while retaining candidate-pair multiplicity only as a diagnostic. Matching policy and Kaplan–Meier estimation are out of scope.