### PR TITLE
Stub Form D amendment-chain deduplication

### DIFF
--- a/specs/form-d-amendment-chain-deduplication/design.md
+++ b/specs/form-d-amendment-chain-deduplication/design.md
@@ -1,0 +1,53 @@
+# Form D Amendment-Chain Deduplication — Design
+
+## Data flow
+
+```text
+Form D filings → accession-grain normalized rows → versioned chain resolver
+                                               ↘ resolution audit
+                    resolved series → one as-of representative → monetary aggregate
+                    unresolved rows ───────────────────────────→ excluded/audited
+```
+
+The accession-grain table remains canonical. Chain and firm aggregates are derived outputs with
+their own grain and policy version.
+
+## Chain identity
+
+Implementation begins with an audit of SEC XML fields and known original/amendment sequences. Use
+an explicit predecessor or offering identifier if the source exposes one. Any fallback key must be
+documented, deterministic, and tested against collisions; plausible-but-ambiguous candidates stay
+unresolved. Issuer name alone is never a chain key.
+
+Candidate fallback components may include issuer CIK, date of first sale, exemption, security
+types, and stable offering attributes, but the implementation may only adopt them after the audit
+shows the collision and missingness behavior. The named chain-policy version makes later rule
+changes explicit.
+
+## Representative selection
+
+Within a resolved series and declared as-of cut:
+
+1. order filings by valid filing date and accession tie-break;
+2. select the latest valid filing representing cumulative progress;
+3. retain its reported `total_amount_sold` as the series amount;
+4. retain earlier accessions as lineage, not additive dollars.
+
+Conflicting same-day records, decreasing/restated values, and orphan amendments are surfaced in
+checks. A decrease is not silently rewritten; the latest disclosed amount and audit flag are both
+preserved when the chain itself is unambiguous.
+
+## Consumer migration
+
+`agency_private_capital` inputs, capital-event summaries, and bootstrap leverage code must consume
+resolved series amounts rather than summing offering rows. Participation outputs may continue to
+use accession-grain filings if their names state that grain. Legacy dollar artifacts are not
+relabelled as chain-resolved.
+
+## Testing strategy
+
+- Original plus two cumulative amendments (5, 8, 10) produces 10, not 23.
+- Two independent resolved offerings produce the sum of two representatives.
+- Orphan and ambiguous amendments are excluded with reasons.
+- Duplicate-accession conflict fails closed.
+- As-of cut selects the latest filing available by that date.

--- a/specs/form-d-amendment-chain-deduplication/requirements.md
+++ b/specs/form-d-amendment-chain-deduplication/requirements.md
@@ -1,0 +1,86 @@
+# Form D Amendment-Chain Deduplication — Requirements
+
+> **Lifecycle status:** Maintenance
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **F1 and F3** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** F1 Form D fundraising profile and F3 disclosed Form D leverage
+**Answers for:** pipeline engineers maintaining SEC private-capital inputs
+**RQ complexity tier:** Descriptive / Inferential downstream; this spec normalizes filings only
+
+---
+
+## Done when
+
+Form D monetary aggregates use at most one as-of amount from each auditable offering/amendment
+chain, retain every source accession for lineage, and exclude unresolved amendment chains from
+dollar totals rather than summing potentially cumulative filings.
+
+---
+
+## Background
+
+Current shared aggregators sum `total_amount_sold` across every kept Form D offering row, including
+rows marked `is_amendment`. Amendments can restate cumulative offering amounts, so original and
+amended filings can be counted more than once. Filing participation remains usable, but shared
+capital totals need a chain-aware source contract before supporting leverage calculations.
+
+## Requirements
+
+### Requirement 1 — Preserve filing lineage
+
+**User story:** As a pipeline engineer, I want every filing retained before aggregation, so chain
+resolution never destroys source evidence.
+
+#### Acceptance Criteria
+
+1. EACH Form D row SHALL retain issuer CIK, accession number, filing date, first-sale date,
+   amendment flag, offering attributes, and reported amounts.
+2. Duplicate accessions SHALL collapse only when canonical content is equivalent; conflicts SHALL
+   fail or enter an explicit quarantine artifact.
+3. A resolved offering series SHALL retain the ordered accessions that support it.
+
+### Requirement 2 — Conservative chain resolution
+
+**User story:** As a reviewer, I want amendment chains resolved by an auditable versioned rule, so
+ambiguous filings cannot silently inflate or suppress capital.
+
+#### Acceptance Criteria
+
+1. THE resolver SHALL prefer explicit SEC linkage fields when available and document every fallback
+   identity component.
+2. IF a filing cannot be assigned to one offering series without ambiguity, THEN it SHALL receive
+   an unresolved status and SHALL NOT enter default monetary aggregates.
+3. Chain-policy version and resolution reason SHALL be present on every resolved or unresolved row.
+
+### Requirement 3 — Chain-aware amounts and counts
+
+**User story:** As a capital-data consumer, I want filings, offering series, and amounts reported at
+their proper grains, so a filing count is not mistaken for a distinct raise count or dollar total.
+
+#### Acceptance Criteria
+
+1. For an auditable chain, THE as-of amount SHALL come from one deterministically selected filing,
+   normally the latest valid amendment as of the declared cut, and SHALL NOT sum chain members.
+2. Independent resolved offering series MAY be summed only after one representative amount per
+   series is selected.
+3. Outputs SHALL report filing count, resolved series count, unresolved filing/series count, and
+   excluded dollars separately.
+4. Existing raw-sum helpers SHALL be removed from headline monetary paths or renamed as explicitly
+   filing-grain diagnostics.
+
+## Out of scope
+
+- Inferring undisclosed private capital or correcting self-reported SEC amounts.
+- Changing SBIR↔Form D company matching.
+- Treating Form D capital as caused by SBIR funding.
+- Heuristically forcing every amendment into a chain to maximize coverage.
+
+## Dependencies
+
+- Form D XML parser with accession and amendment fields — EXISTS
+- High-confidence SBIR↔Form D matching — EXISTS, UNCHANGED
+- Shared agency-private-capital and bootstrap aggregators — EXISTS, RAW-SUM BEHAVIOR

--- a/specs/form-d-amendment-chain-deduplication/tasks.md
+++ b/specs/form-d-amendment-chain-deduplication/tasks.md
@@ -1,0 +1,25 @@
+# Form D Amendment-Chain Deduplication — Tasks
+
+- [ ] 1. Audit SEC amendment-link fields and quantify candidate-key collisions on a fixture cut.
+  - Verify: the chosen policy and unresolved cases are documented before implementation.
+  - Requirements: 2.1–2.3
+
+- [ ] 2. Add accession-grain normalization and duplicate/conflict checks.
+  - Verify: every filing retains source lineage and conflicting accessions fail closed.
+  - Requirements: 1.1–1.3
+
+- [ ] 3. Implement the named conservative chain resolver and resolution audit.
+  - Verify: known chains resolve; ambiguous and orphan amendments remain unresolved.
+  - Requirements: 2.1–2.3
+
+- [ ] 4. Build as-of series amounts and grain-specific quality metrics.
+  - Verify: cumulative amendment fixtures select one amount and independent series remain additive.
+  - Requirements: 3.1–3.3
+
+- [ ] 5. Migrate shared monetary consumers away from raw filing sums.
+  - Verify: no headline capital path sums amendment rows directly.
+  - Requirements: 3.1–3.4
+
+- [ ] 6. Document legacy-artifact boundaries and run repository guards.
+  - Verify: focused tests, `make docs-check`, and `make lint-boundaries` pass.
+  - Requirements: 1.1–3.4

--- a/specs/status.md
+++ b/specs/status.md
@@ -73,6 +73,10 @@ bypassing lifecycle review; the status and rationale still require human judgmen
 - **`follow-on-multiplier-validation` — Active.** Retiered `evidence` →
   `exploratory` (2026-08-15): design-only follow-up without an evidence contract.
   Still called out as an immediate research-plan gap.
+- **`form-d-amendment-chain-deduplication` — Maintenance.** Pipelines-tier correction for
+  monetary aggregation across Form D originals and amendments. Preserve accession-grain lineage,
+  resolve only auditable offering chains, and select one as-of amount per series; matching,
+  attribution, and undisclosed-capital estimation are out of scope.
 - **`iterative-api-enrichment` — Maintenance.** Issue #442 closed the
   shared lifecycle: `SourceAdapter` + `SourceRefreshRunner`, USAspending
   as the reference adapter, and `usaspending_refresh_batch` on the job.


### PR DESCRIPTION
## Description

Adds a pipelines-tier maintenance spec for preventing Form D amendment chains from being summed as independent raises. This is a planning stub only; implementation remains unchecked in `tasks.md`.

## Type of Change

- [x] Documentation update
- [ ] Bug fix

## Versioning Impact

- [x] No release impact

## Testing

- [x] `make docs-check`
- [x] `git diff --check`

## Scope

The future implementation will preserve accession-grain lineage, resolve only auditable offering chains, select one as-of amount per series, and exclude unresolved amendments from default dollar totals. Company matching, causal attribution, and undisclosed-capital estimation are out of scope.