### PR TITLE
Stub EDGAR type-specific event-date preservation

### DIFF
--- a/specs/edgar-type-specific-event-dates/design.md
+++ b/specs/edgar-type-specific-event-dates/design.md
@@ -1,0 +1,50 @@
+# EDGAR Type-Specific Event Dates — Design
+
+## Current flow
+
+Inbound searches return dated `EdgarMAEvent` objects. `enrich_company` then keeps only the latest
+event per filer and serializes a company profile containing all-time mention types plus one latest
+date across those retained events. The filing-grain objects are not the authoritative persisted
+interface.
+
+## Proposed flow
+
+```text
+EDGAR hits → normalized Edgar mention events → event artifact
+                                          ↘ deterministic profile aggregation
+```
+
+The event artifact is canonical. Its identity should include target company identity, accession
+number, and mention type; if one accession legitimately yields multiple classified contexts, add a
+stable context ordinal or source locator rather than collapsing them by filer. Profile summaries
+are derived conveniences and never replace the event rows.
+
+## Schema
+
+At minimum preserve:
+
+- target canonical name/identifier;
+- filer CIK and name;
+- accession number and form type;
+- filing date;
+- mention type and existing noise/classification metadata;
+- source query cut or manifest fingerprint.
+
+Add `latest_mention_date_by_type` only if the serialization format supports a stable typed mapping;
+otherwise publish a separate long-form type summary. Keep `latest_mention_date` as an explicitly
+generic compatibility field during migration.
+
+## Failure and migration behavior
+
+Duplicate byte-equivalent events collapse deterministically. Same-identity conflicts are emitted
+to a quarantine/check table and block profile publication. Existing profiles are not assigned
+synthetic type dates: consumers must either join the new event artifact or mark the dated branch
+unavailable until regeneration.
+
+## Testing strategy
+
+- One target with an older acquisition-related filing and a newer unrelated filing.
+- Two distinct accessions from the same filer, both retained.
+- Duplicate and conflicting event identities.
+- Round-trip provenance from profile type/date back to accession.
+- Compatibility test naming latest-any-mention semantics explicitly.

--- a/specs/edgar-type-specific-event-dates/requirements.md
+++ b/specs/edgar-type-specific-event-dates/requirements.md
@@ -1,0 +1,82 @@
+# EDGAR Type-Specific Event Dates — Requirements
+
+> **Lifecycle status:** Maintenance
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **F1–F2** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** F1 M&A exit timing and F2 SBIR↔M&A event coverage
+**Answers for:** pipeline engineers maintaining SEC-derived capital-event inputs
+**RQ complexity tier:** Descriptive / Relational downstream; this spec preserves event records
+
+---
+
+## Done when
+
+EDGAR inbound-mention enrichment persists each retained filing hit with its own accession, form,
+filer, filing date, and mention type, and every profile-level "latest" date is derived for a named
+type rather than paired with an all-time union of unrelated types.
+
+---
+
+## Background
+
+The enricher already creates dated `EdgarMAEvent` objects, but profile serialization deduplicates
+to the latest event per filer, stores only the union of `mention_types`, and stores one latest date
+across every type. Downstream data can therefore say that a profile has an acquisition-related type
+and a recent mention, but cannot establish that the acquisition-related mention itself was recent.
+
+## Requirements
+
+### Requirement 1 — Preserve event-grain records
+
+**User story:** As a pipeline engineer, I want each retained EDGAR hit persisted at filing grain,
+so aggregation cannot destroy the relationship between event type and date.
+
+#### Acceptance Criteria
+
+1. EACH event record SHALL preserve target company key, filer CIK/name, accession number, form,
+   filing date, mention type, and existing classification metadata.
+2. Deduplication SHALL use a documented filing/event identity and SHALL NOT discard older distinct
+   accessions merely because the filer is the same.
+3. Conflicting records with the same canonical event identity SHALL fail or be quarantined with an
+   explicit conflict reason.
+
+### Requirement 2 — Type-specific summaries
+
+**User story:** As a downstream consumer, I want dates summarized within event type, so an unrelated
+later filing cannot make an older acquisition signal appear recent.
+
+#### Acceptance Criteria
+
+1. Profile summaries SHALL expose latest dates by mention type or derive them from the event table.
+2. A generic latest-any-mention date SHALL be named accordingly and SHALL NOT serve as an
+   acquisition-event date.
+3. Counts, filers, and dates for a type SHALL be computed from the same filtered event rows.
+
+### Requirement 3 — Lineage and migration
+
+**User story:** As a reviewer, I want profile summaries traceable to filings, so every reported date
+can be audited against the source event.
+
+#### Acceptance Criteria
+
+1. Event outputs SHALL be provenance-bound to the query cut and retain accession identifiers.
+2. Profile outputs SHALL record the event-output fingerprint used for aggregation.
+3. Legacy profiles lacking type-specific dates SHALL be treated as incapable of dated type claims,
+   not backfilled from `latest_mention_date`.
+
+## Out of scope
+
+- Validating that a classified mention represents a completed acquisition.
+- Changing mention-type classification rules or confidence thresholds.
+- Adding a new search backend or continuous EDGAR orchestration.
+- Computing M&A rates, causal effects, or citable findings.
+
+## Dependencies
+
+- `EdgarMAEvent` filing-grain model — EXISTS
+- EDGAR inbound-mention search and classification — EXISTS
+- Company-level EDGAR profile output — EXISTS, LOSSY SUMMARY

--- a/specs/edgar-type-specific-event-dates/tasks.md
+++ b/specs/edgar-type-specific-event-dates/tasks.md
@@ -1,0 +1,21 @@
+# EDGAR Type-Specific Event Dates — Tasks
+
+- [ ] 1. Define the filing/event identity and canonical event schema.
+  - Verify: fixtures retain two accessions from one filer without collision.
+  - Requirements: 1.1–1.3
+
+- [ ] 2. Persist normalized inbound-mention events with source lineage.
+  - Verify: every event round-trips accession, form, type, and filing date.
+  - Requirements: 1.1–1.3, 3.1
+
+- [ ] 3. Derive type-specific profile summaries from the event artifact.
+  - Verify: a newer unrelated mention does not change the acquisition-type date.
+  - Requirements: 2.1–2.3, 3.2
+
+- [ ] 4. Add conflict checks and legacy-profile migration guards.
+  - Verify: ambiguous identity blocks publication and legacy generic dates are not retyped.
+  - Requirements: 1.3, 3.1–3.3
+
+- [ ] 5. Migrate capital-event consumers and document claim boundaries.
+  - Verify: focused tests, `make docs-check`, and `make lint-boundaries` pass.
+  - Requirements: 2.1–3.3

--- a/specs/status.md
+++ b/specs/status.md
@@ -56,6 +56,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   test are accepted; and weekly-report refactor T2.3 plus the injected,
   typed-return work in T3.2 are complete. Offline, full-context, and shadow
   gates still precede any production integration.
+- **`edgar-type-specific-event-dates` — Maintenance.** Pipelines-tier repair for lossy
+  EDGAR profile aggregation. Persist filing-grain mention events and derive dates within each event
+  type so latest-any-mention cannot masquerade as an acquisition date; classifier validation and
+  M&A estimation remain out of scope.
 - **`epistemic-tier-enforcement` — Maintenance.** Enforcement follow-on to the
   2026-08 module-labeling sweep (PRs #550–#552). Shipped: the blocking
   tier-aware import guard (`scripts/ci/check_tier_boundaries.py`, in


### PR DESCRIPTION
## Description

Adds a pipelines-tier maintenance spec for preserving EDGAR mention type and filing date at event grain. This is a planning stub only; implementation remains unchecked in `tasks.md`.

## Type of Change

- [x] Documentation update
- [ ] Bug fix

## Versioning Impact

- [x] No release impact

## Testing

- [x] `make docs-check`
- [x] `git diff --check`

## Scope

The future implementation will persist accession-level mention events and derive latest dates within each type. It will not validate completed acquisitions, change classifiers, add a search backend, or estimate M&A rates.