### PR TITLE
Fix the Ruff format check failing on main

### DIFF
--- a/tests/unit/scripts/archive/test_scan_sbir_edgar.py
+++ b/tests/unit/scripts/archive/test_scan_sbir_edgar.py
@@ -34,8 +34,6 @@ def test_request_error_tracker_stops_at_first_closing_quote() -> None:
     tracker = _ServerErrorTracker()
     tracker.register("Acme Labs")
 
-    tracker.write(
-        "EDGAR filing mention search failed for 'Acme Labs': later quoted 'detail': 500"
-    )
+    tracker.write("EDGAR filing mention search failed for 'Acme Labs': later quoted 'detail': 500")
 
     assert tracker.had_error("Acme Labs")


### PR DESCRIPTION
main has been red since `5d2fdd94` (the #582 merge). One file fails the Ruff format check.

```
--- tests/unit/scripts/archive/test_scan_sbir_edgar.py
-    tracker.write(
-        "EDGAR filing mention search failed for 'Acme Labs': later quoted 'detail': 500"
-    )
+    tracker.write("EDGAR filing mention search failed for 'Acme Labs': later quoted 'detail': 500")
```

Ruff wants the call on one 99-character line, inside the repo's 100-character limit.

## Why this matters beyond one file

**Every branch cut after `5d2fdd94` inherits the failure.** PR #709 shows a lint failure for a file it does not touch — I spent a while diagnosing it as mine before checking `main` directly and finding `CI -> failure` on the merge commit itself.

Other open PRs (#700, #701, #685, #672, #644) currently report green only because their checks last ran before that merge. Any push to them will turn them red.

## Verification

- Reproduced on a clean `origin/main` worktree under Python 3.11: `1 file would be reformatted, 982 files already formatted`
- After the fix: `983 files already formatted`
- The 4 tests in that file pass
- Same Ruff 0.14.5 as the lockfile pins, so this is not a version skew

Worth noting it does not reproduce in a long-lived local checkout on 3.12, which is probably why it landed — `make lint` locally can disagree with CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvs35G6Eab8LyHtZQZmpwd