### PR TITLE
Set the writing register: plain language default, STE for technical docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,8 +13,17 @@ an archive candidate even when it still has unchecked tasks.
 
 ## Communication
 
-Write in plain language everywhere: chat replies, commit messages, PR bodies,
-docstrings, notebook narrative, and analysis write-ups.
+Default to the Federal Plain Language Guidelines (plainlanguage.gov) everywhere:
+chat replies, commit messages, PR bodies, docstrings, notebook narrative, and
+analysis write-ups.
+
+Technical documents use the ASD-STE100 Simplified Technical English writing rules
+instead. A document is technical when the reader will execute it or a machine will
+consume it: the server runbook (`docs/deployment/`), study contracts (`studies/`),
+and the contracts in `docs/steering/`. One instruction per sentence; imperative for
+steps; one meaning per word; procedural sentences at 20 words or fewer. The STE
+dictionary is licensed and not in this repo — apply the writing rules, do not claim
+STE compliance.
 
 - Lead with the finding or the change, then the reasoning. Short, concrete sentences.
 - Prefer ordinary words. Keep the terms that carry real precision here (tier names,


### PR DESCRIPTION
## Description

`CLAUDE.md` § Communication now names the Federal Plain Language Guidelines as the default register for chat, commits, PR bodies, docstrings, notebook narrative, and analysis write-ups.

Technical documents use the ASD-STE100 Simplified Technical English writing rules instead. A document is technical when the reader will execute it or a machine will consume it: the server runbook (`docs/deployment/`), study contracts (`studies/`), and the contracts in `docs/steering/`. The STE dictionary is licensed and not in the repo, so the rule asks for the writing rules (one instruction per sentence, imperative steps, one meaning per word, procedural sentences at 20 words or fewer), not compliance.

`CLAUDE.md` is the one place for this. `AGENTS.md` routes to it and the `.Codex/agents/*.toml` wrappers read it first, so no second copy is needed.

Nothing in the repo checks prose register. This is guidance, not a gate.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Versioning Impact

- [x] No release impact (internal or unreleased work)
- [ ] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

Markdown-only change. Ran the hygiene check that `make docs-check` wraps:

- `uv run python scripts/ci/check_removed_src_references.py` — "Repository hygiene checks passed."

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMHd82KqkMSjLLJC7otTCv

---
_Generated by [Claude Code](https://claude.ai/code/session_01TMHd82KqkMSjLLJC7otTCv)_