### PR TITLE
Automate GitHub release publishing from a pushed tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,11 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           tag="${INPUT_TAG:-$REF_NAME}"
-          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          # Mirrors the SemVer regex in check_versioning.py and
+          # extract_release_notes.py: no leading zeros except a literal 0. A
+          # looser gate here would pass v01.2.3 and fail further in with a
+          # less direct error.
+          if ! [[ "${tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
             echo "error: '${tag}' is not a vMAJOR.MINOR.PATCH tag" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,104 @@
+name: Release
+
+# Publishes the GitHub release when a vMAJOR.MINOR.PATCH tag is pushed.
+# Creating and pushing the tag stays manual -- that is the deliberate act that
+# starts a release. Everything after it is mechanical and lives here.
+#
+# See docs/steering/versioning.md for the surrounding policy.
+
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to publish notes for (e.g. v0.12.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish GitHub release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Full history and tags so the previous release can be resolved for
+          # the compare link, and so the tag object type can be inspected.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Resolve the tag being released
+        id: tag
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          tag="${INPUT_TAG:-$REF_NAME}"
+          if ! [[ "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "error: '${tag}' is not a vMAJOR.MINOR.PATCH tag" >&2
+            exit 1
+          fi
+          echo "tag=${tag}" >>"${GITHUB_OUTPUT}"
+
+      - name: Verify the tag is annotated
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if [[ "$(git cat-file -t "${TAG}")" != "tag" ]]; then
+            echo "error: ${TAG} is lightweight; the policy requires an annotated tag" >&2
+            exit 1
+          fi
+
+      # Re-run rather than trusting the tag push's own Version Policy job: this
+      # is the job that publishes, so it should not depend on a separate
+      # workflow having passed first.
+      - name: Validate synchronized version metadata
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: python scripts/ci/check_versioning.py --tag "${TAG}"
+
+      # Written to a file rather than a step output: release notes are
+      # untrusted-ish free text, and interpolating them into a shell command
+      # would be a command-injection seam.
+      - name: Build release notes from CHANGELOG.md
+        shell: bash
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          previous="$(git tag --list 'v*.*.*' --sort=-version:refname \
+            | grep -v "^${TAG}$" | head -n1 || true)"
+          args=(--tag "${TAG}")
+          if [[ -n "${previous}" ]]; then
+            args+=(--previous-tag "${previous}")
+          fi
+          python scripts/ci/extract_release_notes.py "${args[@]}" >"${RUNNER_TEMP}/notes.md"
+          echo "--- release notes ---"
+          cat "${RUNNER_TEMP}/notes.md"
+
+      - name: Publish the release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.tag.outputs.tag }}
+        run: |
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; leaving it untouched."
+            exit 0
+          fi
+          gh release create "${TAG}" \
+            --title "SBIR Analytics ${TAG}" \
+            --notes-file "${RUNNER_TEMP}/notes.md" \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,18 @@ jobs:
           fi
           echo "tag=${tag}" >>"${GITHUB_OUTPUT}"
 
-      - name: Verify the tag is annotated
+      - name: Verify the tag exists and is annotated
         shell: bash
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          if [[ "$(git cat-file -t "${TAG}")" != "tag" ]]; then
-            echo "error: ${TAG} is lightweight; the policy requires an annotated tag" >&2
+          object_type="$(git cat-file -t "${TAG}" 2>/dev/null || true)"
+          if [[ -z "${object_type}" ]]; then
+            echo "error: ${TAG} does not exist in this checkout" >&2
+            exit 1
+          fi
+          if [[ "${object_type}" != "tag" ]]; then
+            echo "error: ${TAG} is ${object_type}, not an annotated tag" >&2
             exit 1
           fi
 
@@ -78,8 +83,11 @@ jobs:
         env:
           TAG: ${{ steps.tag.outputs.tag }}
         run: |
-          previous="$(git tag --list 'v*.*.*' --sort=-version:refname \
-            | grep -v "^${TAG}$" | head -n1 || true)"
+          # The tag immediately *before* TAG in version order -- not simply the
+          # newest other tag, which would be wrong whenever workflow_dispatch
+          # publishes an older tag after newer releases exist.
+          previous="$(git tag --list 'v*.*.*' --sort=version:refname \
+            | awk -v tag="${TAG}" '$0 == tag { exit } { prev = $0 } END { print prev }')"
           args=(--tag "${TAG}")
           if [[ -n "${previous}" ]]; then
             args+=(--previous-tag "${previous}")

--- a/docs/steering/versioning.md
+++ b/docs/steering/versioning.md
@@ -76,16 +76,25 @@ Steps run in this order. Each is labeled with whether it is machine-gated
 3. **(Required — CI)** Run `uv lock` to update the four local-package entries in `uv.lock`; runtime
    defaults and User-Agents derive from `sbir_etl.__version__` and do not need separate edits.
 4. **(Required — CI)** Run `uv run python scripts/ci/check_versioning.py --tag vMAJOR.MINOR.PATCH`.
-5. **(Operator)** Confirm the relevant test and quality checks are green.
-6. **(Operator)** Commit the release preparation before creating an annotated tag:
+5. **(Required — CI)** Add the version's `CHANGELOG.md` section. The release workflow reads it for
+   the release body and fails if it is missing or empty, so a release cannot ship undescribed.
+   Record breaking changes under a `### Breaking` subsection.
+6. **(Operator)** Confirm the relevant test and quality checks are green.
+7. **(Operator)** Commit the release preparation, then create and push an annotated tag:
 
    ```bash
    git tag -a vMAJOR.MINOR.PATCH -m "Release vMAJOR.MINOR.PATCH"
    git push origin vMAJOR.MINOR.PATCH
    ```
 
-7. **(Operator)** Create the GitHub release from that tag and include highlights, compatibility
-   notes, and a full changelog link.
+   Pushing the tag is the only manual step that starts a release. Everything after it is
+   automated: `.github/workflows/release.yml` re-validates the version metadata, confirms the tag
+   is annotated, builds the notes from `CHANGELOG.md`, and publishes the GitHub release as
+   `SBIR Analytics vMAJOR.MINOR.PATCH`.
+
+   If a tag was pushed before that workflow existed, or its run failed, publish it by hand with
+   **Actions → Release → Run workflow** and the tag name. The job is idempotent — it leaves an
+   existing release untouched rather than overwriting it.
 
 Published versions are immutable. If release notes or artifacts expose a defect, publish the fix
 under a new version instead of changing the tagged contents.

--- a/scripts/ci/extract_release_notes.py
+++ b/scripts/ci/extract_release_notes.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Extract one version's CHANGELOG section for use as GitHub release notes.
+
+The release workflow calls this with the tag being published. A missing or
+empty section is an error, not an empty release body: v0.12.0 shipped without
+a CHANGELOG entry because nothing checked, and the gap was only noticed while
+writing the release by hand afterwards.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHANGELOG = ROOT / "CHANGELOG.md"
+SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
+
+
+def normalize_version(reference: str) -> str:
+    """Accept either `1.2.3` or the `v1.2.3` tag form."""
+    version = reference[1:] if reference.startswith("v") else reference
+    if not SEMVER.match(version):
+        raise ValueError(f"{reference!r} is not a vMAJOR.MINOR.PATCH release reference")
+    return version
+
+
+def iter_section_bounds(lines: list[str], version: str) -> tuple[int, int]:
+    """Return the [start, end) line span of a version's section body.
+
+    Headings look like `## [0.12.0] - 2026-08-31`. The section runs to the next
+    `## ` heading or end of file.
+    """
+    heading = re.compile(rf"^## \[{re.escape(version)}\](\s|$)")
+    start = None
+    for index, line in enumerate(lines):
+        if start is None:
+            if heading.match(line):
+                start = index + 1
+            continue
+        if line.startswith("## "):
+            return start, index
+    if start is None:
+        raise LookupError(
+            f"CHANGELOG.md has no '## [{version}]' section. "
+            "Add the release's entry before tagging it."
+        )
+    return start, len(lines)
+
+
+def extract(version: str, changelog: Path = CHANGELOG) -> str:
+    lines = changelog.read_text(encoding="utf-8").splitlines()
+    start, end = iter_section_bounds(lines, version)
+    body = "\n".join(lines[start:end]).strip()
+    if not body:
+        raise LookupError(
+            f"CHANGELOG.md's '## [{version}]' section is empty. "
+            "Describe the release before tagging it."
+        )
+    return body
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="Release tag or version (v1.2.3 or 1.2.3)")
+    parser.add_argument(
+        "--previous-tag",
+        help="Prior release tag; appends a compare link when supplied",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        version = normalize_version(args.tag)
+        body = extract(version)
+    except (ValueError, LookupError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.previous_tag:
+        repo = "hollomancer/sbir-analytics"
+        compare = f"https://github.com/{repo}/compare/{args.previous_tag}...v{version}"
+        body = f"{body}\n\n## Full changelog\n\n{compare}"
+
+    print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/extract_release_notes.py
+++ b/scripts/ci/extract_release_notes.py
@@ -8,6 +8,7 @@ writing the release by hand afterwards.
 """
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -15,6 +16,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 CHANGELOG = ROOT / "CHANGELOG.md"
+DEFAULT_REPOSITORY = "hollomancer/sbir-analytics"
 SEMVER = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
@@ -78,7 +80,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     if args.previous_tag:
-        repo = "hollomancer/sbir-analytics"
+        # Actions sets GITHUB_REPOSITORY; the fallback keeps local runs working.
+        # Hard-coding it would point the compare link at the wrong repository
+        # after a rename, in a mirror, or in a fork's own Actions run.
+        repo = os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPOSITORY
         compare = f"https://github.com/{repo}/compare/{args.previous_tag}...v{version}"
         body = f"{body}\n\n## Full changelog\n\n{compare}"
 

--- a/tests/unit/scripts/test_extract_release_notes.py
+++ b/tests/unit/scripts/test_extract_release_notes.py
@@ -82,7 +82,7 @@ def test_empty_section_is_an_error(tmp_path: Path) -> None:
 
 
 def test_version_prefix_does_not_match_a_longer_version(tmp_path: Path) -> None:
-    """`0.1.0` must not match the `0.1.0` inside a `## [0.1.01]` heading."""
+    """`0.1.1` must not match the `0.1.1` prefix inside a `## [0.1.10]` heading."""
     path = _changelog(
         tmp_path,
         "# Changelog\n\n## [0.1.10] - 2026-01-01\n\n- ten\n",

--- a/tests/unit/scripts/test_extract_release_notes.py
+++ b/tests/unit/scripts/test_extract_release_notes.py
@@ -1,0 +1,92 @@
+"""Tests for the release-notes extractor.
+
+The gap these guard against is concrete: v0.12.0 was tagged and published with
+no CHANGELOG entry, and nothing caught it until the release was written by
+hand afterwards. A missing or empty section must fail the release job rather
+than produce an empty release body.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.ci import extract_release_notes as notes
+
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+## [0.12.0] - 2026-08-31
+
+### Fixed
+
+- Something real (#692).
+
+## [0.11.0] - 2026-08-26
+
+### Added
+
+- An earlier thing (#668).
+"""
+
+
+def _changelog(tmp_path: Path, text: str = CHANGELOG) -> Path:
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize("reference", ["v0.12.0", "0.12.0"])
+def test_normalize_accepts_tag_and_bare_version(reference: str) -> None:
+    assert notes.normalize_version(reference) == "0.12.0"
+
+
+@pytest.mark.parametrize("reference", ["release-1", "v1.2", "v1.2.3.4", "latest", "v01.2.3"])
+def test_normalize_rejects_non_release_references(reference: str) -> None:
+    with pytest.raises(ValueError):
+        notes.normalize_version(reference)
+
+
+def test_extract_returns_only_the_requested_section(tmp_path: Path) -> None:
+    body = notes.extract("0.12.0", _changelog(tmp_path))
+
+    assert "Something real (#692)." in body
+    # Must stop at the next heading rather than running into older releases.
+    assert "An earlier thing" not in body
+    # The version heading itself is dropped; GitHub renders the title separately.
+    assert "## [0.12.0]" not in body
+    assert body.startswith("### Fixed")
+
+
+def test_extract_reads_the_final_section_to_end_of_file(tmp_path: Path) -> None:
+    body = notes.extract("0.11.0", _changelog(tmp_path))
+
+    assert "An earlier thing (#668)." in body
+
+
+def test_missing_section_is_an_error(tmp_path: Path) -> None:
+    with pytest.raises(LookupError, match=r"no '## \[9.9.9\]' section"):
+        notes.extract("9.9.9", _changelog(tmp_path))
+
+
+def test_empty_section_is_an_error(tmp_path: Path) -> None:
+    """A heading with no body must not become an empty release."""
+    path = _changelog(
+        tmp_path,
+        "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n## [0.9.0] - 2025-12-01\n\n- prior\n",
+    )
+
+    with pytest.raises(LookupError, match=r"'## \[1.0.0\]' section is empty"):
+        notes.extract("1.0.0", path)
+
+
+def test_version_prefix_does_not_match_a_longer_version(tmp_path: Path) -> None:
+    """`0.1.0` must not match the `0.1.0` inside a `## [0.1.01]` heading."""
+    path = _changelog(
+        tmp_path,
+        "# Changelog\n\n## [0.1.10] - 2026-01-01\n\n- ten\n",
+    )
+
+    with pytest.raises(LookupError):
+        notes.extract("0.1.1", path)

--- a/tests/unit/scripts/test_extract_release_notes.py
+++ b/tests/unit/scripts/test_extract_release_notes.py
@@ -90,3 +90,25 @@ def test_version_prefix_does_not_match_a_longer_version(tmp_path: Path) -> None:
 
     with pytest.raises(LookupError):
         notes.extract("0.1.1", path)
+
+
+def test_compare_link_uses_the_actions_repository(tmp_path, monkeypatch, capsys) -> None:
+    """A fork or renamed repo must not get a compare link to the original."""
+    monkeypatch.setattr(notes, "CHANGELOG", _changelog(tmp_path))
+    monkeypatch.setenv("GITHUB_REPOSITORY", "someone-else/a-fork")
+
+    assert notes.main(["--tag", "v0.12.0", "--previous-tag", "v0.11.0"]) == 0
+
+    out = capsys.readouterr().out
+    assert "https://github.com/someone-else/a-fork/compare/v0.11.0...v0.12.0" in out
+
+
+def test_compare_link_falls_back_when_unset(tmp_path, monkeypatch, capsys) -> None:
+    """Local runs have no GITHUB_REPOSITORY and should still produce a link."""
+    monkeypatch.setattr(notes, "CHANGELOG", _changelog(tmp_path))
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    assert notes.main(["--tag", "v0.12.0", "--previous-tag", "v0.11.0"]) == 0
+
+    out = capsys.readouterr().out
+    assert f"https://github.com/{notes.DEFAULT_REPOSITORY}/compare/v0.11.0...v0.12.0" in out


### PR DESCRIPTION
## Description

Publishing the GitHub release was the last hand-run step in the versioning checklist — and the one where something actually went wrong. v0.12.0 was tagged with **no CHANGELOG entry**, and nothing caught it until the release was being written by hand afterwards (fixed retroactively in #695).

Pushing an annotated tag stays manual; that's the deliberate act that starts a release. Everything after it now runs in `.github/workflows/release.yml`:

1. Resolves and format-checks the tag
2. Confirms it's **annotated**, not lightweight (the policy requires annotated; nothing enforced it before)
3. Re-runs `check_versioning.py --tag`
4. Builds notes from `CHANGELOG.md`
5. Publishes as `SBIR Analytics vX.Y.Z`

The version check is re-run inside this job rather than trusting the tag push's separate Version Policy run, since this is the job that publishes.

**The part that closes the actual gap:** `scripts/ci/extract_release_notes.py` treats a missing or empty CHANGELOG section as an **error**. A release with nothing written about it now fails instead of shipping an empty body. `docs/steering/versioning.md` gains a matching required step.

## Notes on a couple of choices

- **Notes go to a file, not a step output.** Changelog prose interpolated into a shell command via `${{ }}` would be a command-injection seam. Every tag value likewise reaches bash through `env:` rather than direct interpolation.
- **The publish step is idempotent** — an existing release is left untouched rather than overwritten. That makes `workflow_dispatch` safe for a tag pushed *before* this workflow existed. **v0.12.0 is exactly that case**, so once this merges you can publish it from Actions → Release → Run workflow rather than by hand.
- **Section matching is anchored** so `0.1.1` can't match a `## [0.1.10]` heading.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

CI tooling and docs; no runtime or compatibility surface changes.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

Rather than assume the pipeline works, I simulated each workflow step against the real `v0.12.0` tag:

- annotated-tag check passes
- `check_versioning.py --tag v0.12.0` passes at that tag
- previous tag resolves to `v0.11.0`
- extractor emits a 1710-byte body ending in the correct compare link

12 new tests cover parsing and both failure modes (missing section, empty section). `577 passed` across `tests/unit/scripts`; `make lint` and `make lint-boundaries` clean.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P71PDXSUfwwsQZJUAhjpMg

---
_Generated by [Claude Code](https://claude.ai/code/session_01P71PDXSUfwwsQZJUAhjpMg)_