### PR TITLE
Fix four data-integrity defects, consolidate reviewed specs, prepare v0.12.0

### DIFF
--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.11.0"
+  version: "0.12.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.11.0"
+version = "0.12.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/agency_private_capital/form_d_inputs.py
@@ -26,6 +26,20 @@ from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 DEFAULT_FORM_D_MATCHES_PATH = Path("data/form_d_details.jsonl")
 DEFAULT_FORM_D_CONTROL_UNIVERSE_PATH = Path("data/form_d_control_universe.jsonl")
 
+# Staging products from the Form D control-identity producer are shaped closely
+# enough to the legitimate universe that this loader would ingest them silently:
+# `cik`/`issuer_name` satisfy the fallbacks below, nested `filings` is ignored,
+# and a missing `filing_date` turns the year window into a no-op. They are also
+# keyed with ORGANIZATION_KEY_V1 rather than the FORM_D_JOIN_V1 used here, so a
+# join would silently produce zero matched pairs instead of an error.
+_STAGING_FILENAME_SUFFIXES = (".provisional.jsonl", ".identity-staging.jsonl")
+_STAGING_RECORD_KEYS = ("firm_key", "schema_version")
+_STAGING_MANIFEST_GATES = (
+    "ready_for_matching",
+    "complete_sbir_exclusion",
+    "covariates_ready",
+)
+
 
 def normalize_name(value: object) -> str:
     """Compatibility shim for the versioned Form D join-key policy."""
@@ -81,8 +95,11 @@ def load_form_d_control_universe(
     already present in the SBIR matched set is removed before matching.
     """
 
+    records = read_jsonl(path)
+    _reject_staging_universe(path, records)
+
     rows: list[dict[str, Any]] = []
-    for row in _iter_company_form_d_rows(read_jsonl(path), matched_to_sbir=False):
+    for row in _iter_company_form_d_rows(records, matched_to_sbir=False):
         cik = str(row.get("form_d_cik") or "").lstrip("0")
         if not cik or cik in sbir_ciks:
             continue
@@ -97,6 +114,46 @@ def load_form_d_control_universe(
         .drop_duplicates(subset=["form_d_cik"], keep="first")
         .reset_index(drop=True)
     )
+
+
+def _reject_staging_universe(path: Path, records: list[dict[str, Any]]) -> None:
+    """Refuse Form D control-universe staging products.
+
+    The producer emits identity-only staging sets whose gates are still false.
+    Consuming one would join on a different identity profile than the SBIR
+    exclusion was computed with, so fail closed rather than match on it.
+    """
+
+    name = path.name
+    for suffix in _STAGING_FILENAME_SUFFIXES:
+        if name.endswith(suffix):
+            raise ValueError(
+                f"Refusing Form D control universe {path}: '{suffix}' marks a staging "
+                "product that is not ready for matching."
+            )
+
+    if records and any(key in records[0] for key in _STAGING_RECORD_KEYS):
+        present = sorted(key for key in _STAGING_RECORD_KEYS if key in records[0])
+        raise ValueError(
+            f"Refusing Form D control universe {path}: records carry staging key(s) "
+            f"{present}, which the matching-ready universe does not use."
+        )
+
+    manifest_path = path.with_name("form_d_control_universe.manifest.json")
+    if not manifest_path.exists():
+        return
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(manifest, dict):
+        return
+    failed = [gate for gate in _STAGING_MANIFEST_GATES if manifest.get(gate) is False]
+    if failed:
+        raise ValueError(
+            f"Refusing Form D control universe {path}: sibling manifest reports "
+            f"{failed} still false."
+        )
 
 
 def _iter_company_form_d_rows(
@@ -126,8 +183,21 @@ def _iter_company_form_d_rows(
             for year in (_year(o.get("filing_date") or o.get("date_filed")) for o in kept_offerings)
             if year is not None
         )
-        total_sold = _sum_float(o.get("total_amount_sold") for o in kept_offerings)
-        total_offered = _sum_float(o.get("total_offering_amount") for o in kept_offerings)
+        # Form D amendments (D/A) restate the *cumulative* offering totals rather
+        # than adding to them, so summing an original alongside its amendments
+        # double-counts. Collapsing chains exactly needs the SEC file number, which
+        # these records do not carry, so sum originals only and fall back to the
+        # largest restatement when a chain reaches us as amendments alone. That is
+        # a documented lower bound, not an exact total.
+        originals = [o for o in kept_offerings if not o.get("is_amendment")]
+        amendments = [o for o in kept_offerings if o.get("is_amendment")]
+        counted = originals or amendments
+        if originals:
+            total_sold = _sum_float(o.get("total_amount_sold") for o in originals)
+            total_offered = _sum_float(o.get("total_offering_amount") for o in originals)
+        else:
+            total_sold = _max_float(o.get("total_amount_sold") for o in amendments)
+            total_offered = _max_float(o.get("total_offering_amount") for o in amendments)
 
         issuer_name = (
             first.get("entity_name")
@@ -159,7 +229,7 @@ def _iter_company_form_d_rows(
             "industry_group": industry_group or "Unknown",
             "first_form_d_date": first.get("filing_date") or first.get("date_filed") or "",
             "first_form_d_year": filing_years[0] if filing_years else None,
-            "offering_count": len(kept_offerings),
+            "offering_count": len(counted),
             "total_form_d_raised": total_sold,
             "total_form_d_offered": total_offered,
             "security_types": security_types,
@@ -176,6 +246,7 @@ def _offering_from_flat_record(rec: dict[str, Any]) -> dict[str, Any]:
         "securities_types": rec.get("securities_types") or [],
         "total_amount_sold": rec.get("total_amount_sold") or rec.get("total_raised"),
         "total_offering_amount": rec.get("total_offering_amount"),
+        "is_amendment": bool(rec.get("is_amendment")),
     }
 
 
@@ -201,6 +272,11 @@ def _sum_float(values: Iterable[object]) -> float:
             continue
         total += parsed
     return total
+
+
+def _max_float(values: Iterable[object]) -> float:
+    parsed = [v for v in (_float_or_none(value) for value in values) if v is not None]
+    return max(parsed) if parsed else 0.0
 
 
 def _float_or_none(value: object) -> float | None:

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/pairs.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/pairs.py
@@ -294,8 +294,8 @@ def transformed_phase_ii_iii_pairs(
         or DEFAULT_PAIRS_OUTPUT
     )
     ensure_parent_dir(output_path)
-    if not pairs.empty:
-        pairs.to_parquet(output_path, index=False)
+    # Write unconditionally, including when empty; see phase_iii.py for why.
+    pairs.to_parquet(output_path, index=False)
 
     summary = _latency_summary(pairs)
     basis_counts = pairs["identifier_basis"].value_counts().to_dict() if not pairs.empty else {}
@@ -361,8 +361,8 @@ def transformed_phase_transition_survival(
         or DEFAULT_SURVIVAL_OUTPUT
     )
     ensure_parent_dir(output_path)
-    if not survival.empty:
-        survival.to_parquet(output_path, index=False)
+    # Write unconditionally, including when empty; see phase_iii.py for why.
+    survival.to_parquet(output_path, index=False)
 
     total = int(len(survival))
     observed = int(survival["event_observed"].sum()) if total else 0

--- a/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_iii.py
+++ b/packages/sbir-analytics/sbir_analytics/assets/phase_transition/phase_iii.py
@@ -152,8 +152,10 @@ def validated_phase_iii_contracts(context=None) -> Output[pd.DataFrame]:
     phase_iii = _prepare_phase_iii_rows(contracts)
 
     ensure_parent_dir(output_path)
-    if not phase_iii.empty:
-        phase_iii.to_parquet(output_path, index=False)
+    # Write unconditionally, including when empty. Skipping the write left the
+    # previous parquet on disk while checks.json below is overwritten with
+    # total_rows: 0, so a stale table read as a fresh zero-row result.
+    phase_iii.to_parquet(output_path, index=False)
 
     uei_cov = float(phase_iii["recipient_uei"].notna().mean()) if not phase_iii.empty else 0.0
     duns_cov = float(phase_iii["recipient_duns"].notna().mean()) if not phase_iii.empty else 0.0

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.11.0"
+version = "0.12.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.11.0"
+version = "0.12.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.11.0"
+version = "0.12.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/sbir_etl/reporting/phase_transition_analysis.py
+++ b/sbir_etl/reporting/phase_transition_analysis.py
@@ -57,26 +57,36 @@ def generate_phase_transition_report(
     con.execute(f"CREATE VIEW survival AS SELECT * FROM read_parquet({_lit(survival)})")
 
     # 1. Latency distribution — percentiles and month-binned histogram.
+    #
+    # Read from `survival`, not `pairs`. One Phase II award can match several
+    # Phase III contracts, so `pairs` carries several rows per award and would
+    # weight multi-contract awards more heavily here — while the transition rate
+    # and agency counts below are computed per award from `survival`. Reporting
+    # both grains under one transition vocabulary mixed the denominators.
+    # `survival.time_days` is the latency to the earliest Phase III action date
+    # for the award, which is the per-award analogue of `pairs.latency_days`.
     percentiles = con.execute(
         """
         SELECT
             count(*)::BIGINT                          AS n,
-            sum(CASE WHEN latency_days < 0 THEN 1 ELSE 0 END)::BIGINT AS negative,
-            approx_quantile(latency_days, 0.10)       AS p10,
-            approx_quantile(latency_days, 0.25)       AS p25,
-            approx_quantile(latency_days, 0.50)       AS p50,
-            approx_quantile(latency_days, 0.75)       AS p75,
-            approx_quantile(latency_days, 0.90)       AS p90,
-            avg(latency_days)                          AS mean
-        FROM pairs
+            sum(CASE WHEN time_days < 0 THEN 1 ELSE 0 END)::BIGINT AS negative,
+            approx_quantile(time_days, 0.10)          AS p10,
+            approx_quantile(time_days, 0.25)          AS p25,
+            approx_quantile(time_days, 0.50)          AS p50,
+            approx_quantile(time_days, 0.75)          AS p75,
+            approx_quantile(time_days, 0.90)          AS p90,
+            avg(time_days)                             AS mean
+        FROM survival
+        WHERE event_observed
         """
     ).fetchone()
 
     histogram = con.execute(
         """
         WITH binned AS (
-            SELECT CAST(floor(latency_days / 30.0) AS INTEGER) AS month_bin
-            FROM pairs
+            SELECT CAST(floor(time_days / 30.0) AS INTEGER) AS month_bin
+            FROM survival
+            WHERE event_observed
         )
         SELECT month_bin, count(*) AS n
         FROM binned
@@ -86,27 +96,27 @@ def generate_phase_transition_report(
     ).fetchall()
 
     # 2. Agency breakdown — match rate + median latency per Phase II agency.
+    # Counts and median latency both come from `survival` at one row per Phase II
+    # award. The previous LEFT JOIN onto `pairs` fanned each agency out to its
+    # pair rows, so the median was pair-weighted while the rate beside it was
+    # award-weighted.
     agency_breakdown = con.execute(
         """
-        WITH per_agency AS (
-            SELECT
-                coalesce(s.phase_ii_agency, 'UNKNOWN') AS agency,
-                count(*)                                AS phase_ii_total,
-                sum(CASE WHEN s.event_observed THEN 1 ELSE 0 END) AS matched
-            FROM survival s
-            GROUP BY 1
-        )
         SELECT
-            p.agency,
-            p.phase_ii_total,
-            p.matched,
-            round(p.matched::DOUBLE / nullif(p.phase_ii_total, 0), 4) AS match_rate,
-            approx_quantile(pa.latency_days, 0.5)                      AS median_latency_days
-        FROM per_agency p
-        LEFT JOIN pairs pa
-               ON coalesce(pa.phase_ii_agency, 'UNKNOWN') = p.agency
-        GROUP BY p.agency, p.phase_ii_total, p.matched
-        ORDER BY p.phase_ii_total DESC
+            coalesce(phase_ii_agency, 'UNKNOWN') AS agency,
+            count(*)                              AS phase_ii_total,
+            sum(CASE WHEN event_observed THEN 1 ELSE 0 END) AS matched,
+            round(
+                sum(CASE WHEN event_observed THEN 1 ELSE 0 END)::DOUBLE
+                / nullif(count(*), 0),
+                4
+            ) AS match_rate,
+            approx_quantile(
+                CASE WHEN event_observed THEN time_days END, 0.5
+            ) AS median_latency_days
+        FROM survival
+        GROUP BY agency
+        ORDER BY phase_ii_total DESC
         """
     ).fetchall()
 

--- a/specs/phase-iii-source-materialization/tasks.md
+++ b/specs/phase-iii-source-materialization/tasks.md
@@ -1,0 +1,73 @@
+# Phase III Source Materialization — Tasks
+
+**Target epistemic tier:** `pipelines`
+
+**Research question anchor:** B1 (Phase III transition measurement)
+
+The source and lineage layer is implemented; `specs/status.md` records it as
+Maintenance and directs that it be kept aligned with the census and other
+transition consumers rather than extended. These are the remaining alignment
+tasks, folded in from two spec proposals reviewed in PRs #687 and #688 rather
+than given their own registry entries.
+
+## Contract source-field preservation (from #687)
+
+The award-archive projection at `sbir_etl/extractors/usaspending_award_archive.py:36-67`
+decodes a narrow column set, and that narrowness is a deliberate, commented
+memory tradeoff — not an accident. The argument for widening it is that
+`phase_ii.py:143` carries a lenient `\bPHASE\s+(III|II|I)\b` regex whose only
+purpose is to recover a phase from the Element 10Q *label* because the *code*
+was never projected. The goal is deleting that compensating fallback, not
+repairing a live break: the fallback currently works, so nothing is miscounted
+today.
+
+- [ ] 1. Audit the real USAspending archive headers in a notebook.
+  - The projection has never been checked against a genuine header row:
+    `tests/unit/extractors/test_usaspending_award_archive.py:64` synthesizes the
+    CSV header *from `CONTRACT_ARCHIVE_COLUMNS` itself*, and
+    `usaspending_award_archive.py:347` verifies column presence only, never value
+    semantics — so a code/label swap is currently undetectable.
+  - Per CLAUDE.md's notebook-first rule, resolve this before writing the
+    downstream tasks; the header names are an open question, not a settled input.
+  - Verify: a fixture derived from a real archive member, carrying distinct
+    research code and label values.
+
+- [ ] 2. Extend the canonical contract model for the audited fields.
+  - Verify: model serialization preserves each optional field without fallback.
+
+- [ ] 3. Expand the archive projection and row mapping, and state the memory cost.
+  - The existing comment claims narrowness keeps Arrow record batches small for
+    multi-GB members. Measure the change rather than silently reversing it.
+  - Verify: CSV→model tests preserve every added field after normalization, and
+    the projection's memory footprint is recorded.
+
+- [ ] 4. Bind projection and coverage metadata into source checks.
+  - Verify: missing headers fail closed; coverage is emitted per added field.
+
+- [ ] 5. Remove the lenient phase-label regex once the code is projected.
+  - This is the task that justifies the work. Do not add fields without it.
+  - Verify: `phase_ii.py` classifies from the code, and the label fallback is
+    deleted rather than left as dead alternative logic.
+
+## Materialization output integrity (from #688)
+
+The reviewed proposal was framed as a cache-validity problem, but these assets
+have no cache: `phase_iii.py`, `phase_ii.py`, and `pairs.py` all recompute
+unconditionally on every materialization. The fingerprint framework it proposed
+would also have been a second implementation of the manifest already built at
+`packages/sbir-analytics/sbir_analytics/assets/phase_transition/sbir_gov_source.py:290-449`,
+which already carries source SHA, output SHA, ordered-column SHA, and a
+validator that rejects mismatches. Only the empty-output defect was real, and it
+is fixed.
+
+- [x] 1. Write transition parquets unconditionally, including when empty.
+  - The assets wrote the parquet only when the frame was non-empty while writing
+    `checks.json` unconditionally, so a legitimate zero-row run left the previous
+    parquet on disk beside a checks file reporting `total_rows: 0`.
+  - Verify: `tests/unit/phase_transition/test_empty_output_write.py` covers both
+    the stale-overwrite and first-write cases. Done.
+
+- [ ] 2. Extend the existing `sbir_gov_source` manifest to the Phase II/III assets.
+  - Reuse that manifest rather than introducing a parallel fingerprint utility.
+  - Verify: changing a source input invalidates the dependent output; no second
+    canonical-JSON or hashing helper is added.

--- a/specs/sec-source-fidelity/design.md
+++ b/specs/sec-source-fidelity/design.md
@@ -1,0 +1,36 @@
+# SEC Source Fidelity — Design
+
+**Target epistemic tier:** `exploratory`
+
+## EDGAR type-anchored dates
+
+The dedup at `enricher.py:769-780` exists to keep one row per filer. The fix is not to remove
+deduplication but to stop deriving a profile-level date from the deduplicated set:
+
+- Key the retained-event map on `(cik, accession_number)` so distinct filings survive.
+- Replace the single `latest_mention_date` with a per-type mapping, so an M&A date is always the
+  date of an M&A-typed filing.
+- Keep `mention_types` as the type set it already is; add the anchored dates beside it rather than
+  redefining either existing field in place.
+
+Field naming is a decision, not an implementation detail: `latest_mention_date` has two live
+readers, and silently changing its meaning would leave their existing artifacts unexplained. Prefer
+a new field and a deprecation of the old one.
+
+## Form D amendment chains
+
+Amendments restate cumulative totals, so the correct total for a chain is its final restatement, not
+the sum of its filings. Collapsing chains requires grouping filings that belong to the same
+offering, which needs the SEC file number.
+
+The interim behavior now in `form_d_inputs.py` sums originals only and falls back to the largest
+restatement for amendment-only chains. It is deliberately conservative: it under-reports rather than
+over-reports, and the code comment says so. It is not a design, and it should be deleted when task 5
+lands rather than kept as a fallback path.
+
+## What this spec does not do
+
+- It does not promote these artifacts above `exploratory`. Every named consumer is a
+  `scripts/data/` script; promotion needs a pipelines-tier consumer first.
+- It does not add conflict quarantine or legacy-profile migration guards. Those were proposed in the
+  reviewed spec and cut: build them when there is a pipelines-tier consumer to protect.

--- a/specs/sec-source-fidelity/requirements.md
+++ b/specs/sec-source-fidelity/requirements.md
@@ -1,0 +1,96 @@
+# SEC Source Fidelity — Requirements
+
+> **Lifecycle status:** Gated backlog
+> **Spec-file progress:** Not yet started
+> Anchors inventory questions **F1–F2** in
+> [docs/research-questions.md](../../docs/research-questions.md).
+
+**Target epistemic tier:** `exploratory`
+
+**Research question anchor:** F1 M&A exit timing and F2 SBIR↔M&A event coverage
+**Answers for:** engineers maintaining SEC-derived capital-event and Form D inputs
+**RQ complexity tier:** Descriptive; this spec preserves and de-duplicates source event records
+
+---
+
+## Done when
+
+Two SEC-derived source defects are closed: an EDGAR profile can no longer pair an
+acquisition-related mention *type* with a "latest" date belonging to a different type, and Form D
+amendment chains no longer inflate cumulative raised totals.
+
+---
+
+## Background
+
+These were reviewed as two proposals (PRs #690 and #691) and merged here because they are one
+surface: both touch `sbir_etl/enrichers/sec_edgar/` and `sbir_etl/capital_events/`, and both feed
+the same downstream consumers.
+
+**EDGAR type/date decoupling.** `sbir_etl/enrichers/sec_edgar/enricher.py:769-780` keys the dedup
+map on `filer_name or cik`, discarding distinct accessions from the same filer. It then unions
+`mention_types` across the survivors and takes `max(filing_date)` across *all* types. A profile can
+therefore report an acquisition-related type and a recent date without those being the same filing.
+Two consumers already perform exactly that unsafe join —
+`scripts/data/nano_prime_acquisitions.py:283-288` and `scripts/data/nano_ma_signal.py:139-144` both
+intersect `mention_types` with `MA_SIGNAL_TYPES` and then read `latest_mention_date` as the M&A
+date. The mis-attribution is live, not hypothetical.
+
+**Form D amendment chains.** Form D amendments (D/A) restate *cumulative* offering totals rather
+than adding to them, so summing an original alongside its amendments double-counts. A partial fix is
+in place: `form_d_inputs.py` now sums non-amendment offerings only, falling back to the largest
+restatement when a chain arrives as amendments alone. That is a documented lower bound, not an exact
+total — an original plus amendments of 5/8/10 reports 5 where the correct answer is 10.
+
+## Tier note
+
+Both proposals originally declared `pipelines`. That is not yet warranted: every named consumer of
+these event artifacts is under `scripts/data/`, which is exploratory. This spec declares
+`exploratory` and treats promotion as separate, explicit work per
+[docs/steering/epistemic-tiers.md](../../docs/steering/epistemic-tiers.md). Name a pipelines-tier
+consumer before re-tiering.
+
+## Gate
+
+The Form D half is blocked on an open question, not on effort: the SEC **file number** (the
+`021-…` offering identifier) is the chain key, and it appears nowhere in the codebase.
+`FormDFiling` (`sbir_etl/models/sec_edgar.py:195`) carries only the `is_amendment` boolean and a
+per-filing `accession_number`, neither of which groups filings into chains. Resolve that in a
+notebook before implementing an exact collapse.
+
+This spec also overlaps the **Active** `agency-private-capital-comparison` spec, whose Phase 2 is
+gated on a reproducible Form D control-universe producer and whose direct input is
+`form_d_inputs.py`. Coordinate ownership with that spec and with PR #582 before starting.
+
+---
+
+## Requirements
+
+### 1. EDGAR event records preserve their own provenance
+
+1.1 Each retained filing hit SHALL persist its own accession, form type, filer, filing date, and
+mention type rather than being collapsed to one row per filer.
+
+1.2 Any profile-level "latest" date SHALL be derived for a *named* mention type. A date SHALL NOT
+be paired with a union of unrelated types.
+
+1.3 The existing `mention_types` / `latest_mention_date` fields SHALL either keep their current
+meaning or be renamed. They SHALL NOT silently change meaning under the same key.
+
+### 2. Consumers read a type-anchored date
+
+2.1 `nano_prime_acquisitions.py` and `nano_ma_signal.py` SHALL read an M&A-anchored date rather
+than reconstructing one from a type set and an all-type maximum.
+
+2.2 Any artifact regenerated after this change SHALL record that its event dates come from the
+type-anchored field, since prior artifacts were built on the unsafe join.
+
+### 3. Form D amendment chains collapse exactly
+
+3.1 Once the chain key is known, offerings SHALL be grouped into amendment chains and each chain
+SHALL contribute its final restatement to cumulative totals.
+
+3.2 `total_form_d_raised`, `total_form_d_offered`, and `offering_count` SHALL agree on that grain.
+
+3.3 The interim lower-bound behavior SHALL be replaced, not layered over, and its code comment
+SHALL be removed with it.

--- a/specs/sec-source-fidelity/tasks.md
+++ b/specs/sec-source-fidelity/tasks.md
@@ -1,0 +1,29 @@
+# SEC Source Fidelity — Tasks
+
+- [ ] 1. Audit the SEC Form D amendment chain key in a notebook.
+  - The `021-…` file number is absent from the codebase and from `FormDFiling`.
+    Establish where it can be sourced before any implementation task is written.
+  - Verify: a notebook showing an original and its amendments grouped by the
+    proposed key against real filings.
+  - Requirements: 3.1
+
+- [ ] 2. Persist per-filing EDGAR event records.
+  - Verify: two filings from one filer with different accessions both survive
+    serialization, with their own form, date, and mention type.
+  - Requirements: 1.1
+
+- [ ] 3. Derive type-anchored dates and settle the field-naming decision.
+  - Verify: a profile with an old non-M&A mention and a recent unrelated mention
+    cannot report a recent M&A date.
+  - Requirements: 1.2–1.3
+
+- [ ] 4. Migrate the two script consumers and re-label affected artifacts.
+  - Verify: both scripts read the anchored field; regenerated artifacts record
+    the change.
+  - Requirements: 2.1–2.2
+
+- [ ] 5. Replace the interim Form D lower bound with exact chain collapse.
+  - Blocked on task 1.
+  - Verify: an original plus two restating amendments reports the final
+    restatement, and `offering_count` counts one offering.
+  - Requirements: 3.1–3.3

--- a/specs/status.md
+++ b/specs/status.md
@@ -140,6 +140,14 @@ bypassing lifecycle review; the status and rationale still require human judgmen
   ranking/auditability phases remain.
 - **`sbir-ma-match-rate-by-fy` — Gated backlog.** Analysis-only F2 follow-up on
   completed M&A detection. Start only when FY match-rate reporting is requested.
+- **`sec-source-fidelity` — Gated backlog.** Merges two reviewed proposals
+  (PRs #690, #691) into one surface: EDGAR profiles pair an M&A mention *type*
+  with an all-type "latest" date, and Form D amendment chains inflate cumulative
+  raised totals. An interim conservative lower bound is in place for the Form D
+  half. Blocked on locating the SEC file number, the amendment chain key, which
+  is absent from the codebase. Declared `exploratory` rather than `pipelines`:
+  every named consumer is a `scripts/data/` script. Coordinate with the Active
+  `agency-private-capital-comparison` spec, which shares `form_d_inputs.py`.
 - **`state-local-tax-rates` — Maintenance.** Existing hardcoded 2024 provider
   works. Remaining work is data-file/provenance cleanup for fiscal v2.
 - **`sttr-spinout-linkage` — Active.** Phase 0 design frozen as Revision 1 (exploratory,

--- a/tests/unit/agency_private_capital/test_form_d_inputs.py
+++ b/tests/unit/agency_private_capital/test_form_d_inputs.py
@@ -140,3 +140,118 @@ def test_load_form_d_control_universe_dedupes_duplicate_ciks(tmp_path) -> None:
     assert len(df) == 1
     assert df.iloc[0]["form_d_cik"] == "999"
     assert df.iloc[0]["first_form_d_year"] == 2020
+
+
+def test_load_form_d_control_universe_refuses_staging_filename(tmp_path) -> None:
+    path = tmp_path / "form_d_control_identity_universe.provisional.jsonl"
+    _write_jsonl(path, [{"cik": "0000999", "issuer_name": "Staging Co"}])
+
+    with pytest.raises(ValueError, match="staging product"):
+        load_form_d_control_universe(path, sbir_ciks=set())
+
+
+def test_load_form_d_control_universe_refuses_staging_record_keys(tmp_path) -> None:
+    path = tmp_path / "form_d_control_universe.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "cik": "0000999",
+                "issuer_name": "Staging Co",
+                "firm_key": "form_d_cik:999",
+                "schema_version": 1,
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="staging key"):
+        load_form_d_control_universe(path, sbir_ciks=set())
+
+
+def test_load_form_d_control_universe_refuses_ungated_manifest(tmp_path) -> None:
+    path = tmp_path / "form_d_control_universe.jsonl"
+    _write_jsonl(path, [{"cik": "0000999", "issuer_name": "Staging Co"}])
+    (tmp_path / "form_d_control_universe.manifest.json").write_text(
+        json.dumps({"ready_for_matching": False}), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match="ready_for_matching"):
+        load_form_d_control_universe(path, sbir_ciks=set())
+
+
+def test_amendments_do_not_inflate_totals(tmp_path) -> None:
+    """A D/A restates cumulative totals; summing the chain would double-count."""
+
+    path = tmp_path / "form_d_details.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "company_name": "Acme Corp",
+                "form_d_cik": "0000123",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {
+                        "entity_name": "ACME CORP",
+                        "filing_date": "2020-01-01",
+                        "industry_group": "Technology",
+                        "total_amount_sold": 5_000_000,
+                        "total_offering_amount": 5_000_000,
+                        "is_amendment": False,
+                    },
+                    {
+                        "entity_name": "ACME CORP",
+                        "filing_date": "2020-06-01",
+                        "industry_group": "Technology",
+                        "total_amount_sold": 8_000_000,
+                        "total_offering_amount": 8_000_000,
+                        "is_amendment": True,
+                    },
+                ],
+            }
+        ],
+    )
+
+    frame = load_form_d_matches(path)
+
+    assert len(frame) == 1
+    # Naive summing would report 13,000,000 across the two filings.
+    assert frame.loc[0, "total_form_d_raised"] == 5_000_000
+    assert frame.loc[0, "offering_count"] == 1
+
+
+def test_amendment_only_chain_uses_largest_restatement(tmp_path) -> None:
+    """With no original in range, fall back to the final restatement, not zero."""
+
+    path = tmp_path / "form_d_details.jsonl"
+    _write_jsonl(
+        path,
+        [
+            {
+                "company_name": "Beta Labs",
+                "form_d_cik": "0000456",
+                "match_confidence": {"tier": "high"},
+                "offerings": [
+                    {
+                        "entity_name": "BETA LABS",
+                        "filing_date": "2021-03-01",
+                        "industry_group": "Technology",
+                        "total_amount_sold": 2_000_000,
+                        "is_amendment": True,
+                    },
+                    {
+                        "entity_name": "BETA LABS",
+                        "filing_date": "2021-09-01",
+                        "industry_group": "Technology",
+                        "total_amount_sold": 3_500_000,
+                        "is_amendment": True,
+                    },
+                ],
+            }
+        ],
+    )
+
+    frame = load_form_d_matches(path)
+
+    assert len(frame) == 1
+    assert frame.loc[0, "total_form_d_raised"] == 3_500_000

--- a/tests/unit/phase_transition/test_empty_output_write.py
+++ b/tests/unit/phase_transition/test_empty_output_write.py
@@ -1,0 +1,84 @@
+"""Empty-frame materializations must overwrite their parquet, not skip the write.
+
+The assets previously wrote the parquet only when the frame was non-empty while
+writing `checks.json` unconditionally. A run that legitimately produced no rows
+therefore left the *previous* parquet on disk next to a fresh checks file
+reporting `total_rows: 0` — a stale table that reads as a current zero-row
+result, with nothing downstream able to tell the difference.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from dagster import build_asset_context
+
+
+pytestmark = [pytest.mark.fast, pytest.mark.unit]
+
+
+def _contracts(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+PHASE_III_ROW = {
+    "contract_id": "C_III_1",
+    "research": "SMALL BUSINESS INNOVATION RESEARCH PROGRAM PHASE III ACTION",
+    "action_date": "2020-05-01",
+    "vendor_uei": "UEI0000000001",
+    "vendor_name": "Acme Corp",
+    "awarding_agency_name": "DOD",
+}
+
+PHASE_II_ROW = {
+    "contract_id": "C_II_1",
+    "research": "SMALL BUSINESS INNOVATION RESEARCH PROGRAM PHASE II ACTION",
+    "action_date": "2020-05-01",
+    "vendor_uei": "UEI0000000002",
+    "vendor_name": "Beta Labs",
+    "awarding_agency_name": "DOD",
+}
+
+
+@pytest.fixture
+def paths(tmp_path, monkeypatch):
+    contracts_path = tmp_path / "contracts.parquet"
+    output_path = tmp_path / "phase_iii.parquet"
+    monkeypatch.setenv("SBIR_ETL__PHASE_TRANSITION__CONTRACTS_PATH", str(contracts_path))
+    monkeypatch.setenv("SBIR_ETL__PHASE_TRANSITION__PHASE_III_OUTPUT_PATH", str(output_path))
+    return contracts_path, output_path
+
+
+def test_empty_result_overwrites_previous_parquet(paths) -> None:
+    from sbir_analytics.assets.phase_transition.phase_iii import validated_phase_iii_contracts
+
+    contracts_path, output_path = paths
+
+    # First run: real Phase III rows land on disk.
+    _contracts([PHASE_III_ROW]).to_parquet(contracts_path, index=False)
+    validated_phase_iii_contracts(build_asset_context())
+    assert len(pd.read_parquet(output_path)) == 1
+
+    # Second run: the source no longer contains any Phase III row.
+    _contracts([PHASE_II_ROW]).to_parquet(contracts_path, index=False)
+    validated_phase_iii_contracts(build_asset_context())
+
+    checks = json.loads(Path(str(output_path.with_suffix(".checks.json"))).read_text())
+    assert checks["total_rows"] == 0
+    # The parquet must agree with checks.json rather than retaining the old row.
+    assert len(pd.read_parquet(output_path)) == 0
+
+
+def test_empty_result_writes_parquet_when_none_existed(paths) -> None:
+    from sbir_analytics.assets.phase_transition.phase_iii import validated_phase_iii_contracts
+
+    contracts_path, output_path = paths
+    _contracts([PHASE_II_ROW]).to_parquet(contracts_path, index=False)
+
+    validated_phase_iii_contracts(build_asset_context())
+
+    assert output_path.exists()
+    assert len(pd.read_parquet(output_path)) == 0

--- a/tests/unit/reporting/test_phase_transition_analysis.py
+++ b/tests/unit/reporting/test_phase_transition_analysis.py
@@ -33,8 +33,8 @@ def test_report_is_materialized_with_non_citable_marker(tmp_path) -> None:
     _write_parquet(
         survival,
         "SELECT 'ARMY' AS phase_ii_agency, true AS event_observed, "
-        "DATE '2024-06-30' AS phase_ii_end_date "
-        "UNION ALL SELECT 'ARMY', false, DATE '2024-12-31'",
+        "DATE '2024-06-30' AS phase_ii_end_date, 90 AS time_days "
+        "UNION ALL SELECT 'ARMY', false, DATE '2024-12-31', 120",
     )
 
     generate_phase_transition_report(phase_ii, phase_iii, pairs, survival, output)
@@ -45,10 +45,56 @@ def test_report_is_materialized_with_non_citable_marker(tmp_path) -> None:
         "citable": False,
         "notice": "Exploratory analysis; do not cite as an evidence-tier result.",
     }
-    assert report["latency_distribution"]["n"] == 2
+    # Latency is counted over observed events in `survival`, one row per Phase II
+    # award — not over the two `pairs` rows, which share a single award.
+    assert report["latency_distribution"]["n"] == 1
     assert report["cohort_transition_rate"][0]["transition_rate"] == 0.5
 
 
 def test_cli_fails_clearly_when_materializations_are_missing(tmp_path) -> None:
     with pytest.raises(SystemExit, match="Missing upstream parquet files"):
         main(["--phase-ii", str(tmp_path / "missing.parquet")])
+
+
+def test_latency_and_rate_share_the_award_grain(tmp_path) -> None:
+    """One award matching several Phase III contracts must count once.
+
+    `pairs` carries a row per matched contract, so reading latency from it while
+    reading the transition rate from `survival` reported two different
+    denominators under one transition vocabulary.
+    """
+
+    phase_ii = tmp_path / "phase_ii.parquet"
+    phase_iii = tmp_path / "phase_iii.parquet"
+    pairs = tmp_path / "pairs.parquet"
+    survival = tmp_path / "survival.parquet"
+    output = tmp_path / "report"
+
+    _write_parquet(phase_ii, "SELECT 1 AS award_id")
+    _write_parquet(phase_iii, "SELECT 1 AS contract_id")
+    # One award, three Phase III contracts.
+    _write_parquet(
+        pairs,
+        "SELECT 30 AS latency_days, 'NAVY' AS phase_ii_agency "
+        "UNION ALL SELECT 60, 'NAVY' UNION ALL SELECT 900, 'NAVY'",
+    )
+    _write_parquet(
+        survival,
+        "SELECT 'NAVY' AS phase_ii_agency, true AS event_observed, "
+        "DATE '2024-06-30' AS phase_ii_end_date, 30 AS time_days "
+        "UNION ALL SELECT 'NAVY', false, DATE '2024-06-30', 365",
+    )
+
+    generate_phase_transition_report(phase_ii, phase_iii, pairs, survival, output)
+    report = json.loads((output / "phase_transition_report.json").read_text())
+
+    latency = report["latency_distribution"]
+    agency = report["agency_breakdown"][0]
+
+    assert latency["n"] == 1
+    assert latency["percentiles_days"]["p50"] == 30
+    # The agency row's denominator and its median must describe the same awards.
+    assert agency["phase_ii_total"] == 2
+    assert agency["matched"] == 1
+    assert agency["match_rate"] == 0.5
+    assert agency["median_latency_days"] == 30

--- a/uv.lock
+++ b/uv.lock
@@ -2823,7 +2823,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2847,7 +2847,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -3001,7 +3001,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3020,7 +3020,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
## Description

Outcome of a review pass across all 15 open PRs. Four code defects surfaced there were self-contained enough to fix directly; none of the originating branches could be pushed to, so they land here. Also completes the agreed consolidation of the six spec-stub PRs (#686–#691) and prepares the v0.12.0 release.

**Code fixes**

- **Transition parquets are written unconditionally, including when empty** (from #688). `phase_iii.py:155`, `pairs.py:297`, `pairs.py:364` wrote the parquet only when the frame was non-empty while writing `checks.json` unconditionally — a legitimate zero-row run left the *previous* parquet on disk beside a checks file reporting `total_rows: 0`, a stale table reading as a current zero-row result. Empty frames always carry their declared column schema, so an empty write preserves columns.
- **`load_form_d_control_universe` refuses staging products** (from #582). It accepted the identity-staging shape silently: `cik`/`issuer_name` satisfy its fallbacks, nested `filings` is ignored, and a missing `filing_date` turns the year window into a no-op. Staging records are keyed with `ORGANIZATION_KEY_V1` rather than the `FORM_D_JOIN_V1` used here, so the join produced zero matched pairs rather than an error. Now fails closed on staging filenames, `firm_key`/`schema_version` records, and a sibling manifest whose gates are false — enforcing a SHALL that `requirements.md:183`, `tasks.md`, `specs/status.md`, and the research doc all already assert.
- **Form D amendments no longer inflate raised totals** (from #691). D/A filings restate *cumulative* totals rather than adding to them. **Partial fix** — see Known limitation below.
- **Phase-transition report grain repaired** (from #689). Latency percentiles and the month histogram read `FROM pairs` while the transition rate and agency counts read `FROM survival`. One Phase II award can match several Phase III contracts, so the report placed pair-weighted and award-weighted numbers side by side under one transition vocabulary; the agency table compounded it by `LEFT JOIN`ing `pairs` for the median. All three now read `survival` at one row per award.

**Spec consolidation** — three surfaces, not six units of work:

- `specs/phase-iii-source-materialization/tasks.md` carries the surviving work from #687 and #688 rather than two new registry entries. That spec already owns this surface and had no tasks file.
- `specs/sec-source-fidelity/` merges #690 and #691, which touch the same modules and feed the same consumers.
- #686's FY-scalar archive resolver is noted rather than specced — it sits on a path disabled by default with no named consumer.
- Cut from the reviewed proposals: the semantic-fingerprint framework (these assets have no cache, and `sbir_gov_source.py:290-449` already implements the manifest concept), report-key versioning and downstream migration, and EDGAR conflict quarantine.

## Known limitation

The Form D amendment fix is **deliberately incomplete and labeled as such in code**. Exact chain collapse needs the SEC file number (the `021-…` offering identifier); it appears nowhere in the codebase, and `FormDFiling` carries only an `is_amendment` boolean and a per-filing `accession_number`, neither of which groups filings into chains. The interim behavior sums originals only, falling back to the largest restatement for amendment-only chains. On a 5/8/10 chain it reports **5** — not 23, and not the correct 10. It trades a silent overcount for a documented undercount. `specs/sec-source-fidelity/` records the gate.

`sec-source-fidelity` also overlaps the Active `agency-private-capital-comparison` spec and PR #582, which share `form_d_inputs.py`. Ownership needs settling before that spec starts.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [ ] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [x] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

**v0.12.0.** MINOR rather than PATCH because [the policy](docs/steering/versioning.md) treats breaking changes during initial development as minor, and three behavior changes qualify: `load_form_d_control_universe` now raises where it previously loaded; Form D raised totals and offering counts change value; the phase-transition report's latency numbers change grain. Versions synchronized across the four `pyproject.toml` files, `sbir_etl.__version__`, and `config/base.yaml`; `uv.lock` relocked. `check_versioning.py --tag v0.12.0` passes.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

New regressions, each verified to **fail against the previous behavior and pass after the change** rather than assumed:

- `tests/unit/phase_transition/test_empty_output_write.py` — stale-parquet overwrite and first-write cases.
- `tests/unit/reporting/test_phase_transition_analysis.py::test_latency_and_rate_share_the_award_grain` — one award with three Phase III contracts counts once, and the agency row's denominator and median describe the same awards. The pre-existing test asserted `n == 2` off two `pairs` rows for a single award, which was the bug; it now asserts `n == 1`.
- `test_form_d_inputs.py` — three `pytest.raises` staging cases, plus amendment-inflation and amendment-only-chain cases.

`6700 passed, 33 skipped`. `make lint` and `make lint-boundaries` clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P71PDXSUfwwsQZJUAhjpMg

---
_Generated by [Claude Code](https://claude.ai/code/session_01P71PDXSUfwwsQZJUAhjpMg)_