### PR TITLE
Extract the EFTS recall and mention-context change from the supplier-share census

### DIFF
--- a/sbir_etl/enrichers/sec_edgar/client.py
+++ b/sbir_etl/enrichers/sec_edgar/client.py
@@ -270,6 +270,8 @@ class EdgarAPIClient(BaseAsyncAPIClient):
             "startdt": "2000-01-01",
             "enddt": "2026-12-31",
             "forms": forms,
+            "from": 0,
+            "size": limit,
         }
         try:
             response = await self._make_request("GET", "/search-index", params=params)

--- a/sbir_etl/enrichers/sec_edgar/client.py
+++ b/sbir_etl/enrichers/sec_edgar/client.py
@@ -12,6 +12,7 @@ containing a contact email address.
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from html.parser import HTMLParser
 from typing import Any, cast
 
@@ -130,6 +131,12 @@ class EdgarAPIClient(BaseAsyncAPIClient):
         )
         self.timeout = cast(int, self.api_config.get("timeout_seconds", 30))
         self.rate_limit_per_minute = cast(int, self.api_config.get("rate_limit_per_minute", 600))
+        # Optional hook the enricher calls when a mention carries an incomplete
+        # filing reference (no doc_id, accession, filename, or CIK), so a scan
+        # can type that mention as not searchable instead of silently missing.
+        # Declared here so callers set a public attribute, not a private one
+        # read back through __dict__.
+        self.context_incomplete_callback: Callable[[], None] | None = None
 
         # SEC requires a User-Agent with contact info for fair access.
         # Accept contact_email directly from config, or look it up from env.
@@ -257,7 +264,9 @@ class EdgarAPIClient(BaseAsyncAPIClient):
         Args:
             company_name: Company name to search for in filing text.
             forms: Filing types to search (comma-separated, e.g., "8-K,10-K").
-            limit: Maximum results to return.
+            limit: Maximum results to return. Sent to EFTS as ``size``; the
+                server default page is 100, so a ``limit`` above 100 now
+                returns hits that the pre-``size`` request could not.
 
         Returns:
             List of filing mention dicts with: filer_cik, filer_name,

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -149,6 +149,10 @@ def _detect_ma_events(cik: str, filings: list[dict[str, Any]]) -> list[EdgarMAEv
 _MA_FILING_TYPES = "8-K,DEFM14A,PREM14A,SC TO-T,SC 14D9,425"
 _ANNUAL_FILING_TYPES = "10-K,10-Q"
 _OWNERSHIP_FILING_TYPES = "SC 13D,SC 13D/A,SC 13G,SC 13G/A"
+_OPERATING_FILING_TYPES = f"{_MA_FILING_TYPES},{_ANNUAL_FILING_TYPES}"
+_MA_FORM_TYPES = frozenset(_MA_FILING_TYPES.split(","))
+_ANNUAL_FORM_TYPES = frozenset(_ANNUAL_FILING_TYPES.split(","))
+_EFTS_PAGE_SIZE = 100
 
 # SIC code ranges that are almost always noise (REIT/mortgage filings).
 _NOISE_SIC_RANGES = (range(6500, 6800), range(6150, 6200))
@@ -340,12 +344,20 @@ async def _extract_mention_context(
     context_chars: int = 500,
 ) -> str | None:
     """Fetch the filing document and classify the mention by surrounding text."""
-    doc_id = mention.get("doc_id", "")
-    if not doc_id or ":" not in doc_id:
+
+    def mark_context_incomplete() -> None:
+        callback = getattr(client, "__dict__", {}).get("_context_incomplete_callback")
+        if callable(callback):
+            callback()
+
+    doc_id = mention.get("doc_id")
+    if not isinstance(doc_id, str) or ":" not in doc_id:
+        mark_context_incomplete()
         return None
     accession, filename = doc_id.split(":", 1)
-    cik = mention.get("filer_cik", "")
-    if not cik:
+    cik = str(mention.get("filer_cik") or "").strip()
+    if not accession.strip() or not filename.strip() or not cik:
+        mark_context_incomplete()
         return None
 
     text = await client.fetch_filing_document(cik, accession, filename)
@@ -423,6 +435,7 @@ async def _search_filing_mentions_filtered(
     *,
     name_match_threshold: int = 80,
     limit: int = 20,
+    mentions: list[dict] | None = None,
 ) -> list[EdgarMAEvent]:
     """Search for mentions of a company in filings by other public companies.
 
@@ -430,11 +443,15 @@ async def _search_filing_mentions_filtered(
     and name-collision filers (target name is a substring of a different,
     longer filer name).
     """
-    mentions = await client.search_filing_mentions(company_name, forms=forms, limit=limit)
+    if mentions is None:
+        mentions = await client.search_filing_mentions(company_name, forms=forms, limit=limit)
     if not mentions:
         return []
 
-    events: list[EdgarMAEvent] = []
+    # enrich_company ultimately keeps only the latest event from each filer.
+    # Discard older same-tier filings before the expensive document fetch so
+    # that the optimization cannot change the retained event or its tier.
+    latest_by_filer: dict[str, tuple[dict, str, date]] = {}
     for mention in mentions:
         filer_name = mention.get("filer_name", "")
         if not filer_name:
@@ -460,6 +477,12 @@ async def _search_filing_mentions_filtered(
         except ValueError:
             continue
 
+        existing = latest_by_filer.get(filer_name)
+        if existing is None or filing_date > existing[2]:
+            latest_by_filer[filer_name] = (mention, filer_name, filing_date)
+
+    events: list[EdgarMAEvent] = []
+    for mention, filer_name, filing_date in latest_by_filer.values():
         form_type = mention.get("form_type", "")
         mention_type = _classify_mention(mention.get("items", []), form_type)
 
@@ -496,20 +519,11 @@ async def _search_inbound_ma_mentions(
     (2) annual/quarterly — 10-K/10-Q post-acquisition mentions;
     (3) ownership — SC 13D/13G (>5% stakes).
     """
-    strong, annual, ownership = await asyncio.gather(
-        _search_filing_mentions_filtered(
-            client,
+    combined, ownership = await asyncio.gather(
+        client.search_filing_mentions(
             company_name,
-            _MA_FILING_TYPES,
-            name_match_threshold=name_match_threshold,
-            limit=20,
-        ),
-        _search_filing_mentions_filtered(
-            client,
-            company_name,
-            _ANNUAL_FILING_TYPES,
-            name_match_threshold=name_match_threshold,
-            limit=10,
+            forms=_OPERATING_FILING_TYPES,
+            limit=_EFTS_PAGE_SIZE,
         ),
         _search_filing_mentions_filtered(
             client,
@@ -519,6 +533,53 @@ async def _search_inbound_ma_mentions(
             limit=10,
         ),
     )
+
+    # EFTS returns at most 100 hits. When fewer are returned, the complete
+    # strong + annual hit set is present and can be partitioned locally. At
+    # the page boundary, retain the original separate searches so no tier's
+    # top hits can be hidden by the combined result ordering.
+    if len(combined) < _EFTS_PAGE_SIZE:
+        strong_mentions = [
+            mention for mention in combined if mention.get("form_type") in _MA_FORM_TYPES
+        ][:20]
+        annual_mentions = [
+            mention for mention in combined if mention.get("form_type") in _ANNUAL_FORM_TYPES
+        ][:10]
+        strong, annual = await asyncio.gather(
+            _search_filing_mentions_filtered(
+                client,
+                company_name,
+                _MA_FILING_TYPES,
+                name_match_threshold=name_match_threshold,
+                limit=20,
+                mentions=strong_mentions,
+            ),
+            _search_filing_mentions_filtered(
+                client,
+                company_name,
+                _ANNUAL_FILING_TYPES,
+                name_match_threshold=name_match_threshold,
+                limit=10,
+                mentions=annual_mentions,
+            ),
+        )
+    else:
+        strong, annual = await asyncio.gather(
+            _search_filing_mentions_filtered(
+                client,
+                company_name,
+                _MA_FILING_TYPES,
+                name_match_threshold=name_match_threshold,
+                limit=20,
+            ),
+            _search_filing_mentions_filtered(
+                client,
+                company_name,
+                _ANNUAL_FILING_TYPES,
+                name_match_threshold=name_match_threshold,
+                limit=10,
+            ),
+        )
     return strong + annual + ownership
 
 

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -346,7 +346,7 @@ async def _extract_mention_context(
     """Fetch the filing document and classify the mention by surrounding text."""
 
     def mark_context_incomplete() -> None:
-        callback = getattr(client, "__dict__", {}).get("_context_incomplete_callback")
+        callback = getattr(client, "context_incomplete_callback", None)
         if callable(callback):
             callback()
 
@@ -537,8 +537,15 @@ async def _search_inbound_ma_mentions(
     # EFTS returns at most 100 hits. When fewer are returned, the complete
     # strong + annual hit set is present and can be partitioned locally. At
     # the page boundary, retain the original separate searches so no tier's
-    # top hits can be hidden by the combined result ordering.
-    if len(combined) < _EFTS_PAGE_SIZE:
+    # top hits can be hidden by the combined result ordering. The partition
+    # keys on the response's root form, which is not guaranteed to equal the
+    # request vocabulary (an empty root_forms, or a variant such as 8-K12B),
+    # so any hit that lands in neither tier also falls back to the separate
+    # searches rather than being dropped.
+    if len(combined) < _EFTS_PAGE_SIZE and all(
+        mention.get("form_type") in _MA_FORM_TYPES or mention.get("form_type") in _ANNUAL_FORM_TYPES
+        for mention in combined
+    ):
         strong_mentions = [
             mention for mention in combined if mention.get("form_type") in _MA_FORM_TYPES
         ][:20]

--- a/sbir_etl/enrichers/sec_edgar/enricher.py
+++ b/sbir_etl/enrichers/sec_edgar/enricher.py
@@ -534,14 +534,15 @@ async def _search_inbound_ma_mentions(
         ),
     )
 
-    # EFTS returns at most 100 hits. When fewer are returned, the complete
-    # strong + annual hit set is present and can be partitioned locally. At
-    # the page boundary, retain the original separate searches so no tier's
-    # top hits can be hidden by the combined result ordering. The partition
-    # keys on the response's root form, which is not guaranteed to equal the
-    # request vocabulary (an empty root_forms, or a variant such as 8-K12B),
-    # so any hit that lands in neither tier also falls back to the separate
-    # searches rather than being dropped.
+    # Combined inbound search requests one 100-hit page. When fewer than
+    # that page size are returned, the complete strong + annual hit set is
+    # present and can be partitioned locally. At the page boundary, retain
+    # the original separate searches so no tier's top hits can be hidden by
+    # the combined result ordering. Partition keys are the response's root
+    # form, which is not guaranteed to equal the request vocabulary (an
+    # empty root_forms, or a variant such as 8-K12B), so any hit that lands
+    # in neither tier also falls back to the separate searches rather than
+    # being dropped.
     if len(combined) < _EFTS_PAGE_SIZE and all(
         mention.get("form_type") in _MA_FORM_TYPES or mention.get("form_type") in _ANNUAL_FORM_TYPES
         for mention in combined

--- a/scripts/archive/data/refine_ma_medium_tier.py
+++ b/scripts/archive/data/refine_ma_medium_tier.py
@@ -91,6 +91,12 @@ _EMPLOYMENT = re.compile(
 )
 
 
+def _mark_context_incomplete(client: EdgarAPIClient) -> None:
+    callback = getattr(client, "__dict__", {}).get("_context_incomplete_callback")
+    if callable(callback):
+        callback()
+
+
 def classify_direction(
     text: str,
     company_name: str,
@@ -112,7 +118,9 @@ def classify_direction(
         clean = re.sub(
             r"\s*(?:Inc\.?|Corp\.?|LLC|L\.?L\.?C\.?|Ltd\.?|Co\.?|Company|"
             r"Corporation|Incorporated|Limited)\s*$",
-            "", company_name, flags=re.IGNORECASE,
+            "",
+            company_name,
+            flags=re.IGNORECASE,
         ).strip()
         if len(clean) >= 5:
             match = re.search(re.escape(clean), text, re.IGNORECASE)
@@ -122,8 +130,8 @@ def classify_direction(
     # Extract windows before and after the match
     before_start = max(0, match.start() - context_chars)
     after_end = min(len(text), match.end() + context_chars)
-    before_window = text[before_start:match.start()]
-    after_window = text[match.end():after_end]
+    before_window = text[before_start : match.start()]
+    after_window = text[match.end() : after_end]
     full_window = text[before_start:after_end]
 
     # Check for employment/consulting agreement — not an acquisition
@@ -168,7 +176,14 @@ async def refine_events(
     """Re-query EFTS and refine each medium-tier event."""
     semaphore = asyncio.Semaphore(concurrency)
     write_lock = asyncio.Lock()
-    stats = {"target": 0, "not_target": 0, "comparator": 0, "ambiguous": 0, "no_filing": 0, "error": 0}
+    stats = {
+        "target": 0,
+        "not_target": 0,
+        "comparator": 0,
+        "ambiguous": 0,
+        "no_filing": 0,
+        "error": 0,
+    }
     processed = 0
     start_time = time.time()
 
@@ -187,6 +202,7 @@ async def refine_events(
                     limit=10,
                 )
             except Exception:
+                _mark_context_incomplete(client)
                 mentions = []
 
             if not mentions:
@@ -201,19 +217,20 @@ async def refine_events(
             # Try to fetch and classify the first M&A-related filing
             best_direction = "ambiguous"
             for mention in mentions:
-                doc_id = mention.get("doc_id", "")
-                if not doc_id or ":" not in doc_id:
+                doc_id = mention.get("doc_id")
+                if not isinstance(doc_id, str) or ":" not in doc_id:
+                    _mark_context_incomplete(client)
                     continue
-                filer_cik = mention.get("filer_cik", "")
-                if not filer_cik:
+                accession, filename = doc_id.split(":", 1)
+                filer_cik = str(mention.get("filer_cik") or "").strip()
+                if not accession.strip() or not filename.strip() or not filer_cik:
+                    _mark_context_incomplete(client)
                     continue
 
-                accession, filename = doc_id.split(":", 1)
                 try:
-                    text = await client.fetch_filing_document(
-                        filer_cik, accession, filename
-                    )
+                    text = await client.fetch_filing_document(filer_cik, accession, filename)
                 except Exception:
+                    _mark_context_incomplete(client)
                     text = None
 
                 if not text:
@@ -253,7 +270,7 @@ async def refine_events(
     batch_size = 50
     with open(output_path, "a" if resume_done else "w") as out:
         for batch_start in range(0, len(events), batch_size):
-            batch = events[batch_start:batch_start + batch_size]
+            batch = events[batch_start : batch_start + batch_size]
             tasks = [process_one(e, out) for e in batch]
             await asyncio.gather(*tasks)
 
@@ -317,9 +334,9 @@ async def main():
     await client.aclose()
 
     total = sum(stats.values())
-    print(f"\n{'='*60}")
+    print(f"\n{'=' * 60}")
     print(f"MEDIUM-TIER REFINEMENT COMPLETE — {total:,} events")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
     print(f"  Confirmed target:  {stats['target']:,}")
     print(f"  Not target:        {stats['not_target']:,}")
     print(f"  Comparator:        {stats['comparator']:,}")

--- a/scripts/archive/data/refine_ma_medium_tier.py
+++ b/scripts/archive/data/refine_ma_medium_tier.py
@@ -92,7 +92,7 @@ _EMPLOYMENT = re.compile(
 
 
 def _mark_context_incomplete(client: EdgarAPIClient) -> None:
-    callback = getattr(client, "__dict__", {}).get("_context_incomplete_callback")
+    callback = getattr(client, "context_incomplete_callback", None)
     if callable(callback):
         callback()
 

--- a/scripts/archive/data/scan_sbir_edgar.py
+++ b/scripts/archive/data/scan_sbir_edgar.py
@@ -11,6 +11,10 @@ Usage:
     # Resume from checkpoint
     python scripts/archive/data/scan_sbir_edgar.py --awards /tmp/sbir_awards_full.csv --resume
 
+    # Scan only the inbound M&A channels, paced below the SEC fair-access ceiling
+    python scripts/archive/data/scan_sbir_edgar.py \
+        --awards /tmp/sbir_awards_full.csv --ma-only --requests-per-second 8
+
     # Skip document fetches (faster, counts only)
     python scripts/archive/data/scan_sbir_edgar.py --awards /tmp/sbir_awards_full.csv --no-doc-fetch
 
@@ -20,15 +24,20 @@ Usage:
 
 import argparse
 import asyncio
+import contextvars
 import csv
 import json
+import re
 import sys
 import time
 from collections import Counter
+from collections.abc import Callable
 from pathlib import Path
 
-# Force unbuffered stdout
-sys.stdout.reconfigure(line_buffering=True)
+# Force line-buffered progress output when the stream supports reconfiguration.
+reconfigure_stdout = getattr(sys.stdout, "reconfigure", None)
+if reconfigure_stdout is not None:
+    reconfigure_stdout(line_buffering=True)
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
@@ -41,10 +50,54 @@ from sbir_etl.enrichers.sec_edgar.enricher import enrich_company
 # The client's rate limiter (600 req/min) is the real throttle; this just
 # keeps enough requests in-flight to fill the rate budget.
 DEFAULT_CONCURRENCY = 8
+DEFAULT_REQUESTS_PER_SECOND = 8.0
+
+
+class _PacedEdgarAPIClient(EdgarAPIClient):
+    """Apply a per-second ceiling in addition to the client's minute limit."""
+
+    def __init__(
+        self,
+        *args,
+        requests_per_second: float,
+        document_error_callback: Callable[[], None] | None = None,
+        disable_document_fetches: bool = False,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self._minimum_interval = 1.0 / requests_per_second
+        self._spacing_lock = asyncio.Lock()
+        self._next_request_at = 0.0
+        self._document_error_callback = document_error_callback
+        self._context_incomplete_callback = document_error_callback
+        self._disable_document_fetches = disable_document_fetches
+
+    async def _wait_for_rate_limit(self) -> None:
+        async with self._spacing_lock:
+            await super()._wait_for_rate_limit()
+            loop = asyncio.get_running_loop()
+            now = loop.time()
+            if self._next_request_at > now:
+                await asyncio.sleep(self._next_request_at - now)
+                now = loop.time()
+            self._next_request_at = now + self._minimum_interval
+
+    async def fetch_filing_document(
+        self,
+        cik: str,
+        accession: str,
+        filename: str,
+    ) -> str | None:
+        if self._disable_document_fetches:
+            return None
+        text = await super().fetch_filing_document(cik, accession, filename)
+        if text is None and self._document_error_callback is not None:
+            self._document_error_callback()
+        return text
 
 
 class _ServerErrorTracker:
-    """Thread-safe loguru sink that tracks which companies hit HTTP 5xx.
+    """Thread-safe loguru sink that tracks failed mention searches.
 
     In concurrent mode, multiple companies are in-flight at once, so we
     match the company name from the log message instead of using a simple
@@ -53,6 +106,7 @@ class _ServerErrorTracker:
 
     def __init__(self):
         self._affected: set[str] = set()
+        self._document_affected: set[str] = set()
         self._active_companies: set[str] = set()
 
     def register(self, company_name: str) -> None:
@@ -62,15 +116,25 @@ class _ServerErrorTracker:
         self._active_companies.discard(company_name)
 
     def write(self, message):
-        if "HTTP 5" not in message:
+        match = re.search(
+            r"EDGAR filing mention search failed for '(.*)':",
+            str(message),
+        )
+        if match is None:
             return
-        for name in self._active_companies:
-            if name in message:
-                self._affected.add(name)
-                return
+        name = match.group(1)
+        if name in self._active_companies:
+            self._affected.add(name)
 
     def had_error(self, company_name: str) -> bool:
         return company_name in self._affected
+
+    def mark_document_error(self, company_name: str | None) -> None:
+        if company_name in self._active_companies:
+            self._document_affected.add(company_name)
+
+    def had_document_error(self, company_name: str) -> bool:
+        return company_name in self._document_affected
 
 
 def load_companies(awards_csv: str) -> list[tuple[str, int]]:
@@ -97,21 +161,59 @@ def load_company_cities(awards_csv: str) -> dict[str, str]:
 
 
 _STATE_NAME_TO_CODE = {
-    "ALABAMA": "AL", "ALASKA": "AK", "ARIZONA": "AZ", "ARKANSAS": "AR",
-    "CALIFORNIA": "CA", "COLORADO": "CO", "CONNECTICUT": "CT", "DELAWARE": "DE",
-    "FLORIDA": "FL", "GEORGIA": "GA", "HAWAII": "HI", "IDAHO": "ID",
-    "ILLINOIS": "IL", "INDIANA": "IN", "IOWA": "IA", "KANSAS": "KS",
-    "KENTUCKY": "KY", "LOUISIANA": "LA", "MAINE": "ME", "MARYLAND": "MD",
-    "MASSACHUSETTS": "MA", "MICHIGAN": "MI", "MINNESOTA": "MN",
-    "MISSISSIPPI": "MS", "MISSOURI": "MO", "MONTANA": "MT", "NEBRASKA": "NE",
-    "NEVADA": "NV", "NEW HAMPSHIRE": "NH", "NEW JERSEY": "NJ",
-    "NEW MEXICO": "NM", "NEW YORK": "NY", "NORTH CAROLINA": "NC",
-    "NORTH DAKOTA": "ND", "OHIO": "OH", "OKLAHOMA": "OK", "OREGON": "OR",
-    "PENNSYLVANIA": "PA", "RHODE ISLAND": "RI", "SOUTH CAROLINA": "SC",
-    "SOUTH DAKOTA": "SD", "TENNESSEE": "TN", "TEXAS": "TX", "UTAH": "UT",
-    "VERMONT": "VT", "VIRGINIA": "VA", "WASHINGTON": "WA",
-    "WEST VIRGINIA": "WV", "WISCONSIN": "WI", "WYOMING": "WY",
-    "DISTRICT OF COLUMBIA": "DC", "PUERTO RICO": "PR", "GUAM": "GU",
+    "ALABAMA": "AL",
+    "ALASKA": "AK",
+    "ARIZONA": "AZ",
+    "ARKANSAS": "AR",
+    "CALIFORNIA": "CA",
+    "COLORADO": "CO",
+    "CONNECTICUT": "CT",
+    "DELAWARE": "DE",
+    "FLORIDA": "FL",
+    "GEORGIA": "GA",
+    "HAWAII": "HI",
+    "IDAHO": "ID",
+    "ILLINOIS": "IL",
+    "INDIANA": "IN",
+    "IOWA": "IA",
+    "KANSAS": "KS",
+    "KENTUCKY": "KY",
+    "LOUISIANA": "LA",
+    "MAINE": "ME",
+    "MARYLAND": "MD",
+    "MASSACHUSETTS": "MA",
+    "MICHIGAN": "MI",
+    "MINNESOTA": "MN",
+    "MISSISSIPPI": "MS",
+    "MISSOURI": "MO",
+    "MONTANA": "MT",
+    "NEBRASKA": "NE",
+    "NEVADA": "NV",
+    "NEW HAMPSHIRE": "NH",
+    "NEW JERSEY": "NJ",
+    "NEW MEXICO": "NM",
+    "NEW YORK": "NY",
+    "NORTH CAROLINA": "NC",
+    "NORTH DAKOTA": "ND",
+    "OHIO": "OH",
+    "OKLAHOMA": "OK",
+    "OREGON": "OR",
+    "PENNSYLVANIA": "PA",
+    "RHODE ISLAND": "RI",
+    "SOUTH CAROLINA": "SC",
+    "SOUTH DAKOTA": "SD",
+    "TENNESSEE": "TN",
+    "TEXAS": "TX",
+    "UTAH": "UT",
+    "VERMONT": "VT",
+    "VIRGINIA": "VA",
+    "WASHINGTON": "WA",
+    "WEST VIRGINIA": "WV",
+    "WISCONSIN": "WI",
+    "WYOMING": "WY",
+    "DISTRICT OF COLUMBIA": "DC",
+    "PUERTO RICO": "PR",
+    "GUAM": "GU",
     "VIRGIN ISLANDS": "VI",
 }
 
@@ -151,7 +253,10 @@ def load_checkpoint(path: Path, *, rescan_errors: bool = False) -> set[str]:
             try:
                 rec = json.loads(line)
                 if rescan_errors and (
-                    rec.get("had_server_errors") or rec.get("error")
+                    rec.get("had_server_errors")
+                    or rec.get("document_fetch_errors")
+                    or rec.get("context_classification_complete") is False
+                    or rec.get("error")
                 ):
                     continue
                 done.add(rec["company_name"])
@@ -244,16 +349,20 @@ async def run_city_pass(args) -> None:
                     rate = (i + 1) / elapsed
                     eta = (len(remaining) - i - 1) / rate / 60
                     print(
-                        f"  {i+1:,}/{len(remaining):,} ({rate:.1f}/s, ETA {eta:.0f}min) "
+                        f"  {i + 1:,}/{len(remaining):,} ({rate:.1f}/s, ETA {eta:.0f}min) "
                         f"confirmed={confirmed} unconfirmed={unconfirmed} no_city={no_city}"
                     )
 
     elapsed = time.time() - start_time
-    print(f"\n{'='*60}")
-    print(f"CITY QUALIFICATION COMPLETE — {len(remaining):,} companies in {elapsed/60:.1f} min")
-    print(f"{'='*60}")
-    print(f"Confirmed (name+city match):   {confirmed} ({confirmed/max(1,confirmed+unconfirmed)*100:.0f}%)")
-    print(f"Unconfirmed (name only):       {unconfirmed} ({unconfirmed/max(1,confirmed+unconfirmed)*100:.0f}%)")
+    print(f"\n{'=' * 60}")
+    print(f"CITY QUALIFICATION COMPLETE — {len(remaining):,} companies in {elapsed / 60:.1f} min")
+    print(f"{'=' * 60}")
+    print(
+        f"Confirmed (name+city match):   {confirmed} ({confirmed / max(1, confirmed + unconfirmed) * 100:.0f}%)"
+    )
+    print(
+        f"Unconfirmed (name only):       {unconfirmed} ({unconfirmed / max(1, confirmed + unconfirmed) * 100:.0f}%)"
+    )
     print(f"No city data:                  {no_city}")
     print(f"Output: {output_path}")
 
@@ -261,23 +370,49 @@ async def run_city_pass(args) -> None:
 async def main() -> None:
     parser = argparse.ArgumentParser(description="Scan SBIR awardees against SEC EDGAR")
     parser.add_argument("--awards", required=True, help="Path to SBIR awards CSV")
-    parser.add_argument("--output", default="data/sec_edgar_scan.jsonl",
-                        help="Output JSONL checkpoint file")
-    parser.add_argument("--resume", action="store_true",
-                        help="Resume from existing checkpoint")
-    parser.add_argument("--city-pass", action="store_true",
-                        help="Run city qualification pass on existing scan results")
-    parser.add_argument("--no-doc-fetch", action="store_true",
-                        help="Skip document fetches for context classification")
-    parser.add_argument("--limit", type=int, default=0,
-                        help="Scan only first N companies (0=all)")
-    parser.add_argument("--rescan-errors", action="store_true",
-                        help="Re-scan companies that had server errors in previous run")
-    parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY,
-                        help=f"Companies to enrich concurrently (default {DEFAULT_CONCURRENCY})")
-    parser.add_argument("--contact-email", default="conrad@hollomon.dev",
-                        help="Email for SEC User-Agent")
+    parser.add_argument(
+        "--output", default="data/sec_edgar_scan.jsonl", help="Output JSONL checkpoint file"
+    )
+    parser.add_argument("--resume", action="store_true", help="Resume from existing checkpoint")
+    parser.add_argument(
+        "--city-pass",
+        action="store_true",
+        help="Run city qualification pass on existing scan results",
+    )
+    parser.add_argument(
+        "--no-doc-fetch",
+        action="store_true",
+        help="Skip document fetches for context classification",
+    )
+    parser.add_argument(
+        "--ma-only",
+        action="store_true",
+        help="Skip CIK/XBRL enrichment; scan only inbound M&A mentions",
+    )
+    parser.add_argument("--limit", type=int, default=0, help="Scan only first N companies (0=all)")
+    parser.add_argument(
+        "--rescan-errors",
+        action="store_true",
+        help="Re-scan companies that had search request errors in previous run",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help=f"Companies to enrich concurrently (default {DEFAULT_CONCURRENCY})",
+    )
+    parser.add_argument(
+        "--requests-per-second",
+        type=float,
+        default=DEFAULT_REQUESTS_PER_SECOND,
+        help=f"SEC request pacing ceiling (default {DEFAULT_REQUESTS_PER_SECOND:g})",
+    )
+    parser.add_argument(
+        "--contact-email", default="conrad@hollomon.dev", help="Email for SEC User-Agent"
+    )
     args = parser.parse_args()
+    if args.requests_per_second <= 0:
+        parser.error("--requests-per-second must be positive")
 
     # Dispatch city qualification pass
     if args.city_pass:
@@ -294,7 +429,7 @@ async def main() -> None:
     print(f"  {len(companies):,} unique companies, {total_awards:,} awards")
 
     if args.limit:
-        companies = companies[:args.limit]
+        companies = companies[: args.limit]
         print(f"  Limited to first {args.limit:,}")
 
     # Load checkpoint
@@ -308,6 +443,12 @@ async def main() -> None:
     remaining = [(name, count) for name, count in companies if name not in done]
     print(f"  {len(remaining):,} companies to scan\n")
 
+    # Track request and document failures at the company task grain.
+    error_tracker = _ServerErrorTracker()
+    current_company: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+        "efts_current_company", default=None
+    )
+
     # Initialize client
     config = {
         "base_url": "https://efts.sec.gov/LATEST",
@@ -317,21 +458,23 @@ async def main() -> None:
         "timeout_seconds": 30,
         "contact_email": args.contact_email,
     }
-    client = EdgarAPIClient(config=config)
+    client = _PacedEdgarAPIClient(
+        config=config,
+        requests_per_second=args.requests_per_second,
+        document_error_callback=lambda: error_tracker.mark_document_error(current_company.get()),
+        disable_document_fetches=args.no_doc_fetch,
+    )
 
-    # Monkey-patch out document fetches if requested
+    # Document-free scans are diagnostics only and cannot establish M&A absence.
     if args.no_doc_fetch:
-        async def _no_fetch(*a, **kw):
-            return None
-        client.fetch_filing_document = _no_fetch
         print("  Document fetches DISABLED (counts only)\n")
 
-    # Scan — track server errors per company via loguru sink
-    error_tracker = _ServerErrorTracker()
+    # Scan — track failed mention searches per company via loguru sink
     tracker_id = logger.add(error_tracker, level="WARNING", format="{message}")
 
     with_mentions = 0
     server_errors = 0
+    document_errors = 0
     errors = 0
     start_time = time.time()
     processed = len(done)
@@ -339,17 +482,28 @@ async def main() -> None:
     semaphore = asyncio.Semaphore(args.concurrency)
 
     async def _enrich_one(
-        i: int, name: str, award_count: int, out,
+        i: int,
+        name: str,
+        award_count: int,
+        out,
     ) -> None:
-        nonlocal with_mentions, server_errors, errors, processed
+        nonlocal with_mentions, server_errors, document_errors, errors, processed
 
         async with semaphore:
             error_tracker.register(name)
+            context_token = current_company.set(name)
             try:
-                p = await enrich_company(client, name, award_count=award_count)
+                p = await enrich_company(
+                    client,
+                    name,
+                    award_count=award_count,
+                    resolve_cik=not args.ma_only,
+                    fetch_financials=not args.ma_only,
+                )
 
                 has_mention = p.mention_count > 0
                 had_errors = error_tracker.had_error(name)
+                had_document_errors = error_tracker.had_document_error(name)
 
                 rec = {
                     "company_name": name,
@@ -357,17 +511,26 @@ async def main() -> None:
                     "mention_count": p.mention_count,
                     "mention_filers": p.mention_filers[:5],
                     "mention_types": p.mention_types,
-                    "latest_mention_date": str(p.latest_mention_date) if p.latest_mention_date else None,
+                    "latest_mention_date": str(p.latest_mention_date)
+                    if p.latest_mention_date
+                    else None,
                     "mention_noise_score": p.mention_noise_score,
+                    "context_classification_complete": bool(
+                        not args.no_doc_fetch and not had_document_errors
+                    ),
                 }
                 if had_errors:
                     rec["had_server_errors"] = True
+                if had_document_errors:
+                    rec["document_fetch_errors"] = True
 
                 async with write_lock:
                     if has_mention:
                         with_mentions += 1
                     if had_errors:
                         server_errors += 1
+                    if had_document_errors:
+                        document_errors += 1
                     out.write(json.dumps(rec) + "\n")
                     out.flush()
                     processed += 1
@@ -380,13 +543,14 @@ async def main() -> None:
                     out.flush()
                     processed += 1
             finally:
+                current_company.reset(context_token)
                 error_tracker.unregister(name)
 
     # Process in batches to allow periodic progress reporting
     batch_size = 100
     with open(output_path, "a") as out:
         for batch_start in range(0, len(remaining), batch_size):
-            batch = remaining[batch_start:batch_start + batch_size]
+            batch = remaining[batch_start : batch_start + batch_size]
             tasks = [
                 _enrich_one(batch_start + j, name, count, out)
                 for j, (name, count) in enumerate(batch)
@@ -401,6 +565,7 @@ async def main() -> None:
                 f"  {processed:,}/{len(companies):,} "
                 f"({rate:.1f}/s, ETA {eta_min:.0f}min) "
                 f"mentions={with_mentions} err={errors} 5xx={server_errors}"
+                f" doc_err={document_errors}"
             )
 
     elapsed = time.time() - start_time
@@ -408,12 +573,16 @@ async def main() -> None:
     await client.aclose()
 
     # Summary
-    print(f"\n{'='*60}")
-    print(f"SCAN COMPLETE — {processed:,} companies in {elapsed/60:.1f} min")
-    print(f"{'='*60}")
-    print(f"SEC filing mentions:  {with_mentions:,} ({with_mentions/len(remaining)*100:.1f}%)")
+    print(f"\n{'=' * 60}")
+    print(f"SCAN COMPLETE — {processed:,} companies in {elapsed / 60:.1f} min")
+    print(f"{'=' * 60}")
+    print(
+        f"SEC filing mentions:  {with_mentions:,} "
+        f"({with_mentions / max(len(remaining), 1) * 100:.1f}%)"
+    )
     print(f"Errors:               {errors:,}")
-    print(f"Server errors (5xx):  {server_errors:,} (rescan with --rescan-errors)")
+    print(f"Document fetch errors:{document_errors:,}")
+    print(f"Search request errors: {server_errors:,} (rescan with --rescan-errors)")
     print(f"Output:               {output_path}")
     print("Note: Form D sourced separately via fetch_form_d_index.py")
 
@@ -425,8 +594,11 @@ async def main() -> None:
         "with_mentions": with_mentions,
         "errors": errors,
         "server_errors": server_errors,
+        "search_errors": server_errors,
         "elapsed_seconds": elapsed,
         "doc_fetch_enabled": not args.no_doc_fetch,
+        "ma_only": args.ma_only,
+        "requests_per_second": args.requests_per_second,
     }
     with open(summary_path, "w") as f:
         json.dump(summary, f, indent=2)

--- a/scripts/archive/data/scan_sbir_edgar.py
+++ b/scripts/archive/data/scan_sbir_edgar.py
@@ -117,7 +117,7 @@ class _ServerErrorTracker:
 
     def write(self, message):
         match = re.search(
-            r"EDGAR filing mention search failed for '(.*)':",
+            r"EDGAR filing mention search failed for '(.*?)':",
             str(message),
         )
         if match is None:

--- a/scripts/archive/data/scan_sbir_edgar.py
+++ b/scripts/archive/data/scan_sbir_edgar.py
@@ -69,7 +69,7 @@ class _PacedEdgarAPIClient(EdgarAPIClient):
         self._spacing_lock = asyncio.Lock()
         self._next_request_at = 0.0
         self._document_error_callback = document_error_callback
-        self._context_incomplete_callback = document_error_callback
+        self.context_incomplete_callback = document_error_callback
         self._disable_document_fetches = disable_document_fetches
 
     async def _wait_for_rate_limit(self) -> None:

--- a/tests/unit/enrichers/test_sec_edgar_client.py
+++ b/tests/unit/enrichers/test_sec_edgar_client.py
@@ -150,13 +150,15 @@ class TestSearchFilingMentions:
         """Verify the company name is quoted for exact phrase matching."""
         client._make_request = AsyncMock(return_value={"hits": {"hits": []}})
 
-        await client.search_filing_mentions("Acme Corp")
+        await client.search_filing_mentions("Acme Corp", limit=37)
         call_args = client._make_request.call_args
         # _make_request(method, endpoint, params) — params is positional arg 3
         params = (
             call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("params", {})
         )
         assert params["q"] == '"Acme Corp"'
+        assert params["from"] == 0
+        assert params["size"] == 37
 
     @pytest.mark.asyncio
     async def test_returns_empty_on_error(self, client):

--- a/tests/unit/enrichers/test_sec_edgar_enricher.py
+++ b/tests/unit/enrichers/test_sec_edgar_enricher.py
@@ -323,7 +323,7 @@ class TestSearchInboundMAMentions:
         # Return a match on the first call (strong M&A types), empty on the rest
         mock_client.search_filing_mentions = AsyncMock(
             side_effect=[
-                [  # Strong M&A types (8-K, DEFM14A, etc.)
+                [  # Combined strong M&A + annual forms
                     {
                         "filer_cik": "99999",
                         "filer_name": "LOCKHEED MARTIN CORPORATION",
@@ -333,7 +333,6 @@ class TestSearchInboundMAMentions:
                         "file_description": "Acquisition of Small SBIR Company",
                     },
                 ],
-                [],  # Annual reports (10-K, 10-Q)
                 [],  # Ownership filings (SC 13D/13G)
             ]
         )
@@ -343,8 +342,8 @@ class TestSearchInboundMAMentions:
         assert events[0].is_target is True
         assert events[0].filer_name == "LOCKHEED MARTIN CORPORATION"
         assert events[0].event_type == MAAcquisitionType.ACQUISITION
-        # Should have been called 3 times (one per filing type tier)
-        assert mock_client.search_filing_mentions.call_count == 3
+        # Complete strong + annual pages share one request; ownership stays separate.
+        assert mock_client.search_filing_mentions.call_count == 2
 
     @pytest.mark.asyncio
     async def test_combines_results_across_tiers(self):
@@ -352,7 +351,7 @@ class TestSearchInboundMAMentions:
         mock_client = AsyncMock()
         mock_client.search_filing_mentions = AsyncMock(
             side_effect=[
-                [  # 8-K match
+                [  # Combined page with 8-K and 10-K matches
                     {
                         "filer_cik": "111",
                         "filer_name": "ACQUIRER A",
@@ -361,8 +360,6 @@ class TestSearchInboundMAMentions:
                         "accession_number": "001",
                         "file_description": "",
                     },
-                ],
-                [  # 10-K match from different filer
                     {
                         "filer_cik": "222",
                         "filer_name": "ACQUIRER B",
@@ -396,7 +393,6 @@ class TestSearchInboundMAMentions:
                     },
                 ],
                 [],
-                [],
             ]
         )
 
@@ -410,6 +406,81 @@ class TestSearchInboundMAMentions:
 
         events = await _search_inbound_ma_mentions(mock_client, "Unknown LLC")
         assert events == []
+
+    @pytest.mark.asyncio
+    async def test_fetches_context_only_for_latest_same_filer_hit(self):
+        """Older same-filer filings cannot survive final profile deduplication."""
+        mock_client = AsyncMock()
+        mock_client.search_filing_mentions = AsyncMock(
+            side_effect=[
+                [
+                    {
+                        "filer_cik": "99999",
+                        "filer_name": "ACQUIRER INC",
+                        "form_type": "10-K",
+                        "file_date": "2023-01-01",
+                        "accession_number": "old",
+                        "doc_id": "old-accession:old.htm",
+                    },
+                    {
+                        "filer_cik": "99999",
+                        "filer_name": "ACQUIRER INC",
+                        "form_type": "10-K",
+                        "file_date": "2024-01-01",
+                        "accession_number": "new",
+                        "doc_id": "new-accession:new.htm",
+                    },
+                ],
+                [],
+            ]
+        )
+        mock_client.fetch_filing_document = AsyncMock(
+            return_value="ACQUIRER INC acquired Target Co in 2022."
+        )
+
+        events = await _search_inbound_ma_mentions(mock_client, "Target Co")
+
+        assert len(events) == 1
+        assert events[0].filing_date == date(2024, 1, 1)
+        assert events[0].mention_type == "acquisition"
+        mock_client.fetch_filing_document.assert_awaited_once_with(
+            "99999", "new-accession", "new.htm"
+        )
+
+    @pytest.mark.asyncio
+    async def test_page_boundary_falls_back_to_separate_tier_searches(self):
+        """A possibly truncated combined page cannot hide a tier's top hits."""
+        combined_page = [{"filer_name": ""} for _ in range(100)]
+        mock_client = AsyncMock()
+        mock_client.search_filing_mentions = AsyncMock(
+            side_effect=[
+                combined_page,
+                [],
+                [
+                    {
+                        "filer_cik": "111",
+                        "filer_name": "ACQUIRER A",
+                        "form_type": "8-K",
+                        "file_date": "2024-06-15",
+                        "accession_number": "001",
+                    }
+                ],
+                [
+                    {
+                        "filer_cik": "222",
+                        "filer_name": "ACQUIRER B",
+                        "form_type": "10-K",
+                        "file_date": "2024-03-01",
+                        "accession_number": "002",
+                    }
+                ],
+            ]
+        )
+
+        events = await _search_inbound_ma_mentions(mock_client, "Target Co")
+
+        assert {event.filer_name for event in events} == {"ACQUIRER A", "ACQUIRER B"}
+        assert mock_client.search_filing_mentions.call_count == 4
 
 
 class TestSearchFormDFilings:
@@ -803,3 +874,27 @@ class TestExtractMentionContext:
         mention = {"filer_cik": "12345"}  # No doc_id
         result = await _extract_mention_context(mock_client, "Unknown Co", mention)
         assert result is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "mention",
+        [
+            {"filer_cik": "12345"},
+            {"filer_cik": "12345", "doc_id": "malformed"},
+            {"filer_cik": "12345", "doc_id": ":doc.htm"},
+            {"filer_cik": "12345", "doc_id": "0000012345-20-000001:"},
+            {"doc_id": "0000012345-20-000001:doc.htm"},
+        ],
+    )
+    async def test_incomplete_filing_reference_marks_context_unsearchable(self, mention):
+        from sbir_etl.enrichers.sec_edgar.enricher import _extract_mention_context
+
+        calls = []
+        mock_client = AsyncMock()
+        mock_client.__dict__["_context_incomplete_callback"] = lambda: calls.append(True)
+
+        result = await _extract_mention_context(mock_client, "Unknown Co", mention)
+
+        assert result is None
+        assert calls == [True]
+        mock_client.fetch_filing_document.assert_not_called()

--- a/tests/unit/enrichers/test_sec_edgar_enricher.py
+++ b/tests/unit/enrichers/test_sec_edgar_enricher.py
@@ -448,6 +448,41 @@ class TestSearchInboundMAMentions:
         )
 
     @pytest.mark.asyncio
+    async def test_unpartitionable_form_falls_back_to_separate_tier_searches(self):
+        """A root form outside both tier vocabularies must not be dropped."""
+        combined_page = [
+            {
+                "filer_cik": "333",
+                "filer_name": "ACQUIRER C",
+                "form_type": "8-K12B",
+                "file_date": "2024-05-01",
+                "accession_number": "003",
+            }
+        ]
+        mock_client = AsyncMock()
+        mock_client.search_filing_mentions = AsyncMock(
+            side_effect=[
+                combined_page,
+                [],
+                [
+                    {
+                        "filer_cik": "111",
+                        "filer_name": "ACQUIRER A",
+                        "form_type": "8-K",
+                        "file_date": "2024-06-15",
+                        "accession_number": "001",
+                    }
+                ],
+                [],
+            ]
+        )
+
+        events = await _search_inbound_ma_mentions(mock_client, "Target Co")
+
+        assert {event.filer_name for event in events} == {"ACQUIRER A"}
+        assert mock_client.search_filing_mentions.call_count == 4
+
+    @pytest.mark.asyncio
     async def test_page_boundary_falls_back_to_separate_tier_searches(self):
         """A possibly truncated combined page cannot hide a tier's top hits."""
         combined_page = [{"filer_name": ""} for _ in range(100)]
@@ -891,7 +926,7 @@ class TestExtractMentionContext:
 
         calls = []
         mock_client = AsyncMock()
-        mock_client.__dict__["_context_incomplete_callback"] = lambda: calls.append(True)
+        mock_client.context_incomplete_callback = lambda: calls.append(True)
 
         result = await _extract_mention_context(mock_client, "Unknown Co", mention)
 

--- a/tests/unit/scripts/archive/test_refine_ma_medium_tier.py
+++ b/tests/unit/scripts/archive/test_refine_ma_medium_tier.py
@@ -1,0 +1,58 @@
+import json
+
+import pytest
+
+from scripts.archive.data.refine_ma_medium_tier import refine_events
+
+
+class _IncompleteReferenceClient:
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.incomplete_calls = 0
+        self.fetch_calls = 0
+        self._context_incomplete_callback = self._mark_incomplete
+
+    def _mark_incomplete(self) -> None:
+        self.incomplete_calls += 1
+
+    async def search_filing_mentions(self, company_name: str, **kwargs):
+        if self.mode == "search_error":
+            raise RuntimeError("search failed")
+        if self.mode == "malformed":
+            return [{"doc_id": "malformed", "filer_cik": "12345"}]
+        return [{"doc_id": "0000012345-20-000001:doc.htm", "filer_cik": "12345"}]
+
+    async def fetch_filing_document(self, cik: str, accession: str, filename: str):
+        self.fetch_calls += 1
+        if self.mode == "fetch_error":
+            raise RuntimeError("fetch failed")
+        return None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("mode", "expected_direction", "expected_fetches"),
+    [
+        ("malformed", "ambiguous", 0),
+        ("search_error", "no_filing", 0),
+        ("fetch_error", "ambiguous", 1),
+    ],
+)
+async def test_directional_refinement_marks_incomplete_context(
+    tmp_path, mode: str, expected_direction: str, expected_fetches: int
+) -> None:
+    client = _IncompleteReferenceClient(mode)
+    output = tmp_path / "refined.jsonl"
+
+    await refine_events(
+        [{"company_name": "Alpha", "confidence": "medium"}],
+        client,
+        output,
+        set(),
+        concurrency=1,
+    )
+
+    row = json.loads(output.read_text())
+    assert row["direction"] == expected_direction
+    assert client.incomplete_calls == 1
+    assert client.fetch_calls == expected_fetches

--- a/tests/unit/scripts/archive/test_refine_ma_medium_tier.py
+++ b/tests/unit/scripts/archive/test_refine_ma_medium_tier.py
@@ -10,7 +10,7 @@ class _IncompleteReferenceClient:
         self.mode = mode
         self.incomplete_calls = 0
         self.fetch_calls = 0
-        self._context_incomplete_callback = self._mark_incomplete
+        self.context_incomplete_callback = self._mark_incomplete
 
     def _mark_incomplete(self) -> None:
         self.incomplete_calls += 1

--- a/tests/unit/scripts/archive/test_scan_sbir_edgar.py
+++ b/tests/unit/scripts/archive/test_scan_sbir_edgar.py
@@ -1,0 +1,30 @@
+from scripts.archive.data.scan_sbir_edgar import _ServerErrorTracker
+
+
+def test_request_error_tracker_marks_rate_limited_company() -> None:
+    tracker = _ServerErrorTracker()
+    tracker.register("Acme Labs")
+
+    tracker.write("EDGAR filing mention search failed for 'Acme Labs': 429 Too Many Requests")
+
+    assert tracker.had_error("Acme Labs")
+
+
+def test_request_error_tracker_ignores_unrelated_warning() -> None:
+    tracker = _ServerErrorTracker()
+    tracker.register("Acme Labs")
+
+    tracker.write("A warning unrelated to an EFTS request")
+
+    assert not tracker.had_error("Acme Labs")
+
+
+def test_request_error_tracker_uses_exact_active_company_name() -> None:
+    tracker = _ServerErrorTracker()
+    tracker.register("Acme")
+    tracker.register("Acme Labs")
+
+    tracker.write("EDGAR filing mention search failed for 'Acme Labs': HTTP 500")
+
+    assert not tracker.had_error("Acme")
+    assert tracker.had_error("Acme Labs")

--- a/tests/unit/scripts/archive/test_scan_sbir_edgar.py
+++ b/tests/unit/scripts/archive/test_scan_sbir_edgar.py
@@ -28,3 +28,14 @@ def test_request_error_tracker_uses_exact_active_company_name() -> None:
 
     assert not tracker.had_error("Acme")
     assert tracker.had_error("Acme Labs")
+
+
+def test_request_error_tracker_stops_at_first_closing_quote() -> None:
+    tracker = _ServerErrorTracker()
+    tracker.register("Acme Labs")
+
+    tracker.write(
+        "EDGAR filing mention search failed for 'Acme Labs': later quoted 'detail': 500"
+    )
+
+    assert tracker.had_error("Acme Labs")


### PR DESCRIPTION
## Description

Extracts the `sbir_etl/enrichers/sec_edgar/` change that was riding along inside draft #669 (exploratory supplier-share census) into its own PR, so a pipelines-tier behavior change gets its own review. Three audits on #669 reached the same recommendation. #669 now merges this branch and carries only the census.

**What changes for every caller of `EdgarAPIClient.search_filing_mentions`:**

- The EFTS request now sends explicit `from`/`size`. The server's default page is 100, so a call with `limit > 100` retrieves hits that the old request could not. Callers with `limit <= 100` (the default is 20) get the same set given stable server ordering. The inbound M&A search now requests exactly 100 on a single combined operating-forms query.
- The inbound M&A search issues one combined query and partitions the page locally into the M&A and annual tiers. At the 100-hit page boundary, or when any hit's root form falls outside both tier vocabularies (empty `root_forms`, a variant such as `8-K12B`), it falls back to the separate per-tier queries so no hit is dropped and no tier's top hits are hidden by combined ordering.
- Mention-context extraction reports an incomplete filing reference (missing `doc_id`, accession, filename, or CIK) through a public `EdgarAPIClient.context_incomplete_callback` attribute, so a scan can type that mention as not searchable instead of silently missing. The archived scan and refine scripts set and read that attribute; the earlier private-attribute-through-`__dict__` hook is gone.

**Before/after on tier counts: not measured.** The tier thresholds in `_detect_ma_events` are unchanged. The inputs to tiering can change only for `limit > 100` and via the combined-query path, and the fallback keeps the separate queries wherever the combined page could differ. A measured before/after against the S3 corpus needs the live EFTS endpoint and is not run here. This is the code path that produced the counts #672 packages for Zenodo; #672's `study.yaml` pins `v0.11.0`, so that paper is unaffected, but `CITATION.cff`'s `repository-code` is unpinned.

The archived scripts' formatting-only hunks are carried as-is from #669 so that branch merges cleanly. `scripts/**` is excluded from the repository format check.

Fixes # (none; extracted from #669)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Versioning Impact

- [ ] No release impact (internal or unreleased work)
- [x] PATCH: backward-compatible fix or documentation correction
- [ ] MINOR: new capability, deprecation, or breaking change during `0.x`
- [ ] MAJOR: incompatible public change after `1.0.0`

## Testing

```
uv run pytest tests/unit/enrichers/test_sec_edgar_client.py tests/unit/enrichers/test_sec_edgar_enricher.py tests/unit/scripts/archive/ -q
uv run ruff check sbir_etl/enrichers/sec_edgar tests/unit/enrichers tests/unit/scripts/archive
uv run mypy sbir_etl/enrichers/sec_edgar
uv run python scripts/ci/check_tier_boundaries.py
```

88 tests pass, including a new test that a root form outside both tier vocabularies falls back to the separate searches instead of being dropped. No network calls.

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests pass locally

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RdqC3i72EbSPNjeasdeNHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdqC3i72EbSPNjeasdeNHd)_