### PR TITLE
Add provenance-aware Form D and M&A cross-enrichment

### DIFF
--- a/docs/data/capital-events.md
+++ b/docs/data/capital-events.md
@@ -1,6 +1,6 @@
 # Capital Events & UCC1 Pilot
 
-Assembles a per-firm "capital events" dataset — funding, M&A, patents, federal
+Assembles a per-firm "capital events" dataset — funding, M&A candidates, patents, federal
 contracts, and UCC liens — for the Form D high-confidence cohort. Code lives in
 `sbir_etl/capital_events/`; the UCC1 pilot that feeds it lives in `sbir_etl/ucc/`.
 
@@ -8,6 +8,20 @@ All paths below are under the data root, overridable with the `SBIR_DATA_DIR`
 environment variable. No API credentials are required for either subsystem.
 
 ## Build capital events
+
+To preserve source lineage where Form D and an M&A candidate may describe the same event, first
+build the optional cross-enrichment artifacts:
+
+```bash
+python scripts/data/build_form_d_ma_cross_enrichment.py
+```
+
+Pass its `enriched_ma_events.jsonl` output to `build_capital_events.py
+--ma-events`. The M&A-candidate metadata retains the cross-enrichment relationship
+ID, source classes, and whether evidence exists independently of Form D. These
+rows are unvalidated public-record candidates. They are not verified legal
+exits. Form D amount sold is exempt securities sold, not deal or enterprise
+value.
 
 ```bash
 python scripts/data/build_capital_events.py

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -36,6 +36,7 @@ brief count as maintainer-facing.
 | [M&A exit analysis](sbir-ma-exit-analysis.md) | A4, F1, F2 | Dated analysis; likely understates exits because it uses public filings | Run documented 2026-04-23 |
 | [Capital-pathway cohorts](sbir-pathway-cohorts.md) | F1, F2 | Dated group analysis | 3,639 firms with high-confidence matches; 2026-06-23 |
 | [NASA, Air Force, and DOE commercialization outcomes](nasa-air-force-doe-commercialization-outcomes.md) | B2, B3, F1, F2, F3 | Exploratory multi-channel comparison; non-citable | First Phase II cohorts; 3-, 5-, and 10-year windows through 2024-12-31 |
+| [Form D and M&A-candidate cross-enrichment](form-d-ma-cross-enrichment.md) | B2, B3, F1, F2, F3 | Exploratory provenance and candidate-relationship layer; non-citable | Current Form D and public-record M&A-candidate files; three-agency analysis test case |
 | [UCC-1 pilot](sbir-ucc1-pilot.md) | F1 | Early, partial pilot for one state | California subset; 2026-05-16 |
 | [California UCC API notes](ucc1-bizfileonline-api.md) | E5, F1 | Reference for the data source; not a research result | Web addresses recorded 2026-05-16 |
 | [SEC EDGAR learnings](sec-edgar-sbir-learnings.md) | E5, F1, F2 | Notes on implementation and source behavior | Observations from 2026-04-19 and 2026-04-22 |

--- a/docs/research/form-d-ma-cross-enrichment.md
+++ b/docs/research/form-d-ma-cross-enrichment.md
@@ -1,0 +1,179 @@
+# Form D and M&A-candidate cross-enrichment
+
+**Status:** Exploratory — non-citable
+
+**Test case:** [NASA, Air Force, and DOE commercialization outcomes](nasa-air-force-doe-commercialization-outcomes.md)
+
+## Purpose
+
+Form D and public-record M&A candidates can describe the same corporate event,
+but they add different information. Form D can contribute a target CIK, filing
+accession, exempt securities sold, address, and related persons. EFTS-derived
+evidence can contribute a possible acquirer and an acquisition or subsidiary
+context. Combining the sources can improve event review and identity
+persistence. Treating a Form-D-derived candidate as independent confirmation
+would inflate channel overlap.
+
+Every output relationship has
+`candidate_status=unvalidated_public_record_candidate` and
+`legal_event_validated=false`. A high confidence label describes the strength
+of the source-pattern match. It does not mean that researchers verified the
+target identity, closing status, transaction terms, or legal exit.
+
+The cross-enrichment layer leaves both raw source files unchanged. It writes:
+
+- `enriched_ma_events.jsonl`, preserving every M&A-candidate row and adding source-aware
+  cross-enrichment metadata;
+- `corporate_relationships.jsonl`, one reviewable candidate target-to-acquirer
+  or business-combination relationship per source row; and
+- `form_d_ma_crosswalk.jsonl`, accession-level Form D links, including
+  unlinked business-combination filings.
+
+Acquirers are emitted as `candidate_acquired_by` relationships with
+`auto_merge: false`. A source mention does not prove that an acquisition closed.
+Even a verified acquisition would not make the target and acquirer
+interchangeable identities or prove that later acquirer contracts descend from
+the target's SBIR work.
+
+## Provenance rule
+
+The M&A-candidate file is a composite product, not an independent evidence source. Source
+counts are based on the underlying Form D, EFTS, press, or discovery evidence.
+When an M&A record originated from a Form D business-combination filing, that
+same filing is labeled `originating_evidence` and receives no additional
+confidence credit. A separately detected EFTS event linked to a Form D filing
+is independent corroboration.
+
+This distinction produces two measures:
+
+- **M&A candidate observed:** any retained high- or medium-confidence public-record signal,
+  including Form-D-only business combinations; and
+- **M&A candidate independent of Form D:** a signal supported by EFTS, press, or
+  discovery evidence beyond the Form D filing.
+
+The first is a candidate-detection rate, not an exit rate. The second is used
+when counting independent observed pathways. Neither establishes a completed
+legal transaction.
+
+## Amount-sold interpretation
+
+Form D `total_amount_sold` measures exempt securities sold in the reported
+offering. When Item 10 marks the offering as connected to a business
+combination, this study labels the measure **business-combination-associated
+exempt securities sold**. It can describe acquisition financing, securities
+issued as consideration, recapitalization, or another offering connected to
+the combination. It is not purchase price, seller proceeds, equity value, or
+enterprise value. See the SEC's [Form D and Item 10
+language](https://www.sec.gov/about/forms/formd.pdf).
+
+The relationship metadata makes this limit machine-readable with
+`form_d_amount_sold_is_deal_value=false`, `deal_terms_captured=false`, and
+`enterprise_value_observed=false`. The pipeline continues to collapse Form D
+amendments so cumulative offering amounts are not summed repeatedly.
+
+## Initial materialization
+
+Using the current `form_d_details.jsonl` and `enriched_sbir_ma_events.jsonl`:
+
+| Diagnostic | Count |
+| --- | ---: |
+| M&A-candidate source rows annotated | 5,252 |
+| Distinct target/date/acquirer relationship clusters | 5,239 |
+| Relationships containing Form D evidence | 598 |
+| Relationships containing EFTS evidence | 4,821 |
+| Relationships containing press-wire evidence | 13 |
+| Relationships containing both Form D and EFTS evidence | 180 |
+| Relationships with multiple source classes | 189 |
+| Form-D-only M&A-candidate relationships | 417 |
+| Linked Form D business-combination accessions | 694 |
+| Unlinked Form D business-combination accessions | 116 |
+| Links adding independent Form D corroboration to EFTS evidence | 10 |
+| Acquirer identities automatically merged into targets | 0 |
+
+The accession count exceeds the relationship count because a company can have
+multiple business-combination filings associated with one composite M&A row.
+Originating Form D filings are identified from `form_d_detail` accession or
+filing date, not from proximity to a possibly overwritten composite
+`event_date`. The 366-day window is used only for additional matches on rows
+that do not already have Form D evidence. It is a candidate clustering rule,
+not proof that two records describe the same legal event. Only high-tier Form D
+matches are ingested.
+
+## Three-agency test case
+
+The headline five-year candidate-detection counts from the prior analysis do
+not change: five NASA firms, five Air Force firms, and nine DOE firms have a
+high-confidence public-record candidate. The new provenance field shows that
+only three, three, and four of those respective candidates have evidence
+independent of Form D. The channel-overlap table no longer describes a reused
+Form D filing as a second, independent pathway.
+
+| Agency | High-confidence M&A candidates observed | Independent of Form D |
+| --- | ---: | ---: |
+| NASA | 5 | 3 |
+| Air Force | 5 | 3 |
+| DOE | 9 | 4 |
+
+With independent pathways used for overlap, the shares with no independently
+observed signal across contracts, Form D amount sold, and M&A candidates are 32.4% for
+NASA, 31.5% for Air Force, and 59.8% for DOE. This is an overlap-accounting
+correction, not a revision to the channel-specific headline rates.
+
+## Transaction-terms audit
+
+A 2026-09-09 review traced the 19 five-year high-confidence candidates to the
+retained source summaries. None contains explicit purchase price, cash or stock
+consideration, earn-outs, assumed debt, or enterprise value. Ten candidates
+name a possible acquirer. Twelve contain Form D amount sold, but those amounts
+are offering measures and not deal values.
+
+For those 12 candidates, amount sold totals $412.3 million. The median is $3.44
+million and the range is $45,000 to $344.8 million. One $344.8 million filing
+accounts for 83.6% of the total; the three largest account for 94.7%. The mean
+and agency totals are therefore not representative of a typical firm.
+
+Source spot checks also found candidate-quality problems that aggregate signal
+labels do not reveal:
+
+- A [Horizon Technology Finance
+  filing](https://www.sec.gov/Archives/edgar/data/1487428/000143774926006636/hrzn20251231_10k.htm)
+  describes Slingshot Aerospace as a portfolio investment with a
+  preferred-stock warrant, not as an acquired company.
+- An [OSI Systems subsidiary
+  exhibit](https://www.sec.gov/Archives/edgar/data/1039065/000104746917005596/a2232548zex-21_1.htm)
+  lists DXRay but does not supply the acquisition date or terms retained by
+  this study.
+- A [Global Technologies
+  filing](https://www.sec.gov/Archives/edgar/data/1308841/000110801711000405/ex991.htm)
+  discusses a potential Technology Applications transaction and does not
+  establish that it closed.
+
+These checks are diagnostic, not a complete adjudication of all 19 candidates.
+Until each candidate has a source accession, target-specific excerpt, verified
+identity, closing status, and terms review, the study must not call the counts
+validated exits.
+
+## Implementation
+
+The pure cross-enrichment logic is in
+[`sbir_etl/capital_events/cross_enrichment.py`](../../sbir_etl/capital_events/cross_enrichment.py).
+The materialization command is
+[`scripts/data/build_form_d_ma_cross_enrichment.py`](../../scripts/data/build_form_d_ma_cross_enrichment.py).
+The three-agency generator consumes the enriched M&A JSONL through its existing
+`--ma` argument and reports both observed and independent signal counts. The
+shared M&A capital-event builder also preserves the `cross_enrichment` object in
+event metadata so downstream timeline products do not discard provenance.
+
+## Remaining work
+
+This first slice creates the safe relationship layer. Subsequent work should:
+
+1. incorporate verified press/discovery records as additional evidence classes;
+2. resolve acquirer identifiers such as CIK and UEI, not just names;
+3. create time-bounded predecessor and successor assertions after review;
+4. test post-acquisition contract continuation using those reviewed assertions;
+5. retain filing accession numbers and target-specific source excerpts;
+6. validate closing status and capture cash, stock, earn-out, assumed-debt,
+   purchase-price, and enterprise-value fields when disclosed; and
+7. hand-label linked and unlinked business-combination samples to estimate
+   precision before any evidence-status promotion.

--- a/docs/research/nasa-air-force-doe-commercialization-outcomes.md
+++ b/docs/research/nasa-air-force-doe-commercialization-outcomes.md
@@ -8,7 +8,7 @@
 
 **Primary window:** Five years after a firm's first Phase II award from the agency
 
-**Channels:** Non-Phase-I/II federal prime contracts, SEC Form D offerings, and public-record M&A
+**Channels:** Non-Phase-I/II federal prime contracts, SEC Form D offerings, and public-record M&A candidates
 
 ## Current result status
 

--- a/notebooks/explorations/b2_three_agency_commercialization_outcomes.ipynb
+++ b/notebooks/explorations/b2_three_agency_commercialization_outcomes.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Status:** exploratory — non-citable  \n",
     "**Research questions:** B2/B3, F1/F3  \n",
-    "**Decision this informs:** how three agency portfolios differ in observed federal-contract, private-capital, and acquisition pathways  \n",
+    "**Decision this informs:** how three agency portfolios differ in observed federal-contract, private-capital, and provisional acquisition-candidate pathways  \n",
     "**Data cutoff:** 2024-12-31\n",
     "\n",
     "This notebook is a diagnostic companion. The canonical calculations live in `scripts/data/three_agency_commercialization_outcomes.py`."
@@ -25,7 +25,7 @@
     "- **Population:** NASA, Air Force, and DOE firms with a first SBIR/STTR Phase II award from 2009 onward.\n",
     "- **Grain:** firm × funding agency; firms may appear in more than one agency cohort.\n",
     "- **Anchor:** first Phase II award date from that agency.\n",
-    "- **Outcomes:** observed prime-contract, Form D, and public-filing M&A signals within fixed horizons.\n",
+    "- **Outcomes:** observed prime-contract, Form D, and unvalidated public-filing M&A candidates within fixed horizons.\n",
     "- **Missingness:** no observed signal is not evidence that commercialization did not occur.\n",
     "- **Inference:** descriptive only; no causal or composite-ranking claim."
    ]
@@ -77,7 +77,7 @@
    "outputs": [],
    "source": [
     "primary = outcomes[(outcomes.horizon_years == 5) & ((outcomes.channel == 'federal_contract') | (outcomes.confidence_filter == 'high'))]\n",
-    "primary[['agency', 'channel', 'eligible_firms', 'firms_with_signal', 'rate', 'rate_ci_low', 'rate_ci_high', 'dollars_per_phase_ii_dollar', 'median_latency_years']]"
+    "primary[['agency', 'channel', 'eligible_firms', 'firms_with_signal', 'firms_with_independent_signal', 'rate', 'rate_ci_low', 'rate_ci_high', 'dollars_per_phase_ii_dollar', 'median_latency_years']]"
    ]
   },
   {
@@ -122,6 +122,10 @@
     "- Keep incidence and dollar intensity separate.\n",
     "- Compare high-only SEC results with high+medium sensitivity before interpreting agency differences.\n",
     "- Treat Form D and M&A as incomplete public-data signals with false-positive and false-negative risk.\n",
+    "- Treat Form D amount sold as exempt securities sold, not company, deal, or enterprise value.\n",
+    "- Treat M&A rows as screening candidates, not validated legal exits.\n",
+    "- Use M&A `firms_with_independent_signal` and the provenance-aware overlap table when comparing distinct observed channels.\n",
+    "- Require transaction-level identity, closing-status, and terms review before describing a candidate as an exit.\n",
     "- Check the generated manifest's amendment and linkage audits before quoting a value internally.\n",
     "- Do not attribute an Air Force time break to AFWERX without a separate causal design."
    ]

--- a/sbir_etl/capital_events/cross_enrichment.py
+++ b/sbir_etl/capital_events/cross_enrichment.py
@@ -1,0 +1,442 @@
+"""Bidirectional, provenance-aware Form D and M&A-candidate cross-enrichment.
+
+The source files remain immutable.  This module annotates M&A records with
+matching Form D evidence and emits a relationship/crosswalk layer for downstream
+analysis.  A composite M&A row is an unvalidated public-record candidate, not a
+verified legal exit.  It is not itself counted as an independent source; only
+the underlying Form D, EFTS, press, or discovery evidence is.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import defaultdict
+from collections.abc import Iterable, Iterator
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+from sbir_etl.identity import CompanyNameProfile, normalize_company_name
+
+
+DEFAULT_LINK_WINDOW_DAYS = 366
+CANDIDATE_STATUS = "unvalidated_public_record_candidate"
+HIGH_FORM_D_MATCH_TIER = "high"
+FORM_D_CHANNEL_AMOUNT_SOLD_MEASURE = "exempt_securities_sold"
+FORM_D_AMOUNT_SOLD_MEASURE = "business_combination_associated_exempt_securities_sold"
+
+
+def organization_key(value: object) -> str:
+    """Return the repository's versioned organization identity key."""
+
+    return normalize_company_name(value, profile=CompanyNameProfile.ORGANIZATION_KEY_V1)
+
+
+def parse_iso_date(value: object) -> date | None:
+    """Parse a leading ISO date without guessing other date formats."""
+
+    text = str(value or "").strip()[:10]
+    if not text:
+        return None
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def _amount(value: object) -> float:
+    if not isinstance(value, (str, int, float)):
+        return 0.0
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _relationship_id(target_key: str, event_date: object, acquirer: object) -> str:
+    material = "|".join((target_key, str(event_date or ""), organization_key(acquirer)))
+    return "ma_" + hashlib.sha256(material.encode()).hexdigest()[:20]
+
+
+_SOURCE_CLASS_TOKENS = frozenset({"form_d", "efts", "press", "discovery"})
+
+
+def _signals(record: dict[str, Any]) -> dict[str, Any]:
+    signals = record.get("signals") or {}
+    return signals if isinstance(signals, dict) else {}
+
+
+def _has_discovery_evidence(record: dict[str, Any], signals: dict[str, Any]) -> bool:
+    """Recognize both the local discovery payload and the #699 row shape."""
+
+    if (
+        signals.get("discovery_confirmed")
+        or record.get("discovery_evidence")
+        or record.get("source_url")
+    ):
+        return True
+    source = str(record.get("source") or "").strip()
+    if not source or not record.get("evidence"):
+        return False
+    return source.lower() not in _SOURCE_CLASS_TOKENS
+
+
+def _has_confirmed_press(record: dict[str, Any], signals: dict[str, Any]) -> bool:
+    """Count confirmed press evidence only; ignore raw press-wire hit lists."""
+
+    if signals.get("press_confirmed"):
+        return True
+    evidence = record.get("press_evidence")
+    return bool(evidence) and not isinstance(evidence, list)
+
+
+def evidence_sources(record: dict[str, Any]) -> list[str]:
+    """Return underlying source classes for a composite M&A-candidate row."""
+
+    sources: set[str] = set()
+    signals = _signals(record)
+    if signals.get("form_d_business_combination") or record.get("form_d_detail"):
+        sources.add("form_d")
+    if record.get("efts_detail") or any(
+        value for key, value in signals.items() if str(key).startswith("efts_")
+    ):
+        sources.add("efts")
+    if _has_confirmed_press(record, signals):
+        sources.add("press")
+    if _has_discovery_evidence(record, signals):
+        sources.add("discovery")
+    return sorted(sources)
+
+
+def is_independent_of_form_d(record: dict[str, Any]) -> bool:
+    """Whether an M&A candidate has evidence beyond the Form D filing it may reuse."""
+
+    return any(source != "form_d" for source in evidence_sources(record))
+
+
+def _match_tier(record: dict[str, Any]) -> str:
+    return str((record.get("match_confidence") or {}).get("tier") or "").strip().lower()
+
+
+def _form_d_detail(record: dict[str, Any]) -> dict[str, Any]:
+    detail = record.get("form_d_detail")
+    return detail if isinstance(detail, dict) else {}
+
+
+def _originating_accession(detail: dict[str, Any]) -> str:
+    for key in ("accession_number", "accession"):
+        value = str(detail.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _is_originating_offering(
+    offering: dict[str, Any],
+    *,
+    originating_accession: str,
+    originating_date: date | None,
+) -> bool:
+    if originating_accession:
+        return offering["accession_number"] == originating_accession
+    return originating_date is not None and offering["event_date"] == originating_date
+
+
+def independent_source_count(sources: Iterable[str]) -> int:
+    """Count source classes other than Form D."""
+
+    return sum(1 for source in sources if source and source != "form_d")
+
+
+def relationship_source_classes(row: dict[str, Any]) -> list[str]:
+    """Return source classes, including Form D linked during cross-enrichment."""
+
+    sources = {str(source) for source in row.get("evidence_sources") or [] if source}
+    accessions = row.get("form_d_accession_numbers") or []
+    if accessions or int(row.get("matched_form_d_combination_count") or 0):
+        sources.add("form_d")
+    return sorted(sources)
+
+
+def _form_d_offerings(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    offerings: list[dict[str, Any]] = []
+    for record in records:
+        if _match_tier(record) != HIGH_FORM_D_MATCH_TIER:
+            continue
+        target_name = str(record.get("company_name") or "").strip()
+        target_key = organization_key(target_name)
+        if not target_key:
+            continue
+        record_cik = str(record.get("form_d_cik") or "").lstrip("0")
+        match_tier = HIGH_FORM_D_MATCH_TIER
+        for offering in record.get("offerings") or []:
+            event_date = parse_iso_date(offering.get("filing_date")) or parse_iso_date(
+                offering.get("date_of_first_sale")
+            )
+            offerings.append(
+                {
+                    "target_name": target_name,
+                    "target_key": target_key,
+                    "event_date": event_date,
+                    "accession_number": str(offering.get("accession_number") or "").strip(),
+                    "cik": str(offering.get("cik") or record_cik).lstrip("0"),
+                    "amount_sold": _amount(offering.get("total_amount_sold")),
+                    "is_business_combination": bool(offering.get("is_business_combination")),
+                    "is_amendment": bool(offering.get("is_amendment")),
+                    "match_tier": match_tier,
+                }
+            )
+    return offerings
+
+
+def _within_window(left: date | None, right: date | None, days: int) -> bool:
+    return left is not None and right is not None and abs((left - right).days) <= days
+
+
+def enrich_form_d_and_ma(
+    form_d_records: Iterable[dict[str, Any]],
+    ma_records: Iterable[dict[str, Any]],
+    *,
+    link_window_days: int = DEFAULT_LINK_WINDOW_DAYS,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return enriched M&A candidates, candidate relationships, and Form D links."""
+
+    offerings = _form_d_offerings(form_d_records)
+    by_target: defaultdict[str, list[dict[str, Any]]] = defaultdict(list)
+    for offering in offerings:
+        by_target[offering["target_key"]].append(offering)
+
+    enriched: list[dict[str, Any]] = []
+    relationships: list[dict[str, Any]] = []
+    crosswalk: list[dict[str, Any]] = []
+    linked_accessions: set[str] = set()
+
+    for raw_record in ma_records:
+        record = dict(raw_record)
+        target_name = str(record.get("company_name") or "").strip()
+        target_key = organization_key(target_name)
+        if not target_key:
+            enriched.append(record)
+            continue
+        event_date = parse_iso_date(record.get("event_date"))
+        acquirer = str(record.get("acquirer") or "").strip() or None
+        relationship_id = _relationship_id(target_key, record.get("event_date"), acquirer)
+        target_offerings = by_target.get(target_key, [])
+        sources = evidence_sources(record)
+        independent = any(source != "form_d" for source in sources)
+        form_d_detail = _form_d_detail(record)
+        originating_accession = _originating_accession(form_d_detail)
+        originating_date = parse_iso_date(form_d_detail.get("filing_date"))
+        allow_window = "form_d" not in sources
+        matched_combinations: list[tuple[dict[str, Any], bool]] = []
+        seen_accessions: set[str] = set()
+        for offering in target_offerings:
+            accession = offering["accession_number"]
+            if (
+                not offering["is_business_combination"]
+                or not accession
+                or accession in seen_accessions
+            ):
+                continue
+            originating = _is_originating_offering(
+                offering,
+                originating_accession=originating_accession,
+                originating_date=originating_date,
+            )
+            window_match = allow_window and _within_window(
+                offering["event_date"], event_date, link_window_days
+            )
+            if originating or window_match:
+                seen_accessions.add(accession)
+                matched_combinations.append((offering, originating))
+        after_event = [
+            offering
+            for offering in target_offerings
+            if event_date is not None
+            and offering["event_date"] is not None
+            and offering["event_date"] > event_date
+        ]
+        acquirer_offerings = (
+            [
+                offering
+                for offering in by_target.get(organization_key(acquirer), [])
+                if event_date is not None
+                and offering["event_date"] is not None
+                and offering["event_date"] >= event_date
+            ]
+            if acquirer
+            else []
+        )
+
+        provenance = {
+            "relationship_id": relationship_id,
+            "target_key": target_key,
+            "candidate_status": CANDIDATE_STATUS,
+            "legal_event_validated": False,
+            "deal_terms_captured": False,
+            "enterprise_value_observed": False,
+            "form_d_amount_sold_measure": FORM_D_AMOUNT_SOLD_MEASURE,
+            "form_d_amount_sold_is_deal_value": False,
+            "evidence_sources": sources,
+            "source_class_count": len(sources),
+            "independent_source_count": independent_source_count(sources),
+            "independent_of_form_d": independent,
+            "same_source_only": sources == ["form_d"],
+            "form_d_accession_numbers": sorted(
+                {item["accession_number"] for item, _ in matched_combinations}
+            ),
+            "form_d_ciks": sorted({item["cik"] for item, _ in matched_combinations if item["cik"]}),
+            "matched_form_d_combination_count": len(matched_combinations),
+            "post_event_target_form_d_raw_filing_count": len(after_event),
+            "post_event_target_form_d_raw_amount_sum": sum(
+                item["amount_sold"] for item in after_event
+            ),
+            "acquirer_form_d_accession_numbers": sorted(
+                {
+                    item["accession_number"]
+                    for item in acquirer_offerings
+                    if item["accession_number"]
+                }
+            ),
+            "acquirer_alias_candidate": {
+                "name": acquirer,
+                "relationship": "candidate_acquired_by",
+                "valid_from": event_date.isoformat() if event_date else None,
+                "auto_merge": False,
+            }
+            if acquirer
+            else None,
+        }
+        record["cross_enrichment"] = provenance
+        enriched.append(record)
+        relationships.append(
+            {
+                "relationship_id": relationship_id,
+                "target_name": target_name,
+                "target_key": target_key,
+                "acquirer_name": acquirer,
+                "acquirer_key": organization_key(acquirer),
+                "event_date": event_date.isoformat() if event_date else None,
+                "relationship_type": (
+                    "candidate_acquired_by" if acquirer else "candidate_business_combination"
+                ),
+                "confidence": record.get("confidence"),
+                **provenance,
+            }
+        )
+        for offering, originating in matched_combinations:
+            accession = offering["accession_number"]
+            linked_accessions.add(accession)
+            crosswalk.append(
+                {
+                    "accession_number": accession,
+                    "form_d_cik": offering["cik"],
+                    "target_name": target_name,
+                    "relationship_id": relationship_id,
+                    "acquirer_name": acquirer,
+                    "link_status": "linked",
+                    "legal_event_validated": False,
+                    "evidence_role": "originating_evidence"
+                    if originating
+                    else "independent_corroboration",
+                    "confidence_credit": not originating,
+                    "match_tier": offering["match_tier"],
+                    "date_distance_days": abs((offering["event_date"] - event_date).days)
+                    if offering["event_date"] and event_date
+                    else None,
+                }
+            )
+
+    for offering in offerings:
+        accession = offering["accession_number"]
+        if offering["is_business_combination"] and accession and accession not in linked_accessions:
+            crosswalk.append(
+                {
+                    "accession_number": accession,
+                    "form_d_cik": offering["cik"],
+                    "target_name": offering["target_name"],
+                    "relationship_id": None,
+                    "acquirer_name": None,
+                    "link_status": "unlinked",
+                    "legal_event_validated": False,
+                    "evidence_role": "form_d_only",
+                    "confidence_credit": False,
+                    "match_tier": offering["match_tier"],
+                    "date_distance_days": None,
+                }
+            )
+    relationship_by_id: dict[str, dict[str, Any]] = {}
+    confidence_rank = {"low": 0, "medium": 1, "high": 2}
+    for relationship in relationships:
+        relationship_id = relationship["relationship_id"]
+        current = relationship_by_id.get(relationship_id)
+        if current is None:
+            relationship_by_id[relationship_id] = relationship
+            continue
+        sources = sorted(set(current["evidence_sources"]) | set(relationship["evidence_sources"]))
+        current["evidence_sources"] = sources
+        current["source_class_count"] = len(sources)
+        current["independent_source_count"] = independent_source_count(sources)
+        current["independent_of_form_d"] = any(source != "form_d" for source in sources)
+        current["same_source_only"] = sources == ["form_d"]
+        for field_name in (
+            "form_d_accession_numbers",
+            "form_d_ciks",
+            "acquirer_form_d_accession_numbers",
+        ):
+            current[field_name] = sorted(set(current[field_name]) | set(relationship[field_name]))
+        current["matched_form_d_combination_count"] = len(current["form_d_accession_numbers"])
+        current["post_event_target_form_d_raw_filing_count"] = max(
+            current["post_event_target_form_d_raw_filing_count"],
+            relationship["post_event_target_form_d_raw_filing_count"],
+        )
+        current["post_event_target_form_d_raw_amount_sum"] = max(
+            current["post_event_target_form_d_raw_amount_sum"],
+            relationship["post_event_target_form_d_raw_amount_sum"],
+        )
+        if confidence_rank.get(str(relationship.get("confidence")), -1) > confidence_rank.get(
+            str(current.get("confidence")), -1
+        ):
+            current["confidence"] = relationship.get("confidence")
+
+    crosswalk_by_key: dict[tuple[str, str | None], dict[str, Any]] = {}
+    for link in crosswalk:
+        crosswalk_key = (link["accession_number"], link["relationship_id"])
+        current_link = crosswalk_by_key.get(crosswalk_key)
+        if current_link is None or link["confidence_credit"]:
+            crosswalk_by_key[crosswalk_key] = link
+    return enriched, list(relationship_by_id.values()), list(crosswalk_by_key.values())
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read nonblank JSONL records."""
+
+    with path.open(encoding="utf-8") as stream:
+        return [json.loads(line) for line in stream if line.strip()]
+
+
+def write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> int:
+    """Write JSONL deterministically and return the row count."""
+
+    materialized = list(rows)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as stream:
+        for row in materialized:
+            stream.write(json.dumps(row, sort_keys=True, default=str) + "\n")
+    return len(materialized)
+
+
+def iter_relationship_alias_candidates(
+    relationships: Iterable[dict[str, Any]],
+) -> Iterator[dict[str, Any]]:
+    """Yield review-only candidate relationships; never imply a verified acquisition."""
+
+    for relationship in relationships:
+        candidate = relationship.get("acquirer_alias_candidate")
+        if candidate:
+            yield {
+                "relationship_id": relationship["relationship_id"],
+                "target_key": relationship["target_key"],
+                **candidate,
+            }

--- a/sbir_etl/capital_events/sources/ma_events.py
+++ b/sbir_etl/capital_events/sources/ma_events.py
@@ -1,4 +1,4 @@
-"""M&A events → CapitalEvent builder.
+"""M&A candidates → CapitalEvent builder.
 
 Reads enriched_sbir_ma_events.jsonl. Filters to high+medium confidence.
 The file uses field name `confidence` (not `tier`).
@@ -14,7 +14,7 @@ _KEEP_CONFIDENCES = {"high", "medium"}
 
 
 def build_ma_events(cohort: Iterable[dict], source_path: Path) -> Iterator[dict]:
-    """Yield CapitalEvent rows for high+medium-confidence MA events."""
+    """Yield CapitalEvent rows for high+medium-confidence M&A candidates."""
     if not source_path.exists():
         return
     cohort_names = {row["company_name"] for row in cohort}
@@ -55,6 +55,13 @@ def build_ma_events(cohort: Iterable[dict], source_path: Path) -> Iterator[dict]
                         "signal_count": sum(
                             1 for value in (rec.get("signals") or {}).values() if value is True
                         ),
+                        "candidate_status": (rec.get("cross_enrichment") or {}).get(
+                            "candidate_status", "unvalidated_public_record_candidate"
+                        ),
+                        "legal_event_validated": (rec.get("cross_enrichment") or {}).get(
+                            "legal_event_validated", False
+                        ),
+                        "cross_enrichment": rec.get("cross_enrichment") or {},
                     }
                 ),
             }

--- a/scripts/data/build_form_d_ma_cross_enrichment.py
+++ b/scripts/data/build_form_d_ma_cross_enrichment.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Build provenance-aware Form D/M&A-candidate relationship and crosswalk artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+
+from sbir_etl.capital_events.cross_enrichment import (
+    CANDIDATE_STATUS,
+    DEFAULT_LINK_WINDOW_DAYS,
+    FORM_D_AMOUNT_SOLD_MEASURE,
+    enrich_form_d_and_ma,
+    read_jsonl,
+    relationship_source_classes,
+    write_jsonl,
+)
+
+
+def file_metadata(path: Path) -> dict[str, object]:
+    """Return deterministic file provenance metadata."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "path": str(path.resolve()),
+        "size_bytes": path.stat().st_size,
+        "sha256": digest.hexdigest(),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--form-d", type=Path, default=Path("data/form_d_details.jsonl"))
+    parser.add_argument("--ma", type=Path, default=Path("data/enriched_sbir_ma_events.jsonl"))
+    parser.add_argument(
+        "--output-dir", type=Path, default=Path("data/reports/form_d_ma_cross_enrichment")
+    )
+    parser.add_argument("--link-window-days", type=int, default=DEFAULT_LINK_WINDOW_DAYS)
+    args = parser.parse_args(argv)
+
+    missing = [path for path in (args.form_d, args.ma) if not path.is_file()]
+    if missing:
+        parser.error("missing input(s): " + ", ".join(map(str, missing)))
+
+    enriched, relationships, crosswalk = enrich_form_d_and_ma(
+        read_jsonl(args.form_d),
+        read_jsonl(args.ma),
+        link_window_days=args.link_window_days,
+    )
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    output_paths = {
+        "enriched_ma_events": args.output_dir / "enriched_ma_events.jsonl",
+        "corporate_relationships": args.output_dir / "corporate_relationships.jsonl",
+        "form_d_ma_crosswalk": args.output_dir / "form_d_ma_crosswalk.jsonl",
+    }
+    counts = {
+        "enriched_ma_events": write_jsonl(output_paths["enriched_ma_events"], enriched),
+        "corporate_relationships": write_jsonl(
+            output_paths["corporate_relationships"], relationships
+        ),
+        "form_d_ma_crosswalk": write_jsonl(output_paths["form_d_ma_crosswalk"], crosswalk),
+    }
+    source_classes = Counter(
+        source for row in relationships for source in relationship_source_classes(row)
+    )
+    manifest = {
+        "epistemic_tier": "exploratory",
+        "citable": False,
+        "candidate_status": CANDIDATE_STATUS,
+        "interpretation": {
+            "legal_event_validated": False,
+            "deal_terms_captured": False,
+            "enterprise_value_observed": False,
+            "form_d_amount_sold_measure": FORM_D_AMOUNT_SOLD_MEASURE,
+            "form_d_amount_sold_is_deal_value": False,
+        },
+        "link_window_days": args.link_window_days,
+        "inputs": {"form_d": file_metadata(args.form_d), "ma": file_metadata(args.ma)},
+        "outputs": {
+            name: {**file_metadata(path), "rows": counts[name]}
+            for name, path in output_paths.items()
+        },
+        "counts": counts,
+        "relationship_source_classes": dict(sorted(source_classes.items())),
+        "same_source_only_relationships": sum(
+            bool(row.get("same_source_only")) for row in relationships
+        ),
+        "relationships_with_non_form_d_evidence": sum(
+            bool(row.get("independent_of_form_d")) for row in relationships
+        ),
+        "multi_source_relationships": sum(
+            len(row.get("evidence_sources", [])) >= 2 for row in relationships
+        ),
+        "auto_merged_aliases": 0,
+    }
+    (args.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(manifest, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/three_agency_commercialization_outcomes.py
+++ b/scripts/data/three_agency_commercialization_outcomes.py
@@ -5,7 +5,7 @@ Epistemic tier: exploratory. Outputs are non-citable.
 
 The firm-agency cohort is anchored on each firm's first SBIR or STTR Phase II
 award. Three observed channels remain separate: federal prime contracts, SEC
-Form D offerings, and public-filing M&A signals. A missing signal is not a
+Form D offerings, and unvalidated public-filing M&A candidates. A missing signal is not a
 negative commercialization finding.
 """
 
@@ -26,6 +26,12 @@ from typing import Any
 import numpy as np
 import pandas as pd
 
+from sbir_etl.capital_events.cross_enrichment import (
+    CANDIDATE_STATUS,
+    FORM_D_CHANNEL_AMOUNT_SOLD_MEASURE,
+    evidence_sources,
+    is_independent_of_form_d,
+)
 from sbir_etl.identity import (
     CanonicalMergePolicy,
     CompanyNameProfile,
@@ -522,6 +528,17 @@ def load_form_d_events(
     return result, dict(audit)
 
 
+def ma_provenance_audit_bucket(sources: Iterable[str]) -> str:
+    """Split Form-D-only rows from rows with no recognized underlying source."""
+
+    source_set = {str(source) for source in sources if source}
+    if "form_d" in source_set and all(source == "form_d" for source in source_set):
+        return "form_d_only"
+    if not source_set:
+        return "unclassified"
+    return "independent_of_form_d"
+
+
 def load_ma_events(
     path: Path, cohort: CohortData, cutoff: date
 ) -> tuple[pd.DataFrame, dict[str, int]]:
@@ -544,6 +561,12 @@ def load_ma_events(
             if firm_id is None:
                 stats["unmatched"] += 1
                 continue
+            cross_enrichment = record.get("cross_enrichment") or {}
+            sources = cross_enrichment.get("evidence_sources") or evidence_sources(record)
+            independent = cross_enrichment.get("independent_of_form_d")
+            if independent is None:
+                independent = is_independent_of_form_d(record)
+            stats[ma_provenance_audit_bucket(sources)] += 1
             events.append(
                 {
                     "firm_id": firm_id,
@@ -552,6 +575,9 @@ def load_ma_events(
                     "identity_basis": basis,
                     "confidence": confidence,
                     "acquirer": record.get("acquirer"),
+                    "evidence_sources": ",".join(sorted(sources)),
+                    "independent_of_form_d": bool(independent),
+                    "relationship_id": cross_enrichment.get("relationship_id"),
                 }
             )
             stats["matched"] += 1
@@ -649,6 +675,11 @@ def summarize_channel(
         else:
             has_signal = not matched.empty
             first_date = matched["event_date"].min() if has_signal else None
+        independent_signal = has_signal
+        if channel == "ma" and has_signal:
+            independent_signal = bool(
+                matched.get("independent_of_form_d", pd.Series(False, index=matched.index)).any()
+            )
         per_firm.append(
             {
                 "agency": agency,
@@ -659,6 +690,7 @@ def summarize_channel(
                 "anchor_date": row.anchor_date,
                 "phase_ii_dollars": float(row.phase_ii_dollars),
                 "has_signal": has_signal,
+                "independent_signal": independent_signal,
                 "observed_dollars": observed_dollars,
                 "same_agency_dollars": same_agency_dollars,
                 "first_event_date": first_date,
@@ -690,6 +722,9 @@ def summarize_channel(
         "confidence_filter": confidence_filter,
         "eligible_firms": denominator,
         "firms_with_signal": successes,
+        "firms_with_independent_signal": int(firm_frame["independent_signal"].sum())
+        if denominator
+        else 0,
         "rate": successes / denominator if denominator else math.nan,
         "rate_ci_low": ci_low,
         "rate_ci_high": ci_high,
@@ -712,6 +747,61 @@ def summarize_channel(
         else math.nan,
     }
     return record, firm_frame
+
+
+def build_channel_overlap(firm_frame: pd.DataFrame) -> pd.DataFrame:
+    """Summarize independent five-year pathways without double-counting Form D-derived M&A."""
+
+    primary = firm_frame[
+        (firm_frame["horizon_years"] == PRIMARY_HORIZON)
+        & (
+            (firm_frame["channel"] == "federal_contract")
+            | (firm_frame["confidence_filter"] == "high")
+        )
+    ]
+    overlap = primary.pivot_table(
+        index=["agency", "firm_id"],
+        columns="channel",
+        values="has_signal",
+        aggfunc="max",
+        fill_value=False,
+    ).reset_index()
+    for channel in ("federal_contract", "form_d", "ma"):
+        if channel not in overlap:
+            overlap[channel] = False
+    ma_primary = primary[primary["channel"] == "ma"]
+    if ma_primary.empty:
+        ma_independent = pd.DataFrame(columns=["agency", "firm_id", "ma_independent"])
+    else:
+        ma_independent = (
+            ma_primary.pivot_table(
+                index=["agency", "firm_id"],
+                values="independent_signal",
+                aggfunc="max",
+                fill_value=False,
+            )
+            .rename(columns={"independent_signal": "ma_independent"})
+            .reset_index()
+        )
+    overlap = overlap.merge(ma_independent, on=["agency", "firm_id"], how="left")
+    overlap["ma_independent"] = overlap["ma_independent"].fillna(False).astype(bool)
+    overlap["ma_any_signal"] = overlap["ma"].astype(bool)
+    overlap["ma_same_source_only"] = overlap["ma_any_signal"] & ~overlap["ma_independent"]
+    overlap["pathway"] = overlap.apply(
+        lambda row: "+".join(
+            channel
+            for channel in ("federal_contract", "form_d", "ma")
+            if row[channel if channel != "ma" else "ma_independent"]
+        )
+        or "no_observed_signal",
+        axis=1,
+    )
+    overlap_summary = overlap.groupby(["agency", "pathway"], as_index=False).agg(
+        firms=("firm_id", "size"),
+        ma_any_signal_firms=("ma_any_signal", "sum"),
+        ma_same_source_only_firms=("ma_same_source_only", "sum"),
+    )
+    return overlap_summary
 
 
 def build_outputs(
@@ -772,37 +862,7 @@ def build_outputs(
                 firm_results.append(firms)
     summary_frame = pd.DataFrame(summaries)
     firm_frame = pd.concat(firm_results, ignore_index=True)
-
-    primary = firm_frame[
-        (firm_frame["horizon_years"] == PRIMARY_HORIZON)
-        & (
-            (firm_frame["channel"] == "federal_contract")
-            | (firm_frame["confidence_filter"] == "high")
-        )
-    ]
-    overlap = primary.pivot_table(
-        index=["agency", "firm_id"],
-        columns="channel",
-        values="has_signal",
-        aggfunc="max",
-        fill_value=False,
-    ).reset_index()
-    for channel in ("federal_contract", "form_d", "ma"):
-        if channel not in overlap:
-            overlap[channel] = False
-    overlap["pathway"] = overlap.apply(
-        lambda row: "+".join(
-            channel for channel in ("federal_contract", "form_d", "ma") if row[channel]
-        )
-        or "no_observed_signal",
-        axis=1,
-    )
-    overlap_summary = (
-        overlap.groupby(["agency", "pathway"], as_index=False)
-        .size()
-        .rename(columns={"size": "firms"})
-    )
-    return summary_frame, firm_frame, overlap_summary
+    return summary_frame, firm_frame, build_channel_overlap(firm_frame)
 
 
 def build_vintage_diagnostics(firm_results: pd.DataFrame) -> pd.DataFrame:
@@ -889,10 +949,19 @@ def write_markdown(summary: pd.DataFrame, cohort: pd.DataFrame, path: Path, cuto
         & ((summary["channel"] == "federal_contract") | (summary["confidence_filter"] == "high"))
     ].copy()
     headline["rate_display"] = headline["rate"].map(lambda value: f"{100 * value:.1f}%")
+    headline["independent_rate_display"] = [
+        f"{100 * row.firms_with_independent_signal / row.eligible_firms:.1f}%"
+        if row.eligible_firms
+        else "n/a"
+        for row in headline.itertuples()
+    ]
     headline["leverage_display"] = headline["dollars_per_phase_ii_dollar"].map(
         lambda value: f"{value:.2f}x"
     )
     pivot_rate = headline.pivot(index="agency", columns="channel", values="rate_display")
+    pivot_independent_rate = headline.pivot(
+        index="agency", columns="channel", values="independent_rate_display"
+    )
     pivot_leverage = headline.pivot(index="agency", columns="channel", values="leverage_display")
     lines = [
         "# NASA, Air Force, and DOE SBIR/STTR commercialization outcomes",
@@ -905,8 +974,8 @@ def write_markdown(summary: pd.DataFrame, cohort: pd.DataFrame, path: Path, cuto
         "",
         "A zero means no signal was observed in these public-data channels; it does not mean the firm did not commercialize.",
         "",
-        "| Agency | Eligible firms | Contract rate | Form D rate (high) | M&A rate (high) | Contract $ / Phase II $ | Form D $ / Phase II $ |",
-        "|---|---:|---:|---:|---:|---:|---:|",
+        "| Agency | Eligible firms | Contract rate | Form D rate (high) | M&A candidate rate (high) | M&A candidate independent of Form D | Contract $ / Phase II $ | Form D $ / Phase II $ |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
     ]
     for agency in AGENCY_LABELS:
         eligible = int(
@@ -917,6 +986,7 @@ def write_markdown(summary: pd.DataFrame, cohort: pd.DataFrame, path: Path, cuto
         lines.append(
             f"| {agency} | {eligible:,} | {pivot_rate.loc[agency, 'federal_contract']} | "
             f"{pivot_rate.loc[agency, 'form_d']} | {pivot_rate.loc[agency, 'ma']} | "
+            f"{pivot_independent_rate.loc[agency, 'ma']} | "
             f"{pivot_leverage.loc[agency, 'federal_contract']} | {pivot_leverage.loc[agency, 'form_d']} |"
         )
     lines.extend(
@@ -925,8 +995,8 @@ def write_markdown(summary: pd.DataFrame, cohort: pd.DataFrame, path: Path, cuto
             "## Reading the comparison",
             "",
             "- Contract activity measures subsequent federal-market participation, not proven lineage from a particular Phase II technology.",
-            "- Form D captures disclosed Regulation D financing only. High-confidence matches are the headline; medium-confidence matches remain a sensitivity.",
-            "- M&A uses public-record matches with incomplete coverage and possible identity or classification errors; the direction of net bias is unknown.",
+            "- Form D captures disclosed Regulation D financing only. Amount sold measures exempt securities sold; it is not company, enterprise, or exit value. High-confidence matches are the headline; medium-confidence matches remain a sensitivity.",
+            "- M&A rows are unvalidated public-record candidates, not verified legal exits. Coverage is incomplete and identity or classification errors are possible, so the direction of net bias is unknown. Independent-pathway counts exclude candidates derived only from the same Form D filing.",
             "- Firms may appear in more than one agency cohort; each agency clock begins at that agency's first Phase II award.",
             "",
             "## Cohort and methods",
@@ -935,11 +1005,11 @@ def write_markdown(summary: pd.DataFrame, cohort: pd.DataFrame, path: Path, cuto
             "NASA is the full NASA portfolio; Air Force is the Air Force branch of DoD; DOE includes ARPA-E. "
             "The five-year result includes only firms with a fully observable five-year follow-up period.",
             "",
-            "Federal contract dollars are signed net obligations from any awarding agency. Phase I and II SBIR/STTR actions are excluded by research marker or by a dash-stripped PIID match unless the action is coded Phase III. Form D amounts use actual amount sold, collapse amendments into offering series, and quarantine accessions or CIKs matched to more than one firm.",
+            "Federal contract dollars are signed net obligations from any awarding agency. Phase I and II SBIR/STTR actions are excluded by research marker or by a dash-stripped PIID match unless the action is coded Phase III. Form D amounts use actual exempt securities sold, collapse amendments into offering series, and quarantine accessions or CIKs matched to more than one firm. A business-combination flag does not convert that amount into deal value.",
             "",
             "## Limitations",
             "",
-            "This is a descriptive portfolio comparison, not a causal evaluation. Agency portfolios differ in technology, mission, firm age, and selection. Identity resolution is strongest for UEI/DUNS-linked contracts and weaker for name-keyed SEC signals. Form D and M&A have both false-negative and false-positive risk, so neither is a one-sided bound.",
+            "This is a descriptive portfolio comparison, not a causal evaluation. Agency portfolios differ in technology, mission, firm age, and selection. Identity resolution is strongest for UEI/DUNS-linked contracts and weaker for name-keyed SEC signals. Form D and M&A have both false-negative and false-positive risk, so neither is a one-sided bound. M&A candidates require transaction-level review of identity, closing status, and source terms before they can be described as exits.",
             "",
             "Detailed 3-, 5-, and 10-year estimates, confidence intervals, linkage diagnostics, and channel overlap are in the companion CSV artifacts.",
         ]
@@ -997,6 +1067,14 @@ def main(argv: list[str] | None = None) -> int:
     manifest = {
         "epistemic_tier": "exploratory",
         "citable": False,
+        "ma_candidate_status": CANDIDATE_STATUS,
+        "measure_definitions": {
+            "form_d_amount_sold": FORM_D_CHANNEL_AMOUNT_SOLD_MEASURE,
+            "form_d_amount_sold_is_deal_value": False,
+            "ma_legal_event_validated": False,
+            "ma_deal_terms_captured": False,
+            "ma_enterprise_value_observed": False,
+        },
         "cutoff": args.cutoff.isoformat(),
         "horizons_years": sorted(set(args.horizons)),
         "primary_horizon_years": PRIMARY_HORIZON,

--- a/tests/unit/capital_events/test_cross_enrichment.py
+++ b/tests/unit/capital_events/test_cross_enrichment.py
@@ -1,0 +1,330 @@
+"""Tests for provenance-aware Form D/M&A cross-enrichment."""
+
+from sbir_etl.capital_events.cross_enrichment import (
+    enrich_form_d_and_ma,
+    evidence_sources,
+    independent_source_count,
+    is_independent_of_form_d,
+    relationship_source_classes,
+)
+
+
+def _offering(accession: str, date: str, *, combination: bool = False, amount: float = 0):
+    return {
+        "accession_number": accession,
+        "cik": "0000123",
+        "filing_date": date,
+        "total_amount_sold": amount,
+        "is_business_combination": combination,
+        "is_amendment": False,
+    }
+
+
+def _form_d_record(
+    name: str,
+    offerings: list[dict[str, object]],
+    *,
+    cik: str = "0000123",
+    tier: str = "high",
+):
+    return {
+        "company_name": name,
+        "form_d_cik": cik,
+        "match_confidence": {"tier": tier},
+        "offerings": offerings,
+    }
+
+
+def test_form_d_only_composite_does_not_claim_independent_corroboration():
+    form_d = [
+        _form_d_record(
+            "Acme, Inc.",
+            [
+                _offering("ACC-COMBO", "2020-01-15", combination=True, amount=5_000_000),
+                _offering("ACC-AFTER", "2021-03-01", amount=2_000_000),
+            ],
+        ),
+        _form_d_record(
+            "Giant Co",
+            [_offering("GIANT-AFTER", "2022-01-01", amount=7_000_000)],
+            cik="0000999",
+        ),
+    ]
+    ma = [
+        {
+            "company_name": "ACME INC",
+            "event_date": "2020-02-01",
+            "acquirer": "Giant Co",
+            "confidence": "high",
+            "signals": {"form_d_business_combination": True},
+            "form_d_detail": {"filing_date": "2020-01-15"},
+            "efts_detail": None,
+        }
+    ]
+
+    enriched, relationships, crosswalk = enrich_form_d_and_ma(form_d, ma)
+    provenance = enriched[0]["cross_enrichment"]
+    assert provenance["same_source_only"] is True
+    assert provenance["independent_of_form_d"] is False
+    assert provenance["source_class_count"] == 1
+    assert provenance["independent_source_count"] == 0
+    assert provenance["form_d_accession_numbers"] == ["ACC-COMBO"]
+    assert provenance["post_event_target_form_d_raw_filing_count"] == 1
+    assert provenance["acquirer_form_d_accession_numbers"] == ["GIANT-AFTER"]
+    assert provenance["candidate_status"] == "unvalidated_public_record_candidate"
+    assert provenance["legal_event_validated"] is False
+    assert provenance["deal_terms_captured"] is False
+    assert provenance["enterprise_value_observed"] is False
+    assert (
+        provenance["form_d_amount_sold_measure"]
+        == "business_combination_associated_exempt_securities_sold"
+    )
+    assert provenance["form_d_amount_sold_is_deal_value"] is False
+    assert provenance["acquirer_alias_candidate"]["auto_merge"] is False
+    assert relationships[0]["relationship_type"] == "candidate_acquired_by"
+    assert relationships[0]["legal_event_validated"] is False
+    linked = next(row for row in crosswalk if row["accession_number"] == "ACC-COMBO")
+    assert linked["evidence_role"] == "originating_evidence"
+    assert linked["confidence_credit"] is False
+    assert linked["legal_event_validated"] is False
+    assert linked["match_tier"] == "high"
+
+
+def test_independent_efts_event_can_be_corroborated_by_form_d():
+    form_d = [
+        _form_d_record(
+            "Beta Labs LLC",
+            [_offering("BETA-COMBO", "2023-01-01", combination=True)],
+            cik="456",
+        )
+    ]
+    ma = [
+        {
+            "company_name": "BETA LABS",
+            "event_date": "2023-03-01",
+            "acquirer": "Buyer Inc",
+            "confidence": "medium",
+            "signals": {"efts_acquisition_text": True},
+            "efts_detail": {"mention_types": ["acquisition"]},
+            "form_d_detail": None,
+        }
+    ]
+
+    enriched, _, crosswalk = enrich_form_d_and_ma(form_d, ma)
+    provenance = enriched[0]["cross_enrichment"]
+    assert provenance["evidence_sources"] == ["efts"]
+    assert provenance["independent_of_form_d"] is True
+    assert provenance["source_class_count"] == 1
+    assert provenance["independent_source_count"] == 1
+    linked = next(row for row in crosswalk if row["accession_number"] == "BETA-COMBO")
+    assert linked["evidence_role"] == "independent_corroboration"
+    assert linked["confidence_credit"] is True
+    assert linked["match_tier"] == "high"
+
+
+def test_source_classification_uses_underlying_evidence_not_composite_row():
+    form_d_only = {
+        "signals": {"form_d_business_combination": True},
+        "form_d_detail": {"filing_date": "2020-01-01"},
+    }
+    both = {
+        **form_d_only,
+        "efts_detail": {"mention_types": ["subsidiary"]},
+    }
+    assert evidence_sources(form_d_only) == ["form_d"]
+    assert is_independent_of_form_d(form_d_only) is False
+    assert evidence_sources(both) == ["efts", "form_d"]
+    assert is_independent_of_form_d(both) is True
+
+
+def test_discovery_confirmed_signal_is_independent_evidence():
+    inserted = {
+        "company_name": "Gamma Co",
+        "event_date": "2021-06-01",
+        "confidence": "medium",
+        "signals": {"discovery_confirmed": True},
+        "source": "https://news.example/deal",
+        "evidence": "Buyer Inc acquired Gamma Co",
+    }
+    assert evidence_sources(inserted) == ["discovery"]
+    assert is_independent_of_form_d(inserted) is True
+    enriched, _, _ = enrich_form_d_and_ma([], [inserted])
+    provenance = enriched[0]["cross_enrichment"]
+    assert provenance["evidence_sources"] == ["discovery"]
+    assert provenance["independent_of_form_d"] is True
+    assert provenance["independent_source_count"] == 1
+
+
+def test_raw_press_hits_are_not_independent_corroboration():
+    form_d_plus_hits = {
+        "signals": {"form_d_business_combination": True},
+        "form_d_detail": {"filing_date": "2020-01-01"},
+        "press_wire_signals": [
+            {"title": "Unrelated hit", "link": "https://example.com", "source": "PRNewswire"}
+        ],
+    }
+    assert evidence_sources(form_d_plus_hits) == ["form_d"]
+    assert is_independent_of_form_d(form_d_plus_hits) is False
+    hits_only = {"press_wire_signals": form_d_plus_hits["press_wire_signals"]}
+    assert evidence_sources(hits_only) == []
+    assert is_independent_of_form_d(hits_only) is False
+    extract_token = {"source": "form_d", "evidence": "business combination offering"}
+    assert evidence_sources(extract_token) == []
+
+
+def test_unlinked_form_d_combination_is_preserved_for_review():
+    form_d = [
+        _form_d_record(
+            "No Match LLC",
+            [_offering("UNLINKED", "2018-01-01", combination=True)],
+            cik="777",
+        )
+    ]
+    _, relationships, crosswalk = enrich_form_d_and_ma(form_d, [])
+    assert relationships == []
+    assert crosswalk == [
+        {
+            "accession_number": "UNLINKED",
+            "form_d_cik": "123",
+            "target_name": "No Match LLC",
+            "relationship_id": None,
+            "acquirer_name": None,
+            "link_status": "unlinked",
+            "legal_event_validated": False,
+            "evidence_role": "form_d_only",
+            "confidence_credit": False,
+            "match_tier": "high",
+            "date_distance_days": None,
+        }
+    ]
+
+
+def test_low_tier_form_d_combination_is_not_linked():
+    form_d = [
+        _form_d_record(
+            "3D Control Systems, Inc.",
+            [_offering("LOW-COMBO", "2020-06-01", combination=True)],
+            tier="low",
+        )
+    ]
+    ma = [
+        {
+            "company_name": "3D Control Systems, Inc.",
+            "event_date": "2020-06-15",
+            "acquirer": None,
+            "confidence": "high",
+            "signals": {"efts_acquisition_text": True},
+            "efts_detail": {"mention_types": ["acquisition"]},
+            "form_d_detail": None,
+        }
+    ]
+    _, _, crosswalk = enrich_form_d_and_ma(form_d, ma)
+    assert crosswalk == []
+
+
+def test_originating_form_d_links_by_filing_not_composite_event_date():
+    form_d = [
+        _form_d_record(
+            "Acme, Inc.",
+            [
+                _offering("ORIG-2013", "2013-04-01", combination=True),
+                _offering("NEAR-EFTS", "2026-01-10", combination=True),
+            ],
+        )
+    ]
+    ma = [
+        {
+            "company_name": "ACME INC",
+            "event_date": "2026-01-15",
+            "acquirer": "Buyer Inc",
+            "confidence": "high",
+            "signals": {
+                "form_d_business_combination": True,
+                "efts_acquisition_text": True,
+            },
+            "form_d_detail": {
+                "filing_date": "2013-04-01",
+                "accession_number": "ORIG-2013",
+            },
+            "efts_detail": {
+                "mention_types": ["acquisition"],
+                "latest_mention_date": "2026-01-15",
+            },
+        }
+    ]
+    enriched, _, crosswalk = enrich_form_d_and_ma(form_d, ma)
+    provenance = enriched[0]["cross_enrichment"]
+    assert provenance["form_d_accession_numbers"] == ["ORIG-2013"]
+    linked = {row["accession_number"]: row for row in crosswalk if row["link_status"] == "linked"}
+    assert set(linked) == {"ORIG-2013"}
+    assert linked["ORIG-2013"]["evidence_role"] == "originating_evidence"
+    assert linked["ORIG-2013"]["confidence_credit"] is False
+    unlinked = next(row for row in crosswalk if row["accession_number"] == "NEAR-EFTS")
+    assert unlinked["link_status"] == "unlinked"
+    assert unlinked["evidence_role"] != "originating_evidence"
+
+
+def test_same_date_other_accession_is_not_originating_when_accession_is_known():
+    form_d = [
+        _form_d_record(
+            "Acme, Inc.",
+            [
+                _offering("ORIG-2013", "2013-04-01", combination=True),
+                _offering("OTHER-2013", "2013-04-01", combination=True),
+            ],
+        )
+    ]
+    ma = [
+        {
+            "company_name": "ACME INC",
+            "event_date": "2026-01-15",
+            "acquirer": None,
+            "confidence": "high",
+            "signals": {"form_d_business_combination": True},
+            "form_d_detail": {
+                "filing_date": "2013-04-01",
+                "accession_number": "ORIG-2013",
+            },
+        }
+    ]
+    _, _, crosswalk = enrich_form_d_and_ma(form_d, ma)
+    linked = {row["accession_number"]: row for row in crosswalk if row["link_status"] == "linked"}
+    assert set(linked) == {"ORIG-2013"}
+    other = next(row for row in crosswalk if row["accession_number"] == "OTHER-2013")
+    assert other["link_status"] == "unlinked"
+
+
+def test_empty_accession_is_not_written_to_crosswalk():
+    form_d = [
+        _form_d_record(
+            "Blank Accession LLC",
+            [_offering("", "2019-01-01", combination=True)],
+        )
+    ]
+    ma = [
+        {
+            "company_name": "Blank Accession LLC",
+            "event_date": "2019-01-15",
+            "acquirer": None,
+            "confidence": "high",
+            "signals": {"form_d_business_combination": True},
+            "form_d_detail": {"filing_date": "2019-01-01"},
+        }
+    ]
+    _, _, crosswalk = enrich_form_d_and_ma(form_d, ma)
+    assert crosswalk == []
+
+
+def test_independent_source_count_excludes_form_d():
+    assert independent_source_count(["form_d"]) == 0
+    assert independent_source_count(["efts", "form_d"]) == 1
+    assert independent_source_count(["efts", "press"]) == 2
+
+
+def test_relationship_source_classes_count_linked_form_d():
+    row = {
+        "evidence_sources": ["efts"],
+        "form_d_accession_numbers": ["ACC-1"],
+        "matched_form_d_combination_count": 1,
+    }
+    assert relationship_source_classes(row) == ["efts", "form_d"]

--- a/tests/unit/capital_events/test_ma_events.py
+++ b/tests/unit/capital_events/test_ma_events.py
@@ -6,7 +6,7 @@ import json
 from sbir_etl.capital_events.sources.ma_events import build_ma_events
 
 
-def _ma_row(name, date, confidence, acquirer="GLOBEX CORP", signals=None):
+def _ma_row(name, date, confidence, acquirer="GLOBEX CORP", signals=None, cross_enrichment=None):
     return {
         "company_name": name,
         "event_date": date,
@@ -17,6 +17,7 @@ def _ma_row(name, date, confidence, acquirer="GLOBEX CORP", signals=None):
         "form_d_detail": None,
         "efts_detail": None,
         "sbir_context": {"agency": "DoD"},
+        "cross_enrichment": cross_enrichment or {},
     }
 
 
@@ -66,14 +67,28 @@ def test_metadata_carries_signals(cohort, tmp_path):
                 "2023-06-15",
                 "high",
                 signals={"form_d_business_combination": True},
+                cross_enrichment={
+                    "relationship_id": "ma_test",
+                    "independent_of_form_d": False,
+                },
             )
         )
         + "\n"
     )
     events = list(build_ma_events(cohort, src))
     meta = json.loads(events[0]["metadata"])
-    assert set(meta) == {"signals", "signal_count"}
+    assert set(meta) == {
+        "signals",
+        "signal_count",
+        "candidate_status",
+        "legal_event_validated",
+        "cross_enrichment",
+    }
     assert meta["signals"]["form_d_business_combination"] is True
+    assert meta["candidate_status"] == "unvalidated_public_record_candidate"
+    assert meta["legal_event_validated"] is False
+    assert meta["cross_enrichment"]["relationship_id"] == "ma_test"
+    assert meta["cross_enrichment"]["independent_of_form_d"] is False
 
 
 def test_signal_count_is_recomputed_not_forwarded(cohort, tmp_path):

--- a/tests/unit/scripts/test_three_agency_commercialization_outcomes.py
+++ b/tests/unit/scripts/test_three_agency_commercialization_outcomes.py
@@ -429,3 +429,184 @@ def test_noncohort_identifier_conflict_quarantines_cohort_name_alias(tmp_path: P
         None,
     )
     assert "uei:XYZ789GHJ012" not in cohort.alias_to_firm
+
+
+def test_ma_loader_preserves_signal_but_marks_form_d_only_as_non_independent(tmp_path):
+    ma_path = tmp_path / "enriched_ma.jsonl"
+    ma_path.write_text(
+        json.dumps(
+            {
+                "company_name": "ACME",
+                "event_date": "2018-01-01",
+                "confidence": "high",
+                "acquirer": None,
+                "signals": {"form_d_business_combination": True},
+                "cross_enrichment": {
+                    "relationship_id": "ma_test",
+                    "evidence_sources": ["form_d"],
+                    "independent_of_form_d": False,
+                },
+            }
+        )
+        + "\n"
+    )
+    cohort = MODULE.CohortData(
+        firms=pd.DataFrame(),
+        phase_ii_awards=pd.DataFrame(),
+        alias_to_firm={"name:ACME": "name:ACME"},
+        phase_i_ii_contract_ids=set(),
+        raw_company_names=set(),
+    )
+    events, audit = MODULE.load_ma_events(ma_path, cohort, date(2024, 12, 31))
+    assert len(events) == 1
+    assert bool(events.iloc[0]["independent_of_form_d"]) is False
+    assert events.iloc[0]["relationship_id"] == "ma_test"
+    assert audit["form_d_only"] == 1
+    assert audit.get("unclassified", 0) == 0
+
+
+def test_ma_loader_splits_unclassified_from_form_d_only(tmp_path):
+    ma_path = tmp_path / "enriched_ma.jsonl"
+    ma_path.write_text(
+        json.dumps(
+            {
+                "company_name": "ACME",
+                "event_date": "2018-01-01",
+                "confidence": "high",
+                "acquirer": None,
+                "signals": {},
+                "cross_enrichment": {
+                    "relationship_id": "ma_unclassified",
+                    "evidence_sources": [],
+                    "independent_of_form_d": False,
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cohort = MODULE.CohortData(
+        firms=pd.DataFrame(),
+        phase_ii_awards=pd.DataFrame(),
+        alias_to_firm={"name:ACME": "name:ACME"},
+        phase_i_ii_contract_ids=set(),
+        raw_company_names=set(),
+    )
+    events, audit = MODULE.load_ma_events(ma_path, cohort, date(2024, 12, 31))
+    assert len(events) == 1
+    assert bool(events.iloc[0]["independent_of_form_d"]) is False
+    assert audit.get("form_d_only", 0) == 0
+    assert audit["unclassified"] == 1
+    assert MODULE.ma_provenance_audit_bucket(["form_d"]) == "form_d_only"
+    assert MODULE.ma_provenance_audit_bucket([]) == "unclassified"
+    assert MODULE.ma_provenance_audit_bucket(["efts"]) == "independent_of_form_d"
+
+
+def test_ma_summary_reports_observed_and_independent_signals_separately():
+    eligible = pd.DataFrame(
+        [{"firm_id": "name:ACME", "anchor_date": date(2015, 1, 1), "phase_ii_dollars": 1}]
+    )
+    events = pd.DataFrame(
+        [
+            {
+                "firm_id": "name:ACME",
+                "event_date": date(2018, 1, 1),
+                "amount": 0.0,
+                "confidence": "high",
+                "independent_of_form_d": False,
+            }
+        ]
+    )
+    summary, firms = MODULE.summarize_channel(
+        eligible,
+        events,
+        agency="NASA",
+        horizon=5,
+        channel="ma",
+        confidence_filter="high",
+        cutoff=date(2024, 12, 31),
+    )
+    assert summary["firms_with_signal"] == 1
+    assert summary["firms_with_independent_signal"] == 0
+    assert bool(firms.iloc[0]["has_signal"]) is True
+    assert bool(firms.iloc[0]["independent_signal"]) is False
+
+
+def test_overlap_does_not_double_count_form_d_derived_ma_as_independent_channel():
+    common = {
+        "agency": "NASA",
+        "horizon_years": 5,
+        "confidence_filter": "high",
+        "firm_id": "name:ACME",
+    }
+    firms = pd.DataFrame(
+        [
+            {
+                **common,
+                "channel": "federal_contract",
+                "has_signal": False,
+                "independent_signal": False,
+            },
+            {**common, "channel": "form_d", "has_signal": True, "independent_signal": True},
+            {**common, "channel": "ma", "has_signal": True, "independent_signal": False},
+        ]
+    )
+    overlap = MODULE.build_channel_overlap(firms)
+    assert overlap.iloc[0]["pathway"] == "form_d"
+    assert overlap.iloc[0]["ma_any_signal_firms"] == 1
+    assert overlap.iloc[0]["ma_same_source_only_firms"] == 1
+
+
+def test_generated_memo_labels_ma_as_candidate_and_form_d_amount_as_not_value(tmp_path):
+    rows = []
+    for agency in MODULE.AGENCY_LABELS:
+        for channel, confidence in (
+            ("federal_contract", "all"),
+            ("form_d", "high"),
+            ("ma", "high"),
+        ):
+            rows.append(
+                {
+                    "agency": agency,
+                    "horizon_years": MODULE.PRIMARY_HORIZON,
+                    "channel": channel,
+                    "confidence_filter": confidence,
+                    "eligible_firms": 10,
+                    "firms_with_independent_signal": 1,
+                    "rate": 0.1,
+                    "dollars_per_phase_ii_dollar": 0.0,
+                }
+            )
+    output = tmp_path / "memo.md"
+    MODULE.write_markdown(pd.DataFrame(rows), pd.DataFrame(), output, date(2024, 12, 31))
+    memo = output.read_text()
+    assert "M&A candidate rate (high)" in memo
+    assert "unvalidated public-record candidates" in memo
+    assert "not company, enterprise, or exit value" in memo
+    assert MODULE.FORM_D_CHANNEL_AMOUNT_SOLD_MEASURE == "exempt_securities_sold"
+
+
+def test_write_markdown_guards_zero_eligible_firms(tmp_path):
+    rows = []
+    for agency in MODULE.AGENCY_LABELS:
+        for channel, confidence in (
+            ("federal_contract", "all"),
+            ("form_d", "high"),
+            ("ma", "high"),
+        ):
+            rows.append(
+                {
+                    "agency": agency,
+                    "horizon_years": MODULE.PRIMARY_HORIZON,
+                    "channel": channel,
+                    "confidence_filter": confidence,
+                    "eligible_firms": 0,
+                    "firms_with_independent_signal": 0,
+                    "rate": 0.0,
+                    "dollars_per_phase_ii_dollar": 0.0,
+                }
+            )
+    output = tmp_path / "memo.md"
+    MODULE.write_markdown(pd.DataFrame(rows), pd.DataFrame(), output, date(2024, 12, 31))
+    memo = output.read_text()
+    assert "n/a" in memo


### PR DESCRIPTION
## Stack

This PR is stacked on #700. Review and merge #700 first; GitHub will then retarget this diff cleanly to main. The three-agency analysis from #700 is the integration test case.

## Summary

- add a provenance-aware Form D/M&A cross-enrichment layer without mutating raw inputs
- emit enriched M&A rows, distinct corporate-relationship clusters, and an accession-level Form D crosswalk
- distinguish observed M&A from evidence independent of the originating Form D filing
- prevent same-filing reuse from being counted as two independent commercialization pathways
- emit acquirer relationship candidates with auto-merge disabled
- preserve cross-enrichment metadata in the shared capital-event timeline
- pin input and output hashes in an exploratory, non-citable manifest

## Initial real-data materialization

- 5,252 M&A source rows annotated
- 5,239 distinct target/date/acquirer relationship clusters
- 598 relationships with Form D evidence
- 4,821 with EFTS evidence and 13 with press-wire evidence
- 189 multi-source relationships
- 417 Form-D-only relationships
- 694 linked and 116 unlinked Form D business-combination accessions
- 0 acquirer identities auto-merged into targets

## #700 test-case effect

Five-year high-confidence M&A observed / independent-of-Form-D counts:

| Agency | Observed | Independent |
| --- | ---: | ---: |
| NASA | 5 | 3 |
| Air Force | 5 | 3 |
| DOE | 9 | 4 |

Headline M&A detection remains unchanged. Only distinct-pathway overlap is corrected.

## Validation

- Ruff: passed
- capital-event and three-agency tests: 68 passed
- make docs-check: passed
- real Form D/M&A materialization: passed with unique relationship IDs and hashed artifacts
- #700 full three-agency rerun with enriched M&A: passed
- updated notebook execution: passed

All findings and generated artifacts remain exploratory and non-citable.