### PR TITLE
Repair the press-wire feeds, now that the matcher is fixed

### DIFF
--- a/sbir_etl/enrichers/press_wire.py
+++ b/sbir_etl/enrichers/press_wire.py
@@ -1,7 +1,8 @@
 """Press wire RSS/Atom feed client for SBIR awardee news monitoring.
 
-Polls RSS/Atom feeds from PR Newswire, BusinessWire, and GlobeNewsWire
-for press releases mentioning known SBIR awardee companies. Designed
+Polls RSS/Atom feeds from PR Newswire and GlobeNewsWire for press
+releases mentioning known SBIR awardee companies. BusinessWire was
+dropped on 2026-09-09; see the note on ``FEEDS`` below. Designed
 as a leading-indicator source for commercialization events (contract
 wins, acquisitions, product launches, partnerships) that appear in
 press releases weeks/months before they surface in USAspending or FPDS.

--- a/sbir_etl/enrichers/press_wire.py
+++ b/sbir_etl/enrichers/press_wire.py
@@ -50,10 +50,20 @@ from sbir_etl.enrichers.rate_limiting import RateLimiter
 from sbir_etl.exceptions import APIError
 from sbir_etl.identity import CompanyNameProfile, normalize_company_name
 
+DEFAULT_HEADERS: dict[str, str] = {
+    # Without a descriptive agent PRNewswire 301s and GlobeNewsWire times out,
+    # so two of three feeds returned nothing and poll still reported success.
+    "User-Agent": "sbir-analytics research (https://github.com/hollomancer/sbir-analytics)",
+    "Accept": "application/rss+xml, application/atom+xml, application/xml;q=0.9, */*;q=0.8",
+}
+
 # Feed URLs — public RSS/Atom endpoints
 FEEDS: dict[str, str] = {
     "PRNewswire": "https://www.prnewswire.com/rss/news-releases-list.rss",
-    "BusinessWire": "https://feed.businesswire.com/rss/home/?rss=G1QFDERJXkJeEFpRWA==",
+    # BusinessWire removed 2026-09-09. Its "?rss=G1QFDERJXkJeEFpRWA==" token
+    # returns a valid RSS envelope whose description reads "The channel you
+    # requested is unavailable due to an error during request processing."
+    # A replacement feed URL is needed before it can be restored.
     "GlobeNewsWire": "https://www.globenewswire.com/RSSFeed/subjectcode/01-Business%20Operations/feedTitle/GlobeNewswire%20-%20Business%20Operations",
 }
 
@@ -202,7 +212,7 @@ class PressWireClient(BaseAsyncAPIClient):
         # base_url unused — feed URLs are absolute and passed as endpoint
         self.base_url = ""
         self.rate_limit_per_minute = rate_limit_per_minute
-        self._client = http_client or httpx.AsyncClient(timeout=timeout)
+        self._client = http_client or httpx.AsyncClient(timeout=timeout, follow_redirects=True)
         self._feeds = feeds or dict(FEEDS)
         self._requested_company_names: list[str] = []
         self._watchlist: dict[str, str] = {}  # normalized -> original
@@ -213,6 +223,19 @@ class PressWireClient(BaseAsyncAPIClient):
             automatic_match_count=0,
         )
         self._seen_hashes: set[str] = set()
+
+    def _build_headers(self) -> dict[str, str]:
+        """Ask for feed XML, not JSON, and identify the client.
+
+        ``BaseAsyncAPIClient._build_headers`` requests ``application/json`` and
+        sends a bare ``SBIR-Analytics/<version>`` agent. Both are wrong for a
+        news feed: PRNewswire answered with a 301 and GlobeNewsWire timed out,
+        so two of three feeds returned nothing while ``poll`` reported success.
+        These headers are applied per request, which is the only layer that
+        takes effect -- ``_request_raw`` rebuilds them and would discard
+        anything set on the ``httpx.AsyncClient`` constructor.
+        """
+        return dict(DEFAULT_HEADERS)
 
     # ------------------------------------------------------------------
     # Watchlist management
@@ -449,11 +472,13 @@ class PressWireClient(BaseAsyncAPIClient):
             return []
 
         all_matches: list[PressRelease] = []
+        failed: list[str] = []
 
         for source, url in self._feeds.items():
             xml_text = await self._fetch_feed(source, url)
             if xml_text is None:
                 logger.warning(f"Failed to fetch {source} feed")
+                failed.append(source)
                 continue
 
             items = self._parse_feed(xml_text, source)
@@ -470,7 +495,21 @@ class PressWireClient(BaseAsyncAPIClient):
                     self._seen_hashes.add(item.content_hash)
                     all_matches.append(item)
 
-        logger.info(f"Press wire poll complete: {len(all_matches)} matches")
+        # A total fetch failure produces the same empty list as "nothing in the
+        # news matched", so it has to be raised rather than logged. Every feed
+        # silently 301'd or timed out for want of a User-Agent and this line
+        # still reported success.
+        if failed and len(failed) == len(self._feeds):
+            raise APIError(
+                f"all {len(failed)} press wire feeds failed: {', '.join(failed)}",
+                component="api.press_wire",
+            )
+        if failed:
+            logger.warning(f"{len(failed)} of {len(self._feeds)} feeds failed: {failed}")
+        logger.info(
+            f"Press wire poll complete: {len(all_matches)} matches "
+            f"from {len(self._feeds) - len(failed)} of {len(self._feeds)} feeds"
+        )
         return all_matches
 
     async def poll_all_unfiltered(self) -> list[PressRelease]:

--- a/tests/unit/enrichers/test_press_wire.py
+++ b/tests/unit/enrichers/test_press_wire.py
@@ -15,6 +15,7 @@ from sbir_etl.enrichers.press_wire import (
     _normalize_release_text,
 )
 from sbir_etl.enrichers.sync_wrappers import SyncPressWireClient
+from sbir_etl.exceptions import APIError
 from sbir_etl.identity import CompanyNameProfile
 
 pytestmark = pytest.mark.fast
@@ -119,10 +120,11 @@ class TestInitialization:
         assert isinstance(client, BaseAsyncAPIClient)
 
     def test_default_feeds_used_when_not_specified(self, mock_http_client: AsyncMock) -> None:
+        """BusinessWire dropped 2026-09-09; its token serves an error envelope."""
         c = PressWireClient(http_client=mock_http_client)
         assert "PRNewswire" in c._feeds
-        assert "BusinessWire" in c._feeds
         assert "GlobeNewsWire" in c._feeds
+        assert "BusinessWire" not in c._feeds
 
 
 # ==================== Watchlist ====================
@@ -438,12 +440,14 @@ class TestPoll:
 
         assert len(items) == 2  # Both items, no watchlist filter
 
-    async def test_feed_fetch_500_logged_as_empty(
+    async def test_feed_fetch_500_raises_when_it_is_the_only_feed(
         self, client: PressWireClient, mock_http_client: AsyncMock
     ) -> None:
-        """When a feed returns 5xx, poll continues with other feeds.
+        """Superseded 2026-09-09. This asserted an empty list and hid the fault.
 
-        In this test there's only one feed, so matches should be empty.
+        A 5xx on the only configured feed means nothing was observed, which is
+        not the same as observing that nothing matched. poll continues past a
+        partial failure but raises when every feed is down.
         """
         client.set_watchlist(["Acme Defense Systems"])
         resp = Mock()
@@ -453,9 +457,8 @@ class TestPoll:
             "500", request=Mock(), response=resp
         )
 
-        matches = await client.poll()
-
-        assert matches == []
+        with pytest.raises(APIError, match="all 1 press wire feeds failed"):
+            await client.poll()
 
     async def test_absolute_url_passed_through(
         self, client: PressWireClient, mock_http_client: AsyncMock
@@ -503,3 +506,51 @@ class TestSyncFacade:
             client._client._seen_hashes.add("abc")
             client.reset_seen()
             assert client._client._seen_hashes == set()
+
+
+def test_build_headers_requests_feed_xml_not_json() -> None:
+    """The base client asks for JSON, which is wrong for an RSS feed.
+
+    Without this override PRNewswire answered 301 and GlobeNewsWire timed out,
+    so two of three feeds returned nothing.
+    """
+    from sbir_etl.enrichers.press_wire import PressWireClient
+
+    headers = PressWireClient()._build_headers()
+    assert "rss+xml" in headers["Accept"]
+    assert "application/json" not in headers["Accept"]
+    assert "sbir-analytics" in headers["User-Agent"].lower()
+    assert not headers["User-Agent"].startswith("SBIR-Analytics/")
+
+
+def test_dead_businesswire_feed_is_not_configured() -> None:
+    """BusinessWire's token returns an RSS envelope carrying an error string.
+
+    It parsed as a valid feed with zero items, so the failure was invisible.
+    """
+    from sbir_etl.enrichers.press_wire import FEEDS
+
+    assert "BusinessWire" not in FEEDS
+    assert FEEDS, "at least one feed must remain configured"
+
+
+@pytest.mark.asyncio
+async def test_poll_raises_when_every_feed_fails() -> None:
+    """A total fetch failure must not look like 'nothing matched'.
+
+    Every feed failed silently for want of a User-Agent and poll still logged
+    success and returned an empty list.
+    """
+    from sbir_etl.exceptions import APIError
+    from sbir_etl.enrichers.press_wire import PressWireClient
+
+    client = PressWireClient()
+    client.set_watchlist(["Acme Robotics"])
+
+    async def _fail(source: str, url: str) -> None:
+        return None
+
+    client._fetch_feed = _fail  # type: ignore[assignment]
+    with pytest.raises(APIError, match="all .* press wire feeds failed"):
+        await client.poll()
+    await client.aclose()


### PR DESCRIPTION
Stacked on #718. Review and merge that first.

This fix was written on 2026-09-10 and **deliberately held**. Restoring broken feeds while the matcher had 0/18 precision would have scanned more items at zero precision — making the weekly digest worse, not better. #718 fixes the matcher, so this can land.

## What was broken

`BaseAsyncAPIClient._build_headers` requests `application/json` and sends a bare `SBIR-Analytics/<version>` agent. Both are wrong for a news feed:

- **PRNewswire** answered 301 and the client did not follow it
- **GlobeNewsWire** timed out
- **BusinessWire** returned a valid RSS envelope whose description reads *"The channel you requested is unavailable due to an error during request processing"* — so it parsed as a well-formed feed with zero items, and the failure was invisible

Two of three feeds had been dead, and `poll` reported success either way.

## Three changes

1. **Override `_build_headers`** with a descriptive agent and an RSS/Atom `Accept`. Headers set on the `httpx.AsyncClient` constructor never applied, because `_request_raw` rebuilds them per request — the override has to live in `_build_headers`, which is the layer that takes effect.
2. **Drop BusinessWire.** Its `?rss=` token is revoked. A replacement URL is needed before it can return.
3. **Raise when every feed fails.** A total fetch failure produced the same empty list as "nothing in the news matched".

Verified against the live feeds: **0 items before, 40 after** — 20 from each surviving feed.

## Two superseded tests

- One asserted an empty list when the only feed 500s. That is the defect: nothing observed is not the same as observing nothing.
- One expected BusinessWire in the defaults.

## Verification

1,015 tests pass with #718s matcher fix underneath. `make lint-boundaries` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dvs35G6Eab8LyHtZQZmpwd