### PR TITLE
Add the missing v0.12.0 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ version.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-31
+
+### Fixed
+
+- `validated_phase_iii_contracts` and the `phase_transition_pairs`/survival
+  assets now write their parquet unconditionally, including when the frame
+  is empty. Skipping the write on an empty result left the previous parquet
+  on disk beside a freshly written `checks.json` reporting `total_rows: 0`,
+  so a legitimate zero-row run looked like a stale one (#692).
+- `load_form_d_control_universe` refuses Form D control-universe staging
+  products (a `.provisional.jsonl`/`.identity-staging.jsonl` filename,
+  staging-shaped records, or a sibling manifest reporting an unready gate)
+  instead of loading them silently on a mismatched identity key (#692).
+- Form D amendment filings no longer inflate `total_form_d_raised` and
+  `offering_count` by being summed alongside the filing they amend. The fix
+  is a documented lower bound, not exact chain collapse — that is blocked on
+  locating the SEC file number that links an amendment to its original (#692).
+- The phase-transition report read latency from `pairs` (one row per matched
+  contract) while reading the transition rate and agency counts from
+  `survival` (one row per Phase II award), mixing two denominators under one
+  transition vocabulary. All three now read `survival` (#692).
+
+### Changed
+
+- Consolidated three reviewed spec proposals into the specs that already own
+  the surface they touch, rather than three new registry entries:
+  `specs/phase-iii-source-materialization/tasks.md` gained the transition
+  source/lineage work, and a new `specs/sec-source-fidelity/` spec covers
+  EDGAR event-date and Form D source fidelity (#692).
+
 ## [0.11.0] — 2026-08-26
 
 ### Added


### PR DESCRIPTION
## Description

v0.12.0 was tagged (`v0.12.0` → `a451fbf4`, #692) without a `CHANGELOG.md` entry. Every prior release has one; this is the first gap, caught while drafting the GitHub release notes for v0.12.0.

The tag is already published and immutable per `docs/steering/versioning.md`, so this adds the entry after the fact rather than touching tagged history.

Scoped to exactly what the tagged commit contains: the four data-integrity fixes and the spec consolidation from #692. Deliberately excludes #693 (renamed `sec-source-fidelity` → `edgar-event-date-fidelity`, moved Form D tasks) and #694 (tornado bump) — both landed on `main` after the tag and belong to the next release's entry instead.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

Documents an already-tagged release; does not itself change the version.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

`make docs-check` passes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P71PDXSUfwwsQZJUAhjpMg

---
_Generated by [Claude Code](https://claude.ai/code/session_01P71PDXSUfwwsQZJUAhjpMg)_