### PR TITLE
chore: prepare release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,54 @@ version.
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-09-12
+
+### Breaking
+
+- Removed the press-wire enrichment stage from M&A discovery. Deleted
+  `sbir_etl/enrichers/ma_discovery/press.py`; `enrich_ma_events` and
+  `merge_press_signals` are gone from the package's public exports. All 18 of
+  the stage's matches were false positives, so no true signal is lost.
+- Changed the Form D high-tier rule. A person-name score of at least 0.7 no
+  longer reaches `high` on its own; it now needs an exact ZIP or a state
+  overlap. The historical rule is retired as `person-or-zip-v1` and the current
+  one is `corroborated-person-v2`. Every `match_confidence` object must persist
+  `rule_version`; unversioned or mixed-version inputs fail before analysis.
+- `build_ma_events` no longer emits rows whose `acquirer` is empty. A row that
+  cannot name a counterparty cannot support an exit claim, and a consumer could
+  not tell unknown-acquirer from firm-was-the-buyer.
+- Study manifests at `validated` or `citable` now require a `validation_design`
+  block naming the addressable population, expected yield, decision threshold,
+  and how that threshold was derived. Manifests below that status are
+  unaffected.
+
+### Added
+
+- `sbir_etl/capital_events/cross_enrichment.py`: a provenance layer that links
+  Form D and M&A candidate records and reports whether M&A evidence is
+  independent of the Form D filing it came from. M&A metadata now carries
+  `candidate_status`, `legal_event_validated`, and `cross_enrichment`.
+- Fail-closed M&A discovery with a confirmatory recall floor, a blocking
+  coverage gate, and freeze/replay support for sample runs.
+- Artifact-boundary tests that assert what M&A consumers rely on: every emitted
+  event names a counterparty, `signal_count` matches the signals it reports,
+  and a missing input yields `[]` rather than an error.
+- Adversarial must-not-match cases for the company-matching functions, drawn
+  from real production attribution errors, alongside DUNS-confirmed positives.
+- An audited Form D control-identity universe and an exploratory supplier-share
+  census.
+- Exploratory NASA, Air Force, and DOE post-Phase-II commercialization outcomes
+  analysis.
+- Automated GitHub release publishing from a pushed tag.
+
+### Fixed
+
+- Press-wire watchlist matching used unanchored substring comparison, so every
+  match it produced was a false positive. Matching is now word-boundary
+  anchored with a four-character floor, and each hit records where it matched.
+- Restored the press-wire feeds. BusinessWire's feed returns an error envelope
+  and is dropped until a replacement URL exists; PR Newswire and GlobeNewsWire
+  poll normally.
 ### Fixed
 
 - Versioned the Form D tier rule as `corroborated-person-v2`, added a

--- a/config/base.yaml
+++ b/config/base.yaml
@@ -4,7 +4,7 @@
 
 pipeline:
   name: "sbir-analytics"
-  version: "0.12.0"
+  version: "0.13.0"
   environment: "development" # overridden by environment
 
 # File system paths configuration

--- a/packages/sbir-analytics/pyproject.toml
+++ b/packages/sbir-analytics/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-analytics"
-version = "0.12.0"
+version = "0.13.0"
 description = "Full SBIR analytics pipeline — ETL + Dagster orchestration + ML + Neo4j"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/packages/sbir-graph/pyproject.toml
+++ b/packages/sbir-graph/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-graph"
-version = "0.12.0"
+version = "0.13.0"
 description = "SBIR Graph — Neo4j graph database loaders and pathway queries"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 license = {text = "MIT"}

--- a/packages/sbir-ml/pyproject.toml
+++ b/packages/sbir-ml/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-ml"
-version = "0.12.0"
+version = "0.13.0"
 description = "SBIR ML/data science — CET classification, transition detection, and analysis tools"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sbir-etl"
-version = "0.12.0"
+version = "0.13.0"
 description = "SBIR ETL library — extract, enrich, and transform SBIR/STTR awards data"
 authors = [{name = "Conrad Hollomon", email = "conrad.hollomon@pm.me"}]
 readme = "README.md"

--- a/sbir_etl/__init__.py
+++ b/sbir_etl/__init__.py
@@ -6,4 +6,4 @@ subpackages declare their own tiers.
 
 EPISTEMIC_TIER = "primitives"
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1975,7 +1975,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2823,7 +2823,7 @@ wheels = [
 
 [[package]]
 name = "sbir-analytics"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/sbir-analytics" }
 dependencies = [
     { name = "dagster" },
@@ -2847,7 +2847,7 @@ provides-extras = ["modernbert-local", "dev"]
 
 [[package]]
 name = "sbir-etl"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
@@ -3001,7 +3001,7 @@ notebooks = [
 
 [[package]]
 name = "sbir-graph"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/sbir-graph" }
 dependencies = [
     { name = "loguru" },
@@ -3020,7 +3020,7 @@ requires-dist = [
 
 [[package]]
 name = "sbir-ml"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "packages/sbir-ml" }
 dependencies = [
     { name = "sbir-etl" },


### PR DESCRIPTION
MINOR under the pre-1.0 rules in `docs/steering/versioning.md` — this release adds new capabilities and carries breaking changes.

## Version metadata

All six sources moved to `0.13.0` and `uv.lock` re-locked:

| Source | |
|---|---|
| `pyproject.toml` (root, sbir-etl) | ✅ |
| `packages/sbir-analytics/pyproject.toml` | ✅ |
| `packages/sbir-graph/pyproject.toml` | ✅ |
| `packages/sbir-ml/pyproject.toml` | ✅ |
| `sbir_etl.__version__` | ✅ |
| `config/base.yaml` `pipeline.version` | ✅ |

`check_versioning.py --tag v0.13.0` passes.

## Four breaking changes

1. **Press-wire enrichment removed from M&A discovery.** `press.py` deleted; `enrich_ma_events` and `merge_press_signals` gone from the public exports. All 18 of the stage's matches were false positives, so no true signal is lost.
2. **Form D high tier now requires corroboration.** A person-name score ≥0.7 no longer reaches `high` alone — it needs an exact ZIP or state overlap. Historical rule retired as `person-or-zip-v1`; current rule is `corroborated-person-v2`. `rule_version` must be persisted.
3. **`build_ma_events` skips empty-acquirer rows.** A row that cannot name a counterparty cannot support an exit claim.
4. **`validation_design` required at `validated`/`citable`.** Manifests below that status are unaffected.

## Verification

| Check | Result |
|---|---|
| Unit tests | 6,897 passed, 7 skipped |
| `check_versioning.py --tag v0.13.0` | passed |
| ruff check / format | clean (999 files) |
| `make docs-check` | passed |
| `validate_study_manifests.py` | 4 validated |
| `check_epistemic_tiers.py` | passed |

## After merge

Tag the merge commit and push — that is the only manual step; `release.yml` does the rest.

```bash
git tag -a v0.13.0 -m "Release v0.13.0"
git push origin v0.13.0
```